### PR TITLE
Adding name suffix to filestore instances def name.

### DIFF
--- a/resources/file-system/filestore/README.md
+++ b/resources/file-system/filestore/README.md
@@ -19,12 +19,14 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
 
@@ -35,6 +37,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_filestore_instance.filestore_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 

--- a/resources/file-system/filestore/main.tf
+++ b/resources/file-system/filestore/main.tf
@@ -13,11 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
 
 resource "google_filestore_instance" "filestore_instance" {
   depends_on = [var.network_name]
 
-  name = var.name != null ? var.name : var.deployment_name
+  name = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
   zone = var.zone
   tier = var.filestore_tier
 

--- a/resources/file-system/filestore/module.json
+++ b/resources/file-system/filestore/module.json
@@ -78,6 +78,11 @@
       "name": "google",
       "alias": null,
       "version": "~\u003e 3.0"
+    },
+    {
+      "name": "random",
+      "alias": null,
+      "version": "~\u003e 3.0"
     }
   ],
   "requirements": [
@@ -88,6 +93,10 @@
     {
       "name": "google",
       "version": "~\u003e 3.0"
+    },
+    {
+      "name": "random",
+      "version": "~\u003e 3.0"
     }
   ],
   "resources": [
@@ -97,7 +106,17 @@
       "provider": "google",
       "source": "hashicorp/google",
       "mode": "managed",
-      "version": "latest"
+      "version": "latest",
+      "description": null
+    },
+    {
+      "type": "id",
+      "name": "resource_name_suffix",
+      "provider": "random",
+      "source": "hashicorp/random",
+      "mode": "managed",
+      "version": "latest",
+      "description": null
     }
   ]
 }

--- a/resources/file-system/filestore/versions.tf
+++ b/resources/file-system/filestore/versions.tf
@@ -20,6 +20,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 3.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 
   required_version = ">= 0.14.0"


### PR DESCRIPTION
As it was, if the user created two Filestore instances without
specifying their name, there would be a name clash.