### PR TITLE
Explicitly set zone and project in gcloud commands

### DIFF
--- a/resources/scripts/omnia-install/README.md
+++ b/resources/scripts/omnia-install/README.md
@@ -43,6 +43,8 @@ No modules.
 | <a name="input_depends"></a> [depends](#input\_depends) | Allows to add explicit dependencies | `list(any)` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment, used to name the cluster | `string` | n/a | yes |
 | <a name="input_manager_node"></a> [manager\_node](#input\_manager\_node) | Name of the Omnia manager node | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the Omnia cluster has been created | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | The GCP zone where the Omnia cluster is running | `string` | n/a | yes |
 
 ## Outputs
 

--- a/resources/scripts/omnia-install/main.tf
+++ b/resources/scripts/omnia-install/main.tf
@@ -25,6 +25,8 @@ resource "null_resource" "omnia_install" {
     environment = {
       DEPLOYMENT_NAME = var.deployment_name
       MANAGER_NODE    = var.manager_node
+      ZONE            = var.zone
+      PROJECT_ID      = var.project_id
     }
   }
 }

--- a/resources/scripts/omnia-install/module.json
+++ b/resources/scripts/omnia-install/module.json
@@ -22,6 +22,20 @@
       "description": "Name of the Omnia manager node",
       "default": null,
       "required": true
+    },
+    {
+      "name": "project_id",
+      "type": "string",
+      "description": "Project in which the Omnia cluster has been created",
+      "default": null,
+      "required": true
+    },
+    {
+      "name": "zone",
+      "type": "string",
+      "description": "The GCP zone where the Omnia cluster is running",
+      "default": null,
+      "required": true
     }
   ],
   "modules": [],

--- a/resources/scripts/omnia-install/scripts/create_inventory.py
+++ b/resources/scripts/omnia-install/scripts/create_inventory.py
@@ -23,10 +23,13 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--template", type=str, required=True)
 parser.add_argument("--outfile", type=str, required=True)
 parser.add_argument("--deployment_name", type=str, required=True)
+parser.add_argument("--project_id", type=str, required=True)
+parser.add_argument("--zone", type=str, required=True)
 args = parser.parse_args()
 
 ## Get cluster information
-gcloud_cmd = ["gcloud", "compute", "instances", "list",
+gcloud_cmd = ["gcloud", "compute",  "instances", "list",
+              "--project", args.project_id, "--zones", args.zone,
               "--filter", f"labels.ghpc_deployment={args.deployment_name}",
               "--format",
               "json(name,labels.ghpc_role,networkInterfaces[0].networkIP)"]

--- a/resources/scripts/omnia-install/scripts/install_omnia.sh
+++ b/resources/scripts/omnia-install/scripts/install_omnia.sh
@@ -22,11 +22,14 @@ mkdir -p ${RUNNER_DIR}/ghpc-install/data
 python3 ${RUNNER_DIR}/create_inventory.py     \
   --deployment_name ${DEPLOYMENT_NAME}        \
   --template ${RUNNER_DIR}/inventory.tmpl     \
-  --outfile ${RUNNER_DIR}/ghpc-install/data/inventory
+  --outfile ${RUNNER_DIR}/ghpc-install/data/inventory \
+  --project ${PROJECT_ID} \
+  --zone ${ZONE}
 
 echo "Copying runner data to Omnia Manager..."
-gcloud compute scp --recurse ${RUNNER_DIR}/ghpc-install ${MANAGER_NODE}:
+gcloud compute scp --project ${PROJECT_ID} --zone ${ZONE} \
+  --recurse ${RUNNER_DIR}/ghpc-install ${MANAGER_NODE}:
 
 echo "Applying the Omnia runner..."
-gcloud compute ssh ${MANAGER_NODE} -- \
-  "cd ~/ghpc-install/scripts; source install_omnia.sh"
+gcloud compute ssh --project ${PROJECT_ID} --zone ${ZONE} ${MANAGER_NODE} \
+  -- "cd ~/ghpc-install/scripts; source install_omnia.sh"

--- a/resources/scripts/omnia-install/variables.tf
+++ b/resources/scripts/omnia-install/variables.tf
@@ -29,3 +29,13 @@ variable "manager_node" {
   description = "Name of the Omnia manager node"
   type        = string
 }
+
+variable "zone" {
+  description = "The GCP zone where the Omnia cluster is running"
+  type        = string
+}
+
+variable "project_id" {
+  description = "Project in which the Omnia cluster has been created"
+  type        = string
+}


### PR DESCRIPTION
zone and project had not been set for gcloud compute commands which
could lead to bad behavior if the user defaults are not aligned. This
makes that explicit by adding a variable and setting the value in each
script run to install omnia.