### PR TITLE
Improved makefile, enforce >= 80% eng converage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ vet:
 
 test-engine:
 	$(info **************** running ghpc unit tests **************)
-	go test -cover $(ENG) 2>&1 |  tools/enforce_coverage.pl
+	go test -cover $(ENG) 2>&1 |  perl tools/enforce_coverage.pl
 
 
 test-resources:

--- a/tools/enforce_coverage.pl
+++ b/tools/enforce_coverage.pl
@@ -1,4 +1,4 @@
-#!/bin/perl
+#!/usr/bin/perl
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,7 @@ use warnings;
 
 my $min = 80;
 my $failed = 0;
+
 while (<>){
   print $_;
   if ( $_ =~ /coverage: (\d+\.\d)%/ ) {


### PR DESCRIPTION
Added enforce_coverage to make sure engine tests have at least 80%
coverage (or none).
Added Makefile rule for add-google-license, which can benefit googlers.