### PR TITLE
Adding cloud-build artifacts to accelerate tests.

### DIFF
--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -1,0 +1,41 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Getting Terraform and Packer
+FROM golang:bullseye
+RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -
+RUN apt-get -y update && apt-get -y install software-properties-common
+RUN apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main"
+RUN apt-get -y update && apt-get install -y unzip python3-pip terraform packer
+
+RUN pip install pre-commit
+RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+RUN go install github.com/terraform-docs/terraform-docs@v0.16.0
+RUN go install golang.org/x/lint/golint@latest
+RUN go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+RUN go install github.com/go-critic/go-critic/cmd/gocritic@latest
+RUN go install github.com/google/addlicense@latest
+
+# Setting GHPC dependencies
+WORKDIR /ghpc-tmp
+COPY ./ ./
+
+RUN make ghpc vet
+
+WORKDIR /ghpc
+
+
+
+

--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -1,0 +1,54 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t',
+  'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest',
+  '--cache-from',
+  'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder:latest',
+  '-f', 'tools/cloud-build/Dockerfile',
+  '.' ]
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'run'
+  - '--entrypoint'
+  - '/bin/bash'
+  - '--volume'
+  - '/workspace:/ghpc'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
+  - '-c'
+  - |
+    export PROJECT=build-project
+    addlicense -check . >/dev/null
+    make tests
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'run'
+  - '--entrypoint'
+  - '/bin/bash'
+  - '--volume'
+  - '/workspace:/ghpc'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
+  - '-c'
+  - |
+    pre-commit install --install-hooks
+    tflint --init
+    SKIP=go-unit-tests pre-commit run --all-files
+images: [
+  'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder']
+timeout: "1200s"
+options:
+  machineType: N1_HIGHCPU_8
+

--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -1,0 +1,45 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'run'
+  - '--entrypoint'
+  - '/bin/bash'
+  - '--volume'
+  - '/workspace:/ghpc'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
+  - '-c'
+  - |
+    export PROJECT=build-project
+    addlicense -check . >/dev/null
+    make tests
+- name: 'gcr.io/cloud-builders/docker'
+  args:
+  - 'run'
+  - '--entrypoint'
+  - '/bin/bash'
+  - '--volume'
+  - '/workspace:/ghpc'
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
+  - '-c'
+  - |
+    pre-commit install --install-hooks
+    tflint --init
+    SKIP=go-unit-tests pre-commit run --all-files
+timeout: "1200s"
+options:
+  machineType: N1_HIGHCPU_8
+


### PR DESCRIPTION
* Dockerfile describes a container with everything needed to build and
vet ghpc.
* hpc-tolkit-builder corresponds to the cloud-build rule to build the
builder and then run all tests.
* hpc-toolkit-pr-validation uses the above container to validate a PR.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated any application documentation such as READMEs and user
  guides?
* [ ] Have you followed the guidelines in our Contributing document?

