### PR TITLE
Builder img now uses latest of terraform-docs

### DIFF
--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -y update && apt-get install -y unzip python3-pip terraform packer
 RUN pip install pre-commit
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
-RUN go install github.com/terraform-docs/terraform-docs@v0.16.0
+RUN go install github.com/terraform-docs/terraform-docs@latest
 RUN go install golang.org/x/lint/golint@latest
 RUN go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 RUN go install github.com/go-critic/go-critic/cmd/gocritic@latest


### PR DESCRIPTION
We prefer to always use the latest version of all tools in the builder
image. That will allow us to catch changes in our dependencies before they
actually affect the toolkit.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [ ] Is unit test coverage still above 80%?
* [ ] Have you updated any application documentation such as READMEs and user
  guides?
* [ ] Have you followed the guidelines in our Contributing document?

