### PR TITLE
Add to Makefile make install-deps-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-.PHONY: tests fmt vet test-engine test-resources test-examples packer packer-clean packer-check packer-docs add-google-license
+.PHONY: tests fmt vet test-engine test-resources test-examples packer \
+        packer-clean packer-check packer-docs add-google-license, \
+				check-tflint, check-pre-commit, install-deps-dev
 RES = ./resources
 ENG = ./cmd/... ./pkg/...
 SRC = $(ENG) $(RES)/tests/...
@@ -46,6 +48,30 @@ packer-check:
 	  echo "checking syntax for $${folder}"; \
 	  packer fmt -check $${folder}; \
 	done
+
+ifeq (, $(shell which pre-commit))
+check-pre-commit:
+	$(info WARNING: pre-commit not installed, visit https://pre-commit.com/ for installation instructions.)
+else
+check-pre-commit:
+
+endif
+
+ifeq (, $(shell which tflint))
+check-tflint:
+	$(info WARNING: tflint not installed, visit https://github.com/terraform-linters/tflint#installation for installation instructions.)
+else
+check-tflint:
+
+endif
+
+install-deps-dev: check-pre-commit check-tflint
+	$(info **************** installing developer dependencies ****)
+	go install github.com/terraform-docs/terraform-docs@latest
+	go install golang.org/x/lint/golint@latest
+	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+	go install github.com/go-critic/go-critic/cmd/gocritic@latest
+	go install github.com/google/addlicense@latest
 
 ifeq (, $(shell which terraform-docs))
 packer-docs:

--- a/README.md
+++ b/README.md
@@ -53,11 +53,25 @@ terraform apply
     * `conda install go go-nocgo go-nocgo_osx-64`
 
 ## Development
-Please use the `pre-commit` hooks configured in this repository to ensure
-that all Terraform modules are validated and properly documented before pushing
-code changes. [pre-commit][https://pre-commit.com/] can be installed using
-standard package managers. It is enabled on a repo-by-repo basis by switching to
-the root directory of the repo and running:
+Please use the `pre-commit` hooks [configured](./.pre-commit-config.yaml) in
+this repository to ensure that all Terraform and golang modules are validated
+and properly documented before pushing code changes.
+[pre-commit](https://pre-commit.com/) can be installed using standard package
+managers, more details can be found at on the website.
+
+The pre-commits configured in the HPC Toolkit have a set of
+dependencies that need to be installed before successfully passing all
+pre-commits. TFLint must be installed manually, the instructions can be found
+[here](https://github.com/terraform-linters/tflint#installation). The other
+dependencies can be installed by running the following command in the root
+directory:
+
+```shell
+make install-deps-dev
+```
+
+pre-commit is enabled on a repo-by-repo basis by switching to the root
+directory of the repo and running:
 
 ```shell
 pre-commit install


### PR DESCRIPTION
make install-deps-dev installs development dependencies for running
pre-commit. It also warns if pre-commit or tflint are not installed and
indicates where to install them.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

