### PR TITLE
Set cloud builders to fail on any non-zero command

### DIFF
--- a/tools/cloud-build/hpc-toolkit-builder.yaml
+++ b/tools/cloud-build/hpc-toolkit-builder.yaml
@@ -30,6 +30,7 @@ steps:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
   - '-c'
   - |
+    set -e
     export PROJECT=build-project
     addlicense -check . >/dev/null
     make tests
@@ -43,6 +44,7 @@ steps:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
   - '-c'
   - |
+    set -e
     pre-commit install --install-hooks
     tflint --init
     SKIP=go-unit-tests pre-commit run --all-files

--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -23,8 +23,9 @@ steps:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
   - '-c'
   - |
+    set -e
     export PROJECT=build-project
-    addlicense -check . >/dev/null
+    addlicense -check .
     make tests
 - name: 'gcr.io/cloud-builders/docker'
   args:
@@ -36,6 +37,7 @@ steps:
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder'
   - '-c'
   - |
+    set -e
     pre-commit install --install-hooks
     tflint --init
     SKIP=go-unit-tests pre-commit run --all-files


### PR DESCRIPTION
Set -e on all cloud build docker run commands to fix an error with
addlicense where it would return non-zero, but the script would continue
to run.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

