### PR TITLE
Bug fix: Omnia install script permissions

### DIFF
--- a/pkg/resutils/resutils.go
+++ b/pkg/resutils/resutils.go
@@ -64,10 +64,10 @@ func CopyDirFromResources(fs BaseFS, source string, dest string) error {
 			}
 			copyFile, err := os.Create(entryDest)
 			if err != nil {
-				return nil
+				return err
 			}
 			if _, err = copyFile.Write(fileBytes); err != nil {
-				return nil
+				return err
 			}
 		}
 	}

--- a/resources/scripts/omnia-install/main.tf
+++ b/resources/scripts/omnia-install/main.tf
@@ -21,7 +21,7 @@ resource "null_resource" "omnia_install" {
     "manager"      = var.manager_node
   }
   provisioner "local-exec" {
-    command = "${path.module}/scripts/install_omnia.sh"
+    command = "sh ${path.module}/scripts/install_omnia.sh"
     environment = {
       DEPLOYMENT_NAME = var.deployment_name
       MANAGER_NODE    = var.manager_node


### PR DESCRIPTION
Permissions are not retained when embedding files, therefore the
executable file in the omnia resource cannot be executed on writing to
the blueprint. A quick fix of setting the permissions before executing
was added and a couple minor error handling bugs were caught and fixed
as well.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

