### PR TITLE
Various fixes to integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/create_blueprint.sh
+++ b/tools/cloud-build/daily-tests/create_blueprint.sh
@@ -19,6 +19,7 @@ EXAMPLE_YAML=${EXAMPLE_YAML:-/workspace/examples/hpc-cluster-high-io.yaml}
 PROJECT=${PROJECT:-hpc-toolkit-dev}
 BACKEND_YAML=${ROOT_DIR}/tools/cloud-build/daily-tests/gcs-backend.yaml
 BLUEPRINT_DIR=${BLUEPRINT_DIR:-blueprint}
+BUILD_ID=${BUILD_ID:-undefined-build}
 MAX_NODES=${MAX_NODES:-2}
 echo "Creating blueprint from ${EXAMPLE_YAML} in project ${PROJECT}"
 
@@ -38,14 +39,16 @@ fi
 cd $ROOT_DIR
 make
 
-## Prep deployment blueprint
+## Customize config yaml
 sed -i "s/project_id: .*/project_id: ${PROJECT_ID}/"  ${EXAMPLE_YAML} || \
      { echo "could not set project_id"; exit 1; }
-sed -i "s/blueprint_name: .*/blueprint_name: ${BLUEPRINT_DIR//\//\\/}/" ${EXAMPLE_YAML} || \
+sed -i "s/blueprint_name: .*/blueprint_name: ${BLUEPRINT_DIR}/" ${EXAMPLE_YAML} || \
      { echo "could not set blueprint_name"; exit 1; }
+sed -i "s/deployment_name: \(.*\)/deployment_name: \1-${BUILD_ID:0:6}/" ${EXAMPLE_YAML} || \
+     { echo "could not set deployment_name"; exit 1; }
 sed -i "s/max_node_count: .*/max_node_count: ${MAX_NODES}/"  ${EXAMPLE_YAML} || \
      { echo "could not set max_node_count"; exit 1; }
 
+## Create blueprint and create artifact
 ./ghpc create -c ${EXAMPLE_YAML}
-
 tar -czf ${BLUEPRINT_DIR}.tgz ${BLUEPRINT_DIR}

--- a/tools/cloud-build/daily-tests/daily-tests.yml
+++ b/tools/cloud-build/daily-tests/daily-tests.yml
@@ -36,6 +36,7 @@
       PROJECT_ID: "{{ project }}"
       ROOT_DIR: "{{ workspace }}"
       BLUEPRINT_DIR: "{{ blueprint_dir }}"
+      BUILD_ID: "{{ build_id }}"
     args:
       creates: "{{ workspace }}/{{ blueprint_dir }}.tgz"
   - name: Create Infrastructure and test
@@ -99,7 +100,7 @@
       delegate_to: localhost
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ blueprint_dir }}"
+        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
     - name: Delete Firewall Rule
       command:
         argv:
@@ -138,7 +139,7 @@
       delegate_to: localhost
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ blueprint_dir }}"
+        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
     - name: Delete Firewall Rule
       run_once: true
       delegate_to: localhost

--- a/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
+++ b/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
@@ -21,6 +21,8 @@ steps:
   args:
   - -c
   - |
+    BUILD_ID_FULL=$BUILD_ID
+    LOGIN_ID=slurm-hpc-slurm-io-$${BUILD_ID_FULL:0:6}-login0
     cat <<EOT >> test-vars.yml
     build_id: ${BUILD_ID}
     project: ${PROJECT_ID}
@@ -29,8 +31,8 @@ steps:
     blueprint_yaml: "{{ workspace }}/examples/hpc-cluster-high-io.yaml"
     blueprint_dir: blueprint
     network: default
-    max_nodes: 2
-    login_node: slurm-hpc-slurm-io-login0
+    max_nodes: 5
+    login_node: $${LOGIN_ID}
     partitions:
     - compute
     mounts:

--- a/tools/cloud-build/daily-tests/slurm-tests.yml
+++ b/tools/cloud-build/daily-tests/slurm-tests.yml
@@ -19,7 +19,7 @@
 - name: Check partition compute exists
   fail:
     msg: Test Check Partitions failed
-  when: "\"{{ item }}\" not in partition_output.stdout"
+  when: item not in partition_output.stdout
   loop: "{{ partitions }}"
 
 - name: Get mount info
@@ -30,15 +30,12 @@
 - name: Check if mount exists
   fail:
     msg: "{{ item.item }} not mounted"
-  when: not {{ item.stat.exists }}
+  when: not item.stat.exists
   loop: "{{ stat_mounts.results }}"
 
 - name: Test Mounts on partitions
   command: srun -N 1 ls -laF {{ mounts | join(' ') }}
   loop: "{{ partitions }}"
-- name: Pause for 2 minutes to allow nodes to turn down
-  pause:
-    minutes: 2
 
 - name: Test partitions with hostname
   command: srun -N 2 --partition {{ item }} hostname


### PR DESCRIPTION
* Remove timeout - affinity group leak likely cause of prior failures
* Fix "when" statements in ansible
* Append build ID to deployment name

This version is now passing and cleaning up after itself:
* https://pantheon.corp.google.com/cloud-build/builds;region=global/b6efe50c-aa51-43e2-952d-6b3756ef443f?project=hpc-toolkit-dev
* https://pantheon.corp.google.com/compute/instances?project=hpc-toolkit-dev

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

