### PR TITLE
Update name of nat-ips to be unique

### DIFF
--- a/resources/network/vpc/main.tf
+++ b/resources/network/vpc/main.tf
@@ -94,7 +94,7 @@ module "cloud_router" {
 
 resource "google_compute_address" "nat_ips" {
   count  = 2
-  name   = "nat-ips-${count.index}"
+  name   = "${local.network_name}-nat-ips-${count.index}"
   region = local.region
 }
 


### PR DESCRIPTION
This merge changes the name of the nat-ips deployments to be unique.

### Submission Checklist:

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?

