### PR TITLE
Update spack variables to be lists if not defined

### DIFF
--- a/resources/scripts/spack-install/main.tf
+++ b/resources/scripts/spack-install/main.tf
@@ -23,10 +23,10 @@ locals {
       INSTALL_DIR = var.install_dir
       SPACK_URL   = var.spack_url
       SPACK_REF   = var.spack_ref
-      COMPILERS   = var.compilers
-      LICENSES    = var.licenses
-      PACKAGES    = var.packages
-      MIRRORS     = var.spack_cache_url
+      COMPILERS   = var.compilers == null ? [] : var.compilers
+      LICENSES    = var.licenses == null ? [] : var.licenses
+      PACKAGES    = var.packages == null ? [] : var.packages
+      MIRRORS     = var.spack_cache_url == null ? [] : var.spack_cache_url
     }
   )
 }


### PR DESCRIPTION
This commit sets variables that are used within the spack resource to be
empty lists instead of null values if they are not defined within a
deployment.

### Submission Checklist:

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?

