### PR TITLE
Remove -c flag from expand command

### DIFF
--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
-	"log"
 
 	"github.com/spf13/cobra"
 )
@@ -26,10 +25,8 @@ import (
 func init() {
 	expandCmd.Flags().StringVarP(&yamlFilename, "config", "c", "",
 		"Configuration file for the new blueprints")
-	err := expandCmd.MarkFlagRequired("config")
-	if err != nil {
-		log.Fatalf("Error in init for expand command: %v", err)
-	}
+	cobra.CheckErr(expandCmd.Flags().MarkDeprecated("config",
+		"please see the command usage for more details."))
 	expandCmd.Flags().StringVarP(&outputFilename, "out", "o", "expanded.yaml",
 		"Output file for the expanded yaml.")
 	rootCmd.AddCommand(expandCmd)
@@ -46,6 +43,15 @@ var (
 )
 
 func runExpandCmd(cmd *cobra.Command, args []string) {
+	if yamlFilename == "" {
+		if len(args) == 0 {
+			fmt.Println(cmd.UsageString())
+			return
+		}
+
+		yamlFilename = args[0]
+	}
+
 	blueprintConfig := config.NewBlueprintConfig(yamlFilename)
 	blueprintConfig.ExpandConfig()
 	blueprintConfig.ExportYamlConfig(outputFilename)


### PR DESCRIPTION
This change has been tested with the following test cases. This is similar to [Remove the -c flag for create](https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/68) and makes -c backwards compatible.

**Case 1: ghpc expand help**

This command doesn't show the -c flag in the list of flags as it's deprecated.

```
$ ./ghpc expand --help
Updates the YAML Config in the same way as create, but without writing the blueprint.

Usage:
  ghpc expand [flags]

Flags:
  -h, --help         help for expand
  -o, --out string   Output file for the expanded yaml. (default "expanded.yaml")
```

**Case 2: ghpc expand without -c flag**

Simple success.

```
$ ./ghpc expand examples/hpc-cluster-small.yaml 
Expanded config created successfully, saved as expanded.yaml.

$ ls expanded.yaml 
expanded.yaml
```

**Case 3: ghpc expand with -c flag (Deprecation)**

Success with the deprecation message.

```
$ ./ghpc expand -c examples/hpc-cluster-small.yaml
Flag --config has been deprecated, please see the command usage for more details.
Expanded config created successfully, saved as expanded.yaml.

$ ls expanded.yaml 
expanded.yaml
```

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

