### PR TITLE
Fix bug in applied group terraform backends

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -177,30 +177,6 @@ func importYamlConfig(yamlConfigFilename string) YamlConfig {
 		yamlConfig.Vars = make(map[string]interface{})
 	}
 
-	// 1. DEFAULT: use TerraformBackend configuration (if supplied) in each
-	//    resource group
-	// 2. If top-level TerraformBackendDefaults is defined, insert that
-	//    backend into resource groups which have no explicit
-	//    TerraformBackend
-	// 3. In all cases, add a prefix for GCS backends if one is not defined
-	if yamlConfig.TerraformBackendDefaults.Type != "" {
-		for i, grp := range yamlConfig.ResourceGroups {
-			if grp.TerraformBackend.Type == "" {
-				grp.TerraformBackend = yamlConfig.TerraformBackendDefaults
-			}
-			if grp.TerraformBackend.Type == "gcs" && grp.TerraformBackend.Configuration["prefix"] == nil {
-				DeploymentName := yamlConfig.Vars["deployment_name"]
-				prefix := yamlConfig.BlueprintName
-				if DeploymentName != nil {
-					prefix += "/" + DeploymentName.(string)
-				}
-				prefix += "/" + grp.Name
-				grp.TerraformBackend.Configuration["prefix"] = prefix
-			}
-			yamlConfig.ResourceGroups[i].TerraformBackend = grp.TerraformBackend
-		}
-	}
-
 	return yamlConfig
 }
 

--- a/tools/validate_configs/test_configs/hpc-cluster-project.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-project.yaml
@@ -23,6 +23,12 @@ vars:
   zone: europe-west4-a
   slurm_sa: slurm-sa
 
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: a_bucket
+    impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
+
 resource_groups:
 - group: onboarding
   resources:


### PR DESCRIPTION
### Description
A bug where the backends in all resource groups have the same prefix is
fixed with this change. Before the address of the default configuration
was being added to the groups and it's prefix was added. That prefix
would propogate as the defaults were added to other groups and therefore
the correct prefix was never updated.
    
In addition to the bug fix, the section of code was pulled out into it's
own function in expand as that better represents what it is doing.
    
Tests have been added to hopefully catch this type of bug in the future.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

