### PR TITLE
Fix misspelling in variable description and add validation block

### DIFF
--- a/resources/monitoring/dashboard/README.md
+++ b/resources/monitoring/dashboard/README.md
@@ -69,7 +69,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_base_dashboard"></a> [base\_dashboard](#input\_base\_dashboard) | Baseline dashboard template, select from HPC or Emtpy | `string` | `"HPC"` | no |
+| <a name="input_base_dashboard"></a> [base\_dashboard](#input\_base\_dashboard) | Baseline dashboard template, select from HPC or Empty | `string` | `"HPC"` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_title"></a> [title](#input\_title) | Title of the created dashboard | `string` | `"HPC Toolkit Dashboard"` | no |

--- a/resources/monitoring/dashboard/module.json
+++ b/resources/monitoring/dashboard/module.json
@@ -5,7 +5,7 @@
     {
       "name": "base_dashboard",
       "type": "string",
-      "description": "Baseline dashboard template, select from HPC or Emtpy",
+      "description": "Baseline dashboard template, select from HPC or Empty",
       "default": "HPC",
       "required": false
     },

--- a/resources/monitoring/dashboard/variables.tf
+++ b/resources/monitoring/dashboard/variables.tf
@@ -25,9 +25,13 @@ variable "deployment_name" {
 }
 
 variable "base_dashboard" {
-  description = "Baseline dashboard template, select from HPC or Emtpy"
+  description = "Baseline dashboard template, select from HPC or Empty"
   type        = string
   default     = "HPC"
+  validation {
+    condition     = contains(["HPC", "Empty"], var.base_dashboard)
+    error_message = "Must set var.base_dashboard to either \"HPC\" or \"Empty\"."
+  }
 }
 
 variable "title" {


### PR DESCRIPTION
There is a misspelling in a variable description ("Emtpy"). This PR fixes that and also adds a validation block to restrict the same variable to its valid values.

### Submission Checklist:

* X ] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?