### PR TITLE
Add Spack example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,23 @@ config.
 Please note that global variables defined under `vars` are automatically
 passed to resources if the resources have an input that matches the variable name.
 
+### (Optional) Setting up a remote terraform state
+
+The following commented block will setup a GCS bucket to store and manage the
+terraform state. Add your own bucket name and (optionally) a service account
+in the configuration. If not set, the terraform state will be stored locally
+within the generated blueprint.
+
+Add this block to the top-level of your input YAML:
+
+```yaml
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: a_bucket
+    impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
+```
+
 ## Config Descriptions
 
 ### hpc-cluster-small.yaml
@@ -83,7 +100,10 @@ Quota required for this example:
   needed for `compute` partition_
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for `compute` partition_
-**spack-build.yaml**: Creates a [Spack](../resources/scripts/spack-install/README.md)
+
+### spack-build.yaml
+
+Creates a [Spack](../resources/scripts/spack-install/README.md)
 build VM and a workstation for testing and validating a spack build. The build
 VM will install spack as configured in the spack-install resource in a shared
 location (/apps), then shutdown. Spack supports HPC software package
@@ -97,7 +117,9 @@ including a spack build cache as described in the comments of the example.
 
 ### Experimental
 
-**omnia-cluster-simple.yaml**: Creates a simple omnia cluster, with an
+#### omnia-cluster-simple.yaml
+
+Creates a simple omnia cluster, with an
 omnia-manager node and 8 omnia-compute nodes, on the pre-existing default
 network. Omnia will be automatically installed after the nodes are provisioned.
 All nodes mount a filestore instance on `/home`.

--- a/examples/hpc-cluster-high-io.yaml
+++ b/examples/hpc-cluster-high-io.yaml
@@ -22,16 +22,6 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-# The following commented block will use a GCS bucket to store and manage the
-# terraform state. Add your own bucket name and (optionally) a service account
-# in the configuration. If not set, the terraform state will be stored locally
-# within the generated blueprint.
-# terraform_backend_defaults:
-#   type: gcs
-#   configuration:
-#     bucket: a_bucket
-#     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
-
 resource_groups:
 - group: primary
   resources:

--- a/examples/hpc-cluster-small.yaml
+++ b/examples/hpc-cluster-small.yaml
@@ -22,16 +22,6 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-# The following commented block will use a GCS bucket to store and manage the
-# terraform state. Add your own bucket name and (optionally) a service account
-# in the configuration. If not set, the terraform state will be stored locally
-# within the generated blueprint.
-# terraform_backend_defaults:
-#   type: gcs
-#   configuration:
-#     bucket: a_bucket
-#     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
-
 resource_groups:
 - group: primary
   resources:

--- a/examples/omnia-cluster-simple.yaml
+++ b/examples/omnia-cluster-simple.yaml
@@ -25,16 +25,6 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-# The following commented block will use a GCS bucket to store and manage the
-# terraform state. Add your own bucket name and (optionally) a service account
-# in the configuration. If not set, the terraform state will be stored locally
-# within the generated blueprint.
-# terraform_backend_defaults:
-#   type: gcs
-#   configuration:
-#     bucket: a_bucket
-#     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
-
 resource_groups:
 - group: primary
   resources:

--- a/examples/spack-build.yaml
+++ b/examples/spack-build.yaml
@@ -22,16 +22,6 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-# The following commented block will use a GCS bucket to store and manage the
-# terraform state. Add your own bucket name and (optionally) a service account
-# in the configuration. If not set, the terraform state will be stored locally
-# within the generated blueprint.
-# terraform_backend_defaults:
-#   type: gcs
-#   configuration:
-#     bucket: a_bucket
-#     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
-
 resource_groups:
 - group: primary
   resources:
@@ -81,6 +71,9 @@ resource_groups:
       - type: ansible-local
         source: modules/startup-script/examples/mount.yaml
         destination: "mount.yaml"
+      - type: ansible-local
+        source: modules/spack-install/scripts/install_spack_deps.yml
+        destination: install_spack_deps.yml
       - type: shell
         content: $(spack.startup_script)
         destination: install_spack.sh

--- a/resources/scripts/spack-install/README.md
+++ b/resources/scripts/spack-install/README.md
@@ -77,6 +77,9 @@ Alternatively, it can be added as a startup script via:
     id: startup
     settings:
       runners:
+      - type: ansible-local
+        source: modules/spack-install/scripts/install_spack_deps.yml
+        destination: install_spack_deps.yml
       - type: shell
         content: $(spack.startup_script)
         destination: "/apps/spack-install.sh"

--- a/resources/scripts/spack-install/scripts/install_spack_deps.yml
+++ b/resources/scripts/spack-install/scripts/install_spack_deps.yml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Install dependencies for spack installation
+  hosts: localhost
+  tasks:
+  - name: Install pip3 and git
+    package:
+      name:
+      - python3-pip
+      - git
+  - name: Install google cloud storage
+    pip:
+      name: google-cloud-storage
+      executable: pip3

--- a/resources/scripts/spack-install/templates/install_spack.tpl
+++ b/resources/scripts/spack-install/templates/install_spack.tpl
@@ -12,49 +12,6 @@ fi
 # Only install and configure spack if ${INSTALL_DIR} doesn't exist
 if [ ! -d ${INSTALL_DIR} ]; then
 
-  has_python3_pip () {
-    HAS_PYTHON_PIP=""
-    if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-      HAS_PYTHON_PIP=$(yum list available | grep "^python3-pip")
-    elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-      HAS_PYTHON_PIP=$(apt-cache search --names-only '^python3-pip$')
-    else
-      echo "$PREFIX Unsupported distribution"
-      exit 1
-    fi
-    [[ -n "$${HAS_PYTHON_PIP}" ]]
-  }
-
-  DEPS=""
-  if [ ! "$(which pip3)" ]; then
-    if has_python3_pip; then
-      DEPS="$DEPS python3-pip"
-    else
-      DEPS="$DEPS pip3"
-    fi
-  fi
-
-  if [ ! "$(which git)" ]; then
-    DEPS="$DEPS git"
-  fi
-
-  if [ -n "$DEPS" ]; then
-    echo "$PREFIX Installing dependencies"
-    if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-      yum -y install $DEPS
-    elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
-      echo "$PREFIX WARNING: unsupported installation in debian / ubuntu"
-      apt install -y $DEPS
-    else
-      echo "$PREFIX Unsupported distribution"
-      exit 1
-    fi
-  fi
-
-  # Install google-cloud-storage
-  echo "$PREFIX Installing Google Cloud Storage via pip3..."
-  pip3 install google-cloud-storage > ${LOG_FILE} 2>&1
-
   # Install spack
   echo "$PREFIX Installing spack from ${SPACK_URL}..."
   {


### PR DESCRIPTION
Adds a spack specific example that creates a build VM for Spack that
shuts down on completion. Includes a workstation VM for testing and
verifying the spack installation.

Also made minor updates to the other examples.

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

