### PR TITLE
Filestore module should allow specification of project_id

### DIFF
--- a/resources/file-system/filestore/README.md
+++ b/resources/file-system/filestore/README.md
@@ -91,6 +91,7 @@ No modules.
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this filestore instance. | `string` | `"/shared"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the GCE VPC network to which the instance is connected. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `2660` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The name of the Filestore zone of the instance. | `string` | n/a | yes |
 

--- a/resources/file-system/filestore/main.tf
+++ b/resources/file-system/filestore/main.tf
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -22,6 +23,7 @@ locals {
 }
 
 resource "google_filestore_instance" "filestore_instance" {
+  project    = var.project_id
   provider   = google-beta
   depends_on = [var.network_name]
 

--- a/resources/file-system/filestore/module.json
+++ b/resources/file-system/filestore/module.json
@@ -52,6 +52,13 @@
       "required": true
     },
     {
+      "name": "project_id",
+      "type": "string",
+      "description": "ID of project in which Filestore instance will be created.",
+      "default": null,
+      "required": true
+    },
+    {
       "name": "size_gb",
       "type": "number",
       "description": "Storage size of the filestore instance in GB.",

--- a/resources/file-system/filestore/variables.tf
+++ b/resources/file-system/filestore/variables.tf
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+variable "project_id" {
+  description = "ID of project in which Filestore instance will be created."
+  type        = string
+}
+
 variable "deployment_name" {
   description = "Name of the HPC deployment, used as name of the filestore instace if no name is specified."
   type        = string


### PR DESCRIPTION
Right now, our Filestore module only supports provisioning an instance to the default project specified as the `project_id` global variable. There are situations where we might want to use a different project. In particular, when a Shared VPC is in use a Filestore instance must be in the host project to be accessible to all service projects.

### Submission Checklist:

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?

