### PR TITLE
Add installation of goimports to Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ install-dev-deps: warn-terraform-version warn-packer-version check-pre-commit ch
 	go install github.com/go-critic/go-critic/cmd/gocritic@latest
 	go install github.com/google/addlicense@latest
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest
+	go install golang.org/x/tools/cmd/goimports@latest
 
 ifeq (, $(shell which addlicense))
 add-google-license:

--- a/tools/cloud-build/Dockerfile
+++ b/tools/cloud-build/Dockerfile
@@ -38,7 +38,8 @@ RUN go install github.com/terraform-docs/terraform-docs@latest      && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest          && \
     go install github.com/go-critic/go-critic/cmd/gocritic@latest   && \
     go install github.com/google/addlicense@latest                  && \
-    go install mvdan.cc/sh/v3/cmd/shfmt@latest
+    go install mvdan.cc/sh/v3/cmd/shfmt@latest                      && \
+    go install golang.org/x/tools/cmd/goimports@latest
 
 # Setting GHPC dependencies
 WORKDIR /ghpc-tmp


### PR DESCRIPTION
Adds install of [goimports](https://pkg.go.dev/golang.org/x/tools/cmd/goimports) required by pre-commit checks to both the dockerfile and install-dev-deps rule of the Makefile

### Submission Checklist:

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?

