### PR TITLE
Improve wording of TF Backend documentation

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,10 +14,10 @@ passed to resources if the resources have an input that matches the variable nam
 
 ### (Optional) Setting up a remote terraform state
 
-The following commented block will setup a GCS bucket to store and manage the
-terraform state. Add your own bucket name and (optionally) a service account
-in the configuration. If not set, the terraform state will be stored locally
-within the generated blueprint.
+The following block will configure terraform to point to an existing GCS bucket
+to store and manage the terraform state. Add your own bucket name and
+(optionally) a service account in the configuration. If not set, the terraform
+state will be stored locally within the generated blueprint.
 
 Add this block to the top-level of your input YAML:
 


### PR DESCRIPTION
Makes the block on setting up a TF backend in GCS more clear --> the user
must create a bucket beforehand.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
