### PR TITLE
Fix the deployment name of the high io example

### DIFF
--- a/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
+++ b/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
@@ -63,7 +63,7 @@ steps:
   - -c
   - |
     BUILD_ID_FULL=$BUILD_ID
-    DEPLOYMENT_NAME=hpc-slurm-io-$${BUILD_ID_FULL:0:6}
+    DEPLOYMENT_NAME=hpc-high-io-$${BUILD_ID_FULL:0:6}
     LOGIN_ID=slurm-$${DEPLOYMENT_NAME}-login0
     CONTROLLER_ID=slurm-$${DEPLOYMENT_NAME}-controller
     cat <<EOT > test-vars.yml


### PR DESCRIPTION
Updates the deployment name (used in node names) for the daily
integration tests.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
