### PR TITLE
Better ansible errors

### DIFF
--- a/tools/cloud-build/ansible.cfg
+++ b/tools/cloud-build/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+stdout_callback=debug
+stderr_callback=debug

--- a/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
+++ b/tools/cloud-build/daily-tests/hpc-toolkit-integration-tests.yaml
@@ -28,6 +28,7 @@ steps:
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
   args:
   - -c
   - |
@@ -59,6 +60,7 @@ steps:
   entrypoint: /bin/bash
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
   args:
   - -c
   - |


### PR DESCRIPTION
Configures ansible to provide human readable errors for daily integration tests. Success output should be unchanged. See [this cloud build](https://pantheon.corp.google.com/cloud-build/builds;region=global/fee259e9-880f-4bba-9b68-32cf8830c7ae;step=1?project=508417052821) for an example of what failures look like with this change.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
