### PR TITLE
Set TF_IN_AUTOMATION for Cloud Build integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/daily-tests.yml
+++ b/tools/cloud-build/daily-tests/daily-tests.yml
@@ -49,6 +49,8 @@
         chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
       args:
         creates: "{{ workspace }}/{{ blueprint_dir }}/.terraform"
+      environment:
+        TF_IN_AUTOMATION: "TRUE"
       with_items:
       - "terraform init"
       - "terraform apply -auto-approve -no-color"
@@ -116,6 +118,8 @@
     - name: Tear Down Cluster
       run_once: true
       delegate_to: localhost
+      environment:
+        TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
         chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
@@ -174,6 +178,8 @@
     - name: Tear Down Cluster
       run_once: true
       delegate_to: localhost
+      environment:
+        TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
         chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"


### PR DESCRIPTION
Set `TF_IN_AUTOMATION` environment variable during build processes to produce warning/failure messages appropriate to CI/CD environment.

* https://www.terraform.io/cli/config/environment-variables#tf_in_automation
* https://learn.hashicorp.com/tutorials/terraform/automate-terraform#controlling-terraform-output-in-automation

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?