### PR TITLE
Allow 4.x TPG in all internal resources

### DIFF
--- a/resources/compute/simple-instance/README.md
+++ b/resources/compute/simple-instance/README.md
@@ -43,13 +43,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 

--- a/resources/compute/simple-instance/versions.tf
+++ b/resources/compute/simple-instance/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
   }
 

--- a/resources/database/slurm-cloudsql-federation/README.md
+++ b/resources/database/slurm-cloudsql-federation/README.md
@@ -44,16 +44,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.83 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules

--- a/resources/database/slurm-cloudsql-federation/versions.tf
+++ b/resources/database/slurm-cloudsql-federation/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
     random = {
       source  = "hashicorp/random"

--- a/resources/file-system/filestore/README.md
+++ b/resources/file-system/filestore/README.md
@@ -59,14 +59,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 3.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 3.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.83 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules

--- a/resources/file-system/filestore/versions.tf
+++ b/resources/file-system/filestore/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
     random = {
       source  = "hashicorp/random"

--- a/resources/file-system/nfs-server/README.md
+++ b/resources/file-system/nfs-server/README.md
@@ -44,14 +44,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules

--- a/resources/file-system/nfs-server/versions.tf
+++ b/resources/file-system/nfs-server/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
     random = {
       source  = "hashicorp/random"

--- a/resources/monitoring/dashboard/README.md
+++ b/resources/monitoring/dashboard/README.md
@@ -47,13 +47,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 

--- a/resources/monitoring/dashboard/versions.tf
+++ b/resources/monitoring/dashboard/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
   }
 

--- a/resources/network/pre-existing-vpc/README.md
+++ b/resources/network/pre-existing-vpc/README.md
@@ -46,13 +46,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 

--- a/resources/network/pre-existing-vpc/versions.tf
+++ b/resources/network/pre-existing-vpc/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
   }
 

--- a/resources/project/service-enablement/README.md
+++ b/resources/project/service-enablement/README.md
@@ -39,13 +39,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 

--- a/resources/project/service-enablement/versions.tf
+++ b/resources/project/service-enablement/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
   }
 

--- a/resources/scripts/startup-script/README.md
+++ b/resources/scripts/startup-script/README.md
@@ -115,7 +115,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0, < 2.2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
@@ -123,7 +123,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 3.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0, < 2.2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 

--- a/resources/scripts/startup-script/versions.tf
+++ b/resources/scripts/startup-script/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
     random = {
       source  = "hashicorp/random"

--- a/resources/third-party/file-system/DDN-EXAScaler/README.md
+++ b/resources/third-party/file-system/DDN-EXAScaler/README.md
@@ -40,7 +40,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 

--- a/resources/third-party/file-system/DDN-EXAScaler/versions.tf
+++ b/resources/third-party/file-system/DDN-EXAScaler/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.0"
+      version = ">= 3.83"
     }
   }
 }


### PR DESCRIPTION
The currently supported TPG is 4.x and our internal resources are preventing its usage.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?