### PR TITLE
Update filestore module to eliminate deprecation warnings with 4.x TPG

### DIFF
--- a/resources/file-system/filestore/README.md
+++ b/resources/file-system/filestore/README.md
@@ -59,14 +59,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 3.83 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.4 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -92,8 +92,9 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The resource name of the instance. | `string` | `null` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the GCE VPC network to which the instance is connected. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
 | <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `2660` | no |
-| <a name="input_zone"></a> [zone](#input\_zone) | The name of the Filestore zone of the instance. | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Location for Filestore instances below Enterprise tier. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/resources/file-system/filestore/main.tf
+++ b/resources/file-system/filestore/main.tf
@@ -27,9 +27,9 @@ resource "google_filestore_instance" "filestore_instance" {
   provider   = google-beta
   depends_on = [var.network_name]
 
-  name = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
-  zone = var.zone
-  tier = var.filestore_tier
+  name     = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
+  location = var.filestore_tier == "ENTERPRISE" ? var.region : var.zone
+  tier     = var.filestore_tier
 
   file_shares {
     capacity_gb = var.size_gb

--- a/resources/file-system/filestore/variables.tf
+++ b/resources/file-system/filestore/variables.tf
@@ -25,7 +25,12 @@ variable "deployment_name" {
 }
 
 variable "zone" {
-  description = "The name of the Filestore zone of the instance."
+  description = "Location for Filestore instances below Enterprise tier."
+  type        = string
+}
+
+variable "region" {
+  description = "Location for Filestore instances at Enterprise tier."
   type        = string
 }
 

--- a/resources/file-system/filestore/versions.tf
+++ b/resources/file-system/filestore/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 3.83"
+      version = ">= 4.4"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Toolkit blueprints that include the filestore module will generate this warning when using  releases of the TPG >=4.4. This PR sets the minimum value for the provider to be 4.4 when including the filestore module and adopts the non-deprecated argument list.

The `google-beta` provider remains necessary to support Enterprise tier Filestore instances.

```
╷
│ Warning: Argument is deprecated
│
│   with module.projectsfs.google_filestore_instance.filestore_instance,
│   on modules/filestore/main.tf line 31, in resource "google_filestore_instance" "filestore_instance":
│   31:   zone = var.zone
│
│ Deprecated in favor of location.
│
│ (and 3 more similar warnings elsewhere)
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?
