### PR TITLE
Fix naming collision in nfs-server

### DIFF
--- a/resources/file-system/nfs-server/main.tf
+++ b/resources/file-system/nfs-server/main.tf
@@ -34,7 +34,7 @@ resource "google_compute_disk" "attached_disk" {
 }
 
 resource "google_compute_instance" "compute_instance" {
-  name         = "${var.deployment_name}-nfs-instance"
+  name         = "${local.name}-nfs-instance"
   zone         = var.zone
   machine_type = var.machine_type
 

--- a/tools/validate_configs/test_configs/2-nfs-servers.yaml
+++ b/tools/validate_configs/test_configs/2-nfs-servers.yaml
@@ -1,0 +1,44 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: 2-nfs-servers
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: two-nfs-servers
+  region: us-central1
+  zone: us-central1-a
+
+resource_groups:
+- group: primary
+  resources:
+  - source: resources/network/pre-existing-vpc
+    kind: terraform
+    id: network1
+
+  - source: resources/file-system/nfs-server
+    kind: terraform
+    id: homefs
+    use: [network1]
+    settings:
+      local_mounts: ["/home"]
+
+  - source: resources/file-system/nfs-server
+    kind: terraform
+    id: appsfs
+    use: [network1]
+    settings:
+      local_mounts: ["/apps"]


### PR DESCRIPTION
nfs-server simple-instance's have been named based only on the
deployment_name, it's been updated to use the  unique `local.name`
created for the disk.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
