### PR TITLE
Add a spack cache build option to the spack resource

### DIFF
--- a/resources/scripts/spack-install/README.md
+++ b/resources/scripts/spack-install/README.md
@@ -26,6 +26,10 @@ additional packages, but cannot be used to uninstall packages from the VM.
 **Please note**: Currently, license installation is performed by copying a
 license file from a GCS bucket to a specific directory on the target VM.
 
+**Please note**: When populating a buildcache with packages, the VM this
+spack resource is running on requires the following scope:
+https://www.googleapis.com/auth/devstorage.read_write
+
 ## Example
 
 As an example, the below is a possible definition of a spack installation.
@@ -43,8 +47,14 @@ As an example, the below is a possible definition of a spack installation.
         mirror_url: gs://example-buildcache/linux-centos7
       configs:
       - type: 'single-config'
-        value: 'config:build_tree:/apps/spack/build_stage'
+        value: 'config:install_tree:/apps/spack/opt'
         scope: 'site'
+      - type: 'file'
+        scope: 'site'
+        value: |
+          config:
+            build_stage:
+              - /apps/spack/stage
       - type: 'file'
         scope: 'site'
         value: |
@@ -146,9 +156,11 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_caches_to_populate"></a> [caches\_to\_populate](#input\_caches\_to\_populate) | Defines caches which will be populated with the installed packages.<br>  Each cache must specify a type (either directory, or mirror).<br>  Each cache must also specify a path. For directory caches, this path<br>  must be on a local file system (i.e. file:///path/to/cache). For<br>  mirror paths, this can be any valid URL that spack accepts.<br><br>  NOTE: GPG Keys should be installed before trying to populate a cache<br>  with packages.<br><br>  NOTE: The gpg\_keys variable can be used to install existing GPG keys<br>  and create new GPG keys, both of which are acceptable for populating a<br>  cache. | `list(map(any))` | `[]` | no |
 | <a name="input_compilers"></a> [compilers](#input\_compilers) | Defines compilers for spack to install before installing packages. | `list(string)` | `[]` | no |
 | <a name="input_configs"></a> [configs](#input\_configs) | List of configuration options to set within spack.<br>    Configs can be of type 'single-config' or 'file'.<br>    All configs must specify a value, and a<br>    a scope. | `list(map(any))` | `[]` | no |
 | <a name="input_environments"></a> [environments](#input\_environments) | Defines a spack environment to configure. | <pre>list(object({<br>    name     = string<br>    packages = list(string)<br>  }))</pre> | `null` | no |
+| <a name="input_gpg_keys"></a> [gpg\_keys](#input\_gpg\_keys) | GPG Keys to trust within spack.<br>  Each key must define a type. Valid types are 'file' and 'new'.<br>  Keys of type 'file' must define a path to the key that<br>  should be trusted.<br>  Keys of type 'new' must define a 'name' and 'email' to create<br>  the key with. | `list(map(any))` | `[]` | no |
 | <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/apps/spack"` | no |
 | <a name="input_licenses"></a> [licenses](#input\_licenses) | List of software licenses to install within spack. | <pre>list(object({<br>    source = string<br>    dest   = string<br>  }))</pre> | `null` | no |
 | <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/dev/null"` | no |

--- a/resources/scripts/spack-install/main.tf
+++ b/resources/scripts/spack-install/main.tf
@@ -18,18 +18,20 @@ locals {
   script_content = templatefile(
     "${path.module}/templates/install_spack.tpl",
     {
-      ZONE         = var.zone
-      PROJECT_ID   = var.project_id
-      INSTALL_DIR  = var.install_dir
-      SPACK_URL    = var.spack_url
-      SPACK_REF    = var.spack_ref
-      COMPILERS    = var.compilers == null ? [] : var.compilers
-      CONFIGS      = var.configs == null ? [] : var.configs
-      LICENSES     = var.licenses == null ? [] : var.licenses
-      PACKAGES     = var.packages == null ? [] : var.packages
-      ENVIRONMENTS = var.environments == null ? [] : var.environments
-      MIRRORS      = var.spack_cache_url == null ? [] : var.spack_cache_url
-      LOG_FILE     = var.log_file == null ? "/dev/null" : var.log_file
+      ZONE               = var.zone
+      PROJECT_ID         = var.project_id
+      INSTALL_DIR        = var.install_dir
+      SPACK_URL          = var.spack_url
+      SPACK_REF          = var.spack_ref
+      COMPILERS          = var.compilers == null ? [] : var.compilers
+      CONFIGS            = var.configs == null ? [] : var.configs
+      LICENSES           = var.licenses == null ? [] : var.licenses
+      PACKAGES           = var.packages == null ? [] : var.packages
+      ENVIRONMENTS       = var.environments == null ? [] : var.environments
+      MIRRORS            = var.spack_cache_url == null ? [] : var.spack_cache_url
+      GPG_KEYS           = var.gpg_keys == null ? [] : var.gpg_keys
+      CACHES_TO_POPULATE = var.caches_to_populate == null ? [] : var.caches_to_populate
+      LOG_FILE           = var.log_file == null ? "/dev/null" : var.log_file
     }
   )
 }

--- a/resources/scripts/spack-install/templates/install_spack.tpl
+++ b/resources/scripts/spack-install/templates/install_spack.tpl
@@ -52,6 +52,18 @@ EOF
   spack mirror add --scope site ${m.mirror_name} ${m.mirror_url} >> ${LOG_FILE} 2>&1
   %{endfor ~}
 
+  echo "$PREFIX Installing GPG keys"
+  spack gpg init >> ${LOG_FILE} 2>&1
+  %{for k in GPG_KEYS ~}
+    %{if k.type == "file" ~}
+      spack gpg trust ${k.path}
+    %{endif ~}
+
+    %{if k.type == "new" ~}
+      spack gpg create "${k.name}" ${k.email}
+    %{endif ~}
+  %{endfor ~}
+
   spack buildcache keys --install --trust >> ${LOG_FILE} 2>&1
 else
   source ${INSTALL_DIR}/share/spack/setup-env.sh >> ${LOG_FILE} 2>&1
@@ -59,47 +71,59 @@ fi
 
 echo "$PREFIX Installing licenses..."
 %{for lic in LICENSES ~}
-gsutil cp ${lic.source} ${lic.dest} >> ${LOG_FILE} 2>&1
+  gsutil cp ${lic.source} ${lic.dest} >> ${LOG_FILE} 2>&1
 %{endfor ~}
 
 echo "$PREFIX Installing compilers..."
 %{for c in COMPILERS ~}
-{
-spack install ${c};
-spack load ${c};
-spack clean -s
-} &>> ${LOG_FILE}
+  {
+    spack install ${c};
+    spack load ${c};
+    spack clean -s
+  } &>> ${LOG_FILE}
 %{endfor ~}
 
 spack compiler find --scope site >> ${LOG_FILE} 2>&1
 
 echo "$PREFIX Installing root spack specs..."
 %{for p in PACKAGES ~}
-spack install ${p} >> ${LOG_FILE} 2>&1
-spack clean -s
+  spack install ${p} >> ${LOG_FILE} 2>&1
+  spack clean -s
 %{endfor ~}
 
 echo "$PREFIX Configuring spack environments"
 %{for e in ENVIRONMENTS ~}
+  {
+    spack env create ${e.name};
+    spack env activate ${e.name};
+  } &>> ${LOG_FILE}
 
-{
-spack env create ${e.name};
-spack env activate ${e.name};
-} &>> ${LOG_FILE}
+  echo "$PREFIX    Configuring spack environment ${e.name}"
+  %{for p in e.packages ~}
+    spack add ${p} >> ${LOG_FILE} 2>&1
+  %{endfor ~}
 
-echo "$PREFIX    Configuring spack environment ${e.name}"
-%{for p in e.packages ~}
-spack add ${p} >> ${LOG_FILE} 2>&1
+  echo "$PREFIX    Concretizing spack environment ${e.name}"
+  spack concretize >> ${LOG_FILE} 2>&1
+  echo "$PREFIX    Installing packages for spack environment ${e.name}"
+  spack install >> ${LOG_FILE} 2>&1
+
+  spack env deactivate >> ${LOG_FILE} 2>&1
+  spack clean -s
 %{endfor ~}
 
-echo "$PREFIX    Concretizing spack environment ${e.name}"
-spack concretize >> ${LOG_FILE} 2>&1
-echo "$PREFIX    Installing packages for spack environment ${e.name}"
-spack install >> ${LOG_FILE} 2>&1
-
-spack env deactivate >> ${LOG_FILE} 2>&1
-spack clean -s
-
+echo "$PREFIX Populating defined buildcaches"
+%{for c in CACHES_TO_POPULATE ~}
+  %{if c.type == "directory" ~}
+    # shellcheck disable=SC2046  
+    spack buildcache create -d ${c.path} -af $(spack find --format /{hash})
+    spack gpg publish --rebuild-index -d ${c.path}
+  %{endif ~}
+  %{if c.type == "mirror" ~} 
+    # shellcheck disable=SC2046  
+    spack buildcache create --mirror-url ${c.path} -af $(spack find --format /{hash})
+    spack gpg publish --rebuild-index --mirror-url ${c.path}
+  %{endif ~}
 %{endfor ~}
 
 echo "$PREFIX Setup complete..."

--- a/resources/scripts/spack-install/variables.tf
+++ b/resources/scripts/spack-install/variables.tf
@@ -107,6 +107,75 @@ variable "packages" {
   type        = list(string)
 }
 
+variable "gpg_keys" {
+  description = <<EOT
+  GPG Keys to trust within spack.
+  Each key must define a type. Valid types are 'file' and 'new'.
+  Keys of type 'file' must define a path to the key that
+  should be trusted.
+  Keys of type 'new' must define a 'name' and 'email' to create
+  the key with.
+EOT
+  default     = []
+  type        = list(map(any))
+  validation {
+    condition = alltrue([
+      for k in var.gpg_keys : contains(keys(k), "type")
+    ])
+    error_message = "Each gpg_key must define a type."
+  }
+  validation {
+    condition = alltrue([
+      for k in var.gpg_keys : (k["type"] == "file" || k["type"] == "new")
+    ])
+    error_message = "Valid types for gpg_keys are 'file' and 'new'."
+  }
+  validation {
+    condition = alltrue([
+      for k in var.gpg_keys : ((k["type"] == "file" && contains(keys(k), "path")) || (k["type"] == "new"))
+    ])
+    error_message = "Each gpg_key of type file must define a path."
+  }
+  validation {
+    condition = alltrue([
+      for k in var.gpg_keys : (k["type"] == "file" || ((k["type"] == "new") && contains(keys(k), "name") && contains(keys(k), "email")))
+    ])
+    error_message = "Each gpg_key of type new must define a name and email."
+  }
+}
+
+variable "caches_to_populate" {
+  description = <<EOT
+  Defines caches which will be populated with the installed packages.
+  Each cache must specify a type (either directory, or mirror).
+  Each cache must also specify a path. For directory caches, this path
+  must be on a local file system (i.e. file:///path/to/cache). For
+  mirror paths, this can be any valid URL that spack accepts.
+
+  NOTE: GPG Keys should be installed before trying to populate a cache
+  with packages.
+
+  NOTE: The gpg_keys variable can be used to install existing GPG keys
+  and create new GPG keys, both of which are acceptable for populating a
+  cache.
+EOT
+  default     = []
+  type        = list(map(any))
+  validation {
+    condition = alltrue([
+      for c in var.caches_to_populate : (contains(keys(c), "type") && contains(keys(c), "path"))
+    ])
+    error_message = "Each cache_to_populate must have define both 'type' and 'path'."
+  }
+  validation {
+    condition = alltrue([
+      for c in var.caches_to_populate : (c["type"] == "directory" || c["type"] == "mirror")
+    ])
+
+    error_message = "Cache_to_populate type must be either 'directory' or 'mirror'."
+  }
+}
+
 variable "environments" {
   description = "Defines a spack environment to configure."
   default     = null

--- a/tools/validate_configs/test_configs/spack-buildcache.yaml
+++ b/tools/validate_configs/test_configs/spack-buildcache.yaml
@@ -1,0 +1,100 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: spack-buildcache
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: spack-buildcache
+  region: us-central1
+  zone: us-central1-c
+
+resource_groups:
+- group: primary
+  resources:
+  - source: resources/network/pre-existing-vpc
+    kind: terraform
+    id: network1
+
+  - source: resources/scripts/spack-install
+    kind: terraform
+    id: spack
+    settings:
+      install_dir: /apps/spack
+      spack_url: https://github.com/spack/spack
+      spack_ref: v0.17.1
+      log_file: /var/log/spack.log
+      configs:
+      - type: 'single-config'
+        scope: 'site'
+        value: 'config:install_tree:padded_length:128'
+      compilers:
+      - gcc@10.3.0 target=x86_64
+      packages:
+      - intel-mpi@2018.4.274%gcc@10.3.0
+      - gromacs@2021.2 %gcc@10.3.0 ^intel-mpi@2018.4.274
+      gpg_keys:
+      - type: 'file'
+        path: '/tmp/spack_key.gpg'
+      caches_to_populate:
+      - type: 'mirror'
+        path: ##  Add GCS bucket to populate here ##
+
+  - source: resources/scripts/startup-script
+    kind: terraform
+    id: spack-startup
+    settings:
+      runners:
+      - type: data
+        source: ##  Add path to GPG key here ##
+        destination: /tmp/spack_key.gpg
+      - type: shell
+        content: |
+          #!/bin/bash
+          mkdir /apps
+          chmod a+rwx /apps
+        destination: apps_create.sh
+      - type: shell
+        source: modules/startup-script/examples/install_ansible.sh
+        destination: install_ansible.sh
+      - type: ansible-local
+        source: modules/spack-install/scripts/install_spack_deps.yml
+        destination: install_spack_deps.yml
+      - type: shell
+        content: $(spack.startup_script)
+        destination: install_spack.sh
+      - type: shell
+        destination: shutdown.sh
+        content: shutdown -h
+
+  - source: resources/compute/simple-instance
+    kind: terraform
+    id: spack-build
+    use:
+    - network1
+    - spack-startup
+    settings:
+      name_prefix: spack-builder
+      machine_type: n2-standard-8
+      service_account:
+        email: null
+        scopes:
+        - "https://www.googleapis.com/auth/devstorage.read_write"
+        - "https://www.googleapis.com/auth/logging.write"
+        - "https://www.googleapis.com/auth/monitoring.write"
+        - "https://www.googleapis.com/auth/servicecontrol"
+        - "https://www.googleapis.com/auth/service.management.readonly"
+        - "https://www.googleapis.com/auth/trace.append"


### PR DESCRIPTION
This merge adds variables into the spack resource for adding / creating
GPG keys, and populating a (preexisting) GCS bucket with the spack
packages that have been installed.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?
