### PR TITLE
Revert "Add CODEOWNERS file for new GitHub Team"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# the last match wins, so this sets default ownership of files to the HPC
-# Toolkit team and can be overridden for 3rd party contributions below
-* @GoogleCloudPlatform/hpc-toolkit


### PR DESCRIPTION
* Need to wait until internal TeamSync supports GitHub Team Maintainers

This reverts commit 9c3de44107c977f9687f8a2967a57e1fb96c7eba.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?