### PR TITLE
Fix an unmatched quote in example

### DIFF
--- a/examples/spack-gromacs.yaml
+++ b/examples/spack-gromacs.yaml
@@ -45,8 +45,8 @@ resource_groups:
       spack_ref: v0.17.1
       log_file: /var/log/spack.log
       configs:
-      - type: 'file'
-        scope: site'
+      - type: file
+        scope: site
         value: |
           modules:
             tcl:


### PR DESCRIPTION
One of the spack config feilds was missing a starting quote, I removed
the other as YAML doesn't require quotes at all.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
