### PR TITLE
Add startup-script to install Ops Agent

### DIFF
--- a/resources/scripts/startup-script/examples/install_cloud_ops_agent.sh
+++ b/resources/scripts/startup-script/examples/install_cloud_ops_agent.sh
@@ -73,10 +73,10 @@ handle_redhat() {
 }
 
 main() {
-	if [ -f /etc/debian_version ]; then
-		handle_debian
-	elif [ -f /etc/redhat-release ]; then
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
 		handle_redhat
+	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
+		handle_debian
 	else
 		fail "Unsupported platform."
 	fi


### PR DESCRIPTION
Add the startup-script script `resources/scripts/startup-script/examples/install_cloud_ops_agent.sh` to support users to install Ops Agent in VM which doesn't have any monitoring/logging agents if they would like. For more details on the test cases I covered, please refer to the ticket for this update.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
