### PR TITLE
Update URL for ansible-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,8 +56,8 @@ repos:
   hooks:
   - id: go-critic
     args: [-disable, "#experimental,sloppyTypeAssert"]
-- repo: https://github.com/ansible-community/ansible-lint.git
-  rev: v5.4.0  # https://github.com/ansible-community/ansible-lint/releases/
+- repo: https://github.com/ansible/ansible-lint.git
+  rev: v5.4.0
   hooks:
   - id: ansible-lint
 - repo: https://github.com/adrienverge/yamllint.git


### PR DESCRIPTION
The URL for the ansible-lint pre-commit hook has changed and (I believe) was causing some delays.

I do not believe we should upgrade the release to v6.x until we analyze the impact of its dropping support for Ansible 2.9 (the CentOS 7 EPEL version)

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?
