### PR TITLE
Revert "Toggle filestore api as part of nightly cleanup"

### DIFF
--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -15,33 +15,6 @@
 ---
 
 steps:
-
-# See https://cloud.google.com/filestore/docs/troubleshooting#api_cannot_be_disabled
-- name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: /bin/bash
-  args:
-  - -c
-  - |
-    curl -X POST \
-    "https://serviceusage.googleapis.com/v1/projects/${PROJECT_ID}/services/file.googleapis.com:disable" \
-    --header "Content-Type: application/json" \
-    --header "Authorization: Bearer "$(gcloud auth print-access-token) \
-    --data '{"checkIfServiceHasUsage": "SKIP", "disableDependentServices": false}'
-
-# previous call is async, give time for it to resolve
-- name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: sleep
-  args:
-  - "60"
-
-- name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
-  entrypoint: gcloud
-  args:
-  - services
-  - enable
-  - --project=${PROJECT_ID}
-  - file.googleapis.com
-
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/hpc-toolkit-builder
   entrypoint: /bin/bash
   env:


### PR DESCRIPTION
Rollback of #174 but leaves documentation update.

This reverts commit db998396ba6438979e065a3a940178f6af965d05.
This reverts commit 67b2dc90e595bd1c8a52afa29aa4fabc460e706e.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
