### PR TITLE
Update plugin to address build error with TFLint

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -13,7 +13,7 @@
 // limitations under the License.
 plugin "google" {
   enabled = true
-  version = "0.12.1"
+  version = "0.15.0"
   source  = "github.com/terraform-linters/tflint-ruleset-google"
 }
 rule "terraform_deprecated_index" {


### PR DESCRIPTION
The weekly integration test failed with `tflint` errors related to TFLint plugin incompatiblity with the Google provider. Various issues in TFLint repo suggest that upgrading our outdated version of the plugin will address this.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?
