### PR TITLE
Fix the way of GitHub module handling

### DIFF
--- a/pkg/reswriter/reswriter.go
+++ b/pkg/reswriter/reswriter.go
@@ -70,6 +70,10 @@ func getTemplate(filename string) string {
 func copySource(blueprintPath string, resourceGroups *[]config.ResourceGroup) {
 	for iGrp, grp := range *resourceGroups {
 		for iRes, resource := range grp.Resources {
+			if sourcereader.IsGitHubPath(resource.Source) {
+				continue
+			}
+
 			/* Copy source files */
 			resourceName := filepath.Base(resource.Source)
 			(*resourceGroups)[iGrp].Resources[iRes].ResourceName = resourceName

--- a/pkg/reswriter/tfwriter.go
+++ b/pkg/reswriter/tfwriter.go
@@ -30,6 +30,7 @@ import (
 	ctyJson "github.com/zclconf/go-cty/cty/json"
 
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/sourcereader"
 )
 
 // TFWriter writes terraform to the blueprint folder
@@ -274,7 +275,13 @@ func writeMain(
 		moduleBody := moduleBlock.Body()
 
 		// Add source attribute
-		moduleSource := cty.StringVal(fmt.Sprintf("./modules/%s", res.ResourceName))
+		var moduleSource cty.Value
+		if sourcereader.IsGitHubPath(res.Source) {
+			moduleSource = cty.StringVal(res.Source)
+		} else {
+			moduleSource = cty.StringVal(fmt.Sprintf("./modules/%s", res.ResourceName))
+		}
+
 		moduleBody.SetAttributeValue("source", moduleSource)
 
 		// For each Setting

--- a/pkg/sourcereader/github.go
+++ b/pkg/sourcereader/github.go
@@ -20,6 +20,7 @@ import (
 	"hpc-toolkit/pkg/resreader"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/hashicorp/go-getter"
 )
@@ -63,17 +64,18 @@ func (r GitHubSourceReader) GetResourceInfo(resPath string, kind string) (resrea
 
 	resDir, err := ioutil.TempDir("", "git-module-*")
 	defer os.RemoveAll(resDir)
+	writeDir := filepath.Join(resDir, "mod")
 	if err != nil {
 		return resreader.ResourceInfo{}, err
 	}
 
-	if err := copyGitHubResources(resPath, resDir); err != nil {
+	if err := copyGitHubResources(resPath, writeDir); err != nil {
 		return resreader.ResourceInfo{}, fmt.Errorf("failed to clone GitHub resource at %s to tmp dir %s: %v",
-			resPath, resDir, err)
+			resPath, writeDir, err)
 	}
 
 	reader := resreader.Factory(kind)
-	return reader.GetInfo(resDir)
+	return reader.GetInfo(writeDir)
 }
 
 // GetResource copies the GitHub source to a provided destination (the blueprint directory)
@@ -84,14 +86,15 @@ func (r GitHubSourceReader) GetResource(resPath string, copyPath string) error {
 
 	resDir, err := ioutil.TempDir("", "git-module-*")
 	defer os.RemoveAll(resDir)
+	writeDir := filepath.Join(resDir, "mod")
 	if err != nil {
 		return err
 	}
 
-	if err := copyGitHubResources(resPath, resDir); err != nil {
+	if err := copyGitHubResources(resPath, writeDir); err != nil {
 		return fmt.Errorf("failed to clone GitHub resource at %s to tmp dir %s: %v",
-			resPath, resDir, err)
+			resPath, writeDir, err)
 	}
 
-	return copyFromPath(resDir, copyPath)
+	return copyFromPath(writeDir, copyPath)
 }

--- a/pkg/sourcereader/github_test.go
+++ b/pkg/sourcereader/github_test.go
@@ -38,6 +38,16 @@ func (s *MySuite) TestCopyGitHubResources(c *C) {
 	c.Assert(fInfo.Name(), Equals, "terraform_validate")
 	c.Assert(fInfo.Size() > 0, Equals, true)
 	c.Assert(fInfo.IsDir(), Equals, false)
+
+	// Success via HTTPS (Root directory)
+	destDirForHTTPSRootDir := filepath.Join(destDir, "https-rootdir")
+	err = copyGitHubResources("github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1", destDirForHTTPSRootDir)
+	c.Assert(err, IsNil)
+	fInfo, err = os.Stat(filepath.Join(destDirForHTTPSRootDir, "main.tf"))
+	c.Assert(err, IsNil)
+	c.Assert(fInfo.Name(), Equals, "main.tf")
+	c.Assert(fInfo.Size() > 0, Equals, true)
+	c.Assert(fInfo.IsDir(), Equals, false)
 }
 
 func (s *MySuite) TestGetResourceInfo_GitHub(c *C) {


### PR DESCRIPTION
I would like to share my progress with you @tpdownes . I would appreciate if you could review my work and check if I'm going in the right direction.

# 1. Support Terraform modules at the root of GitHub repos

HPC Toolkit currently doesn't support modules at the root of GitHub repos when they are specified like below.

```
- source: github.com/terraform-google-modules/terraform-google-service-accounts
  kind: terraform
  id: central_manager
```

This will be fixed by this commit which is based on [hashicorp/go-getter - Using git always gives error 128 #114](https://github.com/hashicorp/go-getter/issues/114).

# 2. Download remote modules only for the purpose of running terraform-config-inspect, and not save them into blueprints output directory

HPC Toolkit currently downloads modules from GitHub repos and saves them with URL parameters under `modules` directory in a blueprint directory when they are specified like below.

```
- source: github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1
  kind: terraform
  id: central_manager
```

The current solution creates a git repository in a subdirectory of the blueprint. We anticipate that many users will want to manage blueprints with git. So, we are effectively requiring them to use git submodules ("git inside git"). Which is difficult. In addition, downloading GitHub modules is not required for Terraform and directory names with '?' and '=' are not safe in general, so this commit will update the tool to take the following actions:

- Download modules from GitHub and run terraform-config-inspect in temp directory by ghpc.
- Update output Terraform files with the original input GitHub path by ghpc.

**Current output**
```
module "central_manager" {
  source     = "./modules/terraform-google-service-accounts.git?ref=v4.1.1"
  project_id = var.project_id
}
```

**Expected output**
```
module "central_manager" {
  source     = "github.com/terraform-google-modules/terraform-google-service-accounts.git?ref=v4.1.1"
  project_id = var.project_id
}
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [ ] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
