### PR TITLE
Add monitoring dashboard to example

### DIFF
--- a/examples/hpc-cluster-high-io.yaml
+++ b/examples/hpc-cluster-high-io.yaml
@@ -104,3 +104,8 @@ resource_groups:
     - slurm_controller
     settings:
       login_machine_type: n2-standard-4
+
+  - source: resources/monitoring/dashboard
+    kind: terraform
+    id: hpc_dashboard
+    outputs: [instructions]

--- a/resources/monitoring/dashboard/README.md
+++ b/resources/monitoring/dashboard/README.md
@@ -77,5 +77,7 @@ No modules.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for accessing the monitoring dashboard |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/resources/monitoring/dashboard/outputs.tf
+++ b/resources/monitoring/dashboard/outputs.tf
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "instructions" {
+  description = "Instructions for accessing the monitoring dashboard"
+  value       = <<-EOT
+  A monitoring dashboard has been created. To view, navigate to the following URL:
+  https://console.cloud.google.com/monitoring/dashboards/builder${regex("/[0-9a-z-]*$", google_monitoring_dashboard.dashboard.id)}
+  EOT
+}


### PR DESCRIPTION
Added the default HPC dashboard to the slurm-high-io example. To support
usability, an output with instructions and a URL to the dashboard was
created and promoted using `outputs`.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
