### PR TITLE
Change Terraform commands to use -chdir to avoid having to cd

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,8 @@ proceed is displayed. For the `hpc-cluster-small` example, the message will
 appear similar to:
 
 ```shell
-cd hpc-cluster-small/primary
-terraform init
-terraform apply
+terraform -chdir=hpc-cluster-small/primary init
+terraform -chdir=hpc-cluster-small/primary apply
 ```
 
 Use these commands to run terraform and deploy your cluster. If the `apply` is

--- a/pkg/reswriter/tfwriter.go
+++ b/pkg/reswriter/tfwriter.go
@@ -357,9 +357,8 @@ func writeVersions(dst string) error {
 
 func printTerraformInstructions(grpPath string) {
 	printInstructionsPreamble("Terraform", grpPath)
-	fmt.Printf("  cd %s\n", grpPath)
-	fmt.Println("  terraform init")
-	fmt.Println("  terraform apply")
+	fmt.Printf("  terraform -chdir=%s init\n", grpPath)
+	fmt.Printf("  terraform -chdir=%s apply\n", grpPath)
 }
 
 // writeTopLevel writes any needed files to the top layer of the blueprint


### PR DESCRIPTION
Output now looks like:
```
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary apply
```

Tested: manually ran `ghpc create` with multi group yaml and deployed both resource groups with outputted commands.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
