### PR TITLE
Change default VM type in Packer resource

### DIFF
--- a/resources/packer/custom-image/README.md
+++ b/resources/packer/custom-image/README.md
@@ -90,7 +90,7 @@ No resources.
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | n/a | <pre>list(object({<br>    playbook_file   = string<br>    galaxy_file     = string<br>    extra_arguments = list(string)<br>  }))</pre> | `[]` | no |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
-| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2d-standard-4"` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The service account email to use. If null or 'default', then the default Compute Engine service account will be used. | `string` | `null` | no |

--- a/resources/packer/custom-image/variables.pkr.hcl
+++ b/resources/packer/custom-image/variables.pkr.hcl
@@ -19,7 +19,7 @@ variable "project_id" {
 variable "machine_type" {
   description = "VM machine type on which to build new image"
   type        = string
-  default     = "n2d-standard-4"
+  default     = "n2-standard-4"
 }
 
 variable "disk_size" {


### PR DESCRIPTION
The N2 VM type is more uniformly available across Cloud regions and zones than N2D.

This PR will remain a draft until #211 is merged.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?