### PR TITLE
Simplify Packer example and adopt Toolkit practices

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -168,8 +168,8 @@ boot-time startup scripts because
 
 [hpcimage]: https://cloud.google.com/compute/docs/instances/create-hpc-vm
 
-**Note**: it is important _not to modify_ the subnetwork name in either of the
-two resource groups without modifying them both. These _must_ match!
+**Note**:  this example relies on the default behavior of the Toolkit to derive
+naming convention for networks and other resources from the `deployment_name`.
 
 #### Custom Network (resource group)
 

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -27,13 +27,6 @@ resource_groups:
   - source: resources/network/vpc
     kind: terraform
     id: network1
-    settings:
-      primary_subnetwork:
-        name: custom-image-builder-subnetwork
-        description: Custom Image Building Subnetwork
-        new_bits: 15
-        private_access: true
-        flow_logs: false
     outputs:
     - subnetwork_name
 - group: packer
@@ -42,7 +35,6 @@ resource_groups:
     kind: packer
     id: custom-image
     settings:
-      subnetwork: custom-image-builder-subnetwork
       use_iap: true
       omit_external_ip: true
       disk_size: 100

--- a/resources/packer/custom-image/README.md
+++ b/resources/packer/custom-image/README.md
@@ -89,17 +89,18 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | n/a | <pre>list(object({<br>    playbook_file   = string<br>    galaxy_file     = string<br>    extra_arguments = list(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | HPC Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `false` | no |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which to create VM and image | `string` | n/a | yes |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The service account email to use. If null or 'default', then the default Compute Engine service account will be used. | `string` | `null` | no |
 | <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Service account scopes to attach to the instance. See<br>https://cloud.google.com/compute/docs/access/service-accounts. | `list(string)` | `null` | no |
 | <a name="input_source_image"></a> [source\_image](#input\_source\_image) | Source OS image to build from | `string` | `null` | no |
 | <a name="input_source_image_family"></a> [source\_image\_family](#input\_source\_image\_family) | Alternative to source\_image. Specify image family to build from latest image in family | `string` | `"hpc-centos-7"` | no |
 | <a name="input_source_image_project_id"></a> [source\_image\_project\_id](#input\_source\_image\_project\_id) | A list of project IDs to search for the source image. Packer will search the<br>first project ID in the list first, and fall back to the next in the list,<br>until it finds the source image. | `list(string)` | <pre>[<br>  "cloud-hpc-image-public"<br>]</pre> | no |
 | <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username) | Username to use for SSH access to VM | `string` | `"packer"` | no |
-| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Name of subnetwork in which to provision image building VM | `string` | n/a | yes |
+| <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name) | Name of subnetwork in which to provision image building VM | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Assign network tags to apply firewall rules to VM instance | `list(string)` | `null` | no |
 | <a name="input_use_iap"></a> [use\_iap](#input\_use\_iap) | Use IAP proxy when connecting by SSH | `bool` | `false` | no |
 | <a name="input_use_os_login"></a> [use\_os\_login](#input\_use\_os\_login) | Use OS Login when connecting by SSH | `bool` | `false` | no |

--- a/resources/packer/custom-image/image.pkr.hcl
+++ b/resources/packer/custom-image/image.pkr.hcl
@@ -12,15 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+locals {
+  subnetwork_name = var.subnetwork_name != null ? var.subnetwork_name : "${var.deployment_name}-primary-subnet"
+}
+
 source "googlecompute" "hpc_centos_7" {
   project_id              = var.project_id
-  image_name              = "example-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
-  image_family            = "example-v1"
+  image_name              = "${var.deployment_name}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
+  image_family            = var.deployment_name
   machine_type            = var.machine_type
   disk_size               = var.disk_size
   omit_external_ip        = var.omit_external_ip
   use_internal_ip         = var.omit_external_ip
-  subnetwork              = var.subnetwork
+  subnetwork              = local.subnetwork_name
   source_image            = var.source_image
   source_image_family     = var.source_image_family
   source_image_project_id = var.source_image_project_id

--- a/resources/packer/custom-image/variables.pkr.hcl
+++ b/resources/packer/custom-image/variables.pkr.hcl
@@ -12,8 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+variable "deployment_name" {
+  description = "HPC Toolkit deployment name"
+  type        = string
+}
+
 variable "project_id" {
-  type = string
+  description = "Project in which to create VM and image"
+  type        = string
 }
 
 variable "machine_type" {
@@ -33,9 +39,10 @@ variable "zone" {
   type        = string
 }
 
-variable "subnetwork" {
+variable "subnetwork_name" {
   description = "Name of subnetwork in which to provision image building VM"
   type        = string
+  default     = null
 }
 
 variable "omit_external_ip" {


### PR DESCRIPTION
* Packer template resource adopts standard Toolkit input settings for deployment_name and subnetwork_name
* Packer template subnetwork_name will default to same value as used by the VPC resource

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?