### PR TITLE
Fix packer integration test

### DIFF
--- a/tools/validate_configs/test_configs/packer.yaml
+++ b/tools/validate_configs/test_configs/packer.yaml
@@ -36,7 +36,6 @@ resource_groups:
     kind: packer
     id: my-custom-image
     settings:
-      subnetwork: "subnet-central1"
       use_iap: true
       omit_external_ip: true
       disk_size: 100


### PR DESCRIPTION
#214 renamed the setting `subnetwork` to `subnetwork_name` and aligned its default value to that in the VPC resource. This PR eliminates the (now invalid) `subnetwork` variable in favor of allowing `subnetwork_name` to take on its default value.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?