### PR TITLE
Restore tfstate on create overwrite

### DIFF
--- a/pkg/reswriter/packerwriter.go
+++ b/pkg/reswriter/packerwriter.go
@@ -87,3 +87,8 @@ func writePackerAutovars(vars map[string]cty.Value, dst string) error {
 func (w PackerWriter) writeResourceGroups(yamlConfig *config.YamlConfig, bpDirectory string) error {
 	return w.writeResourceLevel(yamlConfig, bpDirectory)
 }
+
+func (w PackerWriter) restoreState(bpDir string) error {
+	// TODO: implement state restoration for Packer
+	return nil
+}

--- a/pkg/reswriter/reswriter_test.go
+++ b/pkg/reswriter/reswriter_test.go
@@ -182,6 +182,7 @@ func (s *MySuite) TestWriteBlueprint(c *C) {
 	c.Check(err, NotNil)
 }
 
+// tfwriter.go
 func (s *MySuite) TestRestoreTfState(c *C) {
 	// set up dir structure
 	//
@@ -202,7 +203,8 @@ func (s *MySuite) TestRestoreTfState(c *C) {
 	emptyFile, _ := os.Create(prevStateFile)
 	emptyFile.Close()
 
-	restoreTfState(bpDir)
+	testWriter := TFWriter{}
+	testWriter.restoreState(bpDir)
 
 	// check state file was moved to current resource group dir
 	curStateFile := filepath.Join(curResourceGroup, tfStateFileName)
@@ -210,7 +212,6 @@ func (s *MySuite) TestRestoreTfState(c *C) {
 	c.Check(err, IsNil)
 }
 
-// tfwriter.go
 func (s *MySuite) TestGetTypeTokens(c *C) {
 	// Success Integer
 	tok := getTypeTokens(cty.NumberIntVal(-1))

--- a/pkg/reswriter/tfwriter.go
+++ b/pkg/reswriter/tfwriter.go
@@ -18,6 +18,7 @@ package reswriter
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -29,6 +30,11 @@ import (
 
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/sourcereader"
+)
+
+const (
+	tfStateFileName       = "terraform.tfstate"
+	tfStateBackupFileName = "terraform.tfstate.backup"
 )
 
 // TFWriter writes terraform to the blueprint folder
@@ -422,6 +428,32 @@ func (w TFWriter) writeResourceGroups(
 		}
 
 		printTerraformInstructions(writePath)
+	}
+	return nil
+}
+
+// Transfers state files from previous resource groups (in .ghpc/) to a newly written blueprint
+func (w TFWriter) restoreState(bpDir string) error {
+	prevResourceGroupPath := filepath.Join(bpDir, hiddenGhpcDirName, prevResourceGroupDirName)
+	files, err := ioutil.ReadDir(prevResourceGroupPath)
+	if err != nil {
+		return fmt.Errorf("Error trying to read previous resources in %s, %w", prevResourceGroupPath, err)
+	}
+
+	for _, f := range files {
+		var tfStateFiles = []string{tfStateFileName, tfStateBackupFileName}
+		for _, stateFile := range tfStateFiles {
+			src := filepath.Join(prevResourceGroupPath, f.Name(), stateFile)
+			dest := filepath.Join(bpDir, f.Name(), tfStateFileName)
+
+			if bytesRead, err := ioutil.ReadFile(src); err == nil {
+				err = ioutil.WriteFile(dest, bytesRead, 0644)
+				if err != nil {
+					return fmt.Errorf("Failed to write previous state file %s, %w", dest, err)
+				}
+			}
+		}
+
 	}
 	return nil
 }


### PR DESCRIPTION
This PR adds two new methods that help manage the lifecycle of a blueprint directory now that we may be overwriting instead of deleting and creating from scratch:
- `prepBpDir` runs before the blueprint is actually written and gets the directory ready to be written to. If overwrite is disabled then it operates the same as before. It handles things such as:
  - Making sure the base directory structure is set up
  - Cleaning up the hidden directory of any previous backups
  - Copying old resource groups to a hidden directory
- `restoreTfState` runs after the blueprint has been written. This transfers over old state files into the new blueprint to keep continuity of state. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
