### PR TITLE
Overwrite logic for create

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -73,7 +73,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	blueprintConfig.ExpandConfig()
-	if err := reswriter.WriteBlueprint(&blueprintConfig.Config, bpDirectory); err != nil {
+	if err := reswriter.WriteBlueprint(&blueprintConfig.Config, bpDirectory, false /* overwriteFlag */); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adds logic that decides whether or not a blueprint should be overwritten on create. It takes into account if the user has approved the action and makes sure that no resource groups are being deleted, which would have the effect of erasing state.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
