### PR TITLE
Add overwrite-blueprint argument to create command

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -33,11 +33,17 @@ func init() {
 		"Configuration file for the new blueprints")
 	cobra.CheckErr(createCmd.Flags().MarkDeprecated("config",
 		"please see the command usage for more details."))
+
 	createCmd.Flags().StringVarP(&bpDirectory, "out", "o", "",
 		"Output directory for the new blueprints")
 	createCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
 	createCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING",
 		validationLevelDesc)
+	createCmd.Flags().BoolVarP(&overwriteBlueprint, "overwrite-blueprint", "w", false,
+		"if set, an existing blueprint dir can be overwritten by the created blueprint. \n"+
+			"Note: Terraform state IS preserved. \n"+
+			"Note: Terraform workspaces are NOT supported (behavior undefined). \n"+
+			"Note: Packer is NOT supported.")
 	rootCmd.AddCommand(createCmd)
 }
 
@@ -45,6 +51,7 @@ var (
 	yamlFilename        string
 	bpDirectory         string
 	cliVariables        []string
+	overwriteBlueprint  bool
 	validationLevel     string
 	validationLevelDesc = "Set validation level to one of (\"ERROR\", \"WARNING\", \"IGNORE\")"
 	createCmd           = &cobra.Command{
@@ -73,7 +80,7 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 	blueprintConfig.ExpandConfig()
-	if err := reswriter.WriteBlueprint(&blueprintConfig.Config, bpDirectory, false /* overwriteFlag */); err != nil {
+	if err := reswriter.WriteBlueprint(&blueprintConfig.Config, bpDirectory, overwriteBlueprint); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/reswriter/reswriter.go
+++ b/pkg/reswriter/reswriter.go
@@ -167,8 +167,11 @@ type OverwriteDeniedError struct {
 }
 
 func (err *OverwriteDeniedError) Error() string {
-	// TODO: Update error message to reference command line flag once feature is launched
-	return fmt.Sprintf("failed to create a directory for blueprint: %v", err.cause)
+	return fmt.Sprintf("Failed to overwrite existing blueprint. "+
+		"Use the -w command line argument to enable overwrite. "+
+		"If overwrite is already enabled then this may be because "+
+		"you are attempting to remove a resource group, which is not supported : %v",
+		err.cause)
 }
 
 // Prepares a blueprint directory to be written to.


### PR DESCRIPTION
Introduces the `--overwrite-blueprint` argument` to the `create` command. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
