### PR TITLE
Improve formatting of overwrite error

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -18,6 +18,7 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/reswriter"
@@ -81,6 +82,11 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 	}
 	blueprintConfig.ExpandConfig()
 	if err := reswriter.WriteBlueprint(&blueprintConfig.Config, bpDirectory, overwriteBlueprint); err != nil {
-		log.Fatal(err)
+		var target *reswriter.OverwriteDeniedError
+		if errors.As(err, &target) {
+			fmt.Printf("\n%s\n", err.Error())
+		} else {
+			log.Fatal(err)
+		}
 	}
 }

--- a/pkg/reswriter/reswriter.go
+++ b/pkg/reswriter/reswriter.go
@@ -167,10 +167,11 @@ type OverwriteDeniedError struct {
 }
 
 func (err *OverwriteDeniedError) Error() string {
-	return fmt.Sprintf("Failed to overwrite existing blueprint. "+
-		"Use the -w command line argument to enable overwrite. "+
+	return fmt.Sprintf("Failed to overwrite existing blueprint.\n\n"+
+		"Use the -w command line argument to enable overwrite.\n"+
 		"If overwrite is already enabled then this may be because "+
-		"you are attempting to remove a resource group, which is not supported : %v",
+		"you are attempting to remove a resource group, which is not supported.\n"+
+		"original error: %v",
 		err.cause)
 }
 


### PR DESCRIPTION
Previous cli output:
```bash
$ ./ghpc create  examples/my_blueprint.yaml 
2022/04/21 14:08:15 Failed to overwrite existing blueprint. Use the -w command line argument to enable overwrite. If overwrite is already enabled then this may be because you are attempting to remove a resource group, which is not supported : The directory already exists: my_blueprint
```

Updated output
```bash
$ ./ghpc create  examples/my_blueprint.yaml 

Failed to overwrite existing blueprint.

Use the -w command line argument to enable overwrite.
If overwrite is already enabled then this may be because you are attempting to remove a resource group, which is not supported.
original error: The directory already exists: my_blueprint
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
