### PR TITLE
Install pre-commit hooks before parallelizing

### DIFF
--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -82,4 +82,4 @@ steps:
     time make tests
 timeout: "1200s"
 options:
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8

--- a/tools/cloud-build/split-pre-commit-hooks.sh
+++ b/tools/cloud-build/split-pre-commit-hooks.sh
@@ -20,4 +20,4 @@ split -l "$sl" hooks.txt
 echo go-unit-tests >>xaa && cat xaa xab | sort | uniq | xargs | sed -e 's/ /,/g' >hooks1.txt
 echo go-unit-tests >>xab && cat xab xac | sort | uniq | xargs | sed -e 's/ /,/g' >hooks2.txt
 echo go-unit-tests >>xac && cat xac xaa | sort | uniq | xargs | sed -e 's/ /,/g' >hooks3.txt
-echo "created hooks1.txt hooks2.txt and hooks3.txt with three lists of hooks to skp"
+echo "created hooks1.txt hooks2.txt and hooks3.txt with three lists of hooks to skip"


### PR DESCRIPTION
### Description
To attempt to solve an intermittent failure causing the pr-validation to time out, `--install-hooks` flag is added to the first step which runs sequentially. 

In the failed validations, the following message can be seen on each call to pre-commit run --all-files:
```
[INFO] Locking pre-commit directory
[INFO] Locking pre-commit directory
[INFO] Locking pre-commit directory
[INFO] Locking pre-commit directory
[INFO] Locking pre-commit directory
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
