### PR TITLE
Create flag for specifying backend config

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -28,6 +28,7 @@ import (
 )
 
 const msgCLIVars = "Comma-separated list of name=value variables to override YAML configuration. Can be invoked multiple times."
+const msgCLIBackendConfig = "Comma-separated list of name=value variables to set Terraform backend configuration. Can be invoked multiple times."
 
 func init() {
 	createCmd.Flags().StringVarP(&yamlFilename, "config", "c", "",
@@ -38,6 +39,7 @@ func init() {
 	createCmd.Flags().StringVarP(&bpDirectory, "out", "o", "",
 		"Output directory for the new blueprints")
 	createCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
+	createCmd.Flags().StringSliceVar(&cliBEConfigVars, "backend-config", nil, msgCLIBackendConfig)
 	createCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING",
 		validationLevelDesc)
 	createCmd.Flags().BoolVarP(&overwriteBlueprint, "overwrite-blueprint", "w", false,
@@ -52,6 +54,7 @@ var (
 	yamlFilename        string
 	bpDirectory         string
 	cliVariables        []string
+	cliBEConfigVars     []string
 	overwriteBlueprint  bool
 	validationLevel     string
 	validationLevelDesc = "Set validation level to one of (\"ERROR\", \"WARNING\", \"IGNORE\")"
@@ -76,6 +79,9 @@ func runCreateCmd(cmd *cobra.Command, args []string) {
 	blueprintConfig := config.NewBlueprintConfig(yamlFilename)
 	if err := blueprintConfig.SetCLIVariables(cliVariables); err != nil {
 		log.Fatalf("Failed to set the variables at CLI: %v", err)
+	}
+	if err := blueprintConfig.SetBackendConfig(cliBEConfigVars); err != nil {
+		log.Fatalf("Failed to set the backend config at CLI: %v", err)
 	}
 	if err := blueprintConfig.SetValidationLevel(validationLevel); err != nil {
 		log.Fatal(err)

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -31,6 +31,7 @@ func init() {
 	expandCmd.Flags().StringVarP(&outputFilename, "out", "o", "expanded.yaml",
 		"Output file for the expanded yaml.")
 	expandCmd.Flags().StringSliceVar(&cliVariables, "vars", nil, msgCLIVars)
+	expandCmd.Flags().StringSliceVar(&cliBEConfigVars, "backend-config", nil, msgCLIBackendConfig)
 	expandCmd.Flags().StringVarP(&validationLevel, "validation-level", "l", "WARNING",
 		validationLevelDesc)
 	rootCmd.AddCommand(expandCmd)
@@ -59,6 +60,9 @@ func runExpandCmd(cmd *cobra.Command, args []string) {
 	blueprintConfig := config.NewBlueprintConfig(yamlFilename)
 	if err := blueprintConfig.SetCLIVariables(cliVariables); err != nil {
 		log.Fatalf("Failed to set the variables at CLI: %v", err)
+	}
+	if err := blueprintConfig.SetBackendConfig(cliBEConfigVars); err != nil {
+		log.Fatalf("Failed to set the backend config at CLI: %v", err)
 	}
 	if err := blueprintConfig.SetValidationLevel(validationLevel); err != nil {
 		log.Fatal(err)

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,16 @@ terraform_backend_defaults:
     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
 ```
 
+You can set the configuration at CLI as well like below:
+
+```shell
+./ghpc create examples/hpc-cluster-small.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}" --backend-config "bucket=${GCS_BUCKET}"
+```
+
+> **_NOTE:_** The `--backend-config` argument supports comma-separated list of name=value
+> variables to set Terraform Backend configuration in blueprints. This feature only supports
+> variables of string type. If you set configuration by both Yaml and CLI, the tool uses values at CLI. "gcs" is set as type by default.
+
 ## Config Descriptions
 
 ### hpc-cluster-small.yaml

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -393,6 +393,34 @@ func (bc *BlueprintConfig) SetCLIVariables(cliVariables []string) error {
 	return nil
 }
 
+// SetBackendConfig sets the backend config variables at CLI
+func (bc *BlueprintConfig) SetBackendConfig(cliBEConfigVars []string) error {
+	// Set "gcs" as default value when --backend-config is specified at CLI
+	if len(cliBEConfigVars) > 0 {
+		bc.Config.TerraformBackendDefaults.Type = "gcs"
+		bc.Config.TerraformBackendDefaults.Configuration = make(map[string]interface{})
+	}
+
+	for _, config := range cliBEConfigVars {
+		arr := strings.SplitN(config, "=", 2)
+
+		if len(arr) != 2 {
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", config)
+		}
+
+		key, value := arr[0], arr[1]
+		switch key {
+		case "type":
+			bc.Config.TerraformBackendDefaults.Type = value
+		default:
+			bc.Config.TerraformBackendDefaults.Configuration[key] = value
+		}
+
+	}
+
+	return nil
+}
+
 // IsLiteralVariable returns true if string matches variable ((ctx.name))
 func IsLiteralVariable(str string) bool {
 	match, err := regexp.MatchString(literalExp, str)


### PR DESCRIPTION
**Updates**

* Add `--backend-config` flag for `ghpc create` and `ghpc expand`.
* Update examples/README.md on the usage and note.

For this PR, I checked the following test cases.

## CLI Usage

```
$ ./ghpc create --help
Create a new blueprint based on a provided YAML config.

Usage:
  ghpc create FILENAME [flags]

Flags:
      --backend-config strings    Comma-separated list of name=value variables to set Terraform backend configuration. Can be invoked multiple times.
...
```

## Case 1: No backend config by Yaml and CLI

This checks that backend config is not created if it's not specified by Yaml or CLI.
Just run the following command with the default `examples/hpc-cluster-small.yaml`:

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary validate
  terraform -chdir=hpc-cluster-small/primary apply
```

Success if Terraform Backend statement is not present in `hpc-cluster-small/primary/main.tf`.

## Case 2: Backend config by Yaml file

Add the following section in `examples/hpc-cluster-small.yaml`.

```
terraform_backend_defaults:
  type: gcs
  configuration:
    bucket: a_bucket
    impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
```

Run the following command:

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary validate
  terraform -chdir=hpc-cluster-small/primary apply
```

Success if Terraform Backend statement is present in `hpc-cluster-small/primary/main.tf` like below.

```
$ cat hpc-cluster-small/primary/main.tf
...
terraform {
  backend "gcs" {
    impersonate_service_account = "a_bucket_reader@project.iam.gserviceaccount.com"
    prefix                      = "hpc-cluster-small/hpc-small/primary"
    bucket                      = "a_bucket"
  }
}
...
```

## Case 3: Backend config by CLI

No backend section in Yaml file which is the default `examples/hpc-cluster-small.yaml`, run the following command:

**With "type=gcs":**
```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml --backend-config "type=gcs,bucket=a_bucket,impersonate_service_account=a_bucket_reader@project.iam.gserviceaccount.com"
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary validate
  terraform -chdir=hpc-cluster-small/primary apply
```

**Without "type=gcs":**
The tool sets "gcs" as backend type by default.
```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml --backend-config "bucket=a_bucket,impersonate_service_account=a_bucket_reader@project.iam.gserviceaccount.com"
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary validate
  terraform -chdir=hpc-cluster-small/primary apply
```

Success if Terraform Backend statement is present in `hpc-cluster-small/primary/main.tf` like below.

```
$ cat hpc-cluster-small/primary/main.tf
...
terraform {
  backend "gcs" {
    bucket                      = "a_bucket"
    impersonate_service_account = "a_bucket_reader@project.iam.gserviceaccount.com"
    prefix                      = "hpc-cluster-small/hpc-small/primary"
  }
}
...
```

## Case 4: Backend config by Yaml file & CLI

The toolkit overrides the backend config in the yaml file by variables at CLI.

Add the following section in `examples/hpc-cluster-small.yaml`.

```
terraform_backend_defaults:
  type: gcs
  configuration:
    bucket: a_bucket
    impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
```

Run the following command:

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml --backend-config "type=gcs,bucket=a_bucket_cli,impersonate_service_account=a_bucket_reader_cli@project.iam.gserviceaccount.com"
```

Success if Terraform Backend statement is present in `hpc-cluster-small/primary/main.tf` and it has the variables set by CLI (e.g. `a_bucket_cli`, not `a_bucket`) like below.

```
$ cat hpc-cluster-small/primary/main.tf
...
terraform {
  backend "gcs" {
    bucket                      = "a_bucket_cli"
    impersonate_service_account = "a_bucket_reader_cli@project.iam.gserviceaccount.com"
    prefix                      = "hpc-cluster-small/hpc-small/primary"
  }
}
...
```

## Expand command
Tested `./ghpc expand` similar to `./ghpc create` with the test cases above.

If no Terraform backend config is specified, `terraform_backend_defaults` doesn't have any values in `expanded.yaml` like below:

```
$ cat expanded.yaml
...
terraform_backend_defaults:
  type: ""
  configuration: {}
```

If Terraform backend config is specified by Yaml or CLI, `terraform_backend_defaults` looks like below:

```
terraform_backend_defaults:
  type: gcs
  configuration:
    bucket: a_bucket
    impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
```

If Terraform backend config is specified by Yaml and CLI, `terraform_backend_defaults` has the values set by CLI:

```
terraform_backend_defaults:
  type: gcs
  configuration:
    bucket: a_bucket_cli
    impersonate_service_account: a_bucket_reader_cli@project.iam.gserviceaccount.com
```

## Appendix

Run with parameters at minimum:

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" examples/hpc-cluster-small.yaml --backend-config "bucket=a_bucket_cli"
Terraform group was successfully created in directory hpc-cluster-small/primary
To deploy, run the following commands:
  terraform -chdir=hpc-cluster-small/primary init
  terraform -chdir=hpc-cluster-small/primary validate
  terraform -chdir=hpc-cluster-small/primary apply
```

```
$ cat hpc-cluster-small/primary/main.tf
...
terraform {
  backend "gcs" {
    bucket = "a_bucket_cli"
    prefix = "hpc-cluster-small/hpc-small/primary"
  }
}
...
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
