### PR TITLE
Improve instructions to use GitHub client in Google Cloud Shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ and intends to address the HPC deployment needs of a broad range of customers.
 ## Installation
 
 These instructions assume you are using
-[Cloud Shell](https://cloud.google.com/shell) which comes with the above
-dependencies pre-installed (minus Packer which is not needed for this example).
+[Cloud Shell](https://cloud.google.com/shell) which comes with the
+[dependencies](#dependencies) pre-installed.
 
 To use the HPC-Toolkit, you must clone the project from GitHub and build the
 `ghpc` binary.


### PR DESCRIPTION
Adopt instructions for GitHub client `gh` authentication in Cloud Shell and eliminate note re: Packer now that Packer 1.8.0 is available by default.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?