### PR TITLE
Explicitly enable the default Compute Engine service account

### DIFF
--- a/docs/tutorials/basic.md
+++ b/docs/tutorials/basic.md
@@ -182,7 +182,7 @@ To avoid incurring ongoing charges we will want to destroy our cluster. Run the
 following command in the cloud shell terminal (not in the pop-up):
 
 ```bash
-terraform -chdir=hpc-cluster-small/primary destroy --auto-approve
+terraform -chdir=hpc-cluster-small/primary destroy -auto-approve
 ```
 
 When complete you should see something like:


### PR DESCRIPTION
Addresses cases where the default GCE SA has been disabled during project creation or by other policy mechanism.  (100% of projects I create are like this). Cloud shell output from command will now looks like this:

```
granting roles/editor to     142289519278-compute@developer.gserviceaccount.com
Enabled service account [142289519278-compute@developer.gserviceaccount.com].
Updated IAM policy for project [toolkit-demo-zero-e913].
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?