### PR TITLE
Update integration tests to use 'deployment_name'

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -40,15 +40,15 @@
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
     args:
-      creates: "{{ workspace }}/{{ blueprint_dir }}.tgz"
+      creates: "{{ workspace }}/{{ deployment_name }}.tgz"
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
       command:
         cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
       args:
-        creates: "{{ workspace }}/{{ blueprint_dir }}/.terraform"
+        creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
       with_items:
@@ -117,7 +117,7 @@
         TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
     - name: Fail Out
       fail:
         msg: "Failed while setting up test infrastructure"
@@ -166,4 +166,4 @@
         TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/packer-integration-test.yml
@@ -29,15 +29,15 @@
       BLUEPRINT_DIR: "{{ blueprint_dir }}"
       DEPLOYMENT_NAME: "{{ deployment_name }}"
     args:
-      creates: "{{ workspace }}/{{ blueprint_dir }}.tgz"
+      creates: "{{ workspace }}/{{ deployment_name }}.tgz"
   - name: Create Infrastructure and test
     block:
     - name: Create Network with Terraform
       command:
         cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/builder-env"
+        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"
       args:
-        creates: "{{ workspace }}/{{ blueprint_dir }}/.terraform"
+        creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
       with_items:
@@ -47,7 +47,7 @@
     - name: Create VM image with Packer
       command:
         cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/packer/custom-image"
+        chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
       with_items:
       - packer init .
       - packer validate .
@@ -56,7 +56,7 @@
       ansible.builtin.shell: |
         gcloud compute images delete --project={{ project }} --quiet $(jq -r '.builds[-1].artifact_id' packer-manifest.json | cut -d ":" -f2)
       args:
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/packer/custom-image"
+        chdir: "{{ workspace }}/{{ deployment_name }}/packer/custom-image"
     ## Always cleanup network
     always:
     - name: Tear Down Network
@@ -66,4 +66,4 @@
         TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve -no-color
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/builder-env"
+        chdir: "{{ workspace }}/{{ deployment_name }}/builder-env"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -41,15 +41,15 @@
       DEPLOYMENT_NAME: "{{ deployment_name }}"
       NETWORK: "{{ network }}"
     args:
-      creates: "{{ workspace }}/{{ blueprint_dir }}.tgz"
+      creates: "{{ workspace }}/{{ deployment_name }}.tgz"
   - name: Create Infrastructure and test
     block:
     - name: Create Cluster with Terraform
       command:
         cmd: "{{ item }}"
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
       args:
-        creates: "{{ workspace }}/{{ blueprint_dir }}/.terraform"
+        creates: "{{ workspace }}/{{ deployment_name }}/.terraform"
       environment:
         TF_IN_AUTOMATION: "TRUE"
       with_items:
@@ -123,7 +123,7 @@
         TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"
     - name: Fail Out
       fail:
         msg: "Failed while setting up test infrastructure"
@@ -187,4 +187,4 @@
         TF_IN_AUTOMATION: "TRUE"
       command:
         cmd: terraform destroy -auto-approve
-        chdir: "{{ workspace }}/{{ blueprint_dir }}/primary"
+        chdir: "{{ workspace }}/{{ deployment_name }}/primary"

--- a/tools/cloud-build/daily-tests/create_blueprint.sh
+++ b/tools/cloud-build/daily-tests/create_blueprint.sh
@@ -72,7 +72,7 @@ sed -i "s/max_node_count: .*/max_node_count: ${MAX_NODES}/" "${EXAMPLE_YAML}" ||
 		echo "could not write blueprint"
 		exit 1
 	}
-tar -czf "${BLUEPRINT_DIR}.tgz" "${BLUEPRINT_DIR}" ||
+tar -czf "${DEPLOYMENT_NAME}.tgz" "${DEPLOYMENT_NAME}" ||
 	{
 		echo "could not tarball blueprint"
 		exit 1


### PR DESCRIPTION
Updates integration tests to expect generated folder to be named after `deployment_name` instead of `blueprint_name`.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
