### PR TITLE
Update schema to deployment_groups and modules

### DIFF
--- a/community/examples/omnia-cluster.yaml
+++ b/community/examples/omnia-cluster.yaml
@@ -22,9 +22,9 @@ vars:
   zone: us-central1-c
   region: us-central1
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
 
   ## Network
   - source: modules/network/vpc

--- a/community/examples/spack-gromacs.yaml
+++ b/community/examples/spack-gromacs.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/examples/README.md
+++ b/examples/README.md
@@ -258,9 +258,9 @@ vars:
     global_label: label_value
 
 # Many modules can be added from local and remote directories.
-resource_groups:
+deployment_groups:
 - group: groupName
-  resources:
+  modules:
 
   # Local source, prefixed with ./ (/ and ../ also accepted)
   - source: ./modules/role/module-name # Required: Points to the module directory.
@@ -377,9 +377,9 @@ other modules. For global and module variables, the syntax is as follows:
 vars:
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
   - group: primary
-     resources:
+     modules:
        - source: path/to/module/1
          id: resource1
          ...

--- a/examples/hpc-cluster-high-io.yaml
+++ b/examples/hpc-cluster-high-io.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
   # Example - ./modules/network/pre-existing-vpc

--- a/examples/hpc-cluster-small.yaml
+++ b/examples/hpc-cluster-small.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -21,9 +21,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: builder-env
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1
@@ -40,7 +40,7 @@ resource_groups:
     outputs:
     - startup_script
 - group: packer
-  resources:
+  modules:
   - source: modules/packer/custom-image
     kind: packer
     id: custom-image

--- a/modules/README.md
+++ b/modules/README.md
@@ -104,7 +104,7 @@ matching names, and the setting has no explicit value, then it will be set to
 the used module's output. For example, see the following YAML:
 
 ```yaml
-resources:
+modules:
 - source: modules/network/vpc
   kind: terraform
   id: network1

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,7 +68,7 @@ var errorMessages = map[string]string{
 type ResourceGroup struct {
 	Name             string           `yaml:"group"`
 	TerraformBackend TerraformBackend `yaml:"terraform_backend"`
-	Resources        []Resource
+	Resources        []Resource       `yaml:"modules"`
 }
 
 func (g ResourceGroup) getResourceByID(resID string) Resource {
@@ -187,7 +187,7 @@ type YamlConfig struct {
 	Validators               []validatorConfig
 	ValidationLevel          int `yaml:"validation_level,omitempty"`
 	Vars                     map[string]interface{}
-	ResourceGroups           []ResourceGroup  `yaml:"resource_groups"`
+	ResourceGroups           []ResourceGroup  `yaml:"deployment_groups"`
 	TerraformBackendDefaults TerraformBackend `yaml:"terraform_backend_defaults"`
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -47,9 +47,9 @@ terraform_backend_defaults:
   type: gcs
   configuration:
     bucket: hpc-toolkit-tf-state
-resource_groups:
+deployment_groups:
 - group: group1
-  resources:
+  modules:
   - source: ./modules/network/vpc
     kind: terraform
     id: "vpc"

--- a/tools/cloud-build/daily-tests/blueprints/lustre-with-new-vpc.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-with-new-vpc.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
   # Example - ./modules/network/pre-existing-vpc

--- a/tools/cloud-build/daily-tests/blueprints/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/monitoring.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network

--- a/tools/validate_configs/test_configs/2-nfs-servers.yaml
+++ b/tools/validate_configs/test_configs/2-nfs-servers.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/2filestore-4instances.yaml
+++ b/tools/validate_configs/test_configs/2filestore-4instances.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: infrastructure
-  resources:
+  modules:
   - source: ./modules/network/vpc
     kind: terraform
     id: network

--- a/tools/validate_configs/test_configs/complex-data.yaml
+++ b/tools/validate_configs/test_configs/complex-data.yaml
@@ -38,9 +38,9 @@ vars:
     - val1
     - 43.5
 
-resource_groups:
+deployment_groups:
 - group: infrastructure
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network

--- a/tools/validate_configs/test_configs/dashboards.yaml
+++ b/tools/validate_configs/test_configs/dashboards.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/monitoring/dashboard
     kind: terraform
     id: hpc_dash

--- a/tools/validate_configs/test_configs/exascaler-existing-vpc.yaml
+++ b/tools/validate_configs/test_configs/exascaler-existing-vpc.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: ./modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/exascaler-new-vpc.yaml
+++ b/tools/validate_configs/test_configs/exascaler-new-vpc.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/gpu.yaml
+++ b/tools/validate_configs/test_configs/gpu.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc

--- a/tools/validate_configs/test_configs/hpc-cluster-high-io-remote-state.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-high-io-remote-state.yaml
@@ -28,9 +28,9 @@ terraform_backend_defaults:
     bucket: a_bucket
     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/hpc-cluster-project.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-project.yaml
@@ -29,9 +29,9 @@ terraform_backend_defaults:
     bucket: a_bucket
     impersonate_service_account: a_bucket_reader@project.iam.gserviceaccount.com
 
-resource_groups:
+deployment_groups:
 - group: onboarding
-  resources:
+  modules:
   - source: ./community/modules/project/new-project
     kind: terraform
     id: project
@@ -51,7 +51,7 @@ resource_groups:
       - "compute.googleapis.com"
 
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc

--- a/tools/validate_configs/test_configs/hpc-cluster-service-acct.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-service-acct.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple-nfs-sql.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/hpc-cluster-simple.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/hpc-cluster-slurm-with-startup.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-slurm-with-startup.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
   # Example - ./modules/network/vpc

--- a/tools/validate_configs/test_configs/instance-with-startup.yaml
+++ b/tools/validate_configs/test_configs/instance-with-startup.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/label_test.yaml
+++ b/tools/validate_configs/test_configs/label_test.yaml
@@ -25,9 +25,9 @@ vars:
     "ghpc_custom": "custom_label"
     "ghpc_deployment": "custom_deployment"
 
-resource_groups:
+deployment_groups:
 - group: infrastructure
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network

--- a/tools/validate_configs/test_configs/new_project.yaml
+++ b/tools/validate_configs/test_configs/new_project.yaml
@@ -19,9 +19,9 @@ blueprint_name: new_project
 vars:
   deployment_name: new_project_deployment
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: ./community/modules/project/new-project
     kind: terraform
     id: project

--- a/tools/validate_configs/test_configs/overwrite_labels.yaml
+++ b/tools/validate_configs/test_configs/overwrite_labels.yaml
@@ -26,9 +26,9 @@ vars:
     ghpc_blueprint: custom_blueprint
     ghpc_deployment: custom_deployment
 
-resource_groups:
+deployment_groups:
 - group: infrastructure
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network

--- a/tools/validate_configs/test_configs/packer.yaml
+++ b/tools/validate_configs/test_configs/packer.yaml
@@ -22,16 +22,16 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: network
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1
     settings:
       network_name: $(vars.deployment_name)
 - group: packer
-  resources:
+  modules:
   - source: modules/packer/custom-image
     kind: packer
     id: my-custom-image

--- a/tools/validate_configs/test_configs/pre-existing-fs.yaml
+++ b/tools/validate_configs/test_configs/pre-existing-fs.yaml
@@ -24,9 +24,9 @@ vars:
   local_mount: /home
   network_name: default
 
-resource_groups:
+deployment_groups:
 - group: storage
-  resources:
+  modules:
   # the pre-existing-vpc is not needed here, since filestore will use the
   # network-name from global vars
   - source: modules/file-system/filestore
@@ -34,7 +34,7 @@ resource_groups:
     id: homefs-filestore
 
 - group: compute
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/rocky-linux.yaml
+++ b/tools/validate_configs/test_configs/rocky-linux.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: ./modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/simple-startup.yaml
+++ b/tools/validate_configs/test_configs/simple-startup.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: ./modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/slurm-two-partitions-workstation.yaml
+++ b/tools/validate_configs/test_configs/slurm-two-partitions-workstation.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/spack-buildcache.yaml
+++ b/tools/validate_configs/test_configs/spack-buildcache.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-c
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/startup-options.yaml
+++ b/tools/validate_configs/test_configs/startup-options.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: ./modules/network/pre-existing-vpc
     kind: terraform
     id: network1

--- a/tools/validate_configs/test_configs/test_outputs.yaml
+++ b/tools/validate_configs/test_configs/test_outputs.yaml
@@ -22,9 +22,9 @@ vars:
   region: europe-west4
   zone: europe-west4-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   - source: modules/compute/simple-instance
     kind: terraform
     id: instance

--- a/tools/validate_configs/test_configs/use-resources.yaml
+++ b/tools/validate_configs/test_configs/use-resources.yaml
@@ -22,9 +22,9 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-resource_groups:
+deployment_groups:
 - group: primary
-  resources:
+  modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../,
   # / as a prefix. To refer to a local module, prefix with ./, ../ or /
   # Example - ./modules/network/pre-existing-vpc


### PR DESCRIPTION
Note: will update to merge into develop once [PR#241](https://github.com/GoogleCloudPlatform/hpc-toolkit/pull/241) is merged.

Updated schema for blueprints to take deployment_groups rather than
resource_groups and modules rather than resources. Internal
representation remains the same.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
