### PR TITLE
Run pre-commit groups in separate dirs

### DIFF
--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -37,6 +37,11 @@ steps:
     set -e -x
     time tflint --init
     export SKIP=$(cat hooks1.txt)
+    tmp_dir=$$(mktemp -d -t pre-commit-group-1-XXXXX)
+    echo "Running pre-commit group 1 in $${tmp_dir}"
+    git worktree add $$tmp_dir/group1
+    cd $$tmp_dir/group1
+    export PRE_COMMIT_HOME=$$tmp_dir
     echo skipping: $$SKIP
     time pre-commit run --all-files
 - id: pre-commits2
@@ -51,6 +56,11 @@ steps:
     set -e
     time tflint --init
     export SKIP=$(cat hooks2.txt)
+    tmp_dir=$$(mktemp -d -t pre-commit-group-2-XXXXX)
+    echo "Running pre-commit group 2 in $${tmp_dir}"
+    git worktree add $$tmp_dir/group2
+    cd $$tmp_dir/group2
+    export PRE_COMMIT_HOME=$$tmp_dir
     echo skipping: $$SKIP
     time pre-commit run --all-files
 - id: pre-commits3
@@ -65,6 +75,11 @@ steps:
     set -e
     time tflint --init
     export SKIP=$(cat hooks3.txt)
+    tmp_dir=$$(mktemp -d -t pre-commit-group-3-XXXXX)
+    echo "Running pre-commit group 3 in $${tmp_dir}"
+    git worktree add $$tmp_dir/group3
+    cd $$tmp_dir/group3
+    export PRE_COMMIT_HOME=$$tmp_dir
     echo skipping: $$SKIP
     time pre-commit run --all-files
 - id: make-tests


### PR DESCRIPTION
Create temp directories for each pre-commit group, copy the repo and run
the tests there. This should hopefully decrease any errors related to
race conditions in using the pre-commit staging directory.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [ ] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
