### PR TITLE
Reduce pr validation timeout to fail faster in deadlocks

### DIFF
--- a/tools/cloud-build/hpc-toolkit-pr-validation.yaml
+++ b/tools/cloud-build/hpc-toolkit-pr-validation.yaml
@@ -80,6 +80,6 @@ steps:
     export PROJECT=build-project
     time addlicense -check . || { echo "addlicense failed"; exit 1; }
     time make tests
-timeout: "1200s"
+timeout: "600s"
 options:
   machineType: N1_HIGHCPU_8


### PR DESCRIPTION
A successful pr validation takes < 5 min. In cases of deadlock the build does not timeout until 20 min have passed. In cases of deadlock the tests can be unresponsive and impossible to cancel. Reducing the timeout to something more reasonable (2x run time) will provide faster feedback. 

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
