### PR TITLE
Standardize Slurm image variables

### DIFF
--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/README.md
@@ -30,10 +30,13 @@ connected to a module subnetwork and with homefs mounted.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -41,7 +44,9 @@ No modules.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs
 
@@ -54,8 +59,8 @@ No resources.
 | <a name="input_exclusive"></a> [exclusive](#input\_exclusive) | Exclusive job access to nodes | `bool` | `true` | no |
 | <a name="input_gpu_count"></a> [gpu\_count](#input\_gpu\_count) | Number of GPUs attached to the partition compute instances | `number` | `0` | no |
 | <a name="input_gpu_type"></a> [gpu\_type](#input\_gpu\_type) | Type of GPUs attached to the partition compute instances | `string` | `null` | no |
-| <a name="input_image"></a> [image](#input\_image) | Image to be used of the compute VMs in this partition | `string` | `"projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"` | no |
 | <a name="input_image_hyperthreads"></a> [image\_hyperthreads](#input\_image\_hyperthreads) | Enable hyperthreading | `bool` | `false` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Image to be used for the compute VMs in this partition | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "schedmd-slurm-21-08-4-hpc-centos-7",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
 | <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Instance template to use to create partition instances | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to partition compute instances. List of key key, value pairs. | `any` | `{}` | no |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Compute Platform machine type to use for this partition compute nodes | `string` | `"c2-standard-60"` | no |

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/outputs.tf
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "google_compute_image" "compute_image" {
+  family  = var.instance_image.family
+  project = var.instance_image.project
+}
+
 output "partition" {
   description = "The partition structure containing all the set variables"
   value = {
@@ -21,7 +26,7 @@ output "partition" {
     static_node_count : var.static_node_count
     max_node_count : var.max_node_count
     zone : var.zone
-    image : var.image
+    image : data.google_compute_image.compute_image.self_link
     image_hyperthreads : var.image_hyperthreads
     compute_disk_type : var.compute_disk_type
     compute_disk_size_gb : var.compute_disk_size_gb

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/variables.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/variables.tf
@@ -41,10 +41,16 @@ variable "zone" {
   type        = string
 }
 
-variable "image" {
-  description = "Image to be used of the compute VMs in this partition"
-  type        = string
-  default     = "projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"
+variable "instance_image" {
+  description = "Image to be used for the compute VMs in this partition"
+  type = object({
+    family  = string,
+    project = string
+  })
+  default = {
+    family  = "schedmd-slurm-21-08-4-hpc-centos-7"
+    project = "schedmd-slurm-public"
+  }
 }
 
 variable "image_hyperthreads" {

--- a/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
+++ b/community/modules/compute/SchedMD-slurm-on-gcp-partition/versions.tf
@@ -15,5 +15,12 @@
 */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+
   required_version = ">= 0.14.0"
 }

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/README.md
@@ -50,10 +50,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -63,7 +66,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs
 
@@ -76,7 +81,6 @@ No resources.
 | <a name="input_compute_node_scopes"></a> [compute\_node\_scopes](#input\_compute\_node\_scopes) | Scopes to apply to compute nodes. | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/monitoring.write",<br>  "https://www.googleapis.com/auth/logging.write",<br>  "https://www.googleapis.com/auth/devstorage.read_only"<br>]</pre> | no |
 | <a name="input_compute_node_service_account"></a> [compute\_node\_service\_account](#input\_compute\_node\_service\_account) | Service Account for compute nodes. | `string` | `null` | no |
 | <a name="input_compute_startup_script"></a> [compute\_startup\_script](#input\_compute\_startup\_script) | Custom startup script to run on the compute nodes | `string` | `null` | no |
-| <a name="input_controller_image"></a> [controller\_image](#input\_controller\_image) | Slurm image to use for the controller instance | `string` | `"projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"` | no |
 | <a name="input_controller_instance_template"></a> [controller\_instance\_template](#input\_controller\_instance\_template) | Instance template to use to create controller instance | `string` | `null` | no |
 | <a name="input_controller_machine_type"></a> [controller\_machine\_type](#input\_controller\_machine\_type) | Compute Platform machine type to use in controller node creation | `string` | `"n2-standard-2"` | no |
 | <a name="input_controller_scopes"></a> [controller\_scopes](#input\_controller\_scopes) | Scopes to apply to the controller | `list(string)` | <pre>[<br>  "https://www.googleapis.com/auth/cloud-platform",<br>  "https://www.googleapis.com/auth/devstorage.read_only"<br>]</pre> | no |
@@ -88,6 +92,7 @@ No resources.
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment | `string` | n/a | yes |
 | <a name="input_disable_compute_public_ips"></a> [disable\_compute\_public\_ips](#input\_disable\_compute\_public\_ips) | If set to true, create Cloud NAT gateway and enable IAP FW rules | `bool` | `true` | no |
 | <a name="input_disable_controller_public_ips"></a> [disable\_controller\_public\_ips](#input\_disable\_controller\_public\_ips) | If set to true, create Cloud NAT gateway and enable IAP FW rules | `bool` | `false` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Slurm image to use for the controller instance | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "schedmd-slurm-21-08-4-hpc-centos-7",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
 | <a name="input_intel_select_solution"></a> [intel\_select\_solution](#input\_intel\_select\_solution) | Configure the cluster to meet the performance requirement of the Intel Select Solution | `string` | `null` | no |
 | <a name="input_jwt_key"></a> [jwt\_key](#input\_jwt\_key) | Specific libjwt key to use | `any` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to controller instance. List of key key, value pairs. | `any` | `{}` | no |

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/main.tf
@@ -14,11 +14,16 @@
  * limitations under the License.
 */
 
+data "google_compute_image" "compute_image" {
+  family  = var.instance_image.family
+  project = var.instance_image.project
+}
+
 module "slurm_cluster_controller" {
   source                        = "github.com/SchedMD/slurm-gcp//tf/modules/controller/?ref=v4.1.5"
   boot_disk_size                = var.boot_disk_size
   boot_disk_type                = var.boot_disk_type
-  image                         = var.controller_image
+  image                         = data.google_compute_image.compute_image.self_link
   instance_template             = var.controller_instance_template
   cluster_name                  = var.cluster_name != null ? var.cluster_name : "slurm-${var.deployment_name}"
   compute_node_scopes           = var.compute_node_scopes

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/variables.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/variables.tf
@@ -25,10 +25,16 @@ variable "boot_disk_type" {
   default     = "pd-standard"
 }
 
-variable "controller_image" {
+variable "instance_image" {
   description = "Slurm image to use for the controller instance"
-  type        = string
-  default     = "projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"
+  type = object({
+    family  = string,
+    project = string
+  })
+  default = {
+    family  = "schedmd-slurm-21-08-4-hpc-centos-7"
+    project = "schedmd-slurm-public"
+  }
 }
 
 variable "controller_instance_template" {

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-controller/versions.tf
@@ -15,5 +15,12 @@
 */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+
   required_version = ">= 0.14.0"
 }

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/README.md
@@ -50,10 +50,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
 
 ## Modules
 
@@ -63,7 +66,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+|------|------|
+| [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs
 
@@ -76,8 +81,8 @@ No resources.
 | <a name="input_controller_secondary_disk"></a> [controller\_secondary\_disk](#input\_controller\_secondary\_disk) | Create secondary disk mounted to controller node | `bool` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment | `string` | n/a | yes |
 | <a name="input_disable_login_public_ips"></a> [disable\_login\_public\_ips](#input\_disable\_login\_public\_ips) | If set to true, create Cloud NAT gateway and enable IAP FW rules | `bool` | `false` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Disk OS image with Slurm preinstalled to use for login node | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "schedmd-slurm-21-08-4-hpc-centos-7",<br>  "project": "schedmd-slurm-public"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to login instances. List of key key, value pairs. | `any` | `{}` | no |
-| <a name="input_login_image"></a> [login\_image](#input\_login\_image) | Disk OS image with Slurm preinstalled to use for login node | `string` | `"projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"` | no |
 | <a name="input_login_instance_template"></a> [login\_instance\_template](#input\_login\_instance\_template) | Instance template to use to create controller instance | `string` | `null` | no |
 | <a name="input_login_machine_type"></a> [login\_machine\_type](#input\_login\_machine\_type) | Machine type to use for login node instances. | `string` | `"n2-standard-2"` | no |
 | <a name="input_login_node_count"></a> [login\_node\_count](#input\_login\_node\_count) | Number of login nodes in the cluster | `number` | `1` | no |

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/main.tf
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
+data "google_compute_image" "compute_image" {
+  family  = var.instance_image.family
+  project = var.instance_image.project
+}
+
 module "slurm_cluster_login_node" {
   source            = "github.com/SchedMD/slurm-gcp//tf/modules/login/?ref=v4.1.5"
   boot_disk_size    = var.boot_disk_size
   boot_disk_type    = var.boot_disk_type
-  image             = var.login_image
+  image             = data.google_compute_image.compute_image.self_link
   instance_template = var.login_instance_template
   cluster_name = (
     var.cluster_name != null

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/variables.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/variables.tf
@@ -26,10 +26,16 @@ variable "boot_disk_type" {
   default     = "pd-standard"
 }
 
-variable "login_image" {
+variable "instance_image" {
   description = "Disk OS image with Slurm preinstalled to use for login node"
-  type        = string
-  default     = "projects/schedmd-slurm-public/global/images/family/schedmd-slurm-21-08-4-hpc-centos-7"
+  type = object({
+    family  = string,
+    project = string
+  })
+  default = {
+    family  = "schedmd-slurm-21-08-4-hpc-centos-7"
+    project = "schedmd-slurm-public"
+  }
 }
 
 variable "login_instance_template" {

--- a/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
+++ b/community/modules/scheduler/SchedMD-slurm-on-gcp-login-node/versions.tf
@@ -15,5 +15,12 @@
  */
 
 terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+
   required_version = ">= 0.14.0"
 }


### PR DESCRIPTION
Uses standard variable structure (`project`, `family`) for image input instead of self link. 
This allows for definition by variable which is needed for image building example (ref: #254 | [lines](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/596229486808460b6f43b571cecb7069a09da71d/examples/image-builder.yaml#L64-L65)). 
Also add image to outputs so it can be passed from `partition` > `controller` > `login`.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
