### PR TITLE
Set default filestore size to lowest possible

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -93,7 +93,7 @@ No modules.
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the GCE VPC network to which the instance is connected. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Filestore instance will be created. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | Location for Filestore instances at Enterprise tier. | `string` | n/a | yes |
-| <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `2660` | no |
+| <a name="input_size_gb"></a> [size\_gb](#input\_size\_gb) | Storage size of the filestore instance in GB. | `number` | `2560` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Location for Filestore instances below Enterprise tier. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -60,7 +60,7 @@ variable "local_mount" {
 variable "size_gb" {
   description = "Storage size of the filestore instance in GB."
   type        = number
-  default     = 2660
+  default     = 2560
 }
 
 variable "filestore_tier" {


### PR DESCRIPTION
The default value of 2660 is probably a typo for 2560, the lowest allowed Filestore size. By "fixing" this to be 2560, it will allow 2 Filestore instances to be provisioned in a quota whose default value (for me) is 2660GB.
 
### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?