### PR TITLE
Update docs and defaults for spack install dir

### DIFF
--- a/community/examples/spack-gromacs.yaml
+++ b/community/examples/spack-gromacs.yaml
@@ -56,7 +56,7 @@ deployment_groups:
       configs:
       - type: single-config
         scope: defaults
-        value: "config:build_stage:/apps/spack/spack-stage"
+        value: "config:build_stage:/sw/spack/spack-stage"
       - type: file
         scope: defaults
         value: |

--- a/community/modules/scripts/spack-install/README.md
+++ b/community/modules/scripts/spack-install/README.md
@@ -161,7 +161,7 @@ No resources.
 | <a name="input_configs"></a> [configs](#input\_configs) | List of configuration options to set within spack.<br>    Configs can be of type 'single-config' or 'file'.<br>    All configs must specify a value, and a<br>    a scope. | `list(map(any))` | `[]` | no |
 | <a name="input_environments"></a> [environments](#input\_environments) | Defines a spack environment to configure. | <pre>list(object({<br>    name     = string<br>    packages = list(string)<br>  }))</pre> | `null` | no |
 | <a name="input_gpg_keys"></a> [gpg\_keys](#input\_gpg\_keys) | GPG Keys to trust within spack.<br>  Each key must define a type. Valid types are 'file' and 'new'.<br>  Keys of type 'file' must define a path to the key that<br>  should be trusted.<br>  Keys of type 'new' must define a 'name' and 'email' to create<br>  the key with. | `list(map(any))` | `[]` | no |
-| <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/apps/spack"` | no |
+| <a name="input_install_dir"></a> [install\_dir](#input\_install\_dir) | Directory to install spack into. | `string` | `"/sw/spack"` | no |
 | <a name="input_licenses"></a> [licenses](#input\_licenses) | List of software licenses to install within spack. | <pre>list(object({<br>    source = string<br>    dest   = string<br>  }))</pre> | `null` | no |
 | <a name="input_log_file"></a> [log\_file](#input\_log\_file) | Defines the logfile that script output will be written to | `string` | `"/dev/null"` | no |
 | <a name="input_packages"></a> [packages](#input\_packages) | Defines root packages for spack to install (in order). | `list(string)` | `[]` | no |

--- a/community/modules/scripts/spack-install/variables.tf
+++ b/community/modules/scripts/spack-install/variables.tf
@@ -27,7 +27,7 @@ variable "project_id" {
 variable "install_dir" {
   description = "Directory to install spack into."
   type        = string
-  default     = "/apps/spack"
+  default     = "/sw/spack"
 }
 
 variable "spack_url" {

--- a/examples/README.md
+++ b/examples/README.md
@@ -253,7 +253,7 @@ cluster with software installed with
 [Spack](../community/modules/scripts/spack-install/README.md) The controller
 will install and configure spack, and install
 [gromacs](https://www.gromacs.org/) using spack. Spack is installed in a shared
-location (/apps) via filestore. This build leverages the startup-script module
+location (/sw) via filestore. This build leverages the startup-script module
 and can be applied in any cluster by using the output of spack-install or
 startup-script modules.
 
@@ -278,7 +278,7 @@ node. To use spack in the controller or compute nodes, the following command
 must be run first:
 
 ```shell
-source /apps/spack/share/spack/setup-env.sh
+source /sw/spack/share/spack/setup-env.sh
 ```
 
 To load the gromacs module, use spack:


### PR DESCRIPTION
Move from /apps to /sw everywhere it's referenced. /apps is a shared mounted directory used with slurm-on-gcp, so we need to avoid mounting over top of it by default.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
