### PR TITLE
Add threads-per-node option for vm-instance

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -333,6 +333,13 @@ omnia-manager node and 2 omnia-compute nodes, on the pre-existing default
 network. Omnia will be automatically installed after the nodes are provisioned.
 All nodes mount a filestore instance on `/home`.
 
+**_NOTE:_** The omnia-cluster.yaml example uses `vm-instance` modules to create
+the cluster. For these instances, Simultaneous Multithreading (SMT) is turned
+off by default, meaning that only the physical cores are visible. For the
+compute nodes, this means that 30 physical cores are visible on the
+c2-standard-60 VMs. To activate all 60 virtual cores, include
+`threads_per_core=2` under settings for the compute vm-instance module.
+
 [omnia-cluster.yaml]: ../community/examples/omnia-cluster.yaml
 
 ## Blueprint Schema

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -22,6 +22,12 @@ This creates a cluster of 8 compute VMs named `compute-[0-7]` on the network
 defined by the `network1` module. The VMs are of type c2-standard-60 and mount
 the `homefs` file system module.
 
+> **_NOTE:_**: Simultaneous Multithreading (SMT) is deactivated by default
+> (threads_per_core=1), which means only the physical cores are visible on the
+> VM. With SMT disabled, a machine of type c2-standard-60 will only have the 30
+> physical cores visible. To change this, set `threads_per_core=2` under
+> settings.
+
 ### Placement
 
 The `placement_policy` variable can be used to control where your VM instances
@@ -132,6 +138,7 @@ No modules.
 | <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing, allowing for preemption | `bool` | `false` | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script used on the instance | `string` | `null` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to attach the VM. | `string` | `null` | no |
+| <a name="input_threads_per_core"></a> [threads\_per\_core](#input\_threads\_per\_core) | Sets the number of threads per physical core. By setting threads\_per\_core<br>greater than 1, Simultaneous Multithreading (SMT) is enabled extending the<br>total number of virtual cores. For example, a machine of type c2-standard-60<br>will have 60 virtual cores with threads\_per\_core equal to 2. With<br>threads\_per\_core equal to 1 (SMT turned off), only the 30 physical cores will<br>be available on the VM.<br><br>Disabling SMT can be more performant in many HPC workloads, therefore it is<br>disabled by default. | `number` | `1` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Compute Platform zone | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -123,5 +123,9 @@ resource "google_compute_instance" "compute_vm" {
     provisioning_model  = local.provisioning_model
   }
 
+  advanced_machine_features {
+    threads_per_core = var.threads_per_core
+  }
+
   metadata = merge(local.network_storage, local.startup_script, var.metadata)
 }

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -185,3 +185,19 @@ variable "spot" {
   type        = bool
   default     = false
 }
+
+variable "threads_per_core" {
+  description = <<-EOT
+  Sets the number of threads per physical core. By setting threads_per_core
+  greater than 1, Simultaneous Multithreading (SMT) is enabled extending the
+  total number of virtual cores. For example, a machine of type c2-standard-60
+  will have 60 virtual cores with threads_per_core equal to 2. With
+  threads_per_core equal to 1 (SMT turned off), only the 30 physical cores will
+  be available on the VM.
+
+  Disabling SMT can be more performant in many HPC workloads, therefore it is
+  disabled by default.
+  EOT
+  type        = number
+  default     = 1
+}

--- a/tools/validate_configs/test_configs/threads_per_core.yaml
+++ b/tools/validate_configs/test_configs/threads_per_core.yaml
@@ -1,0 +1,93 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: threads-per-core
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: threads-per-core
+  region: us-central1
+  zone: us-central1-c
+
+deployment_groups:
+- group: primary
+  modules:
+  # Source is an embedded module, denoted by "modules/*" without ./, ../, /
+  # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
+  # Example - ./modules/network/vpc
+  - source: modules/network/pre-existing-vpc
+    kind: terraform
+    id: network1
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: n1-2-threads
+    use:
+    - network1
+    settings:
+      name_prefix: n1-2-threads
+      machine_type: n1-standard-32
+      threads_per_core: 2
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: n1-1-thread
+    use:
+    - network1
+    settings:
+      name_prefix: n1-1-thread
+      machine_type: n1-standard-32
+      threads_per_core: 1
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: n2-2-threads
+    use:
+    - network1
+    settings:
+      name_prefix: n2-2-threads
+      machine_type: n2-standard-32
+      threads_per_core: 2
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: n2-1-thread
+    use:
+    - network1
+    settings:
+      name_prefix: n2-1-thread
+      machine_type: n2-standard-32
+      threads_per_core: 1
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: c2-2-threads
+    use:
+    - network1
+    settings:
+      name_prefix: c2-2-threads
+      machine_type: c2-standard-30
+      threads_per_core: 2
+
+  - source: ./modules/compute/vm-instance
+    kind: terraform
+    id: c2-1-thread
+    use:
+    - network1
+    settings:
+      name_prefix: c2-1-thread
+      machine_type: c2-standard-30
+      threads_per_core: 1


### PR DESCRIPTION
This commits add the [threads-per-core](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance#threads_per_core) advanced machine features option to the vm-instance module. Default is 1, as it is typically more performant in classic HPC workloads.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
