### PR TITLE
Reduce 'suspend_time' in example to minimize destroy leaving behind compute nodes 

### DIFF
--- a/examples/hpc-cluster-small.yaml
+++ b/examples/hpc-cluster-small.yaml
@@ -74,6 +74,7 @@ deployment_groups:
     - compute_partition
     settings:
       login_node_count: 1
+      suspend_time: 60
 
   - source: community/modules/scheduler/SchedMD-slurm-on-gcp-login-node
     kind: terraform


### PR DESCRIPTION
The default `suspend_time` is 5 minutes. This is a long time to ask our users to wait for nodes to be cleaned up in a 15 min tutorial. If we do not ask them to wait then there is a high likelihood that destroy will fail, requiring manual cleanup. It was decided that 1 minute was a reasonable time for the user to wait for cleanup.

Tested:
I manually tested to confirm the cleanup time. Nodes start to be deleted after 1 min but take another 3 minutes to actually be deleted fully.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
