### PR TITLE
Add `make install` option for root and user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ MIN_PACKER_VERSION=1.6 # for building images
 MIN_TERRAFORM_VERSION=1.0 # for deploying modules
 MIN_GOLANG_VERSION=1.16 # for building ghpc
 
-.PHONY: tests format add-google-license install-dev-deps \
+.PHONY: install install-user tests format add-google-license install-dev-deps \
         warn-go-missing warn-terraform-missing warn-packer-missing \
-				warn-go-version warn-terraform-version warn-packer-version \
-				test-engine validate_configs packer-check \
-				terraform-format packer-format \
+        warn-go-version warn-terraform-version warn-packer-version \
+        test-engine validate_configs packer-check \
+        terraform-format packer-format \
         check-tflint check-pre-commit
 
 ENG = ./cmd/... ./pkg/...
@@ -19,6 +19,21 @@ PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name 
 ghpc: warn-go-version warn-terraform-version warn-packer-version $(shell find ./cmd ./pkg ghpc.go -type f)
 	$(info **************** building ghpc ************************)
 	go build ghpc.go
+
+install-user:
+	$(info ******** installing ghpc in ~/bin *********************)
+	mkdir -p ~/bin
+	install -t ~/bin ./ghpc
+
+ifeq ($(shell id -u), 0)
+install:
+	$(info ***** installing ghpc in /usr/local/bin ***************)
+	install -t /usr/local/bin ./ghpc
+
+else
+install: install-user
+
+endif
 
 tests: warn-terraform-version warn-packer-version test-engine validate_configs packer-check
 

--- a/docs/tutorials/basic.md
+++ b/docs/tutorials/basic.md
@@ -61,6 +61,14 @@ build run:
 
 This should show you the version of the HPC Toolkit you are using.
 
+(Optional) To install the `ghpc` binary in your home directory under bin,
+run the following command:
+
+```bash
+make install
+exec $SHELL -l
+```
+
 ## Generate a Deployment
 
 To create a deployment, an input blueprint file needs to be written or adapted


### PR DESCRIPTION
`make install` will install in /usr/bin if running as root and default
to ~/bin if running as user. The option to force user install is
available as `make install-user`.

I attempted to also verify that /usr/bin exists, but couldn't find a clean way to do that. I'm open to suggestions.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
