### PR TITLE
Fix: terraform.tfstate.backup was written to terraform.tfstate during overwrite

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -263,9 +263,12 @@ func (s *MySuite) TestRestoreTfState(c *C) {
 		depDir, hiddenGhpcDirName, prevDeploymentGroupDirName, deploymentGroupName)
 	curDeploymentGroup := filepath.Join(depDir, deploymentGroupName)
 	prevStateFile := filepath.Join(prevDeploymentGroup, tfStateFileName)
+	prevBuStateFile := filepath.Join(prevDeploymentGroup, tfStateBackupFileName)
 	os.MkdirAll(prevDeploymentGroup, 0755)
 	os.MkdirAll(curDeploymentGroup, 0755)
 	emptyFile, _ := os.Create(prevStateFile)
+	emptyFile.Close()
+	emptyFile, _ = os.Create(prevBuStateFile)
 	emptyFile.Close()
 
 	testWriter := TFWriter{}
@@ -273,7 +276,10 @@ func (s *MySuite) TestRestoreTfState(c *C) {
 
 	// check state file was moved to current resource group dir
 	curStateFile := filepath.Join(curDeploymentGroup, tfStateFileName)
+	curBuStateFile := filepath.Join(curDeploymentGroup, tfStateBackupFileName)
 	_, err := os.Stat(curStateFile)
+	c.Check(err, IsNil)
+	_, err = os.Stat(curBuStateFile)
 	c.Check(err, IsNil)
 }
 

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -450,7 +450,7 @@ func (w TFWriter) restoreState(deploymentDir string) error {
 		var tfStateFiles = []string{tfStateFileName, tfStateBackupFileName}
 		for _, stateFile := range tfStateFiles {
 			src := filepath.Join(prevDeploymentGroupPath, f.Name(), stateFile)
-			dest := filepath.Join(deploymentDir, f.Name(), tfStateFileName)
+			dest := filepath.Join(deploymentDir, f.Name(), stateFile)
 
 			if bytesRead, err := ioutil.ReadFile(src); err == nil {
 				err = ioutil.WriteFile(dest, bytesRead, 0644)


### PR DESCRIPTION
The bug caused terraform.tfstate to be replaced with the contents of terraform.tfstate.backup during state restoration of the create overwrite process (`-w` flag).

Tested:
- ran the modified test prior to code change and observed expected failure

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
