### PR TITLE
Add explicit dependencies in VPC module

### DIFF
--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -17,37 +17,43 @@
 output "network_name" {
   description = "The name of the network created"
   value       = module.vpc.network_name
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "network_self_link" {
   description = "The URI of the VPC being created"
   value       = module.vpc.network_self_link
-
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "subnetworks" {
   description = "All subnetwork resources created by this module"
   value       = module.vpc.subnets
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "subnetwork" {
   description = "The primary subnetwork object created by the input variable primary_subnetwork"
   value       = local.primary_subnetwork
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "subnetwork_name" {
   description = "The name of the primary subnetwork"
   value       = local.primary_subnetwork_name
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "subnetwork_self_link" {
   description = "The self-link to the primary subnetwork"
   value       = local.primary_subnetwork_self_link
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "subnetwork_address" {
   description = "The address range of the primary subnetwork"
   value       = local.primary_subnetwork_ip_cidr_range
+  depends_on  = [module.firewall_rules, module.cloud_router]
 }
 
 output "nat_ips" {


### PR DESCRIPTION
* Most VPC module outputs now depend explicitly upon the firewall rules
  and Cloud Router created by the module. This ensures that any
  resources that depend only upon the VPC or subnetwork names are not
  created until connectivity is active

Take this blueprint:

```yaml
---

blueprint_name: simple-vm

vars:
  deployment_name: simple-vm
  region: us-central1
  zone: us-central1-c

deployment_groups:
- group: primary
  modules:
  - source: modules/network/vpc
    kind: terraform
    id: network1
  - source: modules/compute/vm-instance
    kind: terraform
    id: compute
    use:
    - network1
    settings:
      machine_type: n2d-standard-4
      disable_public_ips: true
```

Status quo will build the VM in parallel with router and firewall rules:

```
module.compute.google_compute_instance.compute_vm[0]: Creating...
module.network1.module.firewall_rules.google_compute_firewall.rules["simple-vm-net-allow-internal-traffic"]: Creation complete after 11s [id=projects/toolkit-demo-not-a-real-project/global/firewalls/simple-vm-net-allow-internal-traffic]
module.network1.module.firewall_rules.google_compute_firewall.rules["simple-vm-net-allow-iap-ssh-ingress"]: Still creating... [20s elapsed]
module.network1.module.cloud_router["us-central1"].google_compute_router_nat.nats["cloud-nat-us-central1"]: Still creating... [10s elapsed]
module.compute.google_compute_instance.compute_vm[0]: Still creating... [10s elapsed]
module.network1.module.firewall_rules.google_compute_firewall.rules["simple-vm-net-allow-iap-ssh-ingress"]: Creation complete after 22s [id=projects/toolkit-demo-not-a-real-project/global/firewalls/simple-vm-net-allow-iap-ssh-ingress]
module.network1.module.cloud_router["us-central1"].google_compute_router_nat.nats["cloud-nat-us-central1"]: Creation complete after 11s [id=toolkit-demo-not-a-real-project/us-central1/simple-vm-net-router/cloud-nat-us-central1]
module.compute.google_compute_instance.compute_vm[0]: Creation complete after 12s [id=projects/toolkit-demo-not-a-real-project/zones/us-central1-c/instances/simple-vm-0]
```

With the new fix, the VM is not created until the network is truly ready:

```
module.network1.module.vpc.module.subnets.google_compute_subnetwork.subnetwork["us-central1/simple-vm-primary-subnet"]: Creation complete after 11s [id=projects/toolkit-demo-not-a-real-project/regions/us-central1/subnetworks/simple-vm-primary-subnet]
module.network1.module.firewall_rules.google_compute_firewall.rules["simple-vm-net-allow-iap-ssh-ingress"]: Creation complete after 11s [id=projects/toolkit-demo-not-a-real-project/global/firewalls/simple-vm-net-allow-iap-ssh-ingress]
module.network1.module.firewall_rules.google_compute_firewall.rules["simple-vm-net-allow-internal-traffic"]: Creation complete after 11s [id=projects/toolkit-demo-not-a-real-project/global/firewalls/simple-vm-net-allow-internal-traffic]
module.network1.module.cloud_router["us-central1"].google_compute_router_nat.nats["cloud-nat-us-central1"]: Still creating... [10s elapsed]
module.network1.module.cloud_router["us-central1"].google_compute_router_nat.nats["cloud-nat-us-central1"]: Still creating... [20s elapsed]
module.network1.module.cloud_router["us-central1"].google_compute_router_nat.nats["cloud-nat-us-central1"]: Creation complete after 21s [id=toolkit-demo-not-a-real-project/us-central1/simple-vm-net-router/cloud-nat-us-central1]
module.compute.google_compute_instance.compute_vm[0]: Creating...
module.compute.google_compute_instance.compute_vm[0]: Still creating... [10s elapsed]
module.compute.google_compute_instance.compute_vm[0]: Creation complete after 12s [id=projects/toolkit-demo-not-a-real-project/zones/us-central1-c/instances/simple-vm-0]
```

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?