### PR TITLE
Fix make tests

### DIFF
--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -108,13 +108,11 @@ pids=()
 for example in $CONFIGS; do
 	JNUM=$(jobs | wc -l)
 	# echo "$JNUM jobs running"
-	if [ "$JNUM" -lt "$NPROCS" ]; then
-		run_test "$example" &
-		pids+=("$!")
-	else
-		# echo "Reached max number of parallel tests (${JNUM}). Waiting for one to finish."
+	if [ "$JNUM" -ge "$NPROCS" ]; then
 		check_background
 	fi
+	run_test "$example" &
+	pids+=("$!")
 done
 JNUM=$(jobs | wc -l)
 while [ "$JNUM" -gt 0 ]; do


### PR DESCRIPTION
* current solution was skipping over 1 test every time check_background
  completed; on older releases of bash this resulted in only 2 or
  3 tests being skipped; on newer releases this led to approximately
  N_CPUs tests being skipped

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?