### PR TITLE
Update name of previous resource groups folder to match new schema

### DIFF
--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	hiddenGhpcDirName          = ".ghpc"
-	prevDeploymentGroupDirName = "previous_resource_groups"
+	prevDeploymentGroupDirName = "previous_deployment_groups"
 	gitignoreTemplate          = "deployment.gitignore.tmpl"
 )
 
@@ -163,7 +163,7 @@ func isOverwriteAllowed(depDir string, overwritingConfig *config.Blueprint, over
 		return false
 	}
 
-	// build list of previous and current resource groups
+	// build list of previous and current deployment groups
 	var prevGroups []string
 	for _, f := range files {
 		if f.IsDir() && f.Name() != hiddenGhpcDirName {
@@ -242,7 +242,7 @@ func prepDepDir(depDir string, overwrite bool) error {
 		return fmt.Errorf("Failed to create directory to save previous deployment groups at %s: %w", prevGroupDir, err)
 	}
 
-	// move resource groups
+	// move deployment groups
 	files, err := ioutil.ReadDir(depDir)
 	if err != nil {
 		return fmt.Errorf("Error trying to read directories in %s, %w", depDir, err)


### PR DESCRIPTION
This should be backward compatible with older versions. The only side effect of using across versions would be that you might have an old `previous_resource_groups` directory left behind that will not be cleaned up.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [x] Are all tests passing? `make tests`
* [x] If applicable, have you written additional unit tests to cover this
  change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated any application documentation such as READMEs and user
  guides?
* [x] Have you followed the guidelines in our Contributing document?
