### PR TITLE
Add example for custom firewall rule applied to SSH bastion

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -138,6 +138,7 @@ No modules.
 | <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing, allowing for preemption | `bool` | `false` | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script used on the instance | `string` | `null` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to attach the VM. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tags, provided as a list | `list(string)` | `[]` | no |
 | <a name="input_threads_per_core"></a> [threads\_per\_core](#input\_threads\_per\_core) | Sets the number of threads per physical core. By setting threads\_per\_core<br>greater than 1, Simultaneous Multithreading (SMT) is enabled extending the<br>total number of virtual cores. For example, a machine of type c2-standard-60<br>will have 60 virtual cores with threads\_per\_core equal to 2. With<br>threads\_per\_core equal to 1 (SMT turned off), only the 30 physical cores will<br>be available on the VM.<br><br>Disabling SMT can be more performant in many HPC workloads, therefore it is<br>disabled by default. | `number` | `1` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | Compute Platform zone | `string` | n/a | yes |
 

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -84,6 +84,7 @@ resource "google_compute_instance" "compute_vm" {
 
   resource_policies = google_compute_resource_policy.placement_policy[*].self_link
 
+  tags   = var.tags
   labels = var.labels
 
   boot_disk {

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -186,6 +186,12 @@ variable "spot" {
   default     = false
 }
 
+variable "tags" {
+  description = "Network tags, provided as a list"
+  type        = list(string)
+  default     = []
+}
+
 variable "threads_per_core" {
   description = <<-EOT
   Sets the number of threads per physical core. By setting threads_per_core


### PR DESCRIPTION
Add support for network tags to `vm-instance` module and make use of it in SSH bastion example.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? `pre-commit
  install`
* [X] Are all tests passing? `make tests`
* [X] If applicable, have you written additional unit tests to cover this
  change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated any application documentation such as READMEs and user
  guides?
* [X] Have you followed the guidelines in our Contributing document?
