### PR TITLE
Changes to SSH key metadata should not trigger action by Terraform

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -28,6 +28,16 @@ the `homefs` file system module.
 > physical cores visible. To change this, set `threads_per_core=2` under
 > settings.
 
+### SSH key metadata
+
+This module will ignore all changes to the `ssh-keys` metadata field that are
+typically set by [external Google Cloud tools that automate SSH access][gcpssh]
+when not using OS Login. For example, clicking on the Google Cloud Console SSH
+button next to VMs in the VM Instances list will temporarily modify VM metadata
+to include a dynamically-generated SSH public key.
+
+[gcpssh]: https://cloud.google.com/compute/docs/connect/add-ssh-keys#metadata
+
 ### Placement
 
 The `placement_policy` variable can be used to control where your VM instances

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -128,4 +128,10 @@ resource "google_compute_instance" "compute_vm" {
   }
 
   metadata = merge(local.network_storage, local.startup_script, var.metadata)
+
+  lifecycle {
+    ignore_changes = [
+      metadata["ssh-keys"],
+    ]
+  }
 }


### PR DESCRIPTION
Without this change, the SSH key metadata added by GCP when you SSH into a machine will trigger an in-place update of the VM. With this change, it will silently accept the metadata into its state without changing the VM. It affects no other metadata and has been tested with and without the ssh-keys field present.

```
  ~ resource "google_compute_instance" "compute_vm" {
        id                   = "projects/toolkit-demo-zero-e913/zones/us-central1-c/instances/image-builder-001-0"
      ~ metadata             = {
          - "ssh-keys"        = <<-EOT
                tpdownes:ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlHeNNycK75rZ+OmGzqUykP8B/rfyYYrEjEw9TJsRo6M= google-ssh {"userName":"tpdownes@google.com","expireOn":"2022-05-17T17:44:33+0000"}
                tpdownes:ssh-rsa AAAAB3NzaC1yc2E1Tk1sNxiMequCXHC4c= google-ssh {"userName":"tpdownes@google.com","expireOn":"2022-05-17T17:44:48+0000"}
            EOT -> null
            # (2 unchan
```
### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [X] Have you written unit tests to cover this change?
* [X] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?