### PR TITLE
Change global variables to deployment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,9 +245,9 @@ deployed.
 ## Blueprint Warnings and Errors
 
 By default, each blueprint is configured with a number of "validator" functions
-which perform basic tests of your global variables. If `project_id`, `region`,
-and `zone` are defined as global variables, then the following validators are
-enabled:
+which perform basic tests of your deployment variables. If `project_id`,
+`region`, and `zone` are defined as deployment variables, then the following
+validators are enabled:
 
 ```yaml
 validators:

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,18 +11,18 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
 * [Instructions](#instructions)
   * [(Optional) Setting up a remote terraform state](#optional-setting-up-a-remote-terraform-state)
 * [Blueprint Descriptions](#blueprint-descriptions)
-  * [hpc-cluster-small.yaml](#hpc-cluster-smallyaml-)
-  * [hpc-cluster-high-io.yaml](#hpc-cluster-high-ioyaml-)
-  * [image-builder.yaml](#image-builderyaml-)
-  * [hpc-cluster-intel-select.yaml](#hpc-cluster-intel-selectyaml-)
-  * [daos-cluster.yaml](#daos-clusteryaml-)
-  * [daos-slurm.yaml](#daos-slurmyaml-)
-  * [spack-gromacs.yaml](#spack-gromacsyaml--)
-  * [omnia-cluster.yaml](#omnia-clusteryaml--)
+  * [hpc-cluster-small.yaml](#hpc-cluster-smallyaml-core-badge)
+  * [hpc-cluster-high-io.yaml](#hpc-cluster-high-ioyaml-core-badge)
+  * [image-builder.yaml](#image-builderyaml-core-badge)
+  * [hpc-cluster-intel-select.yaml](#hpc-cluster-intel-selectyaml-community-badge)
+  * [daos-cluster.yaml](#daos-clusteryaml-community-badge)
+  * [daos-slurm.yaml](#daos-slurmyaml-community-badge)
+  * [spack-gromacs.yaml](#spack-gromacsyaml-community-badge-experimental-badge)
+  * [omnia-cluster.yaml](#omnia-clusteryaml-community-badge-experimental-badge)
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Top Level Parameters](#top-level-parameters)
-  * [Global Variables](#global-variables)
+  * [Deployment Variables](#deployment-variables)
   * [Deployment Groups](#deployment-groups)
 * [Variables](#variables)
   * [Blueprint Variables](#blueprint-variables)
@@ -34,7 +34,7 @@ Ensure your project\_id is set and other deployment variables such as zone and
 region are set correctly under `vars` before creating and deploying an example
 blueprint.
 
-Please note that global variables defined under `vars` are automatically
+Please note that deployment variables defined under `vars` are automatically
 passed to modules if the modules have an input that matches the variable name.
 
 ### (Optional) Setting up a remote terraform state
@@ -445,44 +445,45 @@ deployment_groups:
 
 ## Writing an HPC Blueprint
 
-The blueprint file is composed of 3 primary parts, top-level parameters, global
-variables and deployment groups. These are described in more detail below.
+The blueprint file is composed of 3 primary parts, top-level parameters,
+deployment variables and deployment groups. These are described in more detail
+below.
 
 ### Top Level Parameters
 
 * **blueprint_name** (required): This name can be used to track resources and
   usage across multiple deployments that come from the same blueprint.
 
-### Global Variables
+### Deployment Variables
 
 ```yaml
 vars:
   region: "us-west-1"
   labels:
-    "user-defined-global-label": "slurm-cluster"
+    "user-defined-deployment-label": "slurm-cluster"
   ...
 ```
 
-Global variables are set under the vars field at the top level of the blueprint
-file. These variables can be explicitly referenced in modules as
+Deployment variables are set under the vars field at the top level of the
+blueprint file. These variables can be explicitly referenced in modules as
 [Blueprint Variables](#blueprint-variables). Any module setting (inputs) not
-explicitly provided and matching exactly a global variable name will
+explicitly provided and matching exactly a deployment variable name will
 automatically be set to these values.
 
-Global variables should be used with care. Module default settings with the
-same name as a global variable and not explicitly set will be overwritten by the
-global variable.
+Deployment variables should be used with care. Module default settings with the
+same name as a deployment variable and not explicitly set will be overwritten by
+the deployment variable.
 
-The global “labels” variable is a special case as it will be appended to labels
-found in module settings, whereas normally an explicit module setting would
-be left unchanged. This ensures that global labels can be set alongside module
-specific labels. Precedence is given to the module specific labels if a
-collision occurs. Default module labels will still be overwritten by global
-labels.
+The “labels” deployment variable is a special case as it will be appended to
+labels found in module settings, whereas normally an explicit module setting
+would be left unchanged. This ensures that the deployment-wide labels can be
+set alongside module specific labels. Precedence is given to the module specific
+labels if a collision occurs. Default module labels will still be overwritten by
+deployment labels.
 
 The HPC Toolkit uses special reserved labels for monitoring each deployment.
-These are set automatically, but can be overridden through global vars or
-module settings. They include:
+These are set automatically, but can be overridden in vars or module settings.
+They include:
 
 * ghpc_blueprint: The name of the blueprint the deployment was created from
 * ghpc_deployment: The name of the specific deployment
@@ -525,8 +526,8 @@ and to the output and structure of other modules.
 
 ### Blueprint Variables
 
-Variables in a blueprint file can refer to global variables or the outputs of
-other modules. For global and module variables, the syntax is as follows:
+Variables in a blueprint file can refer to deployment variables or the outputs
+of other modules. For deployment and module variables, the syntax is as follows:
 
 ```yaml
 vars:
@@ -545,8 +546,8 @@ deployment_groups:
             key2: $(resource1.name)
 ```
 
-The variable is referred to by the source, either vars for global or the
-module ID for module variables, followed by the name of the value being
+The variable is referred to by the source, either vars for deploment variables
+or the module ID for module variables, followed by the name of the value being
 referenced. The entire variable is then wrapped in “$()”.
 
 Currently, references to variable attributes and string operations with

--- a/modules/README.md
+++ b/modules/README.md
@@ -211,7 +211,7 @@ settings will become the values for the variables defined in either the
 
 For some modules, there are mandatory variables that must be set,
 therefore `settings` is a required field in that case. In many situations, a
-combination of sensible defaults, global variables and used modules can
+combination of sensible defaults, deployment variables and used modules can
 populated all required settings and therefore the settings field can be left out
 entirely.
 
@@ -251,7 +251,7 @@ value is the following:
 
 1. Explicitly set in the blueprint by the user
 1. Output from a used module, taken in the order provided in the `use` list
-1. Global variable (`vars`) of the same name
+1. Deployment variable (`vars`) of the same name
 1. Default value for the setting
 
 ### Outputs (Optional)
@@ -267,9 +267,9 @@ have in the
 
 The following common naming conventions should be used to decrease the verbosity
 needed to define a blueprint. This is intentional to allow multiple
-modules to share inferred settings from global variables. For example, if all
-modules are to be created in a single region, that region can be defined as a
-global variable, which is shared between all moduels without an explicit
+modules to share inferred settings from deployment variables. For example, if
+all modules are to be created in a single region, that region can be defined as
+a deployment variable, which is shared between all moduels without an explicit
 setting.
 
 * **project_id**: The GCP project ID in which to create the GCP resources.

--- a/modules/network/pre-existing-vpc/README.md
+++ b/modules/network/pre-existing-vpc/README.md
@@ -21,7 +21,7 @@ sharing a single network module between deployment groups.
 
 This creates a pre-existing-vpc module based on the "default" VPC network in
 the GCP project. "default" is the default for network_name unless otherwise
-provided. Note that the project_id setting would be inferred from the global
+provided. Note that the project_id setting would be inferred from the deployment
 variable of the same name, but it was included here for clarity.
 
 ## License

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -60,8 +60,8 @@ with `_net` appended. `network_name` can be set manually as well as part of the
 settings.
 
 Note that `deployment_name` does not need to be set explicitly here,
-it would typically be inferred from the global variable of the same name. It was
-included for clarity.
+it would typically be inferred from the deployment variable of the same name. It
+was included for clarity.
 
 ## License
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -46,7 +46,7 @@ var errorMessages = map[string]string{
 	"fileSaveError":      "failed to write the expanded yaml",
 	// expand
 	"missingSetting":    "a required setting is missing from a module",
-	"globalLabelType":   "global labels are not a map",
+	"globalLabelType":   "deployment variable 'labels' are not a map",
 	"settingsLabelType": "labels in module settings are not a map",
 	"invalidVar":        "invalid variable definition in",
 	"varNotFound":       "Could not find source of variable",
@@ -550,7 +550,7 @@ func (err *DeploymentNameError) Error() string {
 func (b Blueprint) ResolveGlobalVariables(ctyVars map[string]cty.Value) error {
 	origin, err := ConvertMapToCty(b.Vars)
 	if err != nil {
-		return fmt.Errorf("error converting global variables to cty: %w", err)
+		return fmt.Errorf("error converting deployment variables to cty: %w", err)
 	}
 	return ResolveVariables(ctyVars, origin)
 }

--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -65,7 +65,7 @@ func (dc *DeploymentConfig) expand() {
 
 	if err := dc.applyGlobalVariables(); err != nil {
 		log.Fatalf(
-			"failed to apply global variables in modules when expanding the config: %v",
+			"failed to apply deployment variables in modules when expanding the config: %v",
 			err)
 	}
 	dc.expandVariables()
@@ -342,7 +342,7 @@ func updateGlobalVarTypes(vars map[string]interface{}) error {
 	for k, v := range vars {
 		val, err := updateVariableType(v, varContext{}, make(map[string]int))
 		if err != nil {
-			return fmt.Errorf("error setting type for global variable %s: %v", k, err)
+			return fmt.Errorf("error setting type for deployment variable %s: %v", k, err)
 		}
 		vars[k] = val
 	}
@@ -400,7 +400,7 @@ func expandSimpleVariable(
 	if varSource == "vars" { // Global variable
 		// Verify global variable exists
 		if _, ok := context.blueprint.Vars[varValue]; !ok {
-			return "", fmt.Errorf("%s: %s is not a global variable",
+			return "", fmt.Errorf("%s: %s is not a deployment variable",
 				errorMessages["varNotFound"], context.varString)
 		}
 		return fmt.Sprintf("((var.%s))", varValue), nil

--- a/pkg/config/validate.go
+++ b/pkg/config/validate.go
@@ -110,11 +110,11 @@ func (dc DeploymentConfig) executeValidators() error {
 // validateVars checks the global variables for viable types
 func (dc DeploymentConfig) validateVars() error {
 	vars := dc.Config.Vars
-	nilErr := "global variable %s was not set"
+	nilErr := "deployment variable %s was not set"
 
 	// Check for project_id
 	if _, ok := vars["project_id"]; !ok {
-		log.Println("WARNING: No project_id in global variables")
+		log.Println("WARNING: No project_id in deployment variables")
 	}
 
 	// Check type of labels (if they are defined)
@@ -427,9 +427,9 @@ func (dc *DeploymentConfig) getStringValue(inputReference interface{}) (string, 
 				if ok {
 					return valString, nil
 				}
-				return "", fmt.Errorf("the global variable %s is not a string", inputReference)
+				return "", fmt.Errorf("the deployment variable %s is not a string", inputReference)
 			}
 		}
 	}
-	return "", fmt.Errorf("the value %s is not a global variable or was not defined", inputReference)
+	return "", fmt.Errorf("the value %s is not a deployment variable or was not defined", inputReference)
 }

--- a/pkg/config/validator_test.go
+++ b/pkg/config/validator_test.go
@@ -47,7 +47,7 @@ func (s *MySuite) TestValidateVars(c *C) {
 	// Fail: Nil project_id
 	dc.Config.Vars["project_id"] = nil
 	err = dc.validateVars()
-	c.Assert(err, ErrorMatches, "global variable project_id was not set")
+	c.Assert(err, ErrorMatches, "deployment variable project_id was not set")
 
 	// Success: project_id not set
 	delete(dc.Config.Vars, "project_id")

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -64,7 +64,7 @@ func (w PackerWriter) writeDeploymentGroup(
 	ctyGlobals, err := config.ConvertMapToCty(globalVars)
 	if err != nil {
 		return fmt.Errorf(
-			"error converting global vars to cty for writing: %w", err)
+			"error converting deployment vars to cty for writing: %w", err)
 	}
 	groupPath := filepath.Join(deployDir, depGroup.Name)
 	for _, mod := range depGroup.Modules {

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -382,7 +382,7 @@ func (w TFWriter) writeDeploymentGroup(
 	ctyVars, err := config.ConvertMapToCty(globalVars)
 	if err != nil {
 		return fmt.Errorf(
-			"error converting global vars to cty for writing: %v", err)
+			"error converting deployment vars to cty for writing: %v", err)
 	}
 
 	writePath := filepath.Join(deploymentDir, depGroup.Name)

--- a/tools/validate_configs/test_configs/pre-existing-fs.yaml
+++ b/tools/validate_configs/test_configs/pre-existing-fs.yaml
@@ -28,7 +28,7 @@ deployment_groups:
 - group: storage
   modules:
   # the pre-existing-vpc is not needed here, since filestore will use the
-  # network-name from global vars
+  # network-name from deployment vars
   - source: modules/file-system/filestore
     kind: terraform
     id: homefs-filestore


### PR DESCRIPTION
Only affects external facing references, code still refers to global
variables in places.

Also fixed the TOC in the main README - the badges are a required part of the header reference

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
