### PR TITLE
Set enable-oslogin: TRUE by default in VM instance module

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -132,7 +132,7 @@ No modules.
 | <a name="input_disable_public_ips"></a> [disable\_public\_ips](#input\_disable\_public\_ips) | If set to true, instances will not have public IPs | `bool` | `false` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of disk for instances. | `number` | `200` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Disk type for instances. | `string` | `"pd-standard"` | no |
-| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable OS Login on VMs | `string` | `"TRUE"` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with "TRUE" or "FALSE". Set to empty string to inherit project OS Login setting. | `string` | `"TRUE"` | no |
 | <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br>    type  = string,<br>    count = number<br>  }))</pre> | `[]` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances | `number` | `1` | no |
 | <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Instance Image | <pre>object({<br>    family  = string,<br>    project = string<br>  })</pre> | <pre>{<br>  "family": "hpc-centos-7",<br>  "project": "cloud-hpc-image-public"<br>}</pre> | no |

--- a/modules/compute/vm-instance/main.tf
+++ b/modules/compute/vm-instance/main.tf
@@ -130,7 +130,7 @@ resource "google_compute_instance" "compute_vm" {
     threads_per_core = var.threads_per_core
   }
 
-  metadata = merge(local.network_storage, local.startup_script, var.metadata, local.enable_oslogin)
+  metadata = merge(local.network_storage, local.startup_script, local.enable_oslogin, var.metadata)
 
   lifecycle {
     ignore_changes = [

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -209,11 +209,11 @@ variable "threads_per_core" {
 }
 
 variable "enable_oslogin" {
-  description = "Enable OS Login on VMs"
+  description = "Enable or Disable OS Login with \"TRUE\" or \"FALSE\". Set to empty string to inherit project OS Login setting."
   type        = string
   default     = "TRUE"
   validation {
-    condition     = var.enable_oslogin == null ? true : contains(["TRUE", "FALSE", ""], var.enable_oslogin)
+    condition     = var.enable_oslogin == null ? false : contains(["TRUE", "FALSE", ""], var.enable_oslogin)
     error_message = "When set, the enable_oslogin must be set to TRUE, FALSE or \"\"."
   }
 }


### PR DESCRIPTION
### Problem
NFS mount at `/home` like [community/examples/omnia-cluster.yaml](https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/develop/community/examples/omnia-cluster.yaml) breaks the ability to `gcloud compute ssh` into the nodes (OS Login is disabled). This is because the startup-script to mount NFS at /home runs after SSH setting by agent.

### Solution
To address this, we have decided the following change:

```
We decided that the VM instance module should set enable-oslogin: "TRUE" by default but that it should be configurable so that it can be set explicitly to TRUE, FALSE or inherit from the project.

I think the value for "INHERIT" ought to be null or the empty string. I think I prefer null but not sure if that's easily validated.
```

### Test: None enable-oslogin set in YAML config

**Input:**

Not set enable-oslogin in YAML config.

```
$ cat community/examples/omnia-cluster.yaml
vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: omnia-cluster
  zone: us-central1-c
  region: us-central1
```

**Result:**

`"enable-oslogin"  = "TRUE"` is set by default.

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" community/examples/omnia-cluster.yaml --backend-config "type=gcs,bucket=sandbox-of-hayahito-kawamitsu.appspot.com" -o enable_oslogin_null
$ terraform -chdir=enable_oslogin_null/omnia-cluster/primary init
$ terraform -chdir=enable_oslogin_null/omnia-cluster/primary plan
# module.manager.google_compute_instance.compute_vm[0] will be created
  + resource "google_compute_instance" "compute_vm" {
      ...
      + machine_type         = "n2-standard-4"
      + metadata             = {
          + "enable-oslogin"  = "TRUE"
          + "network_storage" = jsonencode(
          ...
```

### Test: enable_oslogin: "TRUE" set in YAML config explicitly

**Input:**

Set `enable_oslogin: "TRUE"` in YAML config explicitly.

```
$ cat community/examples/omnia-cluster.yaml
vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: omnia-cluster
  zone: us-central1-c
  region: us-central1
  enable_oslogin: "TRUE"
```

**Result:**

`"enable-oslogin"  = "TRUE"` is set.

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" community/examples/omnia-cluster.yaml --backend-config "type=gcs,bucket=sandbox-of-hayahito-kawamitsu.appspot.com" -o enable_oslogin_true
$ terraform -chdir=enable_oslogin_true/omnia-cluster/primary init
$ terraform -chdir=enable_oslogin_true/omnia-cluster/primary plan
# module.manager.google_compute_instance.compute_vm[0] will be created
  + resource "google_compute_instance" "compute_vm" {
      ...
      + metadata             = {
          + "enable-oslogin"  = "TRUE"
          + "network_storage" = jsonencode(
          ...
```

### Test: enable_oslogin: "FALSE" set in YAML config explicitly

**Input:**

Set `enable_oslogin: "FALSE"` in YAML config explicitly.

```
$ cat community/examples/omnia-cluster.yaml
vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: omnia-cluster
  zone: us-central1-c
  region: us-central1
  enable_oslogin: "FALSE"
```

**Result:**

`"enable-oslogin"  = "FALSE"` is set.

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" community/examples/omnia-cluster.yaml --backend-config "type=gcs,bucket=sandbox-of-hayahito-kawamitsu.appspot.com" -o enable_oslogin_false
$ terraform -chdir=enable_oslogin_false/omnia-cluster/primary init
$ terraform -chdir=enable_oslogin_false/omnia-cluster/primary plan
# module.manager.google_compute_instance.compute_vm[0] will be created
  + resource "google_compute_instance" "compute_vm" {
      ...
      + metadata             = {
          + "enable-oslogin"  = "FALSE"
          + "network_storage" = jsonencode(
          ...
```

### Test: enable_oslogin: "" set in YAML config

**Input:**

Set `enable_oslogin: ""` in YAML config.

```
$ cat community/examples/omnia-cluster.yaml
vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: omnia-cluster
  zone: us-central1-c
  region: us-central1
  enable_oslogin: ""
```

**Result:**

`enable-oslogin` is not set, and it can be inherited from the project.

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" community/examples/omnia-cluster.yaml --backend-config "type=gcs,bucket=sandbox-of-hayahito-kawamitsu.appspot.com" -o enable_oslogin_empty
$ terraform -chdir=enable_oslogin_empty/omnia-cluster/primary init
$ terraform -chdir=enable_oslogin_empty/omnia-cluster/primary plan
# module.manager.google_compute_instance.compute_vm[0] will be created
  + resource "google_compute_instance" "compute_vm" {
      ...
      + metadata             = {
          + "network_storage" = jsonencode(
                [
                  + {
                      + fs_type       = "nfs"
                      + local_mount   = "/home"
                      + mount_options = "defaults,_netdev"
                      + remote_mount  = "nfsshare"
                      + server_ip     = "10.93.62.186"
                    },
                ]
            )
          + "startup-script"  = <<-EOT
               ...
            EOT
        }
```

### Test: enable_oslogin: "WRONG_INPUT" set in YAML config

**Input:**

Set `enable_oslogin: "WRONG_INPUT"` in YAML config explicitly.

```
$ cat community/examples/omnia-cluster.yaml
vars:
  project_id:  ## Set GCP Project ID Here ##
  deployment_name: omnia-cluster
  zone: us-central1-c
  region: us-central1
  enable_oslogin: "WRONG_INPUT"
```

**Result:**

It doesn't work because the input value is invalid.

```
$ ./ghpc create --vars "project_id=${PROJECT_ID}" community/examples/omnia-cluster.yaml --backend-config "type=gcs,bucket=sandbox-of-hayahito-kawamitsu.appspot.com" -o enable_oslogin_wrong_input
$ terraform -chdir=enable_oslogin_wrong_input/omnia-cluster/primary init
$ terraform -chdir=enable_oslogin_wrong_input/omnia-cluster/primary plan
...
╷
│ Error: Invalid value for variable
│ 
│   on main.tf line 81, in module "manager":
│   81:   enable_oslogin       = var.enable_oslogin
│ 
│ When set, the enable_oslogin must be set to TRUE, FALSE or "".
│ 
│ This was checked by the validation rule at modules/vm-instance/variables.tf:187,3-13.
╵
╷
│ Error: Invalid value for variable
│ 
│   on main.tf line 100, in module "compute":
│  100:   enable_oslogin       = var.enable_oslogin
│ 
│ When set, the enable_oslogin must be set to TRUE, FALSE or "".
│ 
│ This was checked by the validation rule at modules/vm-instance/variables.tf:187,3-13.
╵
```

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
