### PR TITLE
Fix a typo in spack buildcache flag

### DIFF
--- a/community/modules/scripts/spack-install/templates/install_spack.tpl
+++ b/community/modules/scripts/spack-install/templates/install_spack.tpl
@@ -124,7 +124,7 @@ echo "$PREFIX Populating defined buildcaches"
     # shellcheck disable=SC2046
     spack buildcache create --mirror-url ${c.path} -af $(spack find --format /{hash})
     spack gpg publish --mirror-url ${c.path}
-    spack buildcache update-index -mirror-url ${c.path} --keys
+    spack buildcache update-index --mirror-url ${c.path} --keys
   %{endif ~}
 %{endfor ~}
 


### PR DESCRIPTION
This merge fixes a bug in the spack resource (a hyphen was missing) related to populating a build cache.

### Submission Checklist

* [X] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [X] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [ ] Is unit test coverage still above 80%?
* [X] Have you updated all applicable documentation?
* [X] Have you followed the guidelines in our Contributing document?
