### PR TITLE
Update find and install commands to be BSD compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ MIN_GOLANG_VERSION=1.16 # for building ghpc
         check-tflint check-pre-commit
 
 ENG = ./cmd/... ./pkg/...
-TERRAFORM_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.tf" -not -path '*/\.*' -printf '%h\n' | sort -u)
-PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.pkr.hcl" -not -path '*/\.*' -printf '%h\n' | sort -u)
+TERRAFORM_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.tf" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
+PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.pkr.hcl" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
 
 # RULES MEANT TO BE USED DIRECTLY
 
@@ -23,12 +23,12 @@ ghpc: warn-go-version warn-terraform-version warn-packer-version $(shell find ./
 install-user:
 	$(info ******** installing ghpc in ~/bin *********************)
 	mkdir -p ~/bin
-	install -t ~/bin ./ghpc
+	install ./ghpc ~/bin
 
 ifeq ($(shell id -u), 0)
 install:
 	$(info ***** installing ghpc in /usr/local/bin ***************)
-	install -t /usr/local/bin ./ghpc
+	install ./ghpc /usr/local/bin
 
 else
 install: install-user

--- a/README.md
+++ b/README.md
@@ -597,15 +597,14 @@ List of dependencies:
 
 ### MacOS Additional Dependencies
 
-When building the ghpc binary on a Mac there may be some special considerations.
+On macOS, `make` is packaged with the Xcode command line developer tools. To
+install, run the following command:
 
-When you call `make` for the first time you may be asked to install xcode
-developer tools. Alternatively you can build `ghpc` directly using
-`go build ghpc.go`.
+```shell
+xcode-select --install
+```
 
-If you choose to use `make`, you should install `coreutils` and `findutils`
-which are available from common package managers on macOS such as Homebrew,
-Macports, and conda.
+Alternatively you can build `ghpc` directly using `go build ghpc.go`.
 
 ### Notes on Packer
 
@@ -666,6 +665,14 @@ Follow these steps to install and setup pre-commit in your cloned repository:
     ```
 
 Now pre-commit is configured to automatically run before you commit.
+
+### Development on macOS
+
+While macOS is a supported environment for building and executing the Toolkit,
+it is not supported for Toolkit development due to GNU specific shell scripts.
+
+If developing on a mac, a workaround is to install GNU tooling by installing
+`coreutils` and `findutils` from a package manager such as homebrew or conda.
 
 ### Contributing
 


### PR DESCRIPTION
Tested:
- I have run `make` and `make install` on mac, linux desktop, & cloud shell
- I ran individual find commands in all environments listed above and verified there is no diff in output
- I have verified there is no diff in output from the original versions of the find commands to current

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [x] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?
