### PR TITLE
Retry project cleanup up to 4 times each night

### DIFF
--- a/tools/cloud-build/provision/daily-cleanup.tf
+++ b/tools/cloud-build/provision/daily-cleanup.tf
@@ -32,7 +32,8 @@ resource "google_cloudbuild_trigger" "daily_project_cleanup" {
 }
 
 module "daily_project_cleanup_schedule" {
-  source   = "./trigger-schedule"
-  trigger  = google_cloudbuild_trigger.daily_project_cleanup
-  schedule = "0 0 * * MON-FRI"
+  source      = "./trigger-schedule"
+  trigger     = google_cloudbuild_trigger.daily_project_cleanup
+  schedule    = "0 0 * * MON-FRI"
+  retry_count = 4
 }

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -28,6 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_retry_count"></a> [retry\_count](#input\_retry\_count) | Number of times to retry a failed build | `number` | `0` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Describes the schedule on which the job will be executed. | `string` | n/a | yes |
 | <a name="input_trigger"></a> [trigger](#input\_trigger) | View of google\_cloudbuild\_trigger resource | <pre>object({<br>    name    = string<br>    id      = string<br>    project = string<br>  })</pre> | n/a | yes |
 

--- a/tools/cloud-build/provision/trigger-schedule/main.tf
+++ b/tools/cloud-build/provision/trigger-schedule/main.tf
@@ -19,10 +19,11 @@ resource "google_cloud_scheduler_job" "schedule" {
 
   attempt_deadline = "180s"
   retry_config {
-    max_backoff_duration = "3600s"
+    max_backoff_duration = "0s"
     max_doublings        = 5
-    max_retry_duration   = "0s"
-    min_backoff_duration = "5s"
+    max_retry_duration   = "3600s"
+    min_backoff_duration = "1m"
+    retry_count          = var.retry_count
   }
 
   http_target {

--- a/tools/cloud-build/provision/trigger-schedule/variables.tf
+++ b/tools/cloud-build/provision/trigger-schedule/variables.tf
@@ -25,3 +25,9 @@ variable "schedule" {
   description = "Describes the schedule on which the job will be executed."
   type        = string
 }
+
+variable "retry_count" {
+  description = "Number of times to retry a failed build"
+  type        = number
+  default     = 0
+}


### PR DESCRIPTION
Allow project cleanup to attempt retries without altering retry behavior of other triggers.

### Submission Checklist

* [x] Have you installed and run this change against pre-commit? (`pre-commit
  install`)
* [x] Are all tests passing? (`make tests`)
* [ ] Have you written unit tests to cover this change?
* [x] Is unit test coverage still above 80%?
* [x] Have you updated all applicable documentation?
* [x] Have you followed the guidelines in our Contributing document?