### PR TITLE
Add local ssd RAID0 startup script

### DIFF
--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -253,7 +253,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
@@ -298,6 +298,7 @@ No modules.
 | <a name="input_install_docker"></a> [install\_docker](#input\_install\_docker) | Install Docker command line tool and daemon. | `bool` | `false` | no |
 | <a name="input_install_stackdriver_agent"></a> [install\_stackdriver\_agent](#input\_install\_stackdriver\_agent) | Run Google Stackdriver Agent installation script if set to true. Preferred over ops agent for performance. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels for the created GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_local_ssd_filesystem"></a> [local\_ssd\_filesystem](#input\_local\_ssd\_filesystem) | Create and mount a filesystem from local SSD disks (data will be lost if VMs are powered down without enabling migration); enable by setting mountpoint field to a valid directory path. | <pre>object({<br>    fs_type    = optional(string, "ext4")<br>    mountpoint = optional(string, "")<br>  })</pre> | <pre>{<br>  "fs_type": "ext4",<br>  "mountpoint": ""<br>}</pre> | no |
 | <a name="input_prepend_ansible_installer"></a> [prepend\_ansible\_installer](#input\_prepend\_ansible\_installer) | DEPRECATED. Use `install_ansible=false` to prevent ansible installation. | `bool` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy to | `string` | n/a | yes |

--- a/modules/scripts/startup-script/files/setup-raid.yml
+++ b/modules/scripts/startup-script/files/setup-raid.yml
@@ -1,0 +1,76 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+- name: Configure local SSDs
+  become: true
+  hosts: localhost
+  vars:
+    raid_name: localssd
+    array_dev: /dev/md/{{ raid_name }}
+    fstype: ext4
+    interface: nvme
+    mode: '0755'
+  tasks:
+  - name: Get local SSD devices
+    ansible.builtin.find:
+      file_type: link
+      path: /dev/disk/by-id
+      patterns: google-local-{{ "nvme-" if interface == "nvme" else "" }}ssd-*
+    register: local_ssd_devices
+
+  - name: Exit if zero local ssd found
+    ansible.builtin.meta: end_play
+    when: local_ssd_devices.files | length == 0
+
+  - name: Install mdadm
+    ansible.builtin.package:
+      name: mdadm
+      state: present
+
+  - name: Force RAID array if only 1 local SSD
+    ansible.builtin.shell: mdadm --create {{ array_dev }} --name={{ raid_name }} --homehost=any --level=0 --raid-devices=1 /dev/disk/by-id/google-local-nvme-ssd-0 --force
+    args:
+      creates: "{{ array_dev }}"
+    when: local_ssd_devices.files | length == 1
+
+  - name: Create RAID array
+    ansible.builtin.shell: mdadm --create {{ array_dev }} --name={{ raid_name }} --homehost=any --level=0 --raid-devices={{ local_ssd_devices.files | length }} /dev/disk/by-id/google-local-nvme-ssd-*
+    args:
+      creates: "{{ array_dev }}"
+    when: local_ssd_devices.files | length >= 2
+
+  - name: Format filesystem
+    community.general.filesystem:
+      fstype: "{{ fstype }}"
+      device: "{{ array_dev }}"
+      opts: '{{ "-m 0" if fstype == "ext4" else "" }}'
+
+  - name: Mount RAID array
+    ansible.posix.mount:
+      src: "{{ array_dev }}"
+      path: '{{ mountpoint | default("/mnt/" + raid_name) }}'
+      fstype: "{{ fstype }}"
+      # the nofail option is critical as it enables the boot process to complete on machines
+      # that were powered off and had local SSD contents discarded; without this option
+      # VMs may fail to join the network
+      opts: discard,defaults,nofail
+      state: mounted
+
+  - name: Set mount permissions
+    ansible.builtin.file:
+      path: '{{ mountpoint | default("/mnt/" + raid_name) }}'
+      state: directory
+      mode: "{{ mode }}"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -99,7 +99,7 @@ locals {
   ]
 
   local_ssd_filesystem_enabled = can(coalesce(var.local_ssd_filesystem.mountpoint))
-  raid_setup = local.local_ssd_filesystem_enabled ? [] : [
+  raid_setup = !local.local_ssd_filesystem_enabled ? [] : [
     {
       type        = "ansible-local"
       destination = "setup-raid.yml"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -98,7 +98,8 @@ locals {
     },
   ]
 
-  raid_setup = var.local_ssd_filesystem == {} ? [] : [
+  local_ssd_filesystem_enabled = can(coalesce(var.local_ssd_filesystem.mountpoint))
+  raid_setup = local.local_ssd_filesystem_enabled ? [] : [
     {
       type        = "ansible-local"
       destination = "setup-raid.yml"
@@ -111,7 +112,7 @@ locals {
   ]
 
   supplied_ansible_runners = anytrue([for r in var.runners : r.type == "ansible-local"])
-  has_ansible_runners      = anytrue([local.supplied_ansible_runners, local.configure_ssh, var.install_docker, can(coalesce(var.local_ssd_filesystem.mountpoint))])
+  has_ansible_runners      = anytrue([local.supplied_ansible_runners, local.configure_ssh, var.install_docker, local.local_ssd_filesystem_enabled])
   install_ansible          = coalesce(var.install_ansible, local.has_ansible_runners)
   ansible_installer = local.install_ansible ? [{
     type        = "shell"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -98,8 +98,20 @@ locals {
     },
   ]
 
+  raid_setup = var.local_ssd_filesystem == {} ? [] : [
+    {
+      type        = "ansible-local"
+      destination = "setup-raid.yml"
+      content     = file("${path.module}/files/setup-raid.yml")
+      args = join(" ", [
+        "-e mountpoint=${var.local_ssd_filesystem.mountpoint}",
+        "-e fs_type=${var.local_ssd_filesystem.fs_type}",
+      ])
+    },
+  ]
+
   supplied_ansible_runners = anytrue([for r in var.runners : r.type == "ansible-local"])
-  has_ansible_runners      = anytrue([local.supplied_ansible_runners, local.configure_ssh, var.install_docker])
+  has_ansible_runners      = anytrue([local.supplied_ansible_runners, local.configure_ssh, var.install_docker, can(coalesce(var.local_ssd_filesystem.mountpoint))])
   install_ansible          = coalesce(var.install_ansible, local.has_ansible_runners)
   ansible_installer = local.install_ansible ? [{
     type        = "shell"
@@ -122,6 +134,7 @@ locals {
     local.ansible_installer,
     local.configure_ssh_runners,
     local.docker_runner,
+    local.raid_setup,
     var.runners
   )
 

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -126,6 +126,31 @@ variable "install_docker" {
   nullable    = false
 }
 
+variable "local_ssd_filesystem" {
+  description = "Create and mount a filesystem from local SSD disks (data will be lost if VMs are powered down without enabling migration); enable by setting mountpoint field to a valid directory path."
+  type = object({
+    fs_type    = optional(string, "ext4")
+    mountpoint = optional(string, "")
+  })
+
+  validation {
+    condition     = can(coalesce(var.local_ssd_filesystem.fs_type))
+    error_message = "var.local_ssd_filesystem.fs_type must be set to a filesystem supported by the Linux distribution."
+  }
+
+  validation {
+    condition     = var.local_ssd_filesystem.mountpoint == "" || startswith(var.local_ssd_filesystem.mountpoint, "/")
+    error_message = "To enable local SSD filesystems, var.local_ssd_filesystem.mountpoint must be set to an absolute path to a mountpoint."
+  }
+
+  default = {
+    fs_type    = "ext4"
+    mountpoint = ""
+  }
+
+  nullable = false
+}
+
 variable "install_cloud_ops_agent" {
   description = "Warning: Consider using `install_stackdriver_agent` for better performance. Run Google Ops Agent installation script if set to true."
   type        = bool

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.36.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.3"
 }


### PR DESCRIPTION
This PR adds a startup script that will check for existing local ssds and raid if there are 2 or more. 

This script has been tested manually with slurm-gcp v6 and vm-instance with centos, debian, rocky, and ubuntu.

If there are at least 2 local ssds attached, a raid device for them will be created. Using `lsblk -o NAME,FSTYPE,LABEL,UUID,MOUNTPOINT` shows the following.
```
NAME    FSTYPE            LABEL               UUID                                 MOUNTPOINT
sda                                                                                
├─sda1  ext4                                  7be27af0-f080-46f6-bdf8-bc495c775f18 /
├─sda14                                                                            
└─sda15 vfat                                  4FFB-6B16                            /boot/efi
nvme0n1 linux_raid_member ssd-test-debian-0:0 0823949c-a4f7-b097-8712-cbbb5a50066a 
└─md0   ext4              LOCALSSD            6d3ba06d-b59c-4df4-ae5e-29f49ccc5e7a /mnt/localssd
nvme0n2 linux_raid_member ssd-test-debian-0:0 0823949c-a4f7-b097-8712-cbbb5a50066a 
└─md0   ext4              LOCALSSD            6d3ba06d-b59c-4df4-ae5e-29f49ccc5e7a /mnt/localssd
```

When the number of local ssds present is 0 or 1, the script will exit early.
```
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: TASK [Exit if less than 2 local ssd] *******************************************
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script:
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: PLAY RECAP *********************************************************************
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: localhost                  : ok=6    changed=2    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script:
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: stderr=Wed Jun 26 00:21:26 +0000 2024 Info [2370]: === start executing runner: 99-running-script-warning.sh-54ee ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: Wed Jun 26 00:21:26 +0000 2024 Info [2370]: === 99-running-script-warning.sh-54ee finished with exit_code=0 ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: Wed Jun 26 00:21:29 +0000 2024 Info [2370]: === start executing runner: install_ansible_automatic.sh-c9b1 ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: Wed Jun 26 00:23:28 +0000 2024 Info [2370]: === install_ansible_automatic.sh-c9b1 finished with exit_code=0 ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: Wed Jun 26 00:23:31 +0000 2024 Info [2370]: === start executing runner: setup-raid.yml-4df9 ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: Wed Jun 26 00:23:37 +0000 2024 Info [2370]: === setup-raid.yml-4df9 finished with exit_code=0 ===
Jun 26 00:23:37 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script:
Jun 26 00:23:38 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: INFO: Check status of cluster services
Jun 26 00:23:39 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script: INFO: Done setting up compute
Jun 26 00:23:39 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: startup-script exit status 0
Jun 26 00:23:39 ssdtest-computenodeset-0 google_metadata_script_runner[1555]: Finished running startup scripts.
Jun 26 00:23:39 ssdtest-computenodeset-0 systemd[1]: google-startup-scripts.service: Succeeded.
```
### Manual Testing for rebooting.

- Deployed a blueprint that boots up a vm-instance for each of the OS as well as a Slurm-GCP v6 controller and login node.  
- After the instances are setup, verified that the raid0 was set up with `lsblk -o NAME,FSTYPE,LABEL,UUID,MOUNTPOINT` and saved the output.
- Used the command `sudo reboot` to reboot the instance
- When the instances finish setting back up, verified the raid0 was re-established with `lsblk -o NAME,FSTYPE,LABEL,UUID,MOUNTPOINT` and compared the UUIDs of the raid0 local ssds before and after reboot.

A reboot is successful if it can successful recreate the raid device with the local ssd that were up prior to reboot. Rebooting was successful for all the instances.

### Manual Testing for restarting.

- Deployed a blueprint that boots up a vm-instance for each of the OS as well as a Slurm-GCP v6 controller and login node.  
- After the instances are setup, verified that the raid0 was set up with `lsblk -o NAME,FSTYPE,LABEL,UUID,MOUNTPOINT`.
- Manually shut down the instances and then started them back up.
- When the instances finish setting back up, verified the raid0 was created with `lsblk -o NAME,FSTYPE,LABEL,UUID,MOUNTPOINT`.

A restart is successful if it can setup the raid device with the local ssds. Restarting was successful for all the instances except for the Slurm-GCP instances. The current problem is that the Slurm setup verifies that Slurm is already installed and exits early which leads to the startup script not getting executed. 


Cases covered by this PR:
- Centos, Rocky, Ubuntu, Debian VM instances reboot and restart
- Slurm-GCP reboot

Cases that require more thought:
- Slurm-GCP restart
