### PR TITLE
Use Private Service Connect to connect to CloudSQL database

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -63,6 +63,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_bigquery_connection.connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_connection) | resource |
+| [google_compute_address.psc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_forwarding_rule.psc_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_sql_database.database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
 | [google_sql_user.users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
@@ -73,18 +75,16 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | IP address ranges as authorized networks of the Cloud SQL for MySQL instances | `list(string)` | `[]` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |
-| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
-| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where SQL instance will be configured | `string` | n/a | yes |
 | <a name="input_sql_instance_name"></a> [sql\_instance\_name](#input\_sql\_instance\_name) | name given to the sql instance for ease of identificaion | `string` | n/a | yes |
 | <a name="input_sql_password"></a> [sql\_password](#input\_sql\_password) | Password for the SQL database. | `any` | `null` | no |
 | <a name="input_sql_username"></a> [sql\_username](#input\_sql\_username) | Username for the SQL database | `string` | `"slurm"` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Self link of the network where Cloud SQL instance PSC endpoint will be created | `string` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | The machine type to use for the SQL instance | `string` | n/a | yes |
 
 ## Outputs

--- a/community/modules/database/slurm-cloudsql-federation/outputs.tf
+++ b/community/modules/database/slurm-cloudsql-federation/outputs.tf
@@ -18,7 +18,7 @@ output "cloudsql" {
   description = "Describes the cloudsql instance."
   sensitive   = true
   value = {
-    server_ip = google_sql_database_instance.instance.ip_address[0].ip_address
+    server_ip = google_compute_address.psc.address
     user      = google_sql_user.users.name
     password  = google_sql_user.users.password
     db_name   = google_sql_database.database.name

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -14,13 +14,6 @@
  * limitations under the License.
 */
 
-variable "authorized_networks" {
-  description = "IP address ranges as authorized networks of the Cloud SQL for MySQL instances"
-  type        = list(string)
-  default     = []
-  nullable    = false
-}
-
 variable "database_version" {
   description = "The version of the database to be created."
   type        = string
@@ -79,20 +72,7 @@ variable "sql_password" {
   default     = null
 }
 
-variable "network_id" {
-  description = <<-EOT
-    The ID of the GCE VPC network to which the instance is going to be created in.:
-    `projects/<project_id>/global/networks/<network_name>`"
-    EOT
+variable "subnetwork_self_link" {
+  description = "Self link of the network where Cloud SQL instance PSC endpoint will be created"
   type        = string
-  validation {
-    condition     = length(split("/", var.network_id)) == 5
-    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
-  }
-}
-
-variable "private_vpc_connection_peering" {
-  description = "The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation."
-  type        = string
-  default     = null
 }


### PR DESCRIPTION
Use PSC endpoints to access Cloud SQL instance.

Cloud SQL databases do leave some resources running after the instance is removed that prevents removal of PSA range, which then prevents whole cluster recreation.

Removing `authorized_networks` as they are not supported by Cloud SQL when using PSC.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
