### PR TITLE
Don't use instance template for controller

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -196,8 +196,6 @@ limitations under the License.
 |------|--------|---------|
 | <a name="module_bucket"></a> [bucket](#module\_bucket) | terraform-google-modules/cloud-storage/google | ~> 5.0 |
 | <a name="module_daos_network_storage_scripts"></a> [daos\_network\_storage\_scripts](#module\_daos\_network\_storage\_scripts) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.36.0&depth=1 |
-| <a name="module_slurm_controller_instance"></a> [slurm\_controller\_instance](#module\_slurm\_controller\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/_slurm_instance | 6.5.13 |
-| <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 6.5.13 |
 | <a name="module_slurm_files"></a> [slurm\_files](#module\_slurm\_files) | ./modules/slurm_files | n/a |
 | <a name="module_slurm_login_instance"></a> [slurm\_login\_instance](#module\_slurm\_login\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/_slurm_instance | 6.5.13 |
 | <a name="module_slurm_login_template"></a> [slurm\_login\_template](#module\_slurm\_login\_template) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template | 6.5.13 |
@@ -209,6 +207,8 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
+| [google_compute_disk.attached_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_instance.controller](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
 | [google_secret_manager_secret.cloudsql](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.cloudsql_secret_accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.cloudsql_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/cloud_sql.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/cloud_sql.tf
@@ -1,0 +1,43 @@
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_secret_manager_secret" "cloudsql" {
+  count = var.cloudsql != null ? 1 : 0
+
+  secret_id = "${local.slurm_cluster_name}-slurm-secret-cloudsql"
+
+  replication {
+    auto {}
+  }
+
+  labels = {
+    slurm_cluster_name = local.slurm_cluster_name
+  }
+}
+
+resource "google_secret_manager_secret_version" "cloudsql_version" {
+  count = var.cloudsql != null ? 1 : 0
+
+  secret      = google_secret_manager_secret.cloudsql[0].id
+  secret_data = jsonencode(var.cloudsql)
+}
+
+resource "google_secret_manager_secret_iam_member" "cloudsql_secret_accessor" {
+  count = var.cloudsql != null ? 1 : 0
+
+  secret_id = google_secret_manager_secret.cloudsql[0].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${local.service_account.email}"
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -78,5 +78,5 @@ module "slurm_login_instance" {
   zone       = each.value.zone
 
   # trigger replacement of login nodes when the controller instance is replaced
-  replace_trigger = module.slurm_controller_instance.instances_self_links[0]
+  replace_trigger = resource.google_compute_instance.controller.self_link
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
@@ -33,6 +33,16 @@ data "google_compute_default_service_account" "default" {
   project = var.project_id
 }
 
+locals {
+  service_account_email = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
+
+  # can't rely on `email=null` as it's used to instantiate `cloudsql_secret_accessor`
+  service_account = {
+    email  = local.service_account_email
+    scopes = var.service_account_scopes
+  }
+}
+
 # See 
 # * slurm_files.tf
 # * controller.tf

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -19,7 +19,7 @@ output "slurm_cluster_name" {
 
 output "slurm_controller_instance" {
   description = "Compute instance of controller node"
-  value       = module.slurm_controller_instance.slurm_instances[0]
+  value       = resource.google_compute_instance.controller
 }
 
 output "slurm_login_instances" {
@@ -36,6 +36,6 @@ output "instructions" {
   description = "Post deployment instructions."
   value       = <<-EOT
     To SSH to the controller (may need to add '--tunnel-through-iap'):
-      gcloud compute ssh ${module.slurm_controller_instance.instances_self_links[0]}
+      gcloud compute ssh ${resource.google_compute_instance.controller.self_link}
   EOT
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/startup.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/startup.sh
@@ -1,0 +1,210 @@
+#!/bin/bash
+
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SLURM_DIR=/slurm
+FLAGFILE=$SLURM_DIR/slurm_configured_do_not_remove
+SCRIPTS_DIR=$SLURM_DIR/scripts
+if [[ -z "$HOME" ]]; then
+	# google-startup-scripts.service lacks environment variables
+	HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+fi
+
+METADATA_SERVER="metadata.google.internal"
+URL="http://$METADATA_SERVER/computeMetadata/v1"
+HEADER="Metadata-Flavor:Google"
+CURL="curl -sS --fail --header $HEADER"
+UNIVERSE_DOMAIN="$($CURL $URL/instance/attributes/universe_domain)"
+STORAGE_CMD="CLOUDSDK_CORE_UNIVERSE_DOMAIN=$UNIVERSE_DOMAIN gcloud storage"
+
+function devel::zip() {
+	# shellcheck disable=SC2155
+	local BUCKET="$($CURL $URL/instance/attributes/slurm_bucket_path)"
+	if [[ -z $BUCKET ]]; then
+		echo "ERROR: No bucket path detected."
+		return 1
+	fi
+
+	local SLURM_ZIP_URL="$BUCKET/slurm-gcp-devel.zip"
+	local SLURM_ZIP_FILE="$HOME/slurm-gcp-devel.zip"
+	local SLURM_ZIP_DIR="$HOME/slurm-gcp-devel"
+	# shellcheck disable=SC2046
+	eval $(bash -c "$STORAGE_CMD cp $SLURM_ZIP_URL $SLURM_ZIP_FILE")
+	if ! [[ -f "$SLURM_ZIP_FILE" ]]; then
+		echo "INFO: No development files downloaded. Skipping."
+		return 0
+	fi
+	unzip -o "$SLURM_ZIP_FILE" -d "$SCRIPTS_DIR"
+	rm -rf "$SLURM_ZIP_FILE" "$SLURM_ZIP_DIR" # Clean up
+	echo "INFO: Finished inflating '$SLURM_ZIP_FILE'."
+
+	#temporary hack to not make the script fail on TPU vm
+	chown slurm:slurm -R "$SCRIPTS_DIR" || true
+	chmod 700 -R "$SCRIPTS_DIR"
+	echo "INFO: Updated permissions of files in '$SCRIPTS_DIR'."
+}
+
+function config() {
+	# shellcheck disable=SC2155
+	local BUCKET="$($CURL $URL/instance/attributes/slurm_bucket_path)"
+	if [[ -z $BUCKET ]]; then
+		echo "ERROR: No bucket path detected."
+		return 1
+	fi
+
+	local SLURM_CONFIG_URL="$BUCKET/config.yaml"
+	local SLURM_CONFIG_FILE="$SCRIPTS_DIR/config.yaml"
+	# shellcheck disable=SC2046
+	eval $(bash -c "$STORAGE_CMD cp $SLURM_CONFIG_URL $SLURM_CONFIG_FILE")
+	if ! [[ -f "$SLURM_CONFIG_FILE" ]]; then
+		echo "INFO: No config file downloaded. Skipping."
+		return 0
+	fi
+
+	#temporary hack to not make the script fail on TPU vm
+	chown slurm:slurm -R "$SLURM_CONFIG_FILE" || true
+	chmod 600 -R "$SLURM_CONFIG_FILE"
+	echo "INFO: Updated permissions of '$SLURM_CONFIG_FILE'."
+}
+
+PING_METADATA="ping -q -w1 -c1 $METADATA_SERVER"
+echo "INFO: $PING_METADATA"
+for i in $(seq 10); do
+	# shellcheck disable=SC2086
+	[ $i -gt 1 ] && sleep 5
+	$PING_METADATA >/dev/null && s=0 && break || s=$?
+	echo "ERROR: Failed to contact metadata server, will retry"
+done
+# shellcheck disable=SC2086
+if [ $s -ne 0 ]; then
+	echo "ERROR: Unable to contact metadata server, aborting"
+	# shellcheck disable=SC2016
+	wall -n '*** Slurm setup failed in the startup script! see `journalctl -u google-startup-scripts` ***'
+	exit 1
+else
+	echo "INFO: Successfully contacted metadata server"
+fi
+
+GOOGLE_DNS=8.8.8.8
+PING_GOOGLE="ping -q -w1 -c1 $GOOGLE_DNS"
+echo "INFO: $PING_GOOGLE"
+for i in $(seq 5); do
+	# shellcheck disable=SC2086
+	[ $i -gt 1 ] && sleep 2
+	$PING_GOOGLE >/dev/null && s=0 && break || s=$?
+	echo "failed to ping Google DNS, will retry"
+done
+# shellcheck disable=SC2086
+if [ $s -ne 0 ]; then
+	echo "WARNING: No internet access detected"
+else
+	echo "INFO: Internet access detected"
+fi
+
+mkdir -p $SCRIPTS_DIR
+
+SETUP_SCRIPT_FILE=$SCRIPTS_DIR/setup.py
+
+devel::zip
+config
+
+if [ -f $FLAGFILE ]; then
+	echo "WARNING: Slurm was previously configured, quitting"
+	exit 0
+fi
+touch $FLAGFILE
+
+function tpu_setup {
+	#allow the following command to fail, as this attribute does not exist for regular nodes
+	docker_image=$($CURL $URL/instance/attributes/slurm_docker_image 2>/dev/null || true)
+	# shellcheck disable=SC2086
+	if [ -z $docker_image ]; then #Not a tpu node, do not do anything
+		return
+	fi
+	if [ "$OS_ENV" == "slurm_container" ]; then #Already inside the slurm container, we should continue starting
+		return
+	fi
+
+	#given a input_string like "WORKER_0:Joseph;WORKER_1:richard;WORKER_2:edward;WORKER_3:john" and a number 1, this function will print richard
+	parse_metadata() {
+		local number=$1
+		local input_string=$2
+		# shellcheck disable=SC2155
+		local word=$(echo "$input_string" | awk -v n="$number" -F ':|;' '{ for (i = 1; i <= NF; i+=2) if ($(i) == "WORKER_"n) print $(i+1) }')
+		echo "$word"
+	}
+
+	input_string=$($CURL $URL/instance/attributes/slurm_names)
+	worker_id=$($CURL $URL/instance/attributes/tpu-env | awk '/WORKER_ID/ {print $2}' | tr -d \')
+	# shellcheck disable=SC2086
+	real_name=$(parse_metadata $worker_id $input_string)
+
+	#Prepare to docker pull with gcloud
+	mkdir -p /root/.docker
+	cat <<EOF >/root/.docker/config.json
+{
+  "credHelpers": {
+    "gcr.io": "gcloud",
+	"us-docker.pkg.dev": "gcloud"
+  }
+}
+EOF
+	#cgroup detection
+	CGV=1
+	CGROUP_FLAGS="-v /sys/fs/cgroup:/sys/fs/cgroup:rw"
+	if [ -f /sys/fs/cgroup/cgroup.controllers ]; then #CGV2
+		CGV=2
+	fi
+	if [ $CGV == 2 ]; then
+		CGROUP_FLAGS="--cgroup-parent=docker.slice --cgroupns=private --tmpfs /run --tmpfs /run/lock --tmpfs /tmp"
+		if [ ! -f /etc/systemd/system/docker.slice ]; then #In case that there is no slice prepared for hosting the containers create it
+			printf "[Unit]\nDescription=docker slice\nBefore=slices.target\n[Slice]\nCPUAccounting=true\nMemoryAccounting=true" >/etc/systemd/system/docker.slice
+			systemctl start docker.slice
+		fi
+	fi
+	#for the moment always use --privileged, as systemd might not work properly otherwise
+	TPU_FLAGS="--privileged"
+	# TPU_FLAGS="--cap-add SYS_RESOURCE --device /dev/accel0 --device /dev/accel1 --device /dev/accel2 --device /dev/accel3"
+	# if [ $CGV == 2 ]; then #In case that we are in CGV2 for systemd to work correctly for the moment we go with privileged
+	# 	TPU_FLAGS="--privileged"
+	# fi
+
+	# shellcheck disable=SC2086
+	docker run -d $CGROUP_FLAGS $TPU_FLAGS --net=host --name=slurmd --hostname=$real_name --entrypoint=/usr/bin/systemd --restart unless-stopped $docker_image
+	exit 0
+}
+
+tpu_setup #will do nothing for normal nodes or the container spawned inside TPU
+
+function fetch_feature {
+	if slurmd_feature="$($CURL $URL/instance/attributes/slurmd_feature)"; then
+		echo "$slurmd_feature"
+	else
+		echo ""
+	fi
+}
+SLURMD_FEATURE="$(fetch_feature)"
+
+echo "INFO: Running python cluster setup script"
+chmod +x $SETUP_SCRIPT_FILE
+python3 $SCRIPTS_DIR/util.py
+if [[ -n "$SLURMD_FEATURE" ]]; then
+	echo "INFO: Running dynamic node setup."
+	exec $SETUP_SCRIPT_FILE --slurmd-feature="$SLURMD_FEATURE"
+else
+	exec $SETUP_SCRIPT_FILE
+fi

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -49,7 +49,7 @@ locals {
   login_sa       = toset(flatten([for x in module.slurm_login_template : x.service_account]))
 
   viewers = toset(flatten([
-    "serviceAccount:${module.slurm_controller_template.service_account.email}",
+    "serviceAccount:${local.service_account.email}",
     formatlist("serviceAccount:%s", [for x in local.compute_sa : x.email]),
     formatlist("serviceAccount:%s", [for x in local.compute_tpu_sa : x.email]),
     formatlist("serviceAccount:%s", [for x in local.login_sa : x.email]),


### PR DESCRIPTION
Stop using template to create controller instance.

Move `startup.sh` in toolkit repo (for controller only), no changes to content, but formatting and shellcheck annotations.