### PR TITLE
Move login config into separate `login_config.yaml`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -45,6 +45,7 @@ No modules.
 | [google_storage_bucket_object.controller_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.devel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.epilog_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.login_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.login_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.nodeset_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.prolog_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -146,7 +146,7 @@ def run_custom_scripts():
     elif lkp.instance_role == "compute":
         # compute setup with compute.d and nodeset.d
         custom_dirs = [custom_dir / "compute.d", custom_dir / "nodeset.d"]
-    elif lkp.instance_role == "login":
+    elif lkp.is_login:
         # login setup with only login.d
         custom_dirs = [custom_dir / "login.d"]
     else:
@@ -167,8 +167,8 @@ def run_custom_scripts():
                 timeout = lkp.cfg.get("controller_startup_scripts_timeout", 300)
             elif "/compute.d/" in str(script) or "/nodeset.d/" in str(script):
                 timeout = lkp.cfg.get("compute_startup_scripts_timeout", 300)
-            elif "/login.d/" in str(script):
-                timeout = lkp.cfg.get("login_startup_scripts_timeout", 300)
+            elif "/login.d/" in str(script) and lkp.is_login:
+                timeout = lkp.login_cfg.get("startup_scripts_timeout", 300)
             else:
                 timeout = 300
             timeout = None if not timeout or timeout < 0 else timeout

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -71,8 +71,8 @@ def resolve_network_storage(nodeset=None):
     # On non-controller instances, entries in network_storage could overwrite
     # default exports from the controller. Be careful, of course
     mounts.update(mounts_by_local(cfg.network_storage))
-    if lkp.instance_role in ("login", "controller"):
-        mounts.update(mounts_by_local(cfg.login_network_storage))
+    if lkp.is_login:
+        mounts.update(mounts_by_local(lkp.login_cfg.network_storage))
 
     if nodeset is not None:
         mounts.update(mounts_by_local(nodeset.network_storage))

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -494,7 +494,7 @@ def reconfigure_slurm():
                 log.error(e)
             util.run(f"wall '{update_msg}'", timeout=30)
             log.debug("Done.")
-        elif lkp.instance_role_safe in ["compute", "login"]:
+        elif lkp.instance_role_safe == "compute" or lkp.is_login:
             log.info("Restarting slurmd to make changes take effect.")
             run("systemctl restart slurmd")
             util.run(f"wall '{update_msg}'", timeout=30)


### PR DESCRIPTION
**Breaking change:**
_Before behavior:_ `login_network_storage` gets mounted to both login and controller nodes.
_After behavior:_ `login_network_storage` gets mounted to login nodes only.

This is preparatory step to:
* Support per-login-group  `network_storage` and `startup_script`, instead of common ones for all login nodes.
* Making controller module independent of login module and reversing chain of dependencies.  