### PR TITLE
Add `TopologySummary` to track changes to topology

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-mock
+pytest_unordered
 mock


### PR DESCRIPTION
Topology summary to be stored along `topology.conf` in easily parsable format. The purpose is to detect changes in topology and make  a decision about need for reconfiguration. 
The logic of `requires_reconfigure` is very simple, to be made more complex in follow up PRs.