### PR TITLE
SlurmGCP. Rework logging

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/get_tpu_vmcount.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/get_tpu_vmcount.py
@@ -32,9 +32,7 @@ def get_vmcount_of_tpu_part(part):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
+    parser = argparse.ArgumentParser()
     parser.add_argument(
         "--partitions",
         "-p",

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -19,6 +19,7 @@ import os
 import sys
 import stat
 import time
+import logging
 
 import shutil
 from pathlib import Path
@@ -29,6 +30,8 @@ import util
 from util import lkp, run, cfg, dirs, separate
 from more_executors import Executors, ExceptionRetryPolicy
 
+
+log = logging.getLogger()
 
 def mounts_by_local(mounts):
     """convert list of mounts to dict of mounts, local_mount as key"""
@@ -91,7 +94,7 @@ def separate_external_internal_mounts(mounts):
     return separate(internal_mount, mounts)
 
 
-def setup_network_storage(log):
+def setup_network_storage():
     """prepare network fs mounts and add them to fstab"""
     log.info("Set up network storage")
     # filter mounts into two dicts, cluster-internal and external mounts
@@ -154,7 +157,7 @@ def setup_network_storage(log):
             f.write("\n")
 
     mount_fstab(mounts_by_local(mounts), log)
-    munge_mount_handler(log)
+    munge_mount_handler()
 
 
 def mount_fstab(mounts, log):
@@ -189,7 +192,7 @@ def mount_fstab(mounts, log):
                 raise e
 
 
-def munge_mount_handler(log):
+def munge_mount_handler():
     if not cfg.munge_mount:
         log.error("Missing munge_mount in cfg")
     elif lkp.is_controller:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -45,15 +45,12 @@ from util import (
     TPU,
     chunked,
 )
-from util import lkp, cfg, CONFIG_FILE
+from util import lkp, CONFIG_FILE
 from suspend import delete_instances
 from resume import start_tpu
 import conf
 
-filename = Path(__file__).name
-LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
-
-log = logging.getLogger(filename)
+log = logging.getLogger()
 
 TOT_REQ_CNT = 1000
 
@@ -503,14 +500,8 @@ def main():
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
-    )
-
-    args = util.add_log_args_and_parse(parser)
-    util.chown_slurm(LOGFILE, mode=0o600)
-    util.config_root_logger(filename, level=args.loglevel, logfile=LOGFILE)
-    sys.excepthook = util.handle_exception
+    parser = argparse.ArgumentParser()
+    _ = util.init_log_and_parse(parser)
 
     pid_file = (Path("/tmp") / Path(__file__).name).with_suffix(".pid")
     with pid_file.open("w") as fp:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
@@ -18,8 +18,6 @@
 from typing import List
 import argparse
 import logging
-import sys
-from pathlib import Path
 
 import util
 from util import (
@@ -31,13 +29,11 @@ from util import (
     separate,
     execute_with_futures,
 )
-from util import lkp, cfg, TPU
+from util import lkp, TPU
 
 import slurm_gcp_plugins
 
-filename = Path(__file__).name
-LOGFILE = (Path(cfg.slurm_log_dir if cfg else ".") / filename).with_suffix(".log")
-log = logging.getLogger(filename)
+log = logging.getLogger()
 
 TOT_REQ_CNT = 1000
 
@@ -151,11 +147,6 @@ if __name__ == "__main__":
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("nodelist", help="list of nodes to suspend")
-
-    args = util.add_log_args_and_parse(parser)
-    util.chown_slurm(LOGFILE, mode=0o600)
-    util.config_root_logger(filename, level=args.loglevel, logfile=LOGFILE)
-    log = logging.getLogger(Path(__file__).name)
-    sys.excepthook = util.handle_exception
+    args = util.init_log_and_parse(parser)
 
     main(args.nodelist)


### PR DESCRIPTION
* Don't initialize file-specific logger, instead use "root logger" configured with proper destination file;
* Don't pass `log` as an argument to the `setup_network_storage.py` functions, use "root logger" instead;
* Stop using excessive `argparse.ArgumentParser` initialization since none of scripts define `__doc__`.