### PR TITLE
Move daos agent log to /var/log/daos_agent/

### DIFF
--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -68,6 +68,11 @@ sed -i "s/#.*transport_config/transport_config/g" $daos_config
 sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
 sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
+# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+mkdir /var/log/daos_agent
+chown daos_agent:daos_agent /var/log/daos_agent
+sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
+
 # Start service
 if grep -q "ID=\"rocky\"" /etc/os-release && lsb_release -rs | grep -q "8\.[0-9]"; then
 	systemctl start daos_agent.service

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -e -o pipefail
 
 # Parse access_points.
 for arg in "$@"; do

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -69,7 +69,7 @@ sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
 sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
 # Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
-mkdir /var/log/daos_agent
+mkdir -p /var/log/daos_agent
 chown daos_agent:daos_agent /var/log/daos_agent
 sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
 

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -68,6 +68,11 @@ sed -i "s/#.*transport_config/transport_config/g" $daos_config
 sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
 sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
+# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+mkdir -p /var/log/daos_agent
+chown daos_agent:daos_agent /var/log/daos_agent
+sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
+
 # Start service
 if grep -q "ID=\"rocky\"" /etc/os-release && lsb_release -rs | grep -q "8\.[0-9]"; then
 	systemctl start daos_agent.service

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -e -o pipefail
 
 # Parse access_points.
 for arg in "$@"; do


### PR DESCRIPTION
In daos_agent.yml, the log_file setting is by default /tmp/daos_agent.log. This commit:
- creates a /var/log/daos_agent directory
- sets proper permission
- configure log_file in daos_agent.yml to write logs to /var/log/daos_agent/daos_agent.log

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
