### PR TITLE
Point cloud build trigger provisioning to new github repo name

### DIFF
--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -66,7 +66,7 @@ When prompted for project, use integration test project.
 |------|-------------|------|---------|:--------:|
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |
-| <a name="input_repo_uri"></a> [repo\_uri](#input\_repo\_uri) | URI of GitHub repo | `string` | `"https://github.com/GoogleCloudPlatform/hpc-toolkit"` | no |
+| <a name="input_repo_uri"></a> [repo\_uri](#input\_repo\_uri) | URI of GitHub repo | `string` | `"https://github.com/GoogleCloudPlatform/cluster-toolkit"` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | GCP zone | `string` | `"us-central1-c"` | no |
 
 ## Outputs

--- a/tools/cloud-build/provision/pr-go-build-test.tf
+++ b/tools/cloud-build/provision/pr-go-build-test.tf
@@ -29,7 +29,7 @@ resource "google_cloudbuild_trigger" "pr_go_build_test" {
 
   github {
     owner = "GoogleCloudPlatform"
-    name  = "hpc-toolkit"
+    name  = "cluster-toolkit"
     pull_request {
       branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/tools/cloud-build/provision/pr-ofe-test.tf
+++ b/tools/cloud-build/provision/pr-ofe-test.tf
@@ -26,7 +26,7 @@ resource "google_cloudbuild_trigger" "pr_ofe_test" {
 
   github {
     owner = "GoogleCloudPlatform"
-    name  = "hpc-toolkit"
+    name  = "cluster-toolkit"
     pull_request {
       branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/tools/cloud-build/provision/pr-ofe.tf
+++ b/tools/cloud-build/provision/pr-ofe.tf
@@ -20,7 +20,7 @@ resource "google_cloudbuild_trigger" "pr_ofe_venv" {
 
   github {
     owner = "GoogleCloudPlatform"
-    name  = "hpc-toolkit"
+    name  = "cluster-toolkit"
     pull_request {
       branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/tools/cloud-build/provision/pr-tests.tf
+++ b/tools/cloud-build/provision/pr-tests.tf
@@ -24,7 +24,7 @@ resource "google_cloudbuild_trigger" "pr_test" {
 
   github {
     owner = "GoogleCloudPlatform"
-    name  = "hpc-toolkit"
+    name  = "cluster-toolkit"
     pull_request {
       branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/tools/cloud-build/provision/pr-validation.tf
+++ b/tools/cloud-build/provision/pr-validation.tf
@@ -20,7 +20,7 @@ resource "google_cloudbuild_trigger" "pr_validation" {
 
   github {
     owner = "GoogleCloudPlatform"
-    name  = "hpc-toolkit"
+    name  = "cluster-toolkit"
     pull_request {
       branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -35,5 +35,5 @@ variable "zone" {
 variable "repo_uri" {
   description = "URI of GitHub repo"
   type        = string
-  default     = "https://github.com/GoogleCloudPlatform/hpc-toolkit"
+  default     = "https://github.com/GoogleCloudPlatform/cluster-toolkit"
 }


### PR DESCRIPTION
Moving the repo broke the cloud build triggers. 

This config has already been applied.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cloud HPC Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
