### PR TITLE
Update documentation to reflect rebrand to Cluster Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ If a self directed path is preferred, you can use the following commands to
 build the `gcluster` binary:
 
 ```shell
-git clone https://github.com/GoogleCloudPlatform/hpc-toolkit
-cd hpc-toolkit
+git clone https://github.com/GoogleCloudPlatform/cluster-toolkit
+cd cluster-toolkit
 make
 ./gcluster --version
 ./gcluster --help

--- a/community/front-end/ofe/docs/admin_guide.md
+++ b/community/front-end/ofe/docs/admin_guide.md
@@ -23,7 +23,7 @@ administrators, additional Django superusers can be created from the Admin site
 within TKFE, once it is deployed and running.
 
 The TFKE web application server uses the
-[Cluster Toolkit](https://github.com/GoogleCloudPlatform/hpc-toolkit) to
+[Cluster Toolkit](https://github.com/GoogleCloudPlatform/cluster-toolkit) to
 provision resources for networks, filesystems and clusters, using a service
 account that has its credentials registered to TKFE. The service account is
 used for access management and billing.
@@ -66,8 +66,8 @@ Clone the repository, checkout the corresponding branch, and switch to
 the `frontend` directory as follows:
 
 ```bash
-git clone https://github.com/GoogleCloudPlatform/hpc-toolkit.git
-cd hpc-toolkit
+git clone https://github.com/GoogleCloudPlatform/cluster-toolkit.git
+cd cluster-toolkit
 cd community/frontend/ofe
 ```
 
@@ -268,7 +268,7 @@ admin has to click *Edit Subnet* to create at least one subnet in the VPC.
 Once the network and subnet(s) are defined, click the ‘Apply Cloud Changes’
 button to trigger creation of the VPC and subnet(s).
 
-<!-- Behind the scenes, ghpc is used to get Terraform to provision the cloud resources. -->
+<!-- Behind the scenes, gcluster is used to get Terraform to provision the cloud resources. -->
 
 ### Import an existing VPC
 
@@ -495,7 +495,7 @@ files will show errors from the Django web application.
 Cloud resource deployment log files (from Terraform) are typically shown via
 the FrontEnd web site.  If those logs are not being shown, they can be found on
 the service machine under
-`/opt/gcluster/hpc-toolkit/frontend/(clusters|fs|vpc)/...`.
+`/opt/gcluster/cluster-toolkit/frontend/(clusters|fs|vpc)/...`.
 Cluster Toolkit log files will also be found in those directories.  The Terraform
 log files and status files will be down a few directories, based off of the
 Cluster Number, Deployment ID, and Terraform directory.
@@ -517,7 +517,7 @@ missing. Use the [IAM permissions reference](https://cloud.google.com/iam/docs/p
 to research this and identify additional roles to add to your user account.
 
 Before any attempt to redeploy the TKFE, make sure to run
-`terraform destroy` in `hpc-toolkit/frontend/tf` to remove cloud resources that
+`terraform destroy` in `cluster-toolkit/frontend/tf` to remove cloud resources that
 have been already created.
 
 ### Cluster problems

--- a/docs/tutorials/fsi-montecarlo-on-batch/README.md
+++ b/docs/tutorials/fsi-montecarlo-on-batch/README.md
@@ -45,20 +45,20 @@ via a [PubSub BigQuery subscription](https://cloud.google.com/pubsub/docs/bigque
 
 1. Get the Cluster Toolkit configured.
 
-Build the `ghpc` binary:
+Build the `gcluster` binary:
 
 ```shell
-git clone https://github.com/GoogleCloudPlatform/hpc-toolkit
-cd hpc-toolkit
+git clone https://github.com/GoogleCloudPlatform/cluster-toolkit
+cd cluster-toolkit
 make
-./ghpc --version
-./ghpc --help
+./gcluster --version
+./gcluster --help
 ```
 
-2\. Run `ghpc` on the blueprint `fsi-montecarlo-on-batch.yaml`
+2\. Run `gcluster` on the blueprint `fsi-montecarlo-on-batch.yaml`
 
 ```bash
-./ghpc create community/examples/fsi-montecarlo-on-batch.yaml \
+./gcluster create community/examples/fsi-montecarlo-on-batch.yaml \
    --vars "project_id=${GOOGLE_CLOUD_PROJECT}"
 ```
 
@@ -74,14 +74,14 @@ If successful, you will see output similar to:
 <p>
 To deploy your infrastructure please run:
 
-./ghpc deploy fsimontecarlo
+./gcluster deploy fsimontecarlo
 </p>
 </blockquote>
 
 3\. Deploy the blueprint as instructed:
 
 ```bash
-./ghpc deploy fsimontecarlo
+./gcluster deploy fsimontecarlo
 ```
 
 If successful, this will prompt you:
@@ -228,8 +228,8 @@ ensure you are not billed for any of the Cloud usage.
 
 ### Alternatively
 
-The other choice is to run a `ghpc destroy` command.
+The other choice is to run a `gcluster destroy` command.
 
 ```bash
-./ghpc destroy fsimontecarlo
+./gcluster destroy fsimontecarlo
 ```

--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -97,8 +97,8 @@ storage intact and b) you can build software before you deploy your cluster.
 1. Clone the repo
 
    ```bash
-   git clone https://github.com/GoogleCloudPlatform/hpc-toolkit.git
-   cd hpc-toolkit
+   git clone https://github.com/GoogleCloudPlatform/cluster-toolkit.git
+   cd cluster-toolkit
    ```
 
 1. Build the Cluster Toolkit
@@ -114,12 +114,12 @@ storage intact and b) you can build software before you deploy your cluster.
    the cloud buckets being destroyed, it is recommended you run:
 
    ```bash
-   ./ghpc create examples/hcls-blueprint.yaml -w --vars project_id=<project> --vars bucket_force_delete=true
+   ./gcluster create examples/hcls-blueprint.yaml -w --vars project_id=<project> --vars bucket_force_delete=true
    ```
 
    The `bucket_force_delete` variable makes it easier to tear down the
    deployment. If it is set to the default value of `false`, buckets with
-   objects (files) will not be deleted and the `./ghpc destroy` command will
+   objects (files) will not be deleted and the `./gcluster destroy` command will
    fail partway through.
 
    If the data stored in the buckets should be preseverved, remove the
@@ -127,10 +127,10 @@ storage intact and b) you can build software before you deploy your cluster.
 
 1. Deploy the `enable_apis` group
 
-   Call the following ghpc command to deploy the the hcls blueprint.
+   Call the following gcluster command to deploy the the hcls blueprint.
 
    ```bash
-   ./ghpc deploy hcls-01
+   ./gcluster deploy hcls-01
    ```
 
    This will prompt you to **display**, **apply**, **stop**, or **continue**
@@ -140,20 +140,20 @@ storage intact and b) you can build software before you deploy your cluster.
    cluster.
 
    > [!WARNING]
-   > This ghpc command will run through 4 groups (`enable_apis`, `setup`,
+   > This gcluster command will run through 4 groups (`enable_apis`, `setup`,
    > `software_installation`, and `cluster`) and prompt you to apply each one.
    > If the command is cancelled or exited by accident before finishing, it can
    > be rerun to continue deploying the blueprint.
 
 1. Deploy the `setup` group
 
-   The next `ghpc` prompt will ask you to **display**, **apply**, **stop**, or
+   The next `gcluster` prompt will ask you to **display**, **apply**, **stop**, or
    **continue** without applying the `setup` group. Select 'apply'.
 
    This group will create a network and file systems to be used by the cluster.
 
    > [!NOTE]
-   > At this point do not proceed with the ghpc prompt for the `cluster` group.
+   > At this point do not proceed with the gcluster prompt for the `cluster` group.
    > Continue with the steps below before proceeding.
 
    This step will create a storage bucket for depositing software. The bucket
@@ -163,7 +163,7 @@ storage intact and b) you can build software before you deploy your cluster.
 
    Here are two ways to locate the bucket name:
 
-   1. At the end of the `setup` deployment, ghpc should output a line
+   1. At the end of the `setup` deployment, gcluster should output a line
       `Outputs:`. Under that there should be a line similar to
       `gcs_bucket_path_bucket-software = "gs://hcls-user-provided-software-hcls-01-84d0b51e"`,
       the bucket name is located within the quotes after `gs://`
@@ -200,7 +200,7 @@ storage intact and b) you can build software before you deploy your cluster.
 1. Deploy the `software_installation` group.
 
    Once the file from the prior step has been completely uploaded, you can
-   return to the ghpc command which will ask you to **display**, **apply**,
+   return to the gcluster command which will ask you to **display**, **apply**,
    **stop**, or **continue** without applying the `software_installation` group.
    Select 'apply'.
 
@@ -221,7 +221,7 @@ storage intact and b) you can build software before you deploy your cluster.
 
 1. Deploy the `cluster` group
 
-   The next `ghpc` prompt will ask you to **display**, **apply**, **stop**, or
+   The next `gcluster` prompt will ask you to **display**, **apply**, **stop**, or
    **continue** without applying the `cluster` group. Select 'apply'.
 
    This deployment group contains the Slurm cluster and the Chrome remote
@@ -249,7 +249,7 @@ destroyed first. You can use the following commands to destroy the deployment.
 > associated costs.
 
 ```bash
-./ghpc destroy hcls-01 --auto-approve
+./gcluster destroy hcls-01 --auto-approve
 ```
 
 > [!NOTE]

--- a/docs/videos/healthcare-and-life-sciences/lysozyme-example/README.md
+++ b/docs/videos/healthcare-and-life-sciences/lysozyme-example/README.md
@@ -49,8 +49,8 @@ button or by any other means.
 1. Copy the contents of this directory into the submission directory
 
    ```bash
-   git clone https://github.com/GoogleCloudPlatform/hpc-toolkit.git
-   cp -r hpc-toolkit/docs/videos/healthcare-and-life-sciences/lysozyme-example/* .
+   git clone https://github.com/GoogleCloudPlatform/cluster-toolkit.git
+   cp -r cluster-toolkit/docs/videos/healthcare-and-life-sciences/lysozyme-example/* .
    ```
 
 1. Copy the Lysozyme protein into the submission directory

--- a/examples/cae/README.md
+++ b/examples/cae/README.md
@@ -95,8 +95,8 @@ storage intact and b) you can build software before you deploy your cluster.
 1. Clone the repo
 
    ```bash
-   git clone https://github.com/GoogleCloudPlatform/hpc-toolkit.git
-   cd hpc-toolkit
+   git clone https://github.com/GoogleCloudPlatform/cluster-toolkit.git
+   cd cluster-toolkit
    ```
 
 1. Build the Cluster Toolkit
@@ -109,24 +109,24 @@ storage intact and b) you can build software before you deploy your cluster.
    id.
 
    ```bash
-   ./ghpc create community/examples/cae-slurm.yaml -w --vars project_id=<project>
+   ./gcluster create community/examples/cae-slurm.yaml -w --vars project_id=<project>
    ```
 
 1. Deploy the `setup` group
 
-   Call the following ghpc command to deploy the cae-slurm blueprint.
+   Call the following gcluster command to deploy the cae-slurm blueprint.
 
    ```bash
-   ./ghpc deploy cae-slurm
+   ./gcluster deploy cae-slurm
    ```
 
-   The next `ghpc` prompt will ask you to **display**, **apply**, **stop**, or
+   The next `gcluster` prompt will ask you to **display**, **apply**, **stop**, or
    **continue** without applying the `setup` group. Select 'apply'.
 
    This group will create a network and file systems to be used by the cluster.
 
    > [!WARNING]
-   > This ghpc command will run through 2 deployment groups (3 if you populate
+   > This gcluster command will run through 2 deployment groups (3 if you populate
    > & activate the `software_installation` stage) and prompt you to apply each one.
    > If the command is cancelled or exited by accident before finishing, it can
    > be rerun to continue deploying the blueprint.
@@ -148,13 +148,13 @@ storage intact and b) you can build software before you deploy your cluster.
    > [Software Installation Patterns](#software-installation-patterns) for more information.
 
    If this deployment group is used (needs to be uncomment in the blueprint first),
-   you can return to the ghpc command which will ask you to **display**, **apply**,
+   you can return to the gcluster command which will ask you to **display**, **apply**,
    **stop**, or **continue** without applying the `software_installation` group.
    Select 'apply'.
 
 1. Deploy the `cluster` group
 
-   The next `ghpc` prompt will ask you to **display**, **apply**, **stop**, or
+   The next `gcluster` prompt will ask you to **display**, **apply**, **stop**, or
    **continue** without applying the `cluster` group. Select 'apply'.
 
    This deployment group contains the Slurm cluster and with compute partitions
@@ -182,7 +182,7 @@ commands to destroy the deployment in this reverse order. You will be prompted
 to confirm the deletion of each stage.
 
 ```bash
-./ghpc destroy cae-slurm
+./gcluster destroy cae-slurm
 ```
 
 > [!WARNING]

--- a/examples/machine-learning/a3-highgpu-8g/README.md
+++ b/examples/machine-learning/a3-highgpu-8g/README.md
@@ -22,7 +22,7 @@ Please follow the initial instructions for:
 Verify that your release of the Cluster Toolkit is 1.31.1 or later.
 
 ```shell
-ghpc --version
+gcluster --version
 ```
 
 The solution requires several Python packages to be available. We recommend
@@ -35,7 +35,7 @@ pip3 install -r \
     https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/5.11.1/scripts/requirements.txt
 ```
 
-**Always** activate the environment before running any ghpc commands such as
+**Always** activate the environment before running any gcluster commands such as
 deploy or destroy.
 
 ```shell
@@ -194,7 +194,7 @@ and a Filestore `/home` filesystem. Run the standard Toolkit workflow at the
 command line (approx. 5 minutes):
 
 ```shell
-ghpc deploy ml-slurm-a3-0-base.yaml --auto-approve
+gcluster deploy ml-slurm-a3-0-base.yaml --auto-approve
 ```
 
 Several values will be output to the screen. The output will be similar to:
@@ -226,7 +226,7 @@ Build the custom image using ml-slurm-a3-1-image.yaml and the same workflow
 as above. Run at the command line:
 
 ```shell
-ghpc deploy ml-slurm-a3-1-image.yaml --auto-approve
+gcluster deploy ml-slurm-a3-1-image.yaml --auto-approve
 ```
 
 The image will take approximately 30 minutes to build.
@@ -243,7 +243,7 @@ The image will take approximately 30 minutes to build.
 Provision the cluster blueprint (approximately 5-10 minutes):
 
 ```shell
-ghpc deploy ml-slurm-a3-2-cluster.yaml --auto-approve
+gcluster deploy ml-slurm-a3-2-cluster.yaml --auto-approve
 ```
 
 ## Receive Data Path Manager (RxDM)
@@ -307,8 +307,8 @@ using an alternative image.
 ### Clone the Cluster Toolkit repository containing the NCCL benchmark
 
 ```shell
-git clone https://github.com/GoogleCloudPlatform/hpc-toolkit
-cd hpc-toolkit/examples/machine-learning/a3-highgpu-8g/nccl-tests
+git clone https://github.com/GoogleCloudPlatform/cluster-toolkit
+cd cluster-toolkit/examples/machine-learning/a3-highgpu-8g/nccl-tests
 ```
 
 ### Import the PyTorch image from the NVIDIA Container Registry
@@ -331,4 +331,4 @@ sbatch run-nccl-tests.sh
 
 [consume]: https://cloud.google.com/compute/docs/instances/reservations-consume#consuming_instances_from_any_matching_reservation
 [tkdeps]: https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies
-[tkinstall]: https://github.com/GoogleCloudPlatform/hpc-toolkit/#quickstart
+[tkinstall]: https://github.com/GoogleCloudPlatform/cluster-toolkit/#quickstart


### PR DESCRIPTION
This PR updates references in the documentation to previous repo name `hpc-toolkit` and to the previous binary name `ghpc`. They were updated to `cluster-toolkit` and `gcluster`.
