### PR TITLE
SlurmGCP6. Fix nodes stack in `down*` state.

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -167,19 +167,6 @@ def _find_tpu_node_status(nodename, state):
 
     return NodeStatus.unchanged
 
-
-def allow_power_down(state):
-    config = run(f"{lkp.scontrol} show config").stdout.rstrip()
-    m = re.search(r"SuspendExcStates\s+=\s+(?P<states>[\w\(\)]+)", config)
-    if not m:
-        log.warning("SuspendExcStates not found in Slurm config")
-        return True
-    states = set(m.group("states").split(","))
-    if "(null)" in states or bool(state & state.flags.union(state.base)):
-        return False
-    return True
-
-
 def find_node_status(nodename):
     """Determine node/instance status that requires action"""
     state = lkp.slurm_node(nodename)
@@ -207,7 +194,7 @@ def find_node_status(nodename):
             return NodeStatus.unbacked
         if state.base != "DOWN" and not power_flags:
             return NodeStatus.unbacked
-        if state.base == "DOWN" and not power_flags and allow_power_down(state):
+        if state.base == "DOWN" and not power_flags:
             return NodeStatus.power_down
         if "POWERED_DOWN" in state.flags and lkp.is_static_node(nodename):
             return NodeStatus.resume


### PR DESCRIPTION
Stop checking `SuspenExcStates` in `slurmsync`

**Motivation:**

* Implementation of `allow_power_down` contains multiple bugs.
TL;DR: slurmsync never calls `scontol ... state=power_down` -> nodes are getting stuck in bad state `NOT_RESPONDING`.

* `SuspenExcStates` is a wrong flag to be used, especially if it can be modified by user. If we decide to provide such knob to the customer in the future, it should be a separate and specific to SlurmGCP (not Slurm-wide).