### PR TITLE
Fix references to old name of Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Cluster Toolkit (formally HPC Toolkit)
+# Google Cluster Toolkit (formerly HPC Toolkit)
 
 ## Description
 

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,4 +1,4 @@
-# Cluster Toolkit (formally HPC Toolkit) Commands
+# Cluster Toolkit (formerly HPC Toolkit) Commands
 
 ## gcluster
 

--- a/community/examples/AMD/README.md
+++ b/community/examples/AMD/README.md
@@ -1,4 +1,4 @@
-# AMD solutions for the Cluster Toolkit (formally HPC Toolkit)
+# AMD solutions for the Cluster Toolkit (formerly HPC Toolkit)
 
 > [!NOTE]
 > This document uses Slurm-GCP v6. If you want to use Slurm-GCP v5 version you

--- a/community/examples/intel/README.md
+++ b/community/examples/intel/README.md
@@ -1,4 +1,4 @@
-# Intel Solutions for the Cluster Toolkit (formally HPC Toolkit)
+# Intel Solutions for the Cluster Toolkit (formerly HPC Toolkit)
 
 > **_NOTE:_** The [hpc-slurm-daos.yaml](hpc-slurm-daos.yaml) will not be compatible
 > for newer version of slurm-gcp v6.

--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -1,4 +1,4 @@
-# Network Storage in the Cluster Toolkit (formally HPC Toolkit)
+# Network Storage in the Cluster Toolkit (formerly HPC Toolkit)
 
 The Cluster Toolkit provides powerful tools for working with network
 storage.

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -1,4 +1,4 @@
-# Custom Images in the Cluster Toolkit (formally HPC Toolkit)
+# Custom Images in the Cluster Toolkit (formerly HPC Toolkit)
 
 Please review the
 [introduction to image building](../../../docs/image-building.md) for general


### PR DESCRIPTION
Fix references to old name of the Cluster Toolkit. This change is documentation only and we will not update the version tags in our Terraform and Go code. However, we will create a new tag/release in the GitHub UI after merging.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
