### PR TITLE
Add test for legacy v5 a3-highgpu-8g blueprint

### DIFF
--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -38,6 +38,7 @@ When prompted for project, use integration test project.
 | <a name="module_daily_project_cleanup_filestore_schedule"></a> [daily\_project\_cleanup\_filestore\_schedule](#module\_daily\_project\_cleanup\_filestore\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_project_cleanup_slurm_schedule"></a> [daily\_project\_cleanup\_slurm\_schedule](#module\_daily\_project\_cleanup\_slurm\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_test_schedule"></a> [daily\_test\_schedule](#module\_daily\_test\_schedule) | ./trigger-schedule | n/a |
+| <a name="module_legacy_test_schedule"></a> [legacy\_test\_schedule](#module\_legacy\_test\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_weekly_build_dependency_check_schedule"></a> [weekly\_build\_dependency\_check\_schedule](#module\_weekly\_build\_dependency\_check\_schedule) | ./trigger-schedule | n/a |
 
 ## Resources
@@ -48,6 +49,7 @@ When prompted for project, use integration test project.
 | [google_cloudbuild_trigger.daily_project_cleanup_slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.image_build_test_runner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.legacy_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_go_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_venv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |

--- a/tools/cloud-build/provision/legacy-tests.tf
+++ b/tools/cloud-build/provision/legacy-tests.tf
@@ -1,0 +1,53 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  legacy_tests = [
+    ["ml-a3-highgpu-slurm", "refs/tags/v1.37.1"],
+  ]
+}
+
+resource "google_cloudbuild_trigger" "legacy_test" {
+  count       = length(local.legacy_tests)
+  name        = "LEGACY-test-${local.legacy_tests[count.index][0]}"
+  description = "Runs the '${local.legacy_tests[count.index][0]}' integration test against last supported release"
+  tags        = [local.notify_chat_tag]
+
+  git_file_source {
+    path      = "tools/cloud-build/daily-tests/builds/${local.legacy_tests[count.index][0]}.yaml"
+    revision  = local.legacy_tests[count.index][1]
+    uri       = var.repo_uri
+    repo_type = "GITHUB"
+  }
+
+  source_to_build {
+    uri       = var.repo_uri
+    ref       = local.legacy_tests[count.index][1]
+    repo_type = "GITHUB"
+  }
+  # Following fields will be auto-set by CloudBuild after creation
+  # Specify it explicitly to reduce discreppancy.
+  ignored_files  = []
+  included_files = []
+  substitutions  = {}
+}
+
+# TODO: build solution for scheduling tests in sequence when we have
+# more than 1 test
+module "legacy_test_schedule" {
+  source   = "./trigger-schedule"
+  count    = length(google_cloudbuild_trigger.legacy_test)
+  trigger  = google_cloudbuild_trigger.legacy_test[count.index]
+  schedule = "30 5 * * MON-FRI"
+}


### PR DESCRIPTION
This PR adds a nightly integration test for the legacy v5 a3-highgpu-8g blueprint. The reasoning to use the tag v1.37.1 rather than develop is that the new recommendation is to use the v6 blueprints and existing customers will be running on v1.37.1 or below. We want to best replicate the support environment for our customers. We will make updates to the legacy blueprints on develop _ad hoc_ depending upon customer experience. If so, we may update the tag.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
