### PR TITLE
SlurmGCP. Store nodeset and partition configs in separate files

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -46,7 +46,9 @@ No modules.
 | [google_storage_bucket_object.devel](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.epilog_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.login_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.nodeset_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.nodeset_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.parition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.prolog_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_uuid.cluster_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [archive_file.slurm_gcp_devel_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -67,12 +67,6 @@ locals {
     epilog_scripts   = [for k, v in google_storage_bucket_object.epilog_scripts : k]
     cloud_parameters = var.cloud_parameters
 
-    partitions = { for p in var.partitions : p.partition_name => p }
-    nodeset = {
-      for n in var.nodeset : n.nodeset_name => merge(n, {
-        instance_properties = jsondecode(n.instance_properties_json)
-      })
-    }
     nodeset_dyn = { for n in var.nodeset_dyn : n.nodeset_name => n }
     nodeset_tpu = { for n in var.nodeset_tpu[*].nodeset : n.nodeset_name => n }
 
@@ -96,9 +90,6 @@ locals {
     # Providers
     endpoint_versions = var.endpoint_versions
   }
-
-  config_yaml        = "config.yaml"
-  config_yaml_bucket = format("%s/%s", local.bucket_dir, local.config_yaml)
 
   x_nodeset         = toset(var.nodeset[*].nodeset_name)
   x_nodeset_dyn     = toset(var.nodeset_dyn[*].nodeset_name)
@@ -128,8 +119,26 @@ locals {
 
 resource "google_storage_bucket_object" "config" {
   bucket  = data.google_storage_bucket.this.name
-  name    = local.config_yaml_bucket
+  name    = "${local.bucket_dir}/config.yaml"
   content = yamlencode(local.config)
+}
+
+resource "google_storage_bucket_object" "parition_config" {
+  for_each = { for p in var.partitions : p.partition_name => p }
+
+  bucket  = data.google_storage_bucket.this.name
+  name    = "${local.bucket_dir}/partition_configs/${each.key}.yaml"
+  content = yamlencode(each.value)
+}
+
+resource "google_storage_bucket_object" "nodeset_config" {
+  for_each = { for ns in var.nodeset : ns.nodeset_name => merge(ns, {
+    instance_properties = jsondecode(ns.instance_properties_json)
+  }) }
+
+  bucket  = data.google_storage_bucket.this.name
+  name    = "${local.bucket_dir}/nodeset_configs/${each.key}.yaml"
+  content = yamlencode(each.value)
 }
 
 #########

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -213,8 +213,6 @@ def munge_mount_handler():
         else "defaults,hard,intr,_netdev"
     )
 
-    munge_key = Path(dirs.munge / "munge.key")
-
     log.info(f"Mounting munge share to: {local_mount}")
     local_mount.mkdir()
     if fs_type.lower() == "gcsfuse".lower():
@@ -228,7 +226,7 @@ def munge_mount_handler():
         ]
     else:
         if remote_mount is None:
-            remote_mount = Path("/etc/munge")
+            remote_mount = dirs.munge
         cmd = [
             "mount",
             f"--types={fs_type}",
@@ -252,6 +250,7 @@ def munge_mount_handler():
     else:
         raise err
 
+    munge_key = Path(dirs.munge / "munge.key")
     log.info(f"Copy munge.key from: {local_mount}")
     shutil.copy2(Path(local_mount / "munge.key"), munge_key)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -37,7 +37,6 @@ from util import (
     run,
     separate,
     to_hostlist_fast,
-    Lookup,
     NSDict,
     TPU,
     chunked,
@@ -548,6 +547,8 @@ def main():
         #     log.exception("failed to sync slurm reservation for scheduled maintenance")
 
     try:
+        # TODO: it performs 1 to 4 GCS list requests, 
+        # use cached version, combine with `_list_config_blobs`
         install_custom_scripts(check_hash=True)
     except Exception:
         log.exception("failed to sync custom scripts")


### PR DESCRIPTION
Store nodeset and partition configs in separate files (outside of `config.yaml`)

**Motivation:**
* Reduce side effects of re-configuration;
* Allow for dependency chain inversion.
