### PR TITLE
Add `slurmgcp-managed` infix to resource policy name

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -521,7 +521,7 @@ def create_nodeset_placement_groups(node_list: list, job_id=0):
     region = lkp.node_region(model)
 
     groups = {
-        f"{cfg.slurm_cluster_name}-{nodeset.nodeset_name}-{job_id}-{i}": nodes
+        f"{cfg.slurm_cluster_name}-slurmgcp-managed-{nodeset.nodeset_name}-{job_id}-{i}": nodes
         for i, nodes in enumerate(chunked(node_list, n=PLACEMENT_MAX_CNT))
     }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/cleanup_compute.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/scripts/cleanup_compute.sh
@@ -52,7 +52,7 @@ while true; do
 done
 
 echo "Deleting resource policies"
-policies_filter="name:${cluster_name}-*"
+policies_filter="name:${cluster_name}-slurmgcp-managed-*"
 while true; do
 	policies=$(bash -c "$API_ENDPOINT gcloud compute resource-policies list --project \"${project}\" --format=\"value(selfLink)\" --filter=\"${policies_filter}\" --limit=10 | paste -sd \" \" -")
 	if [[ -z "${policies}" ]]; then


### PR DESCRIPTION
**Motivation:** improve collision avoidance, current matching pattern `"${cluster_name}-*"` is too relaxed.

**Consideration for max length of resource policy name, that**
> `Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'`


* `'slurm_cluster_name' must be a match of regex '^[a-z](?:[a-z0-9]{0,9})$'` = 10
* `nodeset_name = substr(replace(var.name, "/[^a-z0-9]/", ""), 0, 14)` = 14
* assume `len(job_id)` = 10
* assume `len(nodes_chunk_id)`  = 3
* `len("slurmgcp-managed")` = 16

`len("${cluster_name}-slurmgcp-managed-${nodeset_name}-${job_id}-${nodes_chunk_id}")` = 10+1+16+1+14+1+10+3 = 56

**Testing:**

```sh
$ gcloud compute resource-policies list | grep tt0
tt0-slurmgcp-managed-debugnodeset-1-0

$ ./ghpc destroy tt0 $AA
...
module.slurm_controller.null_resource.cleanup_compute[0] (local-exec): Deleted [https://www.googleapis.com/compute/beta/projects/io-playground/zones/us-central1-a/instances/tt0-debugnodeset-0].
module.slurm_controller.null_resource.cleanup_compute[0] (local-exec): Deleted [https://www.googleapis.com/compute/beta/projects/io-playground/zones/us-central1-a/instances/tt0-debugnodeset-1].
module.slurm_controller.null_resource.cleanup_compute[0]: Still destroying... [id=8428718126253180537, 2m20s elapsed]
module.slurm_controller.null_resource.cleanup_compute[0] (local-exec): Deleting resource policies
module.slurm_controller.null_resource.cleanup_compute[0] (local-exec): Deleted [https://www.googleapis.com/compute/beta/projects/io-playground/regions/us-central1/resourcePolicies/tt0-slurmgcp-managed-debugnodeset-1-0].
module.slurm_controller.null_resource.cleanup_compute[0]: Destruction complete after 2m25s
...
$ gcloud compute resource-policies list | grep tt0
$
```

**Followups:**
* Include `nodeset_name` into match pattern of `cleanup_compute.sh` (once cleanup-per-nodeset is implemented).

**Alternative considerations:**
* Use existing `resource.random_uuid.cluster_id` - too long (36 chars); can create unexpected lifecycle dependencies;
* Use dedicated `resource.random_uuid.short_cluster_id` - can create unexpected lifecycle dependencies;