### PR TITLE
Align variable name around gcluster to avoid mismatch

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/gather_startup_script_logs.yml
@@ -16,14 +16,14 @@
 - name: Assert variables are defined
   ansible.builtin.assert:
     that:
-    - ghpc_stderr is defined
+    - gcluster_stderr is defined
 
 # Searches the ghpc stderr for a command that gathers the serial logs from the
 # deployed VM, defaults to an empty string if the command is not found
 - name: Get serial port command
   failed_when: false
   ansible.builtin.set_fact:
-    serial_port_cmd: '{{ ghpc_stderr | regex_findall("please run:\s+(.+?\s+--project\s+\S+)", "\\1") | first | default("") }}'
+    serial_port_cmd: '{{ gcluster_stderr | regex_findall("please run:\s+(.+?\s+--project\s+\S+)", "\\1") | first | default("") }}'
 
 - name: Print serial port command
   failed_when: false


### PR DESCRIPTION
Name mismatch between updated and [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/cad2282a3c2f79cfbe55ca3a3a246519391058fc/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml#L143) was causing assertion to fail and test cleanup to fail.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
