### PR TITLE
Extend timeout on batch test build

### DIFF
--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -56,7 +56,7 @@ steps:
     echo '    source: community/modules/scripts/wait-for-startup' >> $${SG_EXAMPLE}
     echo '    settings:'                                          >> $${SG_EXAMPLE}
     echo '      instance_name: $(spack-builder.name[0])'          >> $${SG_EXAMPLE}
-    echo '      timeout: 2400'                                    >> $${SG_EXAMPLE}
+    echo '      timeout: 10800'                                   >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \


### PR DESCRIPTION
Build is taking longer, extend timeout so test will pass while investigating

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
