### PR TITLE
SlurmGCP. Stop using global mutable `lkp`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/get_tpu_vmcount.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/get_tpu_vmcount.py
@@ -20,8 +20,8 @@ import util
 
 def get_vmcount_of_tpu_part(part):
     res = 0
-    for ns in util.lkp.cfg.partitions[part].partition_nodeset_tpu:
-        tpu_obj = util.TPU(util.lkp.cfg.nodeset_tpu[ns])
+    for ns in util.lookup().cfg.partitions[part].partition_nodeset_tpu:
+        tpu_obj = util.TPU(util.lookup().cfg.nodeset_tpu[ns])
         if res == 0:
             res = tpu_obj.vmcount
         else:
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # valid equals to 0 means that we are ok, otherwise it will be set to one of the previously defined exit codes
     valid = 0
     for part in args.partitions.split(","):
-        if part not in util.lkp.cfg.partitions:
+        if part not in util.lookup().cfg.partitions:
             valid = PART_INVALID
             break
         else:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
@@ -28,7 +28,7 @@ from google.cloud import bigquery as bq
 from google.api_core import retry, exceptions
 
 import util
-from util import lkp, run
+from util import lookup, run
 
 
 SACCT = "sacct"
@@ -175,14 +175,14 @@ job_schema = {field.name: field for field in schema_fields}
 Job = namedtuple("Job", job_schema.keys())
 
 client = bq.Client(
-    project=lkp.cfg.project,
+    project=lookup().cfg.project,
     credentials=util.default_credentials(),
     client_options=util.create_client_options(util.ApiEndpoint.BQ),
 )
-dataset_id = f"{lkp.cfg.slurm_cluster_name}_job_data"
-dataset = bq.DatasetReference(project=lkp.project, dataset_id=dataset_id)
+dataset_id = f"{lookup().cfg.slurm_cluster_name}_job_data"
+dataset = bq.DatasetReference(project=lookup().project, dataset_id=dataset_id)
 table = bq.Table(
-    bq.TableReference(dataset, f"jobs_{lkp.cfg.slurm_cluster_name}"), schema_fields
+    bq.TableReference(dataset, f"jobs_{lookup().cfg.slurm_cluster_name}"), schema_fields
 )
 
 
@@ -197,8 +197,8 @@ def make_job_row(job):
         if field_name in job
     }
     job_row["entry_uuid"] = uuid.uuid4().hex
-    job_row["cluster_id"] = lkp.cfg.cluster_id
-    job_row["cluster_name"] = lkp.cfg.slurm_cluster_name
+    job_row["cluster_id"] = lookup().cfg.cluster_id
+    job_row["cluster_name"] = lookup().cfg.slurm_cluster_name
     return job_row
 
 
@@ -309,7 +309,7 @@ def update_job_idx_cache(jobs, timestamp):
 
 
 def main():
-    if not lkp.cfg.enable_bigquery_load:
+    if not lookup().cfg.enable_bigquery_load:
         print("bigquery load is not currently enabled")
         exit(0)
     init_table()

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -41,7 +41,7 @@ from util import (
     trim_self_link,
     wait_for_operation,
 )
-from util import lkp, NSDict, TPU
+from util import lookup, NSDict, TPU
 
 import slurm_gcp_plugins
 
@@ -61,8 +61,8 @@ def instance_properties(nodeset, model, placement_group, labels=None):
     props = NSDict()
 
     if labels: # merge in extra labels on instance and disks
-        template = lkp.node_template(model)
-        template_info = lkp.template_info(template)
+        template = lookup().node_template(model)
+        template_info = lookup().template_info(template)
 
         props.labels = {**template_info.labels, **labels}
         
@@ -85,7 +85,7 @@ def instance_properties(nodeset, model, placement_group, labels=None):
         zones = list(nodeset.zone_policy_allow or [])
         assert len(zones) == 1, "Only single zone is supported if using a reservation"
 
-        reservation = lkp.reservation(reservation_name, zones[0])
+        reservation = lookup().reservation(reservation_name, zones[0])
 
         props.reservationAffinity = {
             "consumeReservationType": "SPECIFIC_RESERVATION",
@@ -135,10 +135,10 @@ def create_instances_request(nodes, partition_name, placement_group, job_id=None
 
     # model here indicates any node that can be used to describe the rest
     model = next(iter(nodes))
-    nodeset = lkp.node_nodeset(model)
-    template = lkp.node_template(model)
-    region = lkp.node_region(model)
-    partition = lkp.cfg.partitions[partition_name]
+    nodeset = lookup().node_nodeset(model)
+    template = lookup().node_template(model)
+    region = lookup().node_region(model)
+    partition = lookup().cfg.partitions[partition_name]
     log.debug(f"create_instances_request: {model} placement: {placement_group}")
 
     body = NSDict()
@@ -173,16 +173,16 @@ def create_instances_request(nodes, partition_name, placement_group, job_id=None
     }
     body.locationPolicy.targetShape = nodeset.zone_target_shape
 
-    if lkp.cfg.enable_slurm_gcp_plugins:
+    if lookup().cfg.enable_slurm_gcp_plugins:
         slurm_gcp_plugins.pre_instance_bulk_insert(
-            lkp=lkp,
+            lkp=lookup(),
             nodes=nodes,
             placement_group=placement_group,
             request_body=body,
         )
 
-    request = lkp.compute.regionInstances().bulkInsert(
-        project=lkp.project, region=region, body=body.to_dict()
+    request = lookup().compute.regionInstances().bulkInsert(
+        project=lookup().project, region=region, body=body.to_dict()
     )
 
     if log.isEnabledFor(logging.DEBUG):
@@ -228,7 +228,7 @@ def group_nodes_bulk(nodes, resume_data=None):
     )
     jobless_nodes_tpu = []
     for jobless_node in jobless_nodes[:]:
-        if lkp.node_is_tpu(jobless_node):
+        if lookup().node_is_tpu(jobless_node):
             jobless_nodes.remove(jobless_node)
             jobless_nodes_tpu.append(jobless_node)
 
@@ -268,7 +268,7 @@ def group_nodes_bulk(nodes, resume_data=None):
         for job_id, job in jobs.items()
         if not job.tpu
         for placement_group, pg_nodes in job.placement_groups.items()
-        for prefix, nodes in util.groupby_unsorted(pg_nodes, lkp.node_prefix)
+        for prefix, nodes in util.groupby_unsorted(pg_nodes, lookup().node_prefix)
         for i, chunk_nodes in enumerate(chunked(nodes, n=BULK_INSERT_LIMIT))
     ]
     grouped_nodes_tpu = [
@@ -281,8 +281,8 @@ def group_nodes_bulk(nodes, resume_data=None):
         )
         for job_id, job in jobs.items()
         if job.tpu
-        for prefix, nodes in util.groupby_unsorted(job.nodes_resume, lkp.node_prefix)
-        for i, chunk_nodes in enumerate(lkp.chunk_tpu_nodes(list(nodes)))
+        for prefix, nodes in util.groupby_unsorted(job.nodes_resume, lookup().node_prefix)
+        for i, chunk_nodes in enumerate(lookup().chunk_tpu_nodes(list(nodes)))
     ]
 
     def group_name(chunk: BulkChunk):
@@ -339,7 +339,7 @@ def resume_nodes(nodes: List[str], resume_data=None):
     if resume_data is None and global_resume_data is not None:
         resume_data = global_resume_data.deepcopy()
 
-    nodes = sorted(nodes, key=lkp.node_prefix)
+    nodes = sorted(nodes, key=lookup().node_prefix)
     grouped_nodes, grouped_tpu_nodes = group_nodes_bulk(nodes, resume_data)
 
     if log.isEnabledFor(logging.DEBUG):
@@ -365,7 +365,7 @@ def resume_nodes(nodes: List[str], resume_data=None):
         # do not create multiple tpu_objs if nodes with the same prefix are used
         if chunk.prefix not in tpu_objs.keys():
             model = chunk.nodes[0]
-            tpu_objs[chunk.prefix] = TPU(lkp.node_nodeset(model))
+            tpu_objs[chunk.prefix] = TPU(lookup().node_nodeset(model))
 
         tpu_start_data.append({"tpu": tpu_objs[chunk.prefix], "node": chunk.nodes})
 
@@ -466,8 +466,8 @@ def update_job_comment(nodelist: str, comment: str):
         if any(map(lambda node: node in nodes, util.to_hostnames(job.nodelist_resume)))
     )
     for job in job_list:
-        run(f"{lkp.scontrol} update jobid={job.job_id} admincomment='{comment}'")
-        run(f"{lkp.scontrol} notify {job.job_id} '{comment}'")
+        run(f"{lookup().scontrol} update jobid={job.job_id} admincomment='{comment}'")
+        run(f"{lookup().scontrol} notify {job.job_id} '{comment}'")
 
 
 def down_nodes(nodelist, reason):
@@ -475,13 +475,13 @@ def down_nodes(nodelist, reason):
     if isinstance(nodelist, list):
         nodelist = util.to_hostlist(nodelist)
     update_job_comment(nodelist, reason)
-    run(f"{lkp.scontrol} update nodename={nodelist} state=down reason='{reason}'")
+    run(f"{lookup().scontrol} update nodename={nodelist} state=down reason='{reason}'")
 
 
 def hold_job(job_id, reason):
     """hold job, set comment to reason"""
-    run(f"{lkp.scontrol} hold jobid={job_id}")
-    run(f"{lkp.scontrol} update jobid={job_id} comment='{reason}'")
+    run(f"{lookup().scontrol} hold jobid={job_id}")
+    run(f"{lookup().scontrol} update jobid={job_id} comment='{reason}'")
 
 
 def create_placement_request(pg_name, region):
@@ -492,12 +492,12 @@ def create_placement_request(pg_name, region):
             "collocation": "COLLOCATED",
         },
     }
-    if lkp.cfg.enable_slurm_gcp_plugins:
+    if lookup().cfg.enable_slurm_gcp_plugins:
         slurm_gcp_plugins.pre_placement_group_insert(
-            lkp=lkp, pg_name=pg_name, region=region, request_body=config
+            lkp=lookup(), pg_name=pg_name, region=region, request_body=config
         )
-    request = lkp.compute.resourcePolicies().insert(
-        project=lkp.project, region=region, body=config
+    request = lookup().compute.resourcePolicies().insert(
+        project=lookup().project, region=region, body=config
     )
     log_api_request(request)
     return request
@@ -505,7 +505,7 @@ def create_placement_request(pg_name, region):
 
 def create_placement_groups(node_list: list, job_id=0):
     pgs = {}
-    node_map = lkp.nodeset_map(node_list)
+    node_map = lookup().nodeset_map(node_list)
     for _, nodes in node_map.items():
         pgs.update(create_nodeset_placement_groups(nodes, job_id=job_id))
     return pgs
@@ -513,15 +513,15 @@ def create_placement_groups(node_list: list, job_id=0):
 
 def create_nodeset_placement_groups(node_list: list, job_id=0):
     model = next(iter(node_list))
-    nodeset = lkp.node_nodeset(model)
+    nodeset = lookup().node_nodeset(model)
     if not nodeset.enable_placement:
         return {None: node_list}
     if not valid_placement_nodes(node_list):
         return {None: node_list}
-    region = lkp.node_region(model)
+    region = lookup().node_region(model)
 
     groups = {
-        f"{lkp.cfg.slurm_cluster_name}-slurmgcp-managed-{nodeset.nodeset_name}-{job_id}-{i}": nodes
+        f"{lookup().cfg.slurm_cluster_name}-slurmgcp-managed-{nodeset.nodeset_name}-{job_id}-{i}": nodes
         for i, nodes in enumerate(chunked(node_list, n=PLACEMENT_MAX_CNT))
     }
 
@@ -579,7 +579,7 @@ def create_nodeset_placement_groups(node_list: list, job_id=0):
 def valid_placement_nodes(nodelist):
     invalid_types = frozenset(["e2", "t2d", "n1", "t2a", "m1", "m2", "m3"])
     for node in nodelist:
-        mt = lkp.node_template_info(node).machineType
+        mt = lookup().node_template_info(node).machineType
         if mt.split("-")[0] in invalid_types:
             log.warn(f"Unsupported machine type for placement policy: {mt}.")
             log.warn(
@@ -608,7 +608,7 @@ def main(nodelist):
     log.debug(f"ResumeProgram {nodelist}")
     # Filter out nodes not in config.yaml
     other_nodes, pm_nodes = separate(
-        lkp.is_power_managed_node, util.to_hostnames(nodelist)
+        lookup().is_power_managed_node, util.to_hostnames(nodelist)
     )
     if other_nodes:
         log.debug(
@@ -626,7 +626,7 @@ def main(nodelist):
     resume_nodes(pm_nodes, global_resume_data)
     # TODO only run below if resume_nodes succeeds but
     # resume_nodes does not currently return any status.
-    if lkp.cfg.enable_slurm_gcp_plugins:
+    if lookup().cfg.enable_slurm_gcp_plugins:
         slurm_gcp_plugins.post_main_resume_nodes(
             nodelist=nodelist, global_resume_data=global_resume_data
         )

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -27,7 +27,7 @@ from concurrent.futures import as_completed
 from addict import Dict as NSDict
 
 import util
-from util import lkp, run, dirs, separate
+from util import lookup, run, dirs, separate
 from more_executors import Executors, ExceptionRetryPolicy
 
 
@@ -41,21 +41,21 @@ def mounts_by_local(mounts):
 def resolve_network_storage(nodeset=None):
     """Combine appropriate network_storage fields to a single list"""
 
-    if lkp.instance_role == "compute":
+    if lookup().instance_role == "compute":
         try:
-            nodeset = lkp.node_nodeset()
+            nodeset = lookup().node_nodeset()
         except Exception:
             # External nodename, skip lookup
             nodeset = None
 
     # seed mounts with the default controller mounts
-    if lkp.cfg.disable_default_mounts:
+    if lookup().cfg.disable_default_mounts:
         default_mounts = []
     else:
         default_mounts = [
             NSDict(
                 {
-                    "server_ip": lkp.control_addr or lkp.control_host,
+                    "server_ip": lookup().control_addr or lookup().control_host,
                     "remote_mount": str(path),
                     "local_mount": str(path),
                     "fs_type": "nfs",
@@ -73,9 +73,9 @@ def resolve_network_storage(nodeset=None):
 
     # On non-controller instances, entries in network_storage could overwrite
     # default exports from the controller. Be careful, of course
-    mounts.update(mounts_by_local(lkp.cfg.network_storage))
-    if lkp.instance_role in ("login", "controller"):
-        mounts.update(mounts_by_local(lkp.cfg.login_network_storage))
+    mounts.update(mounts_by_local(lookup().cfg.network_storage))
+    if lookup().instance_role in ("login", "controller"):
+        mounts.update(mounts_by_local(lookup().cfg.login_network_storage))
 
     if nodeset is not None:
         mounts.update(mounts_by_local(nodeset.network_storage))
@@ -89,7 +89,7 @@ def separate_external_internal_mounts(mounts):
         # NOTE: Valid Lustre server_ip can take the form of '<IP>@tcp'
         server_ip = mount.server_ip.split("@")[0]
         mount_addr = util.host_lookup(server_ip)
-        return mount_addr == lkp.control_host_addr
+        return mount_addr == lookup().control_host_addr
 
     return separate(internal_mount, mounts)
 
@@ -102,7 +102,7 @@ def setup_network_storage():
     all_mounts = resolve_network_storage()
     ext_mounts, int_mounts = separate_external_internal_mounts(all_mounts)
 
-    if lkp.is_controller:
+    if lookup().is_controller:
         mounts = ext_mounts
     else:
         mounts = ext_mounts + int_mounts
@@ -193,16 +193,16 @@ def mount_fstab(mounts, log):
 
 
 def munge_mount_handler():
-    if not lkp.cfg.munge_mount:
+    if not lookup().cfg.munge_mount:
         log.error("Missing munge_mount in cfg")
-    elif lkp.is_controller:
+    elif lookup().is_controller:
         return
 
-    mount = lkp.cfg.munge_mount
+    mount = lookup().cfg.munge_mount
     server_ip = (
         mount.server_ip
         if mount.server_ip
-        else (lkp.cfg.slurm_control_addr or lkp.cfg.slurm_control_host)
+        else (lookup().cfg.slurm_control_addr or lookup().cfg.slurm_control_host)
     )
     remote_mount = mount.remote_mount
     local_mount = Path("/mnt/munge")
@@ -276,18 +276,18 @@ def setup_nfs_exports():
     mounts.append(
         NSDict(
             {
-                "server_ip": lkp.cfg.munge_mount.server_ip,
-                "remote_mount": lkp.cfg.munge_mount.remote_mount,
+                "server_ip": lookup().cfg.munge_mount.server_ip,
+                "remote_mount": lookup().cfg.munge_mount.remote_mount,
                 "local_mount": Path(f"{dirs.munge}_tmp"),
-                "fs_type": lkp.cfg.munge_mount.fs_type,
-                "mount_options": lkp.cfg.munge_mount.mount_options,
+                "fs_type": lookup().cfg.munge_mount.fs_type,
+                "mount_options": lookup().cfg.munge_mount.mount_options,
             }
         )
     )
     # controller mounts
     _, con_mounts = separate_external_internal_mounts(mounts)
     con_mounts = {m.remote_mount: m for m in con_mounts}
-    for nodeset in lkp.cfg.nodeset.values():
+    for nodeset in lookup().cfg.nodeset.values():
         # get internal mounts for each nodeset by calling
         # resolve_network_storage as from a node in each nodeset
         ns_mounts = resolve_network_storage(nodeset=nodeset)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
@@ -29,7 +29,7 @@ from util import (
     separate,
     execute_with_futures,
 )
-from util import lkp, TPU
+from util import lookup, TPU
 
 import slurm_gcp_plugins
 
@@ -49,9 +49,9 @@ def truncate_iter(iterable, max_count):
 
 
 def delete_instance_request(instance):
-    request = lkp.compute.instances().delete(
-        project=lkp.project,
-        zone=lkp.instance(instance).zone,
+    request = lookup().compute.instances().delete(
+        project=lookup().project,
+        zone=lookup().instance(instance).zone,
         instance=instance,
     )
     log_api_request(request)
@@ -74,10 +74,10 @@ def stop_tpu(data):
 
 def delete_tpu_instances(instances):
     stop_data = []
-    for prefix, nodes in util.groupby_unsorted(instances, lkp.node_prefix):
+    for prefix, nodes in util.groupby_unsorted(instances, lookup().node_prefix):
         log.info(f"Deleting TPU nodes from prefix {prefix}")
         lnodes = list(nodes)
-        tpu_nodeset = lkp.node_nodeset(lnodes[0])
+        tpu_nodeset = lookup().node_nodeset(lnodes[0])
         tpu = TPU(tpu_nodeset)
         stop_data.extend(
             [{"tpu": tpu, "node": node, "nodeset": tpu_nodeset} for node in lnodes]
@@ -87,7 +87,7 @@ def delete_tpu_instances(instances):
 
 def delete_instances(instances):
     """delete instances individually"""
-    invalid, valid = separate(lambda inst: bool(lkp.instance(inst)), instances)
+    invalid, valid = separate(lambda inst: bool(lookup.instance(inst)), instances)
     if len(invalid) > 0:
         log.debug("instances do not exist: {}".format(",".join(invalid)))
     if len(valid) == 0:
@@ -109,7 +109,7 @@ def delete_instances(instances):
 def suspend_nodes(nodes: List[str]) -> None:
     tpu_nodes, other_nodes = [], []
     for node in nodes[:]:
-        if lkp.node_is_tpu(node):
+        if lookup().node_is_tpu(node):
             tpu_nodes.append(node)
         else:
             other_nodes.append(node)
@@ -124,7 +124,7 @@ def main(nodelist):
 
     # Filter out nodes not in config.yaml
     other_nodes, pm_nodes = separate(
-        lkp.is_power_managed_node, util.to_hostnames(nodelist)
+        lookup().is_power_managed_node, util.to_hostnames(nodelist)
     )
     if other_nodes:
         log.debug(
@@ -137,8 +137,8 @@ def main(nodelist):
         return
 
     log.info(f"suspend {nodelist}")
-    if lkp.cfg.enable_slurm_gcp_plugins:
-        slurm_gcp_plugins.pre_main_suspend_nodes(lkp=lkp, nodelist=nodelist)
+    if lookup().cfg.enable_slurm_gcp_plugins:
+        slurm_gcp_plugins.pre_main_suspend_nodes(lkp=lookup(), nodelist=nodelist)
     suspend_nodes(pm_nodes)
 
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -58,7 +58,7 @@ from google.api_core.client_options import ClientOptions  # noqa: E402
     ],
 )
 def test_node_desc(name, expected):
-    assert util.lkp._node_desc(name) == expected
+    assert util.lookup()._node_desc(name) == expected
 
 
 @pytest.mark.parametrize(
@@ -69,7 +69,7 @@ def test_node_desc(name, expected):
 )
 def test_node_desc_fail(name):
     with pytest.raises(Exception):
-        util.lkp._node_desc(name)
+        util.lookup()._node_desc(name)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Replace `lkp` with `lookup() -> Lookup`.

**Motivation:**
This showcases the problem of updating (slurmsync & setup) global `lkp`:

```py
# util.py
lkp = { "value": "watermelon" }

# some.py
from util import lkp
def get_value(): return lkp["value"]

# setup.py
import util
import some

util.lkp = {"value": "apple"} 
print(some.get_value())
```

```sh
$ python showtime/setup.py
watermelon
```

The fix would be:

```py
# instead of
#from util import lkp
#def get_value(): return lkp["value"]
# do:
import util
def get_value(): return util.lkp["value"]
```