### PR TITLE
SlurmGCP. Don't fetch config in `util.py`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -445,8 +445,18 @@ def setup_compute():
 
 def main():
     start_motd()
-    configure_dirs()
+    
+    sleep_seconds = 5
+    while True:
+        try:
+            _, cfg = util.fetch_config()
+            util.update_config(cfg)
+            break
+        except Exception as e:
+            log.exception(f"could not fetch config, sleeping for {sleep_seconds}s")
+            time.sleep(sleep_seconds)
 
+    configure_dirs()
     # call the setup function for the instance type
     {
         "controller": setup_controller,

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -17,7 +17,6 @@
 import argparse
 import datetime
 import fcntl
-import hashlib
 import json
 import logging
 import re
@@ -34,12 +33,8 @@ from util import (
     batch_execute,
     ensure_execute,
     execute_with_futures,
-    fetch_config_yaml,
-    fetch_config_yaml_md5,
     install_custom_scripts,
-    load_config_file,
     run,
-    save_config,
     separate,
     to_hostlist_fast,
     Lookup,
@@ -47,7 +42,7 @@ from util import (
     TPU,
     chunked,
 )
-from util import lookup, CONFIG_FILE
+from util import lookup
 from suspend import delete_instances
 from resume import start_tpu
 import conf
@@ -409,55 +404,35 @@ def sync_slurm():
         do_node_update(status, nodes)
 
 
-def read_hash(filename):
-    filename = Path(filename)
-    if not filename.exists():
-        return None
-    with open(filename, "r", encoding="utf-8") as file:
-        return file.readline()
-
-
-def save_hash(filename, hash):
-    with open(filename, "w+", encoding="utf-8") as file:
-        file.write(hash)
-
-
 def reconfigure_slurm():
-    CONFIG_HASH = Path("/slurm/scripts/.config.hash")
     update_msg = "*** slurm configuration was updated ***"
-    cfg_old = load_config_file(CONFIG_FILE)
-
-    if cfg_old.hybrid:
+    if lookup().cfg.hybrid:
         # terraform handles generating the config.yaml, don't do it here
         return
-
-    hash_new: hashlib.md5 = fetch_config_yaml_md5()
-    hash_old: str = read_hash(CONFIG_HASH)
-
-    if hash_new.hexdigest() != hash_old:
-        log.debug("Delta detected. Reconfiguring Slurm now.")
-        cfg_new = fetch_config_yaml()
-        save_hash(CONFIG_HASH, hash_new.hexdigest())
-        save_config(cfg_new, CONFIG_FILE)
-        cfg_new = load_config_file(CONFIG_FILE)
-        util._lkp = Lookup(cfg_new)
-
-        if lookup().is_controller:
-            conf.gen_controller_configs(lookup())
-            log.info("Restarting slurmctld to make changes take effect.")
-            try:
-                # TODO: consider removing "restart" since "reconfigure" should restart slurmctld as well
-                run("sudo systemctl restart slurmctld.service", check=False)
-                util.scontrol_reconfigure(lookup())
-            except Exception:
-                log.exception("failed to reconfigure slurmctld")
-            util.run(f"wall '{update_msg}'", timeout=30)
-            log.debug("Done.")
-        elif lookup().instance_role_safe in ["compute", "login"]:
-            log.info("Restarting slurmd to make changes take effect.")
-            run("systemctl restart slurmd")
-            util.run(f"wall '{update_msg}'", timeout=30)
-            log.debug("Done.")
+    
+    upd, cfg_new = util.fetch_config()
+    if not upd:
+        log.debug("No changes in config detected.")
+        return
+    log.debug("Changes in config detected. Reconfiguring Slurm now.")
+    util.update_config(cfg_new)
+        
+    if lookup().is_controller:
+        conf.gen_controller_configs(lookup())
+        log.info("Restarting slurmctld to make changes take effect.")
+        try:
+            # TODO: consider removing "restart" since "reconfigure" should restart slurmctld as well
+            run("sudo systemctl restart slurmctld.service", check=False)
+            util.scontrol_reconfigure(lookup())
+        except Exception:
+            log.exception("failed to reconfigure slurmctld")
+        util.run(f"wall '{update_msg}'", timeout=30)
+        log.debug("Done.")
+    elif lookup().instance_role_safe in ["compute", "login"]:
+        log.info("Restarting slurmd to make changes take effect.")
+        run("systemctl restart slurmd")
+        util.run(f"wall '{update_msg}'", timeout=30)
+        log.debug("Done.")
 
 
 def update_topology(lkp: util.Lookup) -> None:


### PR DESCRIPTION
* Only fetch config (from GCS) during `setup` and `slurmsync`.
* During `setup` wait indefinitely until  config is available.
* Use only "devel" checksum on controller labels, this would allow controller instance to start **before** config is stored in a bucket, though it will still wait for "devel.zip" to upload.

**Motivation:** allow for separate lifecycle of config and cluster.