### PR TITLE
Bump django from 4.2.11 to 4.2.15 (Cherrypick #2885)

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -19,7 +19,7 @@ dill==0.3.6
 distlib==0.3.6
 # django-revproxy==0.11.0 released but not yet in pypi
 git+https://github.com/jazzband/django-revproxy.git@d2234005135dc0771b7c4e0bb0465664ccfa5787
-Django==4.2.14
+Django==4.2.15
 django-allauth==0.54.0
 django-extensions==3.2.3
 djangorestframework==3.15.2


### PR DESCRIPTION
This cherry-pick of PR #2885 is required to pass dependency review.