### PR TITLE
In Slurm v6 controller, update `grpcio` to 1.56.2 and `requests` to 2.32.0

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -10,9 +10,9 @@ google-cloud-storage==2.10.0
 google-cloud-tpu==1.10.0
 google-resumable-media==2.5.0
 googleapis-common-protos==1.59.1
-grpcio==1.56.0
+grpcio==1.56.2
 grpcio-status==1.56.0
 httplib2==0.22.0
 more-executors==2.11.4
 pyyaml==6.0
-requests==2.31.0
+requests==2.32.0


### PR DESCRIPTION
Required to fix dependency review before release v1.38.0.

Dependabot was not enabled for this module, so these patches weren't previously identified.  I am enabling dependabot for this module in #2931.