### PR TITLE
Add dependabot scanning for Slurm v6 Controller module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,18 @@ updates:
   # Disable version updates, do security updates only
   # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
   open-pull-requests-limit: 0
+- package-ecosystem: pip
+  directory: /community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/
+  labels:
+  - dependencies
+  - python
+  - release-chore
+  schedule:
+    interval: weekly
+    day: monday
+    time: "03:00"
+    timezone: America/Los_Angeles
+  target-branch: develop
+  # Disable version updates, do security updates only
+  # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
+  open-pull-requests-limit: 0


### PR DESCRIPTION
This will allow us to identify security updates before release.