### PR TITLE
Change dependabot Golang package version update to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,14 @@ updates:
   - go
   - release-chore
   schedule:
-    interval: weekly
+    interval: monthly
     day: monday
     time: "03:00"
     timezone: America/Los_Angeles
   target-branch: develop
+  ignore:
+  - dependency-name: "google.golang.org/api"
+
 - package-ecosystem: pip
   directory: /community/front-end/ofe/
   labels:


### PR DESCRIPTION
This PR changes the package update schedule for Golang packages to a monthly cadence.  It does not change the security patch schedule, which has a weekly cadence. See the [dependabot YAML configuration options](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file) for more info.