### PR TITLE
Implement udev-based approach to mounting aperture devices

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
@@ -91,34 +91,29 @@ deployment_groups:
         mountpoint: /mnt/localssd
         permissions: "1777" # must quote numeric filesystem permissions!
       runners:
-      - type: shell
-        destination: setup_aperture.sh
+      - type: ansible-local
+        destination: slurm_aperture.yml
         content: |
-          #!/bin/bash
-          MAX_APERTURE_RETRIES=10
-          aperture_retries=0
-
-          until lspci -nn -D | grep -q '1ae0:0084' || [ $aperture_retries -eq $MAX_APERTURE_RETRIES ]; do
-            echo "\$(date): APERTURE devices not yet fully available (attempt $aperture_retries/$MAX_APERTURE_RETRIES). Retrying in 5 seconds..."
-            sleep 5
-            aperture_retries=\$((aperture_retries + 1))
-          done
-
-          if [ $aperture_retries -eq $MAX_APERTURE_RETRIES ]; then
-            echo "\$(date): ERROR: APERTURE devices failed to initialize after $MAX_APERTURE_RETRIES retries."
-            # Consider taking additional error-handling actions
-            exit 0
-          fi
-
-          echo "\$(date): Aperture devices ready!"
-          lspci -nn -D | grep '1ae0:0084' | awk '{print $1}' | xargs --no-run-if-empty -I {} -n 1 mkdir -p /dev/aperture_devices/{}
-          lspci -nn -D | grep '1ae0:0084' | awk '{print $1}' | xargs --no-run-if-empty -I {} -n 1 umount -f /dev/aperture_devices/{} || true
-          lspci -nn -D | grep '1ae0:0084' | awk '{print $1}' | xargs --no-run-if-empty -I {} -n 1 mount --bind /sys/bus/pci/devices/{} /dev/aperture_devices/{}
-          if [ -d /dev/aperture_devices ]; then
-              chmod -R a+r /dev/aperture_devices/
-              chmod a+rw /dev/aperture_devices/*/resource*
-          fi
-          echo "\$(date): Aperture devices mounted!"
+          ---
+          - name: Configure Slurm to depend upon aperture devices
+            hosts: all
+            become: true
+            vars: {}
+            tasks:
+            - name: Ensure slurmd starts after aperture devices are ready
+              ansible.builtin.copy:
+                dest: /etc/systemd/system/slurmd.service.d/aperture.conf
+                owner: root
+                group: root
+                mode: 0o644
+                content: |
+                  [Service]
+                  ExecCondition=/usr/bin/test -d /dev/aperture_devices/
+              notify: Reload SystemD
+            handlers:
+            - name: Reload SystemD
+              ansible.builtin.systemd:
+                daemon_reload: true
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -286,6 +286,29 @@ deployment_groups:
               ansible.posix.patch:
                 src: /tmp/bash_completion.patch
                 dest: /usr/share/bash-completion/bash_completion
+      - type: ansible-local
+        destination: aperture_devices.yml
+        content: |
+          ---
+          - name: Setup GPUDirect-TCPXO aperture devices
+            hosts: all
+            become: true
+            tasks:
+            - name: Mount aperture devices to /dev and make writable
+              ansible.builtin.copy:
+                dest: /etc/udev/rules.d/00-a3-megagpu.rules
+                owner: root
+                group: root
+                mode: 0o644
+                content: |
+                  ACTION=="add", SUBSYSTEM=="pci", ATTR{vendor}=="0x1ae0", ATTR{device}=="0x0084", TAG+="systemd", \
+                      RUN+="/usr/bin/mkdir --mode=0755 -p /dev/aperture_devices", \
+                      RUN+="/usr/bin/systemd-mount --type=none --options=bind --collect %S/%p /dev/aperture_devices/%k", \
+                      RUN+="/usr/bin/bash -c '/usr/bin/chmod 0666 /dev/aperture_devices/%k/resource*'"
+              notify: Update initramfs
+            handlers:
+            - name: Update initramfs
+              ansible.builtin.command: /usr/sbin/update-initramfs -u -k all
       - type: data
         destination: /etc/netplan/90-default.yaml
         content: |


### PR DESCRIPTION
This PR swaps a bash script that temporarily tries to bind mount aperture devices under `/dev` with an improved solution that uses [udev](https://opensource.com/article/18/11/udev) rules.

We have had reports of customers whose machines come online without devices mounted under `/dev`. Their problem has been resolved by manually running the bash script. By using `udev` rules, this automates the action whenever the aperture PCI device comes online.

Because this "bakes the configuration into the OS", this PR should also avoid missing mounts when a Slurm compute node restarts and does not re-run startup-scripts.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
