### PR TITLE
Change Parallelstore installation script to not move log folder for debian/ubuntu

### DIFF
--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -90,13 +90,13 @@ sed -i "s/#.*transport_config/transport_config/g" $daos_config
 sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
 sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
-# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
-mkdir -p /var/log/daos_agent
-chown daos_agent:daos_agent /var/log/daos_agent
-sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
-
 # Start service
 if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
+	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
+	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+	mkdir -p /var/log/daos_agent
+	chown daos_agent:daos_agent /var/log/daos_agent
+	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
 	systemctl start daos_agent.service
 elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
 	mkdir -p /var/run/daos_agent

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -90,13 +90,13 @@ sed -i "s/#.*transport_config/transport_config/g" $daos_config
 sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
 sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
-# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
-mkdir -p /var/log/daos_agent
-chown daos_agent:daos_agent /var/log/daos_agent
-sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
-
 # Start service
 if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
+	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
+	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+	mkdir -p /var/log/daos_agent
+	chown daos_agent:daos_agent /var/log/daos_agent
+	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
 	systemctl start daos_agent.service
 elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
 	mkdir -p /var/run/daos_agent


### PR DESCRIPTION
-Added a hotfix for installation script as it fails to properly move the log folders for ubuntu+debian (reverting from a previous pr)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
