### PR TITLE
Update gVNIC driver in A3 Mega solution

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -120,7 +120,7 @@ deployment_groups:
             hosts: all
             become: true
             vars:
-              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.3.4/gve-dkms_1.3.4_all.deb
+              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.4.3/gve-dkms_1.4.3_all.deb
               package_filename: /tmp/{{ package_url | basename }}
             tasks:
             - name: Install driver dependencies


### PR DESCRIPTION
Update the gVNIC driver used by a3-megagpu-8g solution to latest release. This brings in a number of enhancements and bugfixes that impact the network card on a3 mega.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
