### PR TITLE
Update Debian 12 image in A3 Mega solution

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -24,7 +24,7 @@ validators:
 # deployment-image-cluster.yaml
 vars:
   deployment_name: a3mega-image
-  source_image: debian-12-bookworm-v20240515
+  source_image: debian-12-bookworm-v20240815
 
 deployment_groups:
 - group: build_script
@@ -76,7 +76,7 @@ deployment_groups:
             hosts: all
             become: true
             vars:
-              package_url: https://snapshot.debian.org/archive/debian/20240515T205635Z/pool/main/l/linux/linux-headers-6.1.0-21-cloud-amd64_6.1.90-1_amd64.deb
+              package_url: https://snapshot.debian.org/archive/debian/20240819T204354Z/pool/main/l/linux/linux-headers-6.1.0-23-amd64_6.1.99-1_amd64.deb
               package_filename: /tmp/{{ package_url | basename }}
             tasks:
             - name: Download kernel headers package


### PR DESCRIPTION
The Debian 12 image in the A3 mega solution was frozen in #2763 as a workaround to GoogleCloudPlatform/guest-agent#401. The release of the guest-agent in `debian-12-bookworm-v20240815` has been confirmed with the Guest Agent team is _not_ impacted by that issue. The integration test confirms functionality and manual inspection confirms that the device naming is correct.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
