### PR TITLE
Add machine type availability checks to slurm-gcp-v6-nodeset

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -130,7 +130,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers
@@ -138,6 +138,7 @@ modules. For support with the underlying modules, see the instructions in the
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
 
@@ -147,8 +148,10 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [terraform_data.machine_type_zone_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_compute_machine_types.machine_types_by_zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_machine_types) | data source |
 | [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -77,7 +77,7 @@ locals {
     gpu                    = one(local.guest_accelerator)
 
     labels           = local.labels
-    machine_type     = var.machine_type
+    machine_type     = terraform_data.machine_type_zone_validation.output
     metadata         = local.metadata
     min_cpu_platform = var.min_cpu_platform
 
@@ -173,5 +173,30 @@ data "google_compute_reservation" "reservation" {
 
     # TODO: wait for https://github.com/hashicorp/terraform-provider-google/issues/18248
     # Add a validation that if reservation.project != var.project_id it should be a shared reservation
+  }
+}
+
+data "google_compute_machine_types" "machine_types_by_zone" {
+  for_each = local.zones
+  filter   = format("name = \"%s\"", var.machine_type)
+  zone     = each.value
+}
+
+locals {
+  machine_types_by_zone   = data.google_compute_machine_types.machine_types_by_zone
+  zones_with_machine_type = [for k, v in local.machine_types_by_zone : k if length(v.machine_types) > 0]
+}
+
+resource "terraform_data" "machine_type_zone_validation" {
+  input = var.machine_type
+  lifecycle {
+    precondition {
+      condition     = length(local.zones_with_machine_type) > 0
+      error_message = <<-EOT
+        machine type ${var.machine_type} is not available in any of the zones ${jsonencode(local.zones)}". To list zones in which it is available, run:
+
+        gcloud compute machine-types list --filter="name=${var.machine_type}"
+        EOT
+    }
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.4"
 
   required_providers {
     google = {


### PR DESCRIPTION
### Issue
Blueprint yaml files allow users to specify machine and zone combinations that do not exist. Infra is provisioned by Terraform during `./ghpc deploy` , but autoscaling may fail later if capacity is not found by bulk insert APIs in zones specified

### Approach
Created a Terraform precondition to verify that the machine type is available in at least one zone. In case they're not, there is no feasible way for bulk insert to allocate machines, and terraform will exit during plan/apply

### Testing
Ran `./ghpc create`, `./ghpc deploy` on this configuration. The specified machine type does not exist in both zones `us-central1-b` and `us-central1-c`. Verified that Terraform exits and error message is as expected

config:
```yaml
vars:
  deployment_name: hpc-slurm
  region: us-central1
  zone: us-central1-b

deployment_groups:
- group: primary
  modules:
  - id: h3_nodeset
    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
    use: [network]
    settings:
      node_count_dynamic_max: 20
      # Note that H3 is available in only specific zones. https://cloud.google.com/compute/docs/regions-zones
      machine_type: h3-standard-88
      # H3 does not support pd-ssd and pd-standard
      # https://cloud.google.com/compute/docs/compute-optimized-machines#h3_disks
      disk_type: pd-balanced
      bandwidth_tier: gvnic_enabled
      allow_automatic_updates: false
      zones:
      - us-central1-c
```
output:
```
Testing if deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Error: exit status 1

Error: Resource precondition failed

  on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf line 193, in resource "terraform_data" "machine_type_zone_validation":
 193:       condition     = length(local.zones_with_machine_type) > 0
    ├────────────────
    │ local.zones_with_machine_type is empty tuple

machine type h3-standard-88 is not available in any of the zones
["us-central1-b","us-central1-c"]. To list zones in which it is available, run:

gcloud compute machine-types list --filter="name=h3-standard-88"

Hint: terraform plan for deployment group hpc-slurm/primary failed
```
Added 1 valid zone (`us-central1-a`) and verified that infra is correctly provisioned

### Submission Checklist

Please take the following actions before submitting this pull request.

- [x] Fork your PR branch from the Toolkit "develop" branch (not main)
- [x] Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
- [x] Confirm that "make tests" passes all tests
- [ ] Add or modify unit tests to cover code changes
- [x] Ensure that unit test coverage remains above 80%
- [x] Update all applicable documentation
- [x] Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
