### PR TITLE
Add integration test for Parallelstore (vm instances)

### DIFF
--- a/examples/pfs-parallelstore.yaml
+++ b/examples/pfs-parallelstore.yaml
@@ -47,6 +47,7 @@ deployment_groups:
     use: [network, parallelstore]
     settings:
       name_prefix: debian
+      add_deployment_name_before_prefix: true
       instance_count: 1
       instance_image:
         family: debian-12
@@ -59,6 +60,7 @@ deployment_groups:
     use: [network, parallelstore]
     settings:
       name_prefix: ubuntu
+      add_deployment_name_before_prefix: true
       instance_count: 1
       instance_image:
         family: ubuntu-2204-lts

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -100,7 +100,7 @@ if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION
 	systemctl start daos_agent.service
 elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
 	mkdir -p /var/run/daos_agent
-	daos_agent -o /etc/daos/daos_agent.yml &
+	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
 else
 	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 	exit 1

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -100,7 +100,7 @@ if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION
 	systemctl start daos_agent.service
 elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
 	mkdir -p /var/run/daos_agent
-	daos_agent -o /etc/daos/daos_agent.yml &
+	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
 else
 	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 	exit 1

--- a/tools/cloud-build/daily-tests/builds/ps-vm-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/ps-vm-debian.yaml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.vpc
+- m.private-service-access
+- m.parallelstore
+- m.vm-instance
+- vm
+
+timeout: 14400s  # 4hr
+steps:
+- id: parallelstore-vm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ps-vm-debian.yml"

--- a/tools/cloud-build/daily-tests/tests/ps-vm-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/ps-vm-debian.yml
@@ -1,0 +1,29 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: test-parallelstore-vm-debian
+deployment_name: "parallelstore-vm-{{ build }}"
+region: us-central1
+zone: us-central1-a
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/pfs-parallelstore.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-debian-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+custom_vars:
+  mounts:
+  - /parallelstore


### PR DESCRIPTION
Added integration testing for Parallelstore on vm instances (debian + ubuntu)
Small fix for the installation script for parallelstore (was hung during wait-for-startup script so now strout/err is discarded to avoid this)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
