### PR TITLE
Remove default service account

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -80,7 +80,6 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Type |
 |------|------|
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
@@ -50,15 +50,10 @@ locals {
   access_config        = length(var.access_config) == 0 ? local.public_access_config : var.access_config
 
   service_account = {
-    email  = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
+    email  = var.service_account_email
     scopes = var.service_account_scopes
   }
 }
-
-data "google_compute_default_service_account" "default" {
-  project = var.project_id
-}
-
 
 module "slurm_nodeset_template" {
   source = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_instance_template?ref=6.7.0"

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
@@ -39,13 +39,10 @@ be accessed as `tpu` partition.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+No providers.
 
 ## Modules
 
@@ -53,9 +50,7 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+No resources.
 
 ## Inputs
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/main.tf
@@ -20,10 +20,8 @@
 locals {
   name = substr(replace(var.name, "/[^a-z0-9]/", ""), 0, 14)
 
-  service_account_email = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
-
   service_account = {
-    email  = local.service_account_email
+    email  = var.service_account_email
     scopes = var.service_account_scopes
   }
 
@@ -51,8 +49,4 @@ locals {
     reserved        = var.reserved
     network_storage = var.network_storage
   }
-}
-
-data "google_compute_default_service_account" "default" {
-  project = var.project_id
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -17,13 +17,6 @@
 terraform {
   required_version = ">= 1.3"
 
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 3.83"
-    }
-  }
-
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.38.0"
   }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -147,7 +147,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -42,10 +42,8 @@ locals {
   public_access_config = var.enable_public_ips ? [{ nat_ip = null, network_tier = null }] : []
   access_config        = length(var.access_config) == 0 ? local.public_access_config : var.access_config
 
-  service_account_email = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
-
   service_account = {
-    email  = local.service_account_email
+    email  = var.service_account_email
     scopes = var.service_account_scopes
   }
 
@@ -108,10 +106,6 @@ locals {
 
     enable_maintenance_reservation = var.enable_maintenance_reservation
   }
-}
-
-data "google_compute_default_service_account" "default" {
-  project = var.project_id
 }
 
 locals {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -51,7 +51,7 @@ locals {
   viewers = toset(flatten([
     "serviceAccount:${module.slurm_controller_template.service_account.email}",
     formatlist("serviceAccount:%s", [for x in local.compute_sa : x.email]),
-    formatlist("serviceAccount:%s", [for x in local.compute_tpu_sa : x.email]),
+    formatlist("serviceAccount:%s", [for x in local.compute_tpu_sa : x.email if x.email != null]),
     formatlist("serviceAccount:%s", [for x in local.login_sa : x.email]),
   ]))
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -77,7 +77,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 
 ## Inputs

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
@@ -39,10 +39,8 @@ locals {
 
   public_access_config = [{ nat_ip = null, network_tier = null }]
 
-  service_account_email = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
-
   service_account = {
-    email  = local.service_account_email
+    email  = var.service_account_email
     scopes = var.service_account_scopes
   }
 
@@ -95,8 +93,4 @@ locals {
     subnetwork = var.subnetwork_self_link
     tags       = var.tags
   }
-}
-
-data "google_compute_default_service_account" "default" {
-  project = var.project_id
 }


### PR DESCRIPTION
The terraform changes made here remove `google_compute_default_service_account `. To replace it, the service account email is synthesized in the Slurm-GCP repo using the data block `google_project`.

Tested with references pointing to master branch in slurm-fork which are now changes included in tag 6.7.0. It is testing the changes made in [this PR](https://github.com/GoogleCloudPlatform/slurm-gcp/pull/200).

Tested and passed on the following checks
- PR-test-slurm-gcp-v6-ssd
- PR-test-slurm-gcp-v6-startup-scripts
- PR-test-slurm-gcp-v6-tpu

Updating the references to 6.7.0 will take place in a separate PR. 