### PR TITLE
Prevent use of google provider 6.0 where breaking changes are in use

### DIFF
--- a/community/modules/compute/pbspro-execution/README.md
+++ b/community/modules/compute/pbspro-execution/README.md
@@ -75,7 +75,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_execution_startup_script"></a> [execution\_startup\_script](#module\_execution\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.36.0&depth=1 |
-| <a name="module_pbs_execution"></a> [pbs\_execution](#module\_pbs\_execution) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | v1.36.0&depth=1 |
+| <a name="module_pbs_execution"></a> [pbs\_execution](#module\_pbs\_execution) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | 09ae2725 |
 | <a name="module_pbs_install"></a> [pbs\_install](#module\_pbs\_install) | github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scripts/pbspro-install | v1.36.0&depth=1 |
 
 ## Resources

--- a/community/modules/compute/pbspro-execution/main.tf
+++ b/community/modules/compute/pbspro-execution/main.tf
@@ -68,7 +68,7 @@ module "execution_startup_script" {
 }
 
 module "pbs_execution" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=v1.36.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=09ae2725"
 
   instance_count = var.instance_count
   spot           = var.spot

--- a/community/modules/remote-desktop/chrome-remote-desktop/README.md
+++ b/community/modules/remote-desktop/chrome-remote-desktop/README.md
@@ -64,7 +64,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_client_startup_script"></a> [client\_startup\_script](#module\_client\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.36.0&depth=1 |
-| <a name="module_instances"></a> [instances](#module\_instances) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | v1.36.0&depth=1 |
+| <a name="module_instances"></a> [instances](#module\_instances) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | 09ae2725 |
 
 ## Resources
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/main.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/main.tf
@@ -71,7 +71,7 @@ module "client_startup_script" {
 }
 
 module "instances" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=v1.36.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=09ae2725"
 
   instance_count                    = var.instance_count
   name_prefix                       = var.name_prefix

--- a/community/modules/scheduler/pbspro-client/README.md
+++ b/community/modules/scheduler/pbspro-client/README.md
@@ -75,7 +75,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_client_startup_script"></a> [client\_startup\_script](#module\_client\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.36.0&depth=1 |
-| <a name="module_pbs_client"></a> [pbs\_client](#module\_pbs\_client) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | v1.36.0&depth=1 |
+| <a name="module_pbs_client"></a> [pbs\_client](#module\_pbs\_client) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | 09ae2725 |
 | <a name="module_pbs_install"></a> [pbs\_install](#module\_pbs\_install) | github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scripts/pbspro-install | v1.36.0&depth=1 |
 
 ## Resources

--- a/community/modules/scheduler/pbspro-client/main.tf
+++ b/community/modules/scheduler/pbspro-client/main.tf
@@ -57,7 +57,7 @@ module "client_startup_script" {
 }
 
 module "pbs_client" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=v1.36.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=09ae2725"
 
   instance_count = var.instance_count
   spot           = var.spot

--- a/community/modules/scheduler/pbspro-server/README.md
+++ b/community/modules/scheduler/pbspro-server/README.md
@@ -71,7 +71,7 @@ No providers.
 |------|--------|---------|
 | <a name="module_pbs_install"></a> [pbs\_install](#module\_pbs\_install) | github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scripts/pbspro-install | v1.36.0&depth=1 |
 | <a name="module_pbs_qmgr"></a> [pbs\_qmgr](#module\_pbs\_qmgr) | github.com/GoogleCloudPlatform/hpc-toolkit//community/modules/scripts/pbspro-qmgr | v1.36.0&depth=1 |
-| <a name="module_pbs_server"></a> [pbs\_server](#module\_pbs\_server) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | v1.36.0&depth=1 |
+| <a name="module_pbs_server"></a> [pbs\_server](#module\_pbs\_server) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance | 09ae2725 |
 | <a name="module_server_startup_script"></a> [server\_startup\_script](#module\_server\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.36.0&depth=1 |
 
 ## Resources

--- a/community/modules/scheduler/pbspro-server/main.tf
+++ b/community/modules/scheduler/pbspro-server/main.tf
@@ -70,7 +70,7 @@ module "server_startup_script" {
 }
 
 module "pbs_server" {
-  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=v1.36.0&depth=1"
+  source = "github.com/GoogleCloudPlatform/hpc-toolkit//modules/compute/vm-instance?ref=09ae2725"
 
   instance_count = var.instance_count
   spot           = var.spot

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -231,15 +231,15 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | > 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.0 |
 
 ## Modules
 

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 5.0"
+      version = "~> 5.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 5.0"
+      version = "~> 5.0"
     }
   }
   provider_meta "google" {

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -169,16 +169,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.73.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0, <6.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 4.73.0, <6.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.73.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.73.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.73.0, <6.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 4.73.0, <6.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -18,12 +18,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.73.0"
+      version = ">= 4.73.0, <6.0"
     }
 
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.73.0"
+      version = ">= 4.73.0, <6.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
Restrict modules to use google provider <6.0 if they have been impacted by breaking changes in 6.0. See the upgrade guide for details of breaking changes:

https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_6_upgrade

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
