### PR TITLE
Add enroot/pyxis step to a3 series integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-enroot.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-enroot.yml
@@ -1,0 +1,18 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Test enroot/pyxis functionality
+  ansible.builtin.shell: srun --container-image=alpine grep PRETTY /etc/os-release | grep -h "^PRETTY_NAME=\"Alpine Linux"
+  changed_when: false

--- a/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
@@ -27,6 +27,7 @@ network: default
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-enroot.yml
 custom_vars:
   partitions:
   - a3

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
@@ -27,6 +27,7 @@ network: default
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-enroot.yml
 custom_vars:
   partitions:
   - a3mega


### PR DESCRIPTION
This PR adds a validation of pyxis/enroot in our a3-highgpu-8g and a3-megagpu-8g integration tests

The test is very simple: can a simple job read a file in the `alpine` image from DockerHub? This test is sufficient to confirm most real-world observed failures of Pyxis/Spank libraries and the validity of enroot.conf configuration (e.g. #3011)

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
