### PR TITLE
kubernetes provider added to gke-cluster module

### DIFF
--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -110,6 +110,7 @@ limitations under the License.
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 5.0 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers
 

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -306,6 +306,14 @@ resource "google_project_iam_member" "node_service_account_artifact_registry" {
   member  = "serviceAccount:${local.sa_email}"
 }
 
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.gke_cluster.endpoint}"
+  cluster_ca_certificate = base64decode(google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+  token                  = data.google_client_config.default.access_token
+}
+
 module "workload_identity" {
   count   = var.configure_workload_identity_sa ? 1 : 0
   source  = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
@@ -317,14 +325,17 @@ module "workload_identity" {
   project_id          = var.project_id
   roles               = var.enable_gcsfuse_csi ? ["roles/storage.admin"] : []
 
+  providers = {
+    google     = google
+    kubernetes = kubernetes
+  }
+
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [
     data.google_compute_default_service_account.default_sa,
     google_container_cluster.gke_cluster
   ]
 }
-
-data "google_client_config" "default" {}
 
 provider "kubectl" {
   host                   = "https://${google_container_cluster.gke_cluster.endpoint}"

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -325,11 +325,6 @@ module "workload_identity" {
   project_id          = var.project_id
   roles               = var.enable_gcsfuse_csi ? ["roles/storage.admin"] : []
 
-  providers = {
-    google     = google
-    kubernetes = kubernetes
-  }
-
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [
     data.google_compute_default_service_account.default_sa,

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "> 5.0"
     }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
     kubectl = {
       source  = "gavinbunney/kubectl"
       version = ">= 1.7.0"


### PR DESCRIPTION
### Fixed missing kubernetes provider in gke-cluster module
The gke-cluster module is implicitly depended on the kubernetes provider ([because of workload-ldentity module](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/blob/master/modules/workload-identity/)) and the provider was mistakenly removed before.
This PR adds the provider to gke-cluster module.