### PR TITLE
Fix for cleanup script.  The last input is optional

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/scripts/cleanup_compute.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/scripts/cleanup_compute.sh
@@ -22,8 +22,8 @@ universe_domain="$4"
 compute_endpoint_version="$5"
 gcloud_dir="$6"
 
-if [[ $# -ne 5 ]]; then
-	echo "Usage: $0 <project> <cluster_name> <nodeset_name> <universe_domain> <compute_endpoint_version> <gcloud_dir>"
+if [[ $# -ne 5 ]] && [[ $# -ne 6 ]]; then
+	echo "Usage: $0 <project> <cluster_name> <nodeset_name> <universe_domain> <compute_endpoint_version> [<gcloud_dir>]"
 	exit 1
 fi
 


### PR DESCRIPTION
This was failing on cleanups that used the gcloud path override setting.

Tested with bash logic and with a blueprint I am working on.