### PR TITLE
Disable bootstrap GitHub actions in Spack repo before first installation

### DIFF
--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -39,15 +39,25 @@ locals {
 
   finalize_setup_script = <<-EOF
     set -e
+
     . ${var.spack_profile_script_path}
     spack config --scope site add 'packages:all:permissions:read:world'
     spack config --scope site add 'packages:all:permissions:write:group'
     spack gpg init
+
     spack compiler find --scope site
     ${local.add_google_mirror_script}
+
+    # More info: https://github.com/spack/spack/blob/d41fb3d542fd273a95f61e120ce0d506d59905fa/lib/spack/docs/getting_started.rst#bootstrapping-clingo
+    echo 'Disabling clingo bootstrap (install from source instead of buildcache)'
+    spack bootstrap list
+    spack bootstrap disable github-actions-v0.4
+    spack bootstrap disable github-actions-v0.5
+    spack bootstrap list
+
     # perform fast install to make sure Spack is fully initialized
-    spack install xz
-    spack uninstall --yes-to-all xz
+    spack install gnuconfig
+    spack uninstall --yes-to-all gnuconfig
   EOF
 
   script_content = templatefile(


### PR DESCRIPTION
Spack lazy-loads certain things the first time `spack install` is run on a machine.  One of the lazy-loading steps [bootstraps the `clingo` package](https://github.com/spack/spack/blob/d41fb3d542fd273a95f61e120ce0d506d59905fa/lib/spack/docs/getting_started.rst#bootstrapping-clingo), which is used by Spack for the "concretize" step before software installations.  By default, it tries to install `clingo` from the `mirror.spack.io` buildcache.  However, this has recently caused errors in new installations due to errors in clingo.

Specifically, the bootstrapping step tries to install the following spec even on a Rocky Linux 8 system:
```
clingo-bootstrap@=spack%gcc@=10.2.1~docs+ipo+optimized+python+static_libstdcpp build_system=cmake build_type=Release generator=make patches=bebb819,ec99431 arch=linux-centos7-x86_64
```

This causes the following error from `clingo`:
```
/shared/spack/lib/spack/spack/solver/concretize.lp:1079:3-38: info: atom does not occur in any rule head
```

The solution was to prevent Spack from pulling `clingo` from the `mirror.spack.io` buildcache, and build it from sources instead.  This is done by disabling certain GitHub actions in the Spack repo with the following commands:
```sh
$ spack bootstrap disable github-actions-v0.4
$ spack bootstrap disable github-actions-v0.5
```

Whether or not the bootstrap step is enabled or not can be checked by running:
```sh
$ spack bootstrap list
```