### PR TITLE
Updating image builder for internal provider

### DIFF
--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -45,7 +45,10 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     pip install --no-cache-dir -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/v5/scripts/requirements.txt && \
     pip install --no-cache-dir ansible && \
     rm -rf ~/.cache/pip/* && \
+    cd /workspace && \
+    # Add .terraformrc to $HOME to allow use of google-private
+    cp tools/cloud-build/images/test-runner/terraformrc $HOME/.terraformrc && \
     # compile the binary to warm up `/ghpc_go_cache`
-    cd /workspace && make gcluster && \
+    make gcluster && \
     # remove /workspace to reduce image size
     rm -rf /workspace

--- a/tools/cloud-build/images/test-runner/terraformrc
+++ b/tools/cloud-build/images/test-runner/terraformrc
@@ -1,0 +1,12 @@
+# .terraformrc setup for google network mirror
+provider_installation {
+  network_mirror {
+    url = "https://storage.googleapis.com/network-mirror-private-provider/"
+    include = ["hashicorp/google-private"]
+    exclude = ["hashicorp/null", "hashicorp/local", "hashicorp/random", "hashicorp/google", "hashicorp/google-beta"]
+  }
+  direct {
+    include = ["hashicorp/*"]
+    exclude = ["hashicorp/google-private"]
+  }
+}


### PR DESCRIPTION
With the use of the `google-private` internal provider, we should update the test infrastructure.  This will point tests that require `google-private` to the correct bucket to get the binary.  Access to the binary should be restricted to whitelisted users including anyone in the google.com org.