### PR TITLE
Fix Slurm tag on A3 high integration test to match v6 blueprint

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -17,7 +17,7 @@ tags:
 - m.custom-image
 - m.pre-existing-vpc
 - m.startup-script
-- slurm5
+- slurm6
 
 timeout: 14400s  # 4hr
 steps:


### PR DESCRIPTION
#2859 migrated the recommended a3-highgpu-8g Slurm solution from Slurm-GCP v5 to v6. The integration test should have been re-tagged `slurm6`. This PR fixes that oversight.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
