### PR TITLE
Add cluster deployment step to a3-megagpu-8g integration test

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
@@ -27,6 +27,8 @@ vars:
   instance_image:
     family: $(vars.final_image_family)
     project: $(vars.project_id)
+  enable_login_public_ips: true
+  enable_controller_public_ips: true
 
 deployment_groups:
 - group: cluster
@@ -234,7 +236,6 @@ deployment_groups:
       name_prefix: login
       disk_type: pd-balanced
       machine_type: c2-standard-4
-      enable_login_public_ips: false
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
@@ -250,7 +251,6 @@ deployment_groups:
       enable_cleanup_compute: true
       enable_external_prolog_epilog: true
       slurm_conf_tpl: modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
-      enable_controller_public_ips: false
       controller_startup_script: $(controller_startup.startup_script)
       login_startup_script: |
         #!/bin/bash

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
@@ -41,8 +41,12 @@ steps:
     IMAGE_NAME=$(gcloud compute images list --project "${PROJECT_ID}" \
         --no-standard-images --filter="labels.ghpc_deployment~$${BUILD_ID_SHORT}" \
         --format='get(name)' --limit=1)
+    FAMILY_NAME=$(gcloud compute images list --project "${PROJECT_ID}" \
+        --no-standard-images --filter="labels.ghpc_deployment~$${BUILD_ID_SHORT}" \
+        --format='get(family)' --limit=1)
 
     echo $${IMAGE_NAME} > /persistent_volume/image_name
+    echo $${FAMILY_NAME} > /persistent_volume/family_name
   volumes:
   - name: 'persistent_volume'
     path: '/persistent_volume'
@@ -57,8 +61,39 @@ steps:
   - |
     set -x -e
     cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    NFS_DEPLOYMENT_NAME="a3mnfs$${BUILD_ID_SHORT}"
 
-    cat /persistent_volume/image_name | xargs -L1 gcloud compute images delete --project "${PROJECT_ID}" --quiet
+    destroy_on_exit() {
+        ./gcluster destroy "$${NFS_DEPLOYMENT_NAME}" --auto-approve
+        cat /persistent_volume/image_name | xargs -L1 gcloud compute images delete --project "${PROJECT_ID}" --quiet
+    }
+
+    REGION=australia-southeast1
+    ZONE=australia-southeast1-c
+
+    trap 'destroy_on_exit' EXIT
+    ./gcluster deploy \
+        --vars region="$${REGION}" \
+        --vars zone="$${ZONE}" \
+        --vars project_id="${PROJECT_ID}" \
+        --vars deployment_name="$${NFS_DEPLOYMENT_NAME}" \
+        tools/cloud-build/daily-tests/blueprints/nfs-server-homefs.yaml \
+        --auto-approve
+
+    NFS_IP=$(gcloud compute instances list --project "${PROJECT_ID}" \
+        --filter="labels.ghpc_module=nfs-server and labels.ghpc_deployment=$${NFS_DEPLOYMENT_NAME}" \
+        --format='get(networkInterfaces[0].networkIP)')
+
+    FAMILY_NAME=$(</persistent_volume/family_name)
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} nfs_ip=$${NFS_IP}" \
+      --extra-vars="region=$${REGION} zone=$${ZONE} remote_mount_homefs=/exports/home" \
+      --extra-vars="final_image_family=$${FAMILY_NAME}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml"
   volumes:
   - name: 'persistent_volume'
     path: '/persistent_volume'

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
@@ -1,0 +1,50 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone, nfs_ip, remote_mount_homefs, final_image_family must be defined
+# in build file with --extra-vars flag!
+test_name: a3m-cluster
+deployment_name: a3mc-{{ build }}
+slurm_cluster_name: "a3mc{{ build[0:4] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml"
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+network: default
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+custom_vars:
+  partitions:
+  - a3mega
+  - debug
+  mounts:
+  - /home
+cli_deployment_vars:
+  network_name_system: default
+  subnetwork_name_system: default
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  server_ip_homefs: "{{ nfs_ip }}"
+  remote_mount_homefs: "{{ remote_mount_homefs }}"
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+  disk_size_gb: 200
+  a3mega_cluster_size: 2
+  enable_ops_agent: "true"
+  enable_nvidia_dcgm: "true"
+  a3mega_reservation_name: a3mega-reservation-australia-southeast1-c
+  a3mega_maintenance_interval: PERIODIC
+  final_image_family: "{{ final_image_family }}"


### PR DESCRIPTION
The existing a3-megagpu-8g integration test only confirms that the custom image can be built. This PR extends the test to include provisioning the cluster and testing basic functionality.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
