### PR TITLE
add support for enabling tcpx/o in a3 and a3mega vm, provide script for injecting rxdm sidecar and other required components into user workload

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -32,9 +32,9 @@ deployment_groups:
   - id: network1
     source: modules/network/vpc
     settings:
-      subnetwork_name: gke-subnet
+      subnetwork_name: gke-subnet-a3-highgpu
       secondary_ranges:
-        gke-subnet:
+        chdu-gke-subnet-a3-highgpu:
         - range_name: pods
           ip_cidr_range: 10.4.0.0/14
         - range_name: services
@@ -65,5 +65,4 @@ deployment_groups:
       machine_type: a3-highgpu-8g
       autoscaling_total_min_nodes: 2
       zones: [$(vars.zone)]
-
-# We need to do the following here after deployment: https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/README.md#gke-a3-highgpuyaml--
+    outputs: [instructions]

--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -34,7 +34,7 @@ deployment_groups:
     settings:
       subnetwork_name: gke-subnet-a3-highgpu
       secondary_ranges:
-        chdu-gke-subnet-a3-highgpu:
+        gke-subnet-a3-highgpu:
         - range_name: pods
           ip_cidr_range: 10.4.0.0/14
         - range_name: services

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -64,6 +64,5 @@ deployment_groups:
     settings:
       machine_type: a3-megagpu-8g
       autoscaling_total_min_nodes: 2
-      user_workload_path: gpu-direct-workload/sample-tcpxo-workload-job.yaml # gke-node-pool module relative path to the user provided workload
       zones: [$(vars.zone)]
     outputs: [instructions]

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -64,5 +64,6 @@ deployment_groups:
     settings:
       machine_type: a3-megagpu-8g
       autoscaling_total_min_nodes: 2
+      user_workload_path: gpu-direct-workload/sample-tcpxo-workload-job.yaml # gke-node-pool module relative path to the user provided workload
       zones: [$(vars.zone)]
     outputs: [instructions]

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -32,9 +32,9 @@ deployment_groups:
   - id: network1
     source: modules/network/vpc
     settings:
-      subnetwork_name: gke-subnet
+      subnetwork_name: gke-subnet-a3-mega
       secondary_ranges:
-        gke-subnet:
+        gke-subnet-a3-mega:
         - range_name: pods
           ip_cidr_range: 10.4.0.0/14
         - range_name: services
@@ -65,5 +65,4 @@ deployment_groups:
       machine_type: a3-megagpu-8g
       autoscaling_total_min_nodes: 2
       zones: [$(vars.zone)]
-
-# We need to do the following here after deployment: https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/README.md#gke-a3-megagpuyaml--
+    outputs: [instructions]

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -303,7 +303,7 @@ limitations under the License.
 | <a name="input_timeout_update"></a> [timeout\_update](#input\_timeout\_update) | Timeout for updating a node pool | `string` | `null` | no |
 | <a name="input_total_max_nodes"></a> [total\_max\_nodes](#input\_total\_max\_nodes) | DEPRECATED: Use autoscaling\_total\_max\_nodes. | `number` | `null` | no |
 | <a name="input_total_min_nodes"></a> [total\_min\_nodes](#input\_total\_min\_nodes) | DEPRECATED: Use autoscaling\_total\_min\_nodes. | `number` | `null` | no |
-| <a name="input_user_workload_path"></a> [user\_workload\_path](#input\_user\_workload\_path) | The path to the user workload, this should point to the kubernetes job manifest that user want to have the TCPX sidecar injected. | `string` | `null` | no |
+| <a name="input_user_workload_path"></a> [user\_workload\_path](#input\_user\_workload\_path) | The gke-node-pool module relative path to the user workload, this should point to the kubernetes job manifest<br>that user want to have the GPUDirect rxdm sidecar injected. The toolkit would apply the required changes to this<br>user workload and generate a new workload file for user to inspect and apply to the cluster. Details of the required<br>changes can be found in the [GPUDirect user guide](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests) | `string` | `null` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | A list of zones to be used. Zones must be in region of cluster. If null, cluster zones will be inherited. Note `zones` not `zone`; does not work with `zone` deployment variable. | `list(string)` | `null` | no |
 
 ## Outputs

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -233,6 +233,7 @@ limitations under the License.
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
@@ -240,10 +241,13 @@ limitations under the License.
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_kubectl_apply"></a> [kubectl\_apply](#module\_kubectl\_apply) | ../../management/kubectl-apply | n/a |
 
 ## Resources
 
@@ -256,7 +260,11 @@ No modules.
 | [google_project_iam_member.node_service_account_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.node_service_account_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.node_service_account_resource_metadata_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [null_resource.enable_tcpx_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 
 ## Inputs
 
@@ -295,6 +303,7 @@ No modules.
 | <a name="input_timeout_update"></a> [timeout\_update](#input\_timeout\_update) | Timeout for updating a node pool | `string` | `null` | no |
 | <a name="input_total_max_nodes"></a> [total\_max\_nodes](#input\_total\_max\_nodes) | DEPRECATED: Use autoscaling\_total\_max\_nodes. | `number` | `null` | no |
 | <a name="input_total_min_nodes"></a> [total\_min\_nodes](#input\_total\_min\_nodes) | DEPRECATED: Use autoscaling\_total\_min\_nodes. | `number` | `null` | no |
+| <a name="input_user_workload_path"></a> [user\_workload\_path](#input\_user\_workload\_path) | The path to the user workload, this should point to the kubernetes job manifest that user want to have the TCPX sidecar injected. | `string` | `null` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | A list of zones to be used. Zones must be in region of cluster. If null, cluster zones will be inherited. Note `zones` not `zone`; does not work with `zone` deployment variable. | `list(string)` | `null` | no |
 
 ## Outputs
@@ -303,6 +312,7 @@ No modules.
 |------|-------------|
 | <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
 | <a name="output_has_gpu"></a> [has\_gpu](#output\_has\_gpu) | Boolean value indicating whether nodes in the pool are configured with GPUs. |
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions for submitting the sample GPUDirect enabled job. |
 | <a name="output_node_pool_name"></a> [node\_pool\_name](#output\_node\_pool\_name) | Name of the node pool. |
 | <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | Tolerations needed for a pod to be scheduled on this node pool. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -264,7 +264,6 @@ limitations under the License.
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
-| [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 
 ## Inputs
 
@@ -303,7 +302,6 @@ limitations under the License.
 | <a name="input_timeout_update"></a> [timeout\_update](#input\_timeout\_update) | Timeout for updating a node pool | `string` | `null` | no |
 | <a name="input_total_max_nodes"></a> [total\_max\_nodes](#input\_total\_max\_nodes) | DEPRECATED: Use autoscaling\_total\_max\_nodes. | `number` | `null` | no |
 | <a name="input_total_min_nodes"></a> [total\_min\_nodes](#input\_total\_min\_nodes) | DEPRECATED: Use autoscaling\_total\_min\_nodes. | `number` | `null` | no |
-| <a name="input_user_workload_path"></a> [user\_workload\_path](#input\_user\_workload\_path) | The gke-node-pool module relative path to the user workload, this should point to the kubernetes job manifest<br>that user want to have the GPUDirect rxdm sidecar injected. The toolkit would apply the required changes to this<br>user workload and generate a new workload file for user to inspect and apply to the cluster. Details of the required<br>changes can be found in the [GPUDirect user guide](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests) | `string` | `null` | no |
 | <a name="input_zones"></a> [zones](#input\_zones) | A list of zones to be used. Zones must be in region of cluster. If null, cluster zones will be inherited. Note `zones` not `zone`; does not work with `zone` deployment variable. | `list(string)` | `null` | no |
 
 ## Outputs

--- a/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpx-workload-job.yaml
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpx-workload-job.yaml
@@ -1,0 +1,50 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-sample-job
+spec:
+  parallelism: 2
+  completions: 2
+  completionMode: Indexed
+  template:
+    spec:
+      containers:
+      - name: nccl-test
+        image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/nccl-plugin-gpudirecttcpx-dev:v3.1.9
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - |
+          service ssh restart;
+          sleep infinity;
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64
+        volumeMounts:
+        - name: config-volume
+          mountPath: /configs
+        resources:
+          limits:
+            nvidia.com/gpu: 8
+      volumes:
+      - name: config-volume
+        configMap:
+          name: nccl-configmap
+          defaultMode: 0777
+      restartPolicy: Never
+  backoffLimit: 0

--- a/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job.yaml
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job.yaml
@@ -1,0 +1,70 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: my-sample-job
+spec:
+  parallelism: 2
+  completions: 2
+  completionMode: Indexed
+  template:
+    spec:
+      hostname: host1
+      subdomain: nccl-host-1
+      containers:
+      - name: nccl-test
+        image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.3
+        imagePullPolicy: Always
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -ex
+          chmod 755  /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+          cat >/scripts/allgather.sh <<EOF
+          #!/bin/bash
+          /scripts/init_ssh.sh \${@};
+          pushd /scripts;
+          /scripts/gen_hostfiles.sh \${@};
+          popd;
+          BENCHMARK=all_gather_perf NHOSTS=2 NCCL_LIB_DIR="${LD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+          EOF
+          chmod +x /scripts/allgather.sh
+          service ssh restart;
+          sleep infinity;
+        env:
+        - name: LD_LIBRARY_PATH
+          value: /usr/local/nvidia/lib64
+        - name: NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY
+          value: /dev/aperture_devices
+        volumeMounts:
+        - name: nvidia
+          mountPath: /usr/local/nvidia/lib64
+        - name: shared-memory
+          mountPath: /dev/shm
+        resources:
+          limits:
+            nvidia.com/gpu: 8
+      volumes:
+      - name: nvidia
+        hostPath:
+          path: /home/kubernetes/bin/nvidia/lib64
+      - name: shared-memory
+        emptyDir:
+          medium: "Memory"
+          sizeLimit: 1Gi
+      restartPolicy: Never
+  backoffLimit: 0

--- a/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpx-in-workload.py
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpx-in-workload.py
@@ -14,6 +14,7 @@
 
 import yaml
 import argparse
+import os
 
 def main():
     parser = argparse.ArgumentParser(description="TCPX Job Manifest Generator")
@@ -57,8 +58,10 @@ def main():
         file.write(updated_job)
 
     # Step 7: Provide instructions to the user
-    print("\nA new manifest had been generated and updated to have TCPX enabled based on the provided worklad,")
-    print("It can be found in the same path as the original workload file with name ending \"-tcpx\"")
+    print("\nA new manifest has been generated and updated to have TCPX enabled based on the provided workload.")
+    print("It can be found in {path}".format(path=os.path.abspath(new_file_name)))
+    print("You can use the following commands to submit the sample job:")
+    print("  kubectl create -f {path}".format(path=os.path.abspath(new_file_name)))
 
 def add_annotations(job_manifest):
     annotations = {

--- a/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpx-in-workload.py
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpx-in-workload.py
@@ -1,0 +1,182 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="TCPX Job Manifest Generator")
+    parser.add_argument("-f", "--file", required=True, help="Path to your job template YAML file")
+    parser.add_argument("-r", "--rxdm", required=True, help="RxDM version")
+
+    args = parser.parse_args()
+
+    # Get the YAML file from the user
+    if not args.file:
+        args.file = input("Please provide the path to your job template YAML file: ")
+
+    # Get component versions from user
+    if not args.rxdm:
+        args.rxdm = input("Enter the RxDM version: ")
+
+    # Load and modify the YAML
+    with open(args.file, "r") as file:
+        job_manifest = yaml.load(file, Loader=yaml.BaseLoader)
+
+    # Update annotations
+    add_annotations(job_manifest)
+
+    # Update volumes
+    add_volumes(job_manifest)
+
+    # Update tolerations
+    add_tolerations(job_manifest)
+
+    # Add tcpx-daemon container
+    add_tcpx_daemon_container(job_manifest, args.rxdm)
+
+    # Update environment variables and volumeMounts for GPU containers
+    update_gpu_containers(job_manifest)
+
+    # Generate the new YAML file
+    updated_job = str(yaml.dump(job_manifest, default_flow_style=False, width=1000, default_style="|", sort_keys=False)).replace("|-", "")
+
+    new_file_name = args.file.replace(".yaml", "-tcpx.yaml")
+    with open(new_file_name, "w", encoding="utf-8") as file:
+        file.write(updated_job)
+
+    # Step 7: Provide instructions to the user
+    print("\nA new manifest had been generated and updated to have TCPX enabled based on the provided worklad,")
+    print("It can be found in the same path as the original workload file with name ending \"-tcpx\"")
+
+def add_annotations(job_manifest):
+    annotations = {
+        'devices.gke.io/container.tcpx-daemon':"""|+
+- path: /dev/nvidia0
+- path: /dev/nvidia1
+- path: /dev/nvidia2
+- path: /dev/nvidia3
+- path: /dev/nvidia4
+- path: /dev/nvidia5
+- path: /dev/nvidia6
+- path: /dev/nvidia7
+- path: /dev/nvidiactl
+- path: /dev/nvidia-uvm""",
+        "networking.gke.io/default-interface": "eth0",
+        "networking.gke.io/interfaces":"""|
+[
+    {"interfaceName":"eth0","network":"default"},
+    {"interfaceName":"eth1","network":"vpc1"},
+    {"interfaceName":"eth2","network":"vpc2"},
+    {"interfaceName":"eth3","network":"vpc3"},
+    {"interfaceName":"eth4","network":"vpc4"}
+]""",
+    }
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("metadata", {})
+
+    # Add/update annotations
+    pod_template_spec = job_manifest["spec"]["template"]["metadata"]
+    if "annotations" in pod_template_spec:
+        pod_template_spec["annotations"].update(annotations)
+    else:
+        pod_template_spec["annotations"] = annotations
+
+def add_tolerations(job_manifest):
+    tolerations = [
+        {"key": "user-workload", "operator": "Equal", "value": """\"true\"""", "effect": "NoSchedule"},
+    ]
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add tolerations
+    pod_spec = job_manifest["spec"]["template"]["spec"]
+    if "tolerations" in pod_spec:
+        pod_spec["tolerations"].extend(tolerations)
+    else:
+        pod_spec["tolerations"] = tolerations
+
+def add_volumes(job_manifest):
+    volumes = [
+        {"name": "libraries", "hostPath": {"path": "/home/kubernetes/bin/nvidia/lib64"}},
+        {"name": "tcpx-socket", "emptyDir": {}},
+        {"name": "sys", "hostPath": {"path": "/sys"}},
+        {"name": "proc-sys", "hostPath": {"path": "/proc/sys"}},
+    ]
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add volumes
+    pod_spec = job_manifest["spec"]["template"]["spec"]
+    if "volumes" in pod_spec:
+        pod_spec["volumes"].extend(volumes)
+    else:
+        pod_spec["volumes"] = volumes
+
+
+def add_tcpx_daemon_container(job_template, rxdm_version):
+    tcpx_daemon_container = {
+        "name": "tcpx-daemon",
+        "image": f"us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpx/tcpgpudmarxd-dev:{rxdm_version}",   # Use provided RxDM version
+        "imagePullPolicy": "Always",
+        "command": 
+        """- /tcpgpudmarxd/build/app/tcpgpudmarxd
+- --gpu_nic_preset
+- a3vm
+- --gpu_shmem_type
+- fd
+- --uds_path
+- /run/tcpx
+- --setup_param
+- \\\"--verbose 128 2 0 \\\"""",
+        "securityContext": {
+            "capabilities": {"add": ["NET_ADMIN"]}
+        },
+        "volumeMounts": [
+            {"name": "libraries", "mountPath": "/usr/local/nvidia/lib64"},
+            {"name": "tcpx-socket", "mountPath": "/run/tcpx"},
+            {"name": "sys", "mountPath": "/hostsysfs"},
+            {"name": "proc-sys", "mountPath": "/hostprocsysfs"},
+        ],
+        "env": [{"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"}],
+    }
+
+    # Create path if it doesn't exist
+    job_template.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add container
+    pod_spec = job_template["spec"]["template"]["spec"]
+    pod_spec.setdefault("containers", []).insert(0, tcpx_daemon_container)
+
+def update_gpu_containers(job_manifest):
+    env_vars = [{"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"}]
+    volume_mounts = [
+        {"name": "tcpx-socket", "mountPath": "/tmp"},
+        {"name": "libraries", "mountPath": "/usr/local/nvidia/lib64"},
+    ]
+
+    pod_spec = job_manifest.get("spec", {}).get("template", {}).get("spec", {})
+    for container in pod_spec.get("containers", []):
+        # Create path if it doesn't exist
+        container.setdefault("env", [])
+        container.setdefault("volumeMounts", [])
+        if int(container.get("resources", {}).get("limits", {}).get("nvidia.com/gpu", 0)) > 0:
+            container["env"].extend(env_vars)
+            container["volumeMounts"].extend(volume_mounts)
+
+if __name__ == "__main__":
+    main()

--- a/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py
@@ -14,6 +14,7 @@
 
 import yaml
 import argparse
+import os
 
 def main():
     parser = argparse.ArgumentParser(description="TCPXO Job Manifest Generator")
@@ -57,8 +58,10 @@ def main():
         file.write(updated_job)
 
     # Step 7: Provide instructions to the user
-    print("\nA new manifest had been generated and updated to have TCPXO enabled based on the provided worklad,")
-    print("It can be found in the same path as the original workload file with name ending \"-tcpxo\"")
+    print("\nA new manifest has been generated and updated to have TCPXO enabled based on the provided workload")
+    print("It can be found in {path}".format(path=os.path.abspath(new_file_name)))
+    print("You can use the following commands to submit the sample job:")
+    print("  kubectl create -f {path}".format(path=os.path.abspath(new_file_name)))
 
 def add_annotations(job_manifest):
     annotations = {

--- a/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py
@@ -1,0 +1,183 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="TCPXO Job Manifest Generator")
+    parser.add_argument("-f", "--file", required=True, help="Path to your job template YAML file")
+    parser.add_argument("-r", "--rxdm", required=True, help="RxDM version")
+
+    args = parser.parse_args()
+
+    # Get the YAML file from the user
+    if not args.file:
+        args.file = input("Please provide the path to your job template YAML file: ")
+
+    # Get component versions from user
+    if not args.rxdm:
+        args.rxdm = input("Enter the RxDM version: ")
+
+    # Load and modify the YAML
+    with open(args.file, "r") as file:
+        job_manifest = yaml.load(file, Loader=yaml.BaseLoader)
+
+    # Update annotations
+    add_annotations(job_manifest)
+
+    # Update volumes
+    add_volumes(job_manifest)
+
+    # Update tolerations
+    add_tolerations(job_manifest)
+
+    # Add tcpxo-daemon container
+    add_tcpxo_daemon_container(job_manifest, args.rxdm)
+
+    # Update environment variables and volumeMounts for GPU containers
+    update_gpu_containers(job_manifest)
+
+    # Generate the new YAML file
+    updated_job = str(yaml.dump(job_manifest, default_flow_style=False, width=1000, default_style="|", sort_keys=False)).replace("|-", "")
+
+    new_file_name = args.file.replace(".yaml", "-tcpxo.yaml")
+    with open(new_file_name, "w", encoding="utf-8") as file:
+        file.write(updated_job)
+
+    # Step 7: Provide instructions to the user
+    print("\nA new manifest had been generated and updated to have TCPXO enabled based on the provided worklad,")
+    print("It can be found in the same path as the original workload file with name ending \"-tcpxo\"")
+
+def add_annotations(job_manifest):
+    annotations = {
+        'devices.gke.io/container.tcpxo-daemon':"""|+
+- path: /dev/nvidia0
+- path: /dev/nvidia1
+- path: /dev/nvidia2
+- path: /dev/nvidia3
+- path: /dev/nvidia4
+- path: /dev/nvidia5
+- path: /dev/nvidia6
+- path: /dev/nvidia7
+- path: /dev/nvidiactl
+- path: /dev/nvidia-uvm
+- path: /dev/dmabuf_import_helper""",
+        "networking.gke.io/default-interface": "eth0",
+        "networking.gke.io/interfaces": """|
+[
+    {"interfaceName":"eth0","network":"default"},
+    {"interfaceName":"eth1","network":"vpc1"},
+    {"interfaceName":"eth2","network":"vpc2"},
+    {"interfaceName":"eth3","network":"vpc3"},
+    {"interfaceName":"eth4","network":"vpc4"},
+    {"interfaceName":"eth5","network":"vpc5"},
+    {"interfaceName":"eth6","network":"vpc6"},
+    {"interfaceName":"eth7","network":"vpc7"},
+    {"interfaceName":"eth8","network":"vpc8"}
+]""",
+    }
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("metadata", {})
+
+    # Add/update annotations
+    pod_template_spec = job_manifest["spec"]["template"]["metadata"]
+    if "annotations" in pod_template_spec:
+        pod_template_spec["annotations"].update(annotations)
+    else:
+        pod_template_spec["annotations"] = annotations
+
+def add_tolerations(job_manifest):
+    tolerations = [
+        {"key": "user-workload", "operator": "Equal", "value": """\"true\"""", "effect": "NoSchedule"},
+    ]
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add tolerations
+    pod_spec = job_manifest["spec"]["template"]["spec"]
+    if "tolerations" in pod_spec:
+        pod_spec["tolerations"].extend(tolerations)
+    else:
+        pod_spec["tolerations"] = tolerations
+
+def add_volumes(job_manifest):
+    volumes = [
+        {"name": "nvidia-install-dir-host", "hostPath": {"path": "/home/kubernetes/bin/nvidia"}},
+        {"name": "sys", "hostPath": {"path": "/sys"}},
+        {"name": "proc-sys", "hostPath": {"path": "/proc/sys"}},
+        {"name": "aperture-devices", "hostPath": {"path": "/dev/aperture_devices"}},
+    ]
+
+    # Create path if it doesn't exist
+    job_manifest.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add volumes
+    pod_spec = job_manifest["spec"]["template"]["spec"]
+    if "volumes" in pod_spec:
+        pod_spec["volumes"].extend(volumes)
+    else:
+        pod_spec["volumes"] = volumes
+
+
+def add_tcpxo_daemon_container(job_template, rxdm_version):
+    tcpxo_daemon_container = {
+        "name": "tcpxo-daemon",
+        "image": f"us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:{rxdm_version}",   # Use provided RxDM version
+        "imagePullPolicy": "Always",
+        "command": ["/bin/sh", "-c"],
+        "args": [
+            """|
+                set -ex
+                chmod 755 /fts/entrypoint_rxdm_container.sh
+                /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8 --uid= --alsologtostderr"""
+        ],
+        "securityContext": {
+            "capabilities": {"add": ["NET_ADMIN", "NET_BIND_SERVICE"]}
+        },
+        "volumeMounts": [
+            {"name": "nvidia-install-dir-host", "mountPath": "/usr/local/nvidia"},
+            {"name": "sys", "mountPath": "/hostsysfs"},
+            {"name": "proc-sys", "mountPath": "/hostprocsysfs"},
+        ],
+        "env": [{"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"}],
+    }
+
+    # Create path if it doesn't exist
+    job_template.setdefault("spec", {}).setdefault("template", {}).setdefault("spec", {})
+
+    # Add container
+    pod_spec = job_template["spec"]["template"]["spec"]
+    pod_spec.setdefault("containers", []).insert(0, tcpxo_daemon_container)
+
+def update_gpu_containers(job_manifest):
+    env_vars = [
+        {"name": "LD_LIBRARY_PATH", "value": "/usr/local/nvidia/lib64"},
+        {"name": "NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY", "value": "/dev/aperture_devices"},
+    ]
+    volume_mounts = [{"name": "aperture-devices", "mountPath": "/dev/aperture_devices"}]
+
+    pod_spec = job_manifest.get("spec", {}).get("template", {}).get("spec", {})
+    for container in pod_spec.get("containers", []):
+        # Create path if it doesn't exist
+        container.setdefault("env", [])
+        container.setdefault("volumeMounts", [])
+        if int(container.get("resources", {}).get("limits", {}).get("nvidia.com/gpu", 0)) > 0:
+            container["env"].extend(env_vars)
+            container["volumeMounts"].extend(volume_mounts)
+
+if __name__ == "__main__":
+    main()

--- a/modules/compute/gke-node-pool/gpu_direct.tf
+++ b/modules/compute/gke-node-pool/gpu_direct.tf
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+# Enable GPUDirect for A3 and A3Mega VMs, this involve multiple kubectl steps to integrate with the created cluster
+# 1. Install NCCL plugin daemonset
+# 2. Install NRI plugin daemonset
+# 3. Update user workload to inject rxdm sidecar and other required annotation, volume etc.
+locals {
+  user_workload_path_tcpx  = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpx-workload-job.yaml" : "${path.module}/${var.user_workload_path}"
+  user_workload_path_tcpxo = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpxo-workload-job.yaml" : "${path.module}/${var.user_workload_path}"
+
+  gpu_direct_settings = {
+    "a3-highgpu-8g" = {
+      # Manifest to be installed for enabling TCPX on a3-highgpu-8g machines
+      gpu_direct_manifests = [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpx/nccl-tcpx-installer.yaml",      # nccl_plugin v3.1.9 for tcpx
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpx/nccl-config.yaml",              # nccl_configmap
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+      ]
+      updated_user_workload_path = replace(local.user_workload_path_tcpx, ".yaml", "-tcpx.yaml")
+      rxdm_version               = "v2.0.12" # matching nccl-tcpx-installer version v3.1.9
+    }
+    "a3-megagpu-8g" = {
+      # Manifest to be installed for enabling TCPXO on a3-megagpu-8g machines
+      gpu_direct_manifests = [
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.4 for tcpxo
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+      ]
+      updated_user_workload_path = replace(local.user_workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
+      rxdm_version               = "v1.0.10" # matching nccl-tcpxo-installer version v1.0.4
+    }
+  }
+}

--- a/modules/compute/gke-node-pool/gpu_direct.tf
+++ b/modules/compute/gke-node-pool/gpu_direct.tf
@@ -17,10 +17,10 @@
 # Enable GPUDirect for A3 and A3Mega VMs, this involve multiple kubectl steps to integrate with the created cluster
 # 1. Install NCCL plugin daemonset
 # 2. Install NRI plugin daemonset
-# 3. Update user workload to inject rxdm sidecar and other required annotation, volume etc.
+# 3. Update provided workload to inject rxdm sidecar and other required annotation, volume etc.
 locals {
-  user_workload_path_tcpx  = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpx-workload-job.yaml" : "${path.module}/${var.user_workload_path}"
-  user_workload_path_tcpxo = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpxo-workload-job.yaml" : "${path.module}/${var.user_workload_path}"
+  workload_path_tcpx  = "${path.module}/gpu-direct-workload/sample-tcpx-workload-job.yaml"
+  workload_path_tcpxo = "${path.module}/gpu-direct-workload/sample-tcpxo-workload-job.yaml"
 
   gpu_direct_settings = {
     "a3-highgpu-8g" = {
@@ -30,8 +30,8 @@ locals {
         "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpx/nccl-config.yaml",              # nccl_configmap
         "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
       ]
-      updated_user_workload_path = replace(local.user_workload_path_tcpx, ".yaml", "-tcpx.yaml")
-      rxdm_version               = "v2.0.12" # matching nccl-tcpx-installer version v3.1.9
+      updated_workload_path = replace(local.workload_path_tcpx, ".yaml", "-tcpx.yaml")
+      rxdm_version          = "v2.0.12" # matching nccl-tcpx-installer version v3.1.9
     }
     "a3-megagpu-8g" = {
       # Manifest to be installed for enabling TCPXO on a3-megagpu-8g machines
@@ -39,8 +39,8 @@ locals {
         "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.4 for tcpxo
         "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
       ]
-      updated_user_workload_path = replace(local.user_workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
-      rxdm_version               = "v1.0.10" # matching nccl-tcpxo-installer version v1.0.4
+      updated_workload_path = replace(local.workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
+      rxdm_version          = "v1.0.10" # matching nccl-tcpxo-installer version v1.0.4
     }
   }
 }

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -253,3 +253,98 @@ resource "google_project_iam_member" "node_service_account_artifact_registry" {
   role    = "roles/artifactregistry.reader"
   member  = "serviceAccount:${local.sa_email}"
 }
+
+# Enable GPUDirect for A3 and A3Mega VMs, this involve multiple kubectl steps to integrate with the created cluster
+# 1. Install NCCL plugin daemonset
+# 2. Install NRI plugin daemonset
+# 3. Update user workload to inject rxdm sidecar and other required annotation, volume etc.
+locals {
+  split_cluster_id         = split("/", var.cluster_id)
+  user_workload_path_tcpx  = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpx-workload-job.yaml" : var.user_workload_path
+  user_workload_path_tcpxo = var.user_workload_path == null ? "${path.module}/gpu-direct-workload/sample-tcpxo-workload-job.yaml" : var.user_workload_path
+
+  # Manifest to be installed for enabling TCPX on A3 machines
+  tcpx_manifests = [
+    "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpx/nccl-tcpx-installer.yaml",      # nccl_plugin v3.1.9 for tcpx
+    "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpx/nccl-config.yaml",              # nccl_configmap
+    "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+  ]
+
+  # Manifest to be installed for enabling TCPXO on A3Mega machines
+  tcpxo_manifests = [
+    "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.4 for tcpxo
+    "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+  ]
+
+  updated_user_workload_path = (
+    var.machine_type == "a3-highgpu-8g"
+    ? replace(local.user_workload_path_tcpx, ".yaml", "-tcpx.yaml")
+    : var.machine_type == "a3-megagpu-8g"
+    ? replace(local.user_workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
+  : null)
+
+  gpu_direct_manifest = (
+    var.machine_type == "a3-highgpu-8g"
+    ? local.tcpx_manifests
+    : var.machine_type == "a3-megagpu-8g"
+    ? local.tcpxo_manifests
+  : null)
+}
+
+data "google_container_cluster" "gke_cluster" {
+  project  = var.project_id
+  name     = local.split_cluster_id[5]
+  location = local.split_cluster_id[3]
+}
+
+resource "null_resource" "install_dependencies" {
+  provisioner "local-exec" {
+    command = "pip3 install pyyaml argparse"
+  }
+}
+
+# execute script to inject rxdm sidecar into workload to enable tcpx for A3 VM workload
+resource "null_resource" "enable_tcpx_in_workload" {
+  count = var.machine_type == "a3-highgpu-8g" ? 1 : 0
+  triggers = {
+    always_run = timestamp()
+  }
+  # rxdm version v2.0.12 should be matching nccl-tcpx-installer version v3.1.9 
+  # more details in https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#heading=h.n4ytmbxt737h
+  provisioner "local-exec" {
+    command = "python3 ${path.module}/gpu-direct-workload/scripts/enable-tcpx-in-workload.py --file ${local.user_workload_path_tcpx} --rxdm v2.0.12"
+  }
+
+  depends_on = [null_resource.install_dependencies]
+}
+
+# execute script to inject rxdm sidecar into workload to enable tcpxo for A3Mega VM workload
+resource "null_resource" "enable_tcpxo_in_workload" {
+  count = var.machine_type == "a3-megagpu-8g" ? 1 : 0
+  triggers = {
+    always_run = timestamp()
+  }
+  # rxdm version v1.0.10 should be matching nccl-tcpxo-installer version v1.0.4 
+  # more details in https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#heading=h.n4ytmbxt737h
+  provisioner "local-exec" {
+    command = "python3 ${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py --file ${local.user_workload_path_tcpxo} --rxdm v1.0.10"
+  }
+
+  depends_on = [null_resource.install_dependencies]
+}
+
+# apply manifest to enable tcpx
+module "kubectl_apply" {
+  source = "../../management/kubectl-apply"
+
+  cluster_id = data.google_container_cluster.gke_cluster.id
+  project_id = var.project_id
+
+  apply_manifests = flatten([
+    for manifest in local.gpu_direct_manifest : [
+      {
+        source = manifest
+      }
+    ]
+  ])
+}

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -277,8 +277,6 @@ resource "null_resource" "enable_tcpx_in_workload" {
   triggers = {
     always_run = timestamp()
   }
-  # rxdm version v2.0.12 should be matching nccl-tcpx-installer version v3.1.9 
-  # more details in https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#heading=h.n4ytmbxt737h
   provisioner "local-exec" {
     command = "python3 ${path.module}/gpu-direct-workload/scripts/enable-tcpx-in-workload.py --file ${local.user_workload_path_tcpx} --rxdm ${local.gpu_direct_setting.rxdm_version}"
   }
@@ -292,8 +290,6 @@ resource "null_resource" "enable_tcpxo_in_workload" {
   triggers = {
     always_run = timestamp()
   }
-  # rxdm version v1.0.10 should be matching nccl-tcpxo-installer version v1.0.4 
-  # more details in https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#heading=h.n4ytmbxt737h
   provisioner "local-exec" {
     command = "python3 ${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py --file ${local.user_workload_path_tcpxo} --rxdm ${local.gpu_direct_setting.rxdm_version}"
   }

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -69,14 +69,18 @@ output "instructions" {
   description = "Instructions for submitting the sample GPUDirect enabled job."
   value       = <<-EOT
     A sample GKE job that had GPUDirect enabled and NCCL test included has been created locally at:
-      ${abspath(local.gpu_direct_setting.updated_user_workload_path)}
+      ${abspath(local.gpu_direct_setting.updated_workload_path)}
 
-    Use the following commands to:
-    Submit your job:
-      kubectl create -f ${abspath(local.gpu_direct_setting.updated_user_workload_path)}
+    You can use the following commands to submit the sample job:
+      kubectl create -f ${abspath(local.gpu_direct_setting.updated_workload_path)}
 
-    If you would like to enable GPUDirect for your own workload, please provide your Kubernetes Job manifest
-    as user_workload_path in the gke-node-pool blueprint, or follow our instruction to update your workload
+    If you would like to enable GPUDirect for your own workload, please provide the path to your Kubernetes Job manifest
+    as WORKLOAD_PATH in the command below:
+      python3 ${abspath("${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py")} --file $<WORKLOAD_PATH> --rxdm ${local.gpu_direct_setting.rxdm_version}
+
+    Or you can also follow our GPUDirect user guide to update your workload
     https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests
+
+    After the command an updated manifest will be generated and you can deploy it to the clsuter using kubectl
   EOT
 }

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -64,3 +64,19 @@ output "tolerations" {
   description = "Tolerations needed for a pod to be scheduled on this node pool."
   value       = local.tolerations
 }
+
+output "instructions" {
+  description = "Instructions for submitting the sample GPUDirect enabled job."
+  value       = <<-EOT
+    A sample GKE job that had GPUDirect enabled and NCCL test included has been created locally at:
+      ${abspath(local.updated_user_workload_path)}
+
+    Use the following commands to:
+    Submit your job:
+      kubectl create -f ${abspath(local.updated_user_workload_path)}
+
+    If you would like to enable GPUDirect for your own workload, please provide your Kubernetes Job manifest
+    as user_workload_path in the gke-node-pool blueprint, or follow our instruction to update your workload
+    https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests
+  EOT
+}

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -69,11 +69,11 @@ output "instructions" {
   description = "Instructions for submitting the sample GPUDirect enabled job."
   value       = <<-EOT
     A sample GKE job that had GPUDirect enabled and NCCL test included has been created locally at:
-      ${abspath(local.updated_user_workload_path)}
+      ${abspath(local.gpu_direct_setting.updated_user_workload_path)}
 
     Use the following commands to:
     Submit your job:
-      kubectl create -f ${abspath(local.updated_user_workload_path)}
+      kubectl create -f ${abspath(local.gpu_direct_setting.updated_user_workload_path)}
 
     If you would like to enable GPUDirect for your own workload, please provide your Kubernetes Job manifest
     as user_workload_path in the gke-node-pool blueprint, or follow our instruction to update your workload

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -77,6 +77,9 @@ output "instructions" {
     If you would like to enable GPUDirect for your own workload, please follow the below steps:
       export WORKLOAD_PATH=<>
       python3 ${abspath("${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py")} --file $WORKLOAD_PATH --rxdm ${local.gpu_direct_setting.rxdm_version}
+    **WARNING**
+    The "--rxdm" version is tide to the nccl-tcpx/o-installer that had been deployed to your cluster, changing it to other value might have impact on performance
+    **WARNING**
 
     Or you can also follow our GPUDirect user guide to update your workload
     https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -72,8 +72,10 @@ locals {
     a3-megagpu-8g = "enable-tcpxo-in-workload.py"
   }
   gpu_direct_instruction = <<-EOT
-    Since you are using a3-mega machine type, you will have to add gpudirect support to your workload.
-    A sample GKE job that had GPUDirect enabled and NCCL test included has been created locally at:
+    Since you are using ${var.machine_type} machine type that has GPUDirect support, your nodepool had been configured with the required plugins.
+    To fully utilize GPUDirect you will need to add the some components into your workload manifest. Details below:
+
+    A sample GKE job that had GPUDirect enabled and NCCL test included has been generated locally at:
       ${abspath(local.gpu_direct_setting.updated_workload_path)}
 
     You can use the following commands to submit the sample job:

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -74,13 +74,11 @@ output "instructions" {
     You can use the following commands to submit the sample job:
       kubectl create -f ${abspath(local.gpu_direct_setting.updated_workload_path)}
 
-    If you would like to enable GPUDirect for your own workload, please provide the path to your Kubernetes Job manifest
-    as WORKLOAD_PATH in the command below:
-      python3 ${abspath("${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py")} --file $<WORKLOAD_PATH> --rxdm ${local.gpu_direct_setting.rxdm_version}
+    If you would like to enable GPUDirect for your own workload, please follow the below steps:
+      export WORKLOAD_PATH=<>
+      python3 ${abspath("${path.module}/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py")} --file $WORKLOAD_PATH --rxdm ${local.gpu_direct_setting.rxdm_version}
 
     Or you can also follow our GPUDirect user guide to update your workload
     https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests
-
-    After the command an updated manifest will be generated and you can deploy it to the clsuter using kubectl
   EOT
 }

--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -255,6 +255,12 @@ variable "timeout_update" {
   default     = null
 }
 
+variable "user_workload_path" {
+  description = "The path to the user workload, this should point to the kubernetes job manifest that user want to have the TCPX sidecar injected."
+  type        = string
+  default     = null
+}
+
 # Deprecated
 
 # tflint-ignore: terraform_unused_declarations

--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -255,17 +255,6 @@ variable "timeout_update" {
   default     = null
 }
 
-variable "user_workload_path" {
-  description = <<-EOT
-  The gke-node-pool module relative path to the user workload, this should point to the kubernetes job manifest
-  that user want to have the GPUDirect rxdm sidecar injected. The toolkit would apply the required changes to this
-  user workload and generate a new workload file for user to inspect and apply to the cluster. Details of the required
-  changes can be found in the [GPUDirect user guide](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests)
-  EOT
-  type        = string
-  default     = null
-}
-
 # Deprecated
 
 # tflint-ignore: terraform_unused_declarations

--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -256,7 +256,12 @@ variable "timeout_update" {
 }
 
 variable "user_workload_path" {
-  description = "The path to the user workload, this should point to the kubernetes job manifest that user want to have the TCPX sidecar injected."
+  description = <<-EOT
+  The gke-node-pool module relative path to the user workload, this should point to the kubernetes job manifest
+  that user want to have the GPUDirect rxdm sidecar injected. The toolkit would apply the required changes to this
+  user workload and generate a new workload file for user to inspect and apply to the cluster. Details of the required
+  changes can be found in the [GPUDirect user guide](https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests)
+  EOT
   type        = string
   default     = null
 }

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -24,6 +24,10 @@ terraform {
       source  = "hashicorp/google-beta"
       version = "~> 5.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.38.0"


### PR DESCRIPTION
This change add support for enabling tcpx/o in a3 and a3mega vm, it include:
- Install the correct version of NCCL plugin and NRI plugin daemonsets for A3 and A3Mega nodepool
- provide script for injecting rxdm sidecar and other required components into user workload
- provide a sample workload in the format of Kubernetes Job manifest to show how GPUDirect work and what performance it brings

---------------------

SAMPLE OUTPUT of the added enable_tcpxo_in_workload:
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0]: Creating...
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0]: Provisioning with 'local-exec'...
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0] (local-exec): Executing: ["/bin/sh" "-c" "python3 modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py --file modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job.yaml --rxdm v1.0.10"]
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0] (local-exec): A new manifest has been generated and updated to have TCPXO enabled based on the provided workload
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0] (local-exec): It can be found in /home/user/fork/hpc-toolkit/gke-a3-mega/primary/modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job-tcpxo.yaml
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0] (local-exec): You can use the following commands to submit the sample job:
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0] (local-exec):   kubectl create -f /home/user/fork/hpc-toolkit/gke-a3-mega/primary/modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job-tcpxo.yaml
        module.a3-megagpu_pool.null_resource.enable_tcpxo_in_workload[0]: Creation complete after 0s [id=1932468328196680693]
...
...
Apply complete! Resources: 19 added, 1 changed, 1 destroyed.

Outputs:

instructions_a3-megagpu_pool = <<EOT
Since you are using a3-megagpu-8g machine type that has GPUDirect support, your nodepool had been configured with the required plugins.
To use the GPUDirect you will have to add the some components into your workload manifest. Details below

A sample GKE job that had GPUDirect enabled and NCCL test included has been generated locally at:
  /home/user/fork/hpc-toolkit/gke-a3-mega/primary/modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job-tcpxo.yaml

You can use the following commands to submit the sample job:
  kubectl create -f /home/user/fork/hpc-toolkit/gke-a3-mega/primary/modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job-tcpxo.yaml

Follow below steps to enable GPUDirect for your own workload:
  export WORKLOAD_PATH=<>
  python3 /home/user/fork/hpc-toolkit/gke-a3-mega/primary/modules/embedded/modules/compute/gke-node-pool/gpu-direct-workload/scripts/enable-tcpxo-in-workload.py --file $WORKLOAD_PATH --rxdm v1.0.10
**WARNING**
The "--rxdm" version is tide to the nccl-tcpx/o-installer that had been deployed to your cluster, changing it to other value might have impact on performance
**WARNING**

Or you can also follow our GPUDirect user guide to update your workload
https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#add-gpudirect-manifests

After the command an updated manifest will be generated and you can deploy it to the clsuter using kubectl

---------------------

SAMPLE OUTPUT of running python script directly:
        A new manifest has been generated and updated to have TCPXO enabled based on the provided workload
        It can be found in /home/user/chdu/sample-tcpxo-workload-job-tcpxo.yaml
        You can use the following commands to submit the sample job:
          kubectl create -f /home/user/chdu/sample-tcpxo-workload-job-tcpxo.yaml