### PR TITLE
Adds option to allow Kueue/Jobset to be installed on a GKE cluster via blueprints

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -66,3 +66,12 @@ deployment_groups:
       autoscaling_total_min_nodes: 2
       zones: [$(vars.zone)]
     outputs: [instructions]
+
+  - id: workload_component_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+      jobset:
+        install: true

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -66,3 +66,12 @@ deployment_groups:
       autoscaling_total_min_nodes: 2
       zones: [$(vars.zone)]
     outputs: [instructions]
+
+  - id: workload_manager_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+      jobset:
+        install: true

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -1,6 +1,13 @@
 ## Description
 
-This module simplifies applying Kubernetes manifests to GKE clusters. It provides flexible options for specifying manifests, allowing you to either directly embed them as strings content or reference them from URLs, files, templates, or entire .yaml and .tftpl files in directories.
+This module simplifies the following functionality:
+
+* Applying Kubernetes manifests to GKE clusters: It provides flexible options for specifying manifests, allowing you to either directly embed them as strings content or reference them from URLs, files, templates, or entire .yaml and .tftpl files in directories.
+* Deploying commonly used infrastructure like [Kueue](https://kueue.sigs.k8s.io/docs/) or [Jobset](https://jobset.sigs.k8s.io/docs/).
+
+> Note: Kueue can work with a variety of frameworks out of the box, find them [here](https://kueue.sigs.k8s.io/docs/tasks/run/)
+
+### Explanation
 
 * **Manifest:**
   * **Raw String:** Specify manifests directly within the module configuration using the `content: manifest_body` format.
@@ -10,7 +17,7 @@ This module simplifies applying Kubernetes manifests to GKE clusters. It provide
     * A template file (`.tftpl`) to generate a manifest. Ex.: `./template.yaml.tftpl`. You can pass the variables to format the template file in `template_vars`.
     * A directory containing multiple YAML or template files. Ex: `./manifests/`. You can pass the variables to format the template files in `template_vars`.
 
-### Example
+#### Manifest Example
 
 ```yaml
 - id: existing-gke-cluster
@@ -35,6 +42,20 @@ This module simplifies applying Kubernetes manifests to GKE clusters. It provide
       template_vars: {name: "dev-config", public: "false"}
     - source: $(ghpc_stage("manifests"))/
       template_vars: {name: "dev-config", public: "false"}
+```
+
+#### Pre-build infrastructure Example
+
+```yaml
+  - id: workload_component_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+        config_path: $(ghpc_stage("manifests/user-provided-kueue-config.yaml"))
+      jobset:
+        install: true
 ```
 
 > **_NOTE:_**
@@ -79,7 +100,10 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_kubectl"></a> [kubectl](#module\_kubectl) | ./kubectl | n/a |
+| <a name="module_configure_kueue"></a> [configure\_kueue](#module\_configure\_kueue) | ./kubectl | n/a |
+| <a name="module_install_jobset"></a> [install\_jobset](#module\_install\_jobset) | ./kubectl | n/a |
+| <a name="module_install_kueue"></a> [install\_kueue](#module\_install\_kueue) | ./kubectl | n/a |
+| <a name="module_kubectl_apply_manifests"></a> [kubectl\_apply\_manifests](#module\_kubectl\_apply\_manifests) | ./kubectl | n/a |
 
 ## Resources
 
@@ -94,6 +118,8 @@ limitations under the License.
 |------|-------------|------|---------|:--------:|
 | <a name="input_apply_manifests"></a> [apply\_manifests](#input\_apply\_manifests) | A list of manifests to apply to GKE cluster using kubectl. For more details see [kubectl module's inputs](kubectl/README.md). | <pre>list(object({<br/>    content           = optional(string, null)<br/>    source            = optional(string, null)<br/>    template_vars     = optional(map(any), null)<br/>    server_side_apply = optional(bool, false)<br/>    wait_for_rollout  = optional(bool, true)<br/>  }))</pre> | `[]` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the gke cluster resource with format projects/<project\_id>/locations/<region>/clusters/<name>. | `string` | n/a | yes |
+| <a name="input_jobset"></a> [jobset](#input\_jobset) | Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit. | <pre>object({<br/>    install = optional(bool, false)<br/>    version = optional(string, "v0.5.2")<br/>  })</pre> | `{}` | no |
+| <a name="input_kueue"></a> [kueue](#input\_kueue) | Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. | <pre>object({<br/>    install     = optional(bool, false)<br/>    version     = optional(string, "v0.8.1")<br/>    config_path = optional(string, null)<br/>  })</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID that hosts the gke cluster. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/management/kubectl-apply/manifests/jobset-v0.5.2.yaml
+++ b/modules/management/kubectl-apply/manifests/jobset-v0.5.2.yaml
@@ -1,0 +1,8349 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: system
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: namespace
+    app.kubernetes.io/part-of: jobset
+    control-plane: controller-manager
+  name: jobset-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    controller-gen.kubebuilder.io/version: v0.14.0
+  name: jobsets.jobset.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: jobset-webhook-service
+          namespace: jobset-system
+          path: /convert
+      conversionReviewVersions:
+      - v1
+  group: jobset.x-k8s.io
+  names:
+    kind: JobSet
+    listKind: JobSetList
+    plural: jobsets
+    singular: jobset
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Number of restarts
+      jsonPath: .status.restarts
+      name: Restarts
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Completed")].status
+      name: Completed
+      type: string
+    - description: JobSet suspended
+      jsonPath: .spec.suspend
+      name: Suspended
+      type: string
+    - description: Time this JobSet was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: JobSet is the Schema for the jobsets API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: JobSetSpec defines the desired state of JobSet
+            properties:
+              failurePolicy:
+                description: |-
+                  FailurePolicy, if set, configures when to declare the JobSet as
+                  failed.
+                  The JobSet is always declared failed if any job in the set
+                  finished with status failed.
+                properties:
+                  maxRestarts:
+                    description: |-
+                      MaxRestarts defines the limit on the number of JobSet restarts.
+                      A restart is achieved by recreating all active child jobs.
+                    format: int32
+                    type: integer
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              managedBy:
+                description: ManagedBy is used to indicate the controller or entity that manages a JobSet
+                type: string
+              network:
+                description: Network defines the networking options for the jobset.
+                properties:
+                  enableDNSHostnames:
+                    description: |-
+                      EnableDNSHostnames allows pods to be reached via their hostnames.
+                      Pods will be reachable using the fully qualified pod hostname:
+                      <jobSet.name>-<spec.replicatedJob.name>-<job-index>-<pod-index>.<subdomain>
+                    type: boolean
+                  subdomain:
+                    description: |-
+                      Subdomain is an explicit choice for a network subdomain name
+                      When set, any replicated job in the set is added to this network.
+                      Defaults to <jobSet.name> if not set.
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              replicatedJobs:
+                description: ReplicatedJobs is the group of jobs that will form the set.
+                items:
+                  properties:
+                    name:
+                      description: |-
+                        Name is the name of the entry and will be used as a suffix
+                        for the Job name.
+                      type: string
+                    replicas:
+                      default: 1
+                      description: |-
+                        Replicas is the number of jobs that will be created from this ReplicatedJob's template.
+                        Jobs names will be in the format: <jobSet.name>-<spec.replicatedJob.name>-<job-index>
+                      format: int32
+                      type: integer
+                    template:
+                      description: Template defines the template of the Job that will be created.
+                      properties:
+                        metadata:
+                          description: |-
+                            Standard object's metadata of the jobs created from this template.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        spec:
+                          description: |-
+                            Specification of the desired behavior of the job.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                          properties:
+                            activeDeadlineSeconds:
+                              description: |-
+                                Specifies the duration in seconds relative to the startTime that the job
+                                may be continuously active before the system tries to terminate it; value
+                                must be positive integer. If a Job is suspended (at creation or through an
+                                update), this timer will effectively be stopped and reset when the Job is
+                                resumed again.
+                              format: int64
+                              type: integer
+                            backoffLimit:
+                              description: |-
+                                Specifies the number of retries before marking this job failed.
+                                Defaults to 6
+                              format: int32
+                              type: integer
+                            backoffLimitPerIndex:
+                              description: |-
+                                Specifies the limit for the number of retries within an
+                                index before marking this index as failed. When enabled the number of
+                                failures per index is kept in the pod's
+                                batch.kubernetes.io/job-index-failure-count annotation. It can only
+                                be set when Job's completionMode=Indexed, and the Pod's restart
+                                policy is Never. The field is immutable.
+                                This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
+                                feature gate is enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            completionMode:
+                              description: |-
+                                completionMode specifies how Pod completions are tracked. It can be
+                                `NonIndexed` (default) or `Indexed`.
+
+
+                                `NonIndexed` means that the Job is considered complete when there have
+                                been .spec.completions successfully completed Pods. Each Pod completion is
+                                homologous to each other.
+
+
+                                `Indexed` means that the Pods of a
+                                Job get an associated completion index from 0 to (.spec.completions - 1),
+                                available in the annotation batch.kubernetes.io/job-completion-index.
+                                The Job is considered complete when there is one successfully completed Pod
+                                for each index.
+                                When value is `Indexed`, .spec.completions must be specified and
+                                `.spec.parallelism` must be less than or equal to 10^5.
+                                In addition, The Pod name takes the form
+                                `$(job-name)-$(index)-$(random-string)`,
+                                the Pod hostname takes the form `$(job-name)-$(index)`.
+
+
+                                More completion modes can be added in the future.
+                                If the Job controller observes a mode that it doesn't recognize, which
+                                is possible during upgrades due to version skew, the controller
+                                skips updates for the Job.
+                              type: string
+                            completions:
+                              description: |-
+                                Specifies the desired number of successfully finished pods the
+                                job should be run with.  Setting to null means that the success of any
+                                pod signals the success of all pods, and allows parallelism to have any positive
+                                value.  Setting to 1 means that parallelism is limited to 1 and the success of that
+                                pod signals the success of the job.
+                                More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                              format: int32
+                              type: integer
+                            manualSelector:
+                              description: |-
+                                manualSelector controls generation of pod labels and pod selectors.
+                                Leave `manualSelector` unset unless you are certain what you are doing.
+                                When false or unset, the system pick labels unique to this job
+                                and appends those labels to the pod template.  When true,
+                                the user is responsible for picking unique labels and specifying
+                                the selector.  Failure to pick a unique label may cause this
+                                and other jobs to not function correctly.  However, You may see
+                                `manualSelector=true` in jobs that were created with the old `extensions/v1beta1`
+                                API.
+                                More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#specifying-your-own-pod-selector
+                              type: boolean
+                            maxFailedIndexes:
+                              description: |-
+                                Specifies the maximal number of failed indexes before marking the Job as
+                                failed, when backoffLimitPerIndex is set. Once the number of failed
+                                indexes exceeds this number the entire Job is marked as Failed and its
+                                execution is terminated. When left as null the job continues execution of
+                                all of its indexes and is marked with the `Complete` Job condition.
+                                It can only be specified when backoffLimitPerIndex is set.
+                                It can be null or up to completions. It is required and must be
+                                less than or equal to 10^4 when is completions greater than 10^5.
+                                This field is beta-level. It can be used when the `JobBackoffLimitPerIndex`
+                                feature gate is enabled (enabled by default).
+                              format: int32
+                              type: integer
+                            parallelism:
+                              description: |-
+                                Specifies the maximum desired number of pods the job should
+                                run at any given time. The actual number of pods running in steady state will
+                                be less than this number when ((.spec.completions - .status.successful) < .spec.parallelism),
+                                i.e. when the work left to do is less than max parallelism.
+                                More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                              format: int32
+                              type: integer
+                            podFailurePolicy:
+                              description: |-
+                                Specifies the policy of handling failed pods. In particular, it allows to
+                                specify the set of actions and conditions which need to be
+                                satisfied to take the associated action.
+                                If empty, the default behaviour applies - the counter of failed pods,
+                                represented by the jobs's .status.failed field, is incremented and it is
+                                checked against the backoffLimit. This field cannot be used in combination
+                                with restartPolicy=OnFailure.
+
+
+                                This field is beta-level. It can be used when the `JobPodFailurePolicy`
+                                feature gate is enabled (enabled by default).
+                              properties:
+                                rules:
+                                  description: |-
+                                    A list of pod failure policy rules. The rules are evaluated in order.
+                                    Once a rule matches a Pod failure, the remaining of the rules are ignored.
+                                    When no rule matches the Pod failure, the default handling applies - the
+                                    counter of pod failures is incremented and it is checked against
+                                    the backoffLimit. At most 20 elements are allowed.
+                                  items:
+                                    description: |-
+                                      PodFailurePolicyRule describes how a pod failure is handled when the requirements are met.
+                                      One of onExitCodes and onPodConditions, but not both, can be used in each rule.
+                                    properties:
+                                      action:
+                                        description: |-
+                                          Specifies the action taken on a pod failure when the requirements are satisfied.
+                                          Possible values are:
+
+
+                                          - FailJob: indicates that the pod's job is marked as Failed and all
+                                            running pods are terminated.
+                                          - FailIndex: indicates that the pod's index is marked as Failed and will
+                                            not be restarted.
+                                            This value is beta-level. It can be used when the
+                                            `JobBackoffLimitPerIndex` feature gate is enabled (enabled by default).
+                                          - Ignore: indicates that the counter towards the .backoffLimit is not
+                                            incremented and a replacement pod is created.
+                                          - Count: indicates that the pod is handled in the default way - the
+                                            counter towards the .backoffLimit is incremented.
+                                          Additional values are considered to be added in the future. Clients should
+                                          react to an unknown action by skipping the rule.
+                                        type: string
+                                      onExitCodes:
+                                        description: Represents the requirement on the container exit codes.
+                                        properties:
+                                          containerName:
+                                            description: |-
+                                              Restricts the check for exit codes to the container with the
+                                              specified name. When null, the rule applies to all containers.
+                                              When specified, it should match one the container or initContainer
+                                              names in the pod template.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Represents the relationship between the container exit code(s) and the
+                                              specified values. Containers completed with success (exit code 0) are
+                                              excluded from the requirement check. Possible values are:
+
+
+                                              - In: the requirement is satisfied if at least one container exit code
+                                                (might be multiple if there are multiple containers not restricted
+                                                by the 'containerName' field) is in the set of specified values.
+                                              - NotIn: the requirement is satisfied if at least one container exit code
+                                                (might be multiple if there are multiple containers not restricted
+                                                by the 'containerName' field) is not in the set of specified values.
+                                              Additional values are considered to be added in the future. Clients should
+                                              react to an unknown operator by assuming the requirement is not satisfied.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              Specifies the set of values. Each returned container exit code (might be
+                                              multiple in case of multiple containers) is checked against this set of
+                                              values with respect to the operator. The list of values must be ordered
+                                              and must not contain duplicates. Value '0' cannot be used for the In operator.
+                                              At least one element is required. At most 255 elements are allowed.
+                                            items:
+                                              format: int32
+                                              type: integer
+                                            type: array
+                                            x-kubernetes-list-type: set
+                                        required:
+                                        - operator
+                                        - values
+                                        type: object
+                                      onPodConditions:
+                                        description: |-
+                                          Represents the requirement on the pod conditions. The requirement is represented
+                                          as a list of pod condition patterns. The requirement is satisfied if at
+                                          least one pattern matches an actual pod condition. At most 20 elements are allowed.
+                                        items:
+                                          description: |-
+                                            PodFailurePolicyOnPodConditionsPattern describes a pattern for matching
+                                            an actual pod condition type.
+                                          properties:
+                                            status:
+                                              description: |-
+                                                Specifies the required Pod condition status. To match a pod condition
+                                                it is required that the specified status equals the pod condition status.
+                                                Defaults to True.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                Specifies the required Pod condition type. To match a pod condition
+                                                it is required that specified type equals the pod condition type.
+                                              type: string
+                                          required:
+                                          - status
+                                          - type
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - action
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                              - rules
+                              type: object
+                            podReplacementPolicy:
+                              description: |-
+                                podReplacementPolicy specifies when to create replacement Pods.
+                                Possible values are:
+                                - TerminatingOrFailed means that we recreate pods
+                                  when they are terminating (has a metadata.deletionTimestamp) or failed.
+                                - Failed means to wait until a previously created Pod is fully terminated (has phase
+                                  Failed or Succeeded) before creating a replacement Pod.
+
+
+                                When using podFailurePolicy, Failed is the the only allowed value.
+                                TerminatingOrFailed and Failed are allowed values when podFailurePolicy is not in use.
+                                This is an beta field. To use this, enable the JobPodReplacementPolicy feature toggle.
+                                This is on by default.
+                              type: string
+                            selector:
+                              description: |-
+                                A label query over pods that should match the pod count.
+                                Normally, the system sets this field for you.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            suspend:
+                              description: |-
+                                suspend specifies whether the Job controller should create Pods or not. If
+                                a Job is created with suspend set to true, no Pods are created by the Job
+                                controller. If a Job is suspended after creation (i.e. the flag goes from
+                                false to true), the Job controller will delete all active Pods associated
+                                with this Job. Users must design their workload to gracefully handle this.
+                                Suspending a Job will reset the StartTime field of the Job, effectively
+                                resetting the ActiveDeadlineSeconds timer too. Defaults to false.
+                              type: boolean
+                            template:
+                              description: |-
+                                Describes the pod that will be created when executing a job.
+                                The only allowed template.spec.restartPolicy values are "Never" or "OnFailure".
+                                More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/
+                              properties:
+                                metadata:
+                                  description: |-
+                                    Standard object's metadata.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                  properties:
+                                    annotations:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    finalizers:
+                                      items:
+                                        type: string
+                                      type: array
+                                    labels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                    name:
+                                      type: string
+                                    namespace:
+                                      type: string
+                                  type: object
+                                spec:
+                                  description: |-
+                                    Specification of the desired behavior of the pod.
+                                    More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                                  properties:
+                                    activeDeadlineSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod may be active on the node relative to
+                                        StartTime before the system will actively try to mark it failed and kill associated containers.
+                                        Value must be a positive integer.
+                                      format: int64
+                                      type: integer
+                                    affinity:
+                                      description: If specified, the pod's scheduling constraints
+                                      properties:
+                                        nodeAffinity:
+                                          description: Describes node affinity scheduling rules for the pod.
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: |-
+                                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                                properties:
+                                                  preference:
+                                                    description: A node selector term, associated with the corresponding weight.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  weight:
+                                                    description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - preference
+                                                - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to an update), the system
+                                                may or may not try to eventually evict the pod from its node.
+                                              properties:
+                                                nodeSelectorTerms:
+                                                  description: Required. A list of node selector terms. The terms are ORed.
+                                                  items:
+                                                    description: |-
+                                                      A null or empty node selector term matches no objects. The requirements of
+                                                      them are ANDed.
+                                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: A list of node selector requirements by node's labels.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchFields:
+                                                        description: A list of node selector requirements by node's fields.
+                                                        items:
+                                                          description: |-
+                                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                                            that relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: The label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                Represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                An array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                                array must have a single element, which will be interpreted as an integer.
+                                                                This array is replaced during a strategic merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  type: array
+                                              required:
+                                              - nodeSelectorTerms
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                        podAffinity:
+                                          description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - podAffinityTerm
+                                                - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              type: array
+                                          type: object
+                                        podAntiAffinity:
+                                          description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                                          properties:
+                                            preferredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                                the anti-affinity expressions specified by this field, but it may choose
+                                                a node that violates one or more of the expressions. The node that is
+                                                most preferred is the one with the greatest sum of weights, i.e.
+                                                for each node that meets all of the scheduling requirements (resource
+                                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                                compute a sum by iterating through the elements of this field and adding
+                                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                                node(s) with the highest sum are the most preferred.
+                                              items:
+                                                description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                                properties:
+                                                  podAffinityTerm:
+                                                    description: Required. A pod affinity term, associated with the corresponding weight.
+                                                    properties:
+                                                      labelSelector:
+                                                        description: |-
+                                                          A label query over a set of resources, in this case pods.
+                                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      matchLabelKeys:
+                                                        description: |-
+                                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      mismatchLabelKeys:
+                                                        description: |-
+                                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                          be taken into consideration. The keys are used to lookup values from the
+                                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                          to select the group of existing pods which pods will be taken into consideration
+                                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                          pod labels will be ignored. The default value is empty.
+                                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                        x-kubernetes-list-type: atomic
+                                                      namespaceSelector:
+                                                        description: |-
+                                                          A label query over the set of namespaces that the term applies to.
+                                                          The term is applied to the union of the namespaces selected by this field
+                                                          and the ones listed in the namespaces field.
+                                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                                          An empty selector ({}) matches all namespaces.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      namespaces:
+                                                        description: |-
+                                                          namespaces specifies a static list of namespace names that the term applies to.
+                                                          The term is applied to the union of the namespaces listed in this field
+                                                          and the ones selected by namespaceSelector.
+                                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      topologyKey:
+                                                        description: |-
+                                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                                          selected pods is running.
+                                                          Empty topologyKey is not allowed.
+                                                        type: string
+                                                    required:
+                                                    - topologyKey
+                                                    type: object
+                                                  weight:
+                                                    description: |-
+                                                      weight associated with matching the corresponding podAffinityTerm,
+                                                      in the range 1-100.
+                                                    format: int32
+                                                    type: integer
+                                                required:
+                                                - podAffinityTerm
+                                                - weight
+                                                type: object
+                                              type: array
+                                            requiredDuringSchedulingIgnoredDuringExecution:
+                                              description: |-
+                                                If the anti-affinity requirements specified by this field are not met at
+                                                scheduling time, the pod will not be scheduled onto the node.
+                                                If the anti-affinity requirements specified by this field cease to be met
+                                                at some point during pod execution (e.g. due to a pod label update), the
+                                                system may or may not try to eventually evict the pod from its node.
+                                                When there are multiple elements, the lists of nodes corresponding to each
+                                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                              items:
+                                                description: |-
+                                                  Defines a set of pods (namely those matching the labelSelector
+                                                  relative to the given namespace(s)) that this pod should be
+                                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                                  where co-located is defined as running on a node whose value of
+                                                  the label with key <topologyKey> matches that of any node on which
+                                                  a pod of the set of pods is running
+                                                properties:
+                                                  labelSelector:
+                                                    description: |-
+                                                      A label query over a set of resources, in this case pods.
+                                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  matchLabelKeys:
+                                                    description: |-
+                                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  mismatchLabelKeys:
+                                                    description: |-
+                                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                      be taken into consideration. The keys are used to lookup values from the
+                                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                                      to select the group of existing pods which pods will be taken into consideration
+                                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                      pod labels will be ignored. The default value is empty.
+                                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  namespaceSelector:
+                                                    description: |-
+                                                      A label query over the set of namespaces that the term applies to.
+                                                      The term is applied to the union of the namespaces selected by this field
+                                                      and the ones listed in the namespaces field.
+                                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                                      An empty selector ({}) matches all namespaces.
+                                                    properties:
+                                                      matchExpressions:
+                                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                        items:
+                                                          description: |-
+                                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                                            relates the key and values.
+                                                          properties:
+                                                            key:
+                                                              description: key is the label key that the selector applies to.
+                                                              type: string
+                                                            operator:
+                                                              description: |-
+                                                                operator represents a key's relationship to a set of values.
+                                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                              type: string
+                                                            values:
+                                                              description: |-
+                                                                values is an array of string values. If the operator is In or NotIn,
+                                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                the values array must be empty. This array is replaced during a strategic
+                                                                merge patch.
+                                                              items:
+                                                                type: string
+                                                              type: array
+                                                          required:
+                                                          - key
+                                                          - operator
+                                                          type: object
+                                                        type: array
+                                                      matchLabels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        description: |-
+                                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                        type: object
+                                                    type: object
+                                                    x-kubernetes-map-type: atomic
+                                                  namespaces:
+                                                    description: |-
+                                                      namespaces specifies a static list of namespace names that the term applies to.
+                                                      The term is applied to the union of the namespaces listed in this field
+                                                      and the ones selected by namespaceSelector.
+                                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                  topologyKey:
+                                                    description: |-
+                                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                                      selected pods is running.
+                                                      Empty topologyKey is not allowed.
+                                                    type: string
+                                                required:
+                                                - topologyKey
+                                                type: object
+                                              type: array
+                                          type: object
+                                      type: object
+                                    automountServiceAccountToken:
+                                      description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
+                                      type: boolean
+                                    containers:
+                                      description: |-
+                                        List of containers belonging to the pod.
+                                        Containers cannot currently be added or removed.
+                                        There must be at least one container in a Pod.
+                                        Cannot be updated.
+                                      items:
+                                        description: A single application container that you want to run within a pod.
+                                        properties:
+                                          args:
+                                            description: |-
+                                              Arguments to the entrypoint.
+                                              The container image's CMD is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: |-
+                                              Entrypoint array. Not executed within a shell.
+                                              The container image's ENTRYPOINT is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            description: |-
+                                              List of environment variables to set in the container.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvVar represents an environment variable present in a Container.
+                                              properties:
+                                                name:
+                                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                value:
+                                                  description: |-
+                                                    Variable references $(VAR_NAME) are expanded
+                                                    using the previously defined environment variables in the container and
+                                                    any service environment variables. If a variable cannot be resolved,
+                                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                    Escaped references will never be expanded, regardless of whether the variable
+                                                    exists or not.
+                                                    Defaults to "".
+                                                  type: string
+                                                valueFrom:
+                                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      description: Selects a key of a ConfigMap.
+                                                      properties:
+                                                        key:
+                                                          description: The key to select.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the ConfigMap or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      description: |-
+                                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      description: Selects a key of a secret in the pod's namespace
+                                                      properties:
+                                                        key:
+                                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the Secret or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            description: |-
+                                              List of sources to populate environment variables in the container.
+                                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                              will be reported as an event when the container is starting. When a key exists in multiple
+                                              sources, the value associated with the last source will take precedence.
+                                              Values defined by an Env with a duplicate key will take precedence.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvFromSource represents the source of a set of ConfigMaps
+                                              properties:
+                                                configMapRef:
+                                                  description: The ConfigMap to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                secretRef:
+                                                  description: The Secret to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                          image:
+                                            description: |-
+                                              Container image name.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images
+                                              This field is optional to allow higher level config management to default or override
+                                              container images in workload controllers like Deployments and StatefulSets.
+                                            type: string
+                                          imagePullPolicy:
+                                            description: |-
+                                              Image pull policy.
+                                              One of Always, Never, IfNotPresent.
+                                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                            type: string
+                                          lifecycle:
+                                            description: |-
+                                              Actions that the management system should take in response to container lifecycle events.
+                                              Cannot be updated.
+                                            properties:
+                                              postStart:
+                                                description: |-
+                                                  PostStart is called immediately after a container is created. If the handler fails,
+                                                  the container is terminated and restarted according to its restart policy.
+                                                  Other management of the container blocks until the hook completes.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                description: |-
+                                                  PreStop is called immediately before a container is terminated due to an
+                                                  API request or management event such as liveness/startup probe failure,
+                                                  preemption, resource contention, etc. The handler is not called if the
+                                                  container crashes or exits. The Pod's termination grace period countdown begins before the
+                                                  PreStop hook is executed. Regardless of the outcome of the handler, the
+                                                  container will eventually terminate within the Pod's termination grace
+                                                  period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                                  or until the termination grace period is reached.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            description: |-
+                                              Periodic probe of container liveness.
+                                              Container will be restarted if the probe fails.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            description: |-
+                                              Name of the container specified as a DNS_LABEL.
+                                              Each container in a pod must have a unique name (DNS_LABEL).
+                                              Cannot be updated.
+                                            type: string
+                                          ports:
+                                            description: |-
+                                              List of ports to expose from the container. Not specifying a port here
+                                              DOES NOT prevent that port from being exposed. Any port which is
+                                              listening on the default "0.0.0.0" address inside a container will be
+                                              accessible from the network.
+                                              Modifying this array with strategic merge patch may corrupt the data.
+                                              For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                              Cannot be updated.
+                                            items:
+                                              description: ContainerPort represents a network port in a single container.
+                                              properties:
+                                                containerPort:
+                                                  description: |-
+                                                    Number of port to expose on the pod's IP address.
+                                                    This must be a valid port number, 0 < x < 65536.
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  description: What host IP to bind the external port to.
+                                                  type: string
+                                                hostPort:
+                                                  description: |-
+                                                    Number of port to expose on the host.
+                                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                                    If HostNetwork is specified, this must match ContainerPort.
+                                                    Most containers do not need this.
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  description: |-
+                                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                                    named port in a pod must have a unique name. Name for the port that can be
+                                                    referred to by services.
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  description: |-
+                                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                                    Defaults to "TCP".
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            description: |-
+                                              Periodic probe of container service readiness.
+                                              Container will be removed from service endpoints if the probe fails.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            description: Resources resize policy for the container.
+                                            items:
+                                              description: ContainerResizePolicy represents resource resize policy for the container.
+                                              properties:
+                                                resourceName:
+                                                  description: |-
+                                                    Name of the resource to which this resource resize policy applies.
+                                                    Supported values: cpu, memory.
+                                                  type: string
+                                                restartPolicy:
+                                                  description: |-
+                                                    Restart policy to apply when specified resource is resized.
+                                                    If not specified, it defaults to NotRequired.
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            description: |-
+                                              Compute Resources required by this container.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            properties:
+                                              claims:
+                                                description: |-
+                                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                                  that are used by this container.
+
+
+                                                  This is an alpha field and requires enabling the
+                                                  DynamicResourceAllocation feature gate.
+
+
+                                                  This field is immutable. It can only be set for containers.
+                                                items:
+                                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                                        the Pod where this field is used. It makes that resource available
+                                                        inside a container.
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            description: |-
+                                              RestartPolicy defines the restart behavior of individual containers in a pod.
+                                              This field may only be set for init containers, and the only allowed value is "Always".
+                                              For non-init containers or when this field is not specified,
+                                              the restart behavior is defined by the Pod's restart policy and the container type.
+                                              Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                              this init container will be continually restarted on
+                                              exit until all regular containers have terminated. Once all regular
+                                              containers have completed, all init containers with restartPolicy "Always"
+                                              will be shut down. This lifecycle differs from normal init containers and
+                                              is often referred to as a "sidecar" container. Although this init
+                                              container still starts in the init container sequence, it does not wait
+                                              for the container to complete before proceeding to the next init
+                                              container. Instead, the next init container starts immediately after this
+                                              init container is started, or after any startupProbe has successfully
+                                              completed.
+                                            type: string
+                                          securityContext:
+                                            description: |-
+                                              SecurityContext defines the security options the container should be run with.
+                                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                description: |-
+                                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                                  privileges than its parent process. This bool directly controls if
+                                                  the no_new_privs flag will be set on the container process.
+                                                  AllowPrivilegeEscalation is true always when the container is:
+                                                  1) run as Privileged
+                                                  2) has CAP_SYS_ADMIN
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              capabilities:
+                                                description: |-
+                                                  The capabilities to add/drop when running containers.
+                                                  Defaults to the default set of capabilities granted by the container runtime.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  add:
+                                                    description: Added capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    description: Removed capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                description: |-
+                                                  Run container in privileged mode.
+                                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                                  Defaults to false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              procMount:
+                                                description: |-
+                                                  procMount denotes the type of proc mount to use for the containers.
+                                                  The default is DefaultProcMount which uses the container runtime defaults for
+                                                  readonly paths and masked paths.
+                                                  This requires the ProcMountType feature flag to be enabled.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                description: |-
+                                                  Whether this container has a read-only root filesystem.
+                                                  Default is false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to the container.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by this container. If seccomp options are
+                                                  provided at both the pod & container level, the container options
+                                                  override the pod options.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                description: |-
+                                                  The Windows specific settings applied to all containers.
+                                                  If unspecified, the options from the PodSecurityContext will be used.
+                                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is linux.
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    description: |-
+                                                      GMSACredentialSpec is where the GMSA admission webhook
+                                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                    type: string
+                                                  hostProcess:
+                                                    description: |-
+                                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                                      All of a Pod's containers must have the same effective HostProcess value
+                                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    description: |-
+                                                      The UserName in Windows to run the entrypoint of the container process.
+                                                      Defaults to the user specified in image metadata if unspecified.
+                                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            description: |-
+                                              StartupProbe indicates that the Pod has successfully initialized.
+                                              If specified, no other probes are executed until this completes successfully.
+                                              If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                              This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                              when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                              This cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            description: |-
+                                              Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                              is not set, reads from stdin in the container will always result in EOF.
+                                              Default is false.
+                                            type: boolean
+                                          stdinOnce:
+                                            description: |-
+                                              Whether the container runtime should close the stdin channel after it has been opened by
+                                              a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                              sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                              first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                              at which time stdin is closed and remains closed until the container is restarted. If this
+                                              flag is false, a container processes that reads from stdin will never receive an EOF.
+                                              Default is false
+                                            type: boolean
+                                          terminationMessagePath:
+                                            description: |-
+                                              Optional: Path at which the file to which the container's termination message
+                                              will be written is mounted into the container's filesystem.
+                                              Message written is intended to be brief final status, such as an assertion failure message.
+                                              Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                              all containers will be limited to 12kb.
+                                              Defaults to /dev/termination-log.
+                                              Cannot be updated.
+                                            type: string
+                                          terminationMessagePolicy:
+                                            description: |-
+                                              Indicate how the termination message should be populated. File will use the contents of
+                                              terminationMessagePath to populate the container status message on both success and failure.
+                                              FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                              message file is empty and the container exited with an error.
+                                              The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                              Defaults to File.
+                                              Cannot be updated.
+                                            type: string
+                                          tty:
+                                            description: |-
+                                              Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                              Default is false.
+                                            type: boolean
+                                          volumeDevices:
+                                            description: volumeDevices is the list of block devices to be used by the container.
+                                            items:
+                                              description: volumeDevice describes a mapping of a raw block device within a container.
+                                              properties:
+                                                devicePath:
+                                                  description: devicePath is the path inside of the container that the device will be mapped to.
+                                                  type: string
+                                                name:
+                                                  description: name must match the name of a persistentVolumeClaim in the pod
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            description: |-
+                                              Pod volumes to mount into the container's filesystem.
+                                              Cannot be updated.
+                                            items:
+                                              description: VolumeMount describes a mounting of a Volume within a container.
+                                              properties:
+                                                mountPath:
+                                                  description: |-
+                                                    Path within the container at which the volume should be mounted.  Must
+                                                    not contain ':'.
+                                                  type: string
+                                                mountPropagation:
+                                                  description: |-
+                                                    mountPropagation determines how mounts are propagated from the host
+                                                    to container and the other way around.
+                                                    When not set, MountPropagationNone is used.
+                                                    This field is beta in 1.10.
+                                                  type: string
+                                                name:
+                                                  description: This must match the Name of a Volume.
+                                                  type: string
+                                                readOnly:
+                                                  description: |-
+                                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                                    Defaults to false.
+                                                  type: boolean
+                                                subPath:
+                                                  description: |-
+                                                    Path within the volume from which the container's volume should be mounted.
+                                                    Defaults to "" (volume's root).
+                                                  type: string
+                                                subPathExpr:
+                                                  description: |-
+                                                    Expanded path within the volume from which the container's volume should be mounted.
+                                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                                    Defaults to "" (volume's root).
+                                                    SubPathExpr and SubPath are mutually exclusive.
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            description: |-
+                                              Container's working directory.
+                                              If not specified, the container runtime's default will be used, which
+                                              might be configured in the container image.
+                                              Cannot be updated.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    dnsConfig:
+                                      description: |-
+                                        Specifies the DNS parameters of a pod.
+                                        Parameters specified here will be merged to the generated DNS
+                                        configuration based on DNSPolicy.
+                                      properties:
+                                        nameservers:
+                                          description: |-
+                                            A list of DNS name server IP addresses.
+                                            This will be appended to the base nameservers generated from DNSPolicy.
+                                            Duplicated nameservers will be removed.
+                                          items:
+                                            type: string
+                                          type: array
+                                        options:
+                                          description: |-
+                                            A list of DNS resolver options.
+                                            This will be merged with the base options generated from DNSPolicy.
+                                            Duplicated entries will be removed. Resolution options given in Options
+                                            will override those that appear in the base DNSPolicy.
+                                          items:
+                                            description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                            properties:
+                                              name:
+                                                description: Required.
+                                                type: string
+                                              value:
+                                                type: string
+                                            type: object
+                                          type: array
+                                        searches:
+                                          description: |-
+                                            A list of DNS search domains for host-name lookup.
+                                            This will be appended to the base search paths generated from DNSPolicy.
+                                            Duplicated search paths will be removed.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    dnsPolicy:
+                                      description: |-
+                                        Set DNS policy for the pod.
+                                        Defaults to "ClusterFirst".
+                                        Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                        DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                        To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                        explicitly to 'ClusterFirstWithHostNet'.
+                                      type: string
+                                    enableServiceLinks:
+                                      description: |-
+                                        EnableServiceLinks indicates whether information about services should be injected into pod's
+                                        environment variables, matching the syntax of Docker links.
+                                        Optional: Defaults to true.
+                                      type: boolean
+                                    ephemeralContainers:
+                                      description: |-
+                                        List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                        pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                        creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                        ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                                      items:
+                                        description: |-
+                                          An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                          user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                          scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                          removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                          Pod to exceed its resource allocation.
+
+
+                                          To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                          Pod. Ephemeral containers may not be removed or restarted.
+                                        properties:
+                                          args:
+                                            description: |-
+                                              Arguments to the entrypoint.
+                                              The image's CMD is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: |-
+                                              Entrypoint array. Not executed within a shell.
+                                              The image's ENTRYPOINT is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            description: |-
+                                              List of environment variables to set in the container.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvVar represents an environment variable present in a Container.
+                                              properties:
+                                                name:
+                                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                value:
+                                                  description: |-
+                                                    Variable references $(VAR_NAME) are expanded
+                                                    using the previously defined environment variables in the container and
+                                                    any service environment variables. If a variable cannot be resolved,
+                                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                    Escaped references will never be expanded, regardless of whether the variable
+                                                    exists or not.
+                                                    Defaults to "".
+                                                  type: string
+                                                valueFrom:
+                                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      description: Selects a key of a ConfigMap.
+                                                      properties:
+                                                        key:
+                                                          description: The key to select.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the ConfigMap or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      description: |-
+                                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      description: Selects a key of a secret in the pod's namespace
+                                                      properties:
+                                                        key:
+                                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the Secret or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            description: |-
+                                              List of sources to populate environment variables in the container.
+                                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                              will be reported as an event when the container is starting. When a key exists in multiple
+                                              sources, the value associated with the last source will take precedence.
+                                              Values defined by an Env with a duplicate key will take precedence.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvFromSource represents the source of a set of ConfigMaps
+                                              properties:
+                                                configMapRef:
+                                                  description: The ConfigMap to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                secretRef:
+                                                  description: The Secret to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                          image:
+                                            description: |-
+                                              Container image name.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images
+                                            type: string
+                                          imagePullPolicy:
+                                            description: |-
+                                              Image pull policy.
+                                              One of Always, Never, IfNotPresent.
+                                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                            type: string
+                                          lifecycle:
+                                            description: Lifecycle is not allowed for ephemeral containers.
+                                            properties:
+                                              postStart:
+                                                description: |-
+                                                  PostStart is called immediately after a container is created. If the handler fails,
+                                                  the container is terminated and restarted according to its restart policy.
+                                                  Other management of the container blocks until the hook completes.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                description: |-
+                                                  PreStop is called immediately before a container is terminated due to an
+                                                  API request or management event such as liveness/startup probe failure,
+                                                  preemption, resource contention, etc. The handler is not called if the
+                                                  container crashes or exits. The Pod's termination grace period countdown begins before the
+                                                  PreStop hook is executed. Regardless of the outcome of the handler, the
+                                                  container will eventually terminate within the Pod's termination grace
+                                                  period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                                  or until the termination grace period is reached.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            description: Probes are not allowed for ephemeral containers.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            description: |-
+                                              Name of the ephemeral container specified as a DNS_LABEL.
+                                              This name must be unique among all containers, init containers and ephemeral containers.
+                                            type: string
+                                          ports:
+                                            description: Ports are not allowed for ephemeral containers.
+                                            items:
+                                              description: ContainerPort represents a network port in a single container.
+                                              properties:
+                                                containerPort:
+                                                  description: |-
+                                                    Number of port to expose on the pod's IP address.
+                                                    This must be a valid port number, 0 < x < 65536.
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  description: What host IP to bind the external port to.
+                                                  type: string
+                                                hostPort:
+                                                  description: |-
+                                                    Number of port to expose on the host.
+                                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                                    If HostNetwork is specified, this must match ContainerPort.
+                                                    Most containers do not need this.
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  description: |-
+                                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                                    named port in a pod must have a unique name. Name for the port that can be
+                                                    referred to by services.
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  description: |-
+                                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                                    Defaults to "TCP".
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            description: Probes are not allowed for ephemeral containers.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            description: Resources resize policy for the container.
+                                            items:
+                                              description: ContainerResizePolicy represents resource resize policy for the container.
+                                              properties:
+                                                resourceName:
+                                                  description: |-
+                                                    Name of the resource to which this resource resize policy applies.
+                                                    Supported values: cpu, memory.
+                                                  type: string
+                                                restartPolicy:
+                                                  description: |-
+                                                    Restart policy to apply when specified resource is resized.
+                                                    If not specified, it defaults to NotRequired.
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            description: |-
+                                              Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                              already allocated to the pod.
+                                            properties:
+                                              claims:
+                                                description: |-
+                                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                                  that are used by this container.
+
+
+                                                  This is an alpha field and requires enabling the
+                                                  DynamicResourceAllocation feature gate.
+
+
+                                                  This field is immutable. It can only be set for containers.
+                                                items:
+                                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                                        the Pod where this field is used. It makes that resource available
+                                                        inside a container.
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            description: |-
+                                              Restart policy for the container to manage the restart behavior of each
+                                              container within a pod.
+                                              This may only be set for init containers. You cannot set this field on
+                                              ephemeral containers.
+                                            type: string
+                                          securityContext:
+                                            description: |-
+                                              Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                description: |-
+                                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                                  privileges than its parent process. This bool directly controls if
+                                                  the no_new_privs flag will be set on the container process.
+                                                  AllowPrivilegeEscalation is true always when the container is:
+                                                  1) run as Privileged
+                                                  2) has CAP_SYS_ADMIN
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              capabilities:
+                                                description: |-
+                                                  The capabilities to add/drop when running containers.
+                                                  Defaults to the default set of capabilities granted by the container runtime.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  add:
+                                                    description: Added capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    description: Removed capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                description: |-
+                                                  Run container in privileged mode.
+                                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                                  Defaults to false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              procMount:
+                                                description: |-
+                                                  procMount denotes the type of proc mount to use for the containers.
+                                                  The default is DefaultProcMount which uses the container runtime defaults for
+                                                  readonly paths and masked paths.
+                                                  This requires the ProcMountType feature flag to be enabled.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                description: |-
+                                                  Whether this container has a read-only root filesystem.
+                                                  Default is false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to the container.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by this container. If seccomp options are
+                                                  provided at both the pod & container level, the container options
+                                                  override the pod options.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                description: |-
+                                                  The Windows specific settings applied to all containers.
+                                                  If unspecified, the options from the PodSecurityContext will be used.
+                                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is linux.
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    description: |-
+                                                      GMSACredentialSpec is where the GMSA admission webhook
+                                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                    type: string
+                                                  hostProcess:
+                                                    description: |-
+                                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                                      All of a Pod's containers must have the same effective HostProcess value
+                                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    description: |-
+                                                      The UserName in Windows to run the entrypoint of the container process.
+                                                      Defaults to the user specified in image metadata if unspecified.
+                                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            description: Probes are not allowed for ephemeral containers.
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            description: |-
+                                              Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                              is not set, reads from stdin in the container will always result in EOF.
+                                              Default is false.
+                                            type: boolean
+                                          stdinOnce:
+                                            description: |-
+                                              Whether the container runtime should close the stdin channel after it has been opened by
+                                              a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                              sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                              first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                              at which time stdin is closed and remains closed until the container is restarted. If this
+                                              flag is false, a container processes that reads from stdin will never receive an EOF.
+                                              Default is false
+                                            type: boolean
+                                          targetContainerName:
+                                            description: |-
+                                              If set, the name of the container from PodSpec that this ephemeral container targets.
+                                              The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                              If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                              The container runtime must implement support for this feature. If the runtime does not
+                                              support namespace targeting then the result of setting this field is undefined.
+                                            type: string
+                                          terminationMessagePath:
+                                            description: |-
+                                              Optional: Path at which the file to which the container's termination message
+                                              will be written is mounted into the container's filesystem.
+                                              Message written is intended to be brief final status, such as an assertion failure message.
+                                              Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                              all containers will be limited to 12kb.
+                                              Defaults to /dev/termination-log.
+                                              Cannot be updated.
+                                            type: string
+                                          terminationMessagePolicy:
+                                            description: |-
+                                              Indicate how the termination message should be populated. File will use the contents of
+                                              terminationMessagePath to populate the container status message on both success and failure.
+                                              FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                              message file is empty and the container exited with an error.
+                                              The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                              Defaults to File.
+                                              Cannot be updated.
+                                            type: string
+                                          tty:
+                                            description: |-
+                                              Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                              Default is false.
+                                            type: boolean
+                                          volumeDevices:
+                                            description: volumeDevices is the list of block devices to be used by the container.
+                                            items:
+                                              description: volumeDevice describes a mapping of a raw block device within a container.
+                                              properties:
+                                                devicePath:
+                                                  description: devicePath is the path inside of the container that the device will be mapped to.
+                                                  type: string
+                                                name:
+                                                  description: name must match the name of a persistentVolumeClaim in the pod
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            description: |-
+                                              Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                              Cannot be updated.
+                                            items:
+                                              description: VolumeMount describes a mounting of a Volume within a container.
+                                              properties:
+                                                mountPath:
+                                                  description: |-
+                                                    Path within the container at which the volume should be mounted.  Must
+                                                    not contain ':'.
+                                                  type: string
+                                                mountPropagation:
+                                                  description: |-
+                                                    mountPropagation determines how mounts are propagated from the host
+                                                    to container and the other way around.
+                                                    When not set, MountPropagationNone is used.
+                                                    This field is beta in 1.10.
+                                                  type: string
+                                                name:
+                                                  description: This must match the Name of a Volume.
+                                                  type: string
+                                                readOnly:
+                                                  description: |-
+                                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                                    Defaults to false.
+                                                  type: boolean
+                                                subPath:
+                                                  description: |-
+                                                    Path within the volume from which the container's volume should be mounted.
+                                                    Defaults to "" (volume's root).
+                                                  type: string
+                                                subPathExpr:
+                                                  description: |-
+                                                    Expanded path within the volume from which the container's volume should be mounted.
+                                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                                    Defaults to "" (volume's root).
+                                                    SubPathExpr and SubPath are mutually exclusive.
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            description: |-
+                                              Container's working directory.
+                                              If not specified, the container runtime's default will be used, which
+                                              might be configured in the container image.
+                                              Cannot be updated.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    hostAliases:
+                                      description: |-
+                                        HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                        file if specified. This is only valid for non-hostNetwork pods.
+                                      items:
+                                        description: |-
+                                          HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                          pod's hosts file.
+                                        properties:
+                                          hostnames:
+                                            description: Hostnames for the above IP address.
+                                            items:
+                                              type: string
+                                            type: array
+                                          ip:
+                                            description: IP address of the host file entry.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    hostIPC:
+                                      description: |-
+                                        Use the host's ipc namespace.
+                                        Optional: Default to false.
+                                      type: boolean
+                                    hostNetwork:
+                                      description: |-
+                                        Host networking requested for this pod. Use the host's network namespace.
+                                        If this option is set, the ports that will be used must be specified.
+                                        Default to false.
+                                      type: boolean
+                                    hostPID:
+                                      description: |-
+                                        Use the host's pid namespace.
+                                        Optional: Default to false.
+                                      type: boolean
+                                    hostUsers:
+                                      description: |-
+                                        Use the host's user namespace.
+                                        Optional: Default to true.
+                                        If set to true or not present, the pod will be run in the host user namespace, useful
+                                        for when the pod needs a feature only available to the host user namespace, such as
+                                        loading a kernel module with CAP_SYS_MODULE.
+                                        When set to false, a new userns is created for the pod. Setting false is useful for
+                                        mitigating container breakout vulnerabilities even allowing users to run their
+                                        containers as root without actually having root privileges on the host.
+                                        This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                                      type: boolean
+                                    hostname:
+                                      description: |-
+                                        Specifies the hostname of the Pod
+                                        If not specified, the pod's hostname will be set to a system-defined value.
+                                      type: string
+                                    imagePullSecrets:
+                                      description: |-
+                                        ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                        If specified, these secrets will be passed to individual puller implementations for them to use.
+                                        More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                                      items:
+                                        description: |-
+                                          LocalObjectReference contains enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the referent.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                    initContainers:
+                                      description: |-
+                                        List of initialization containers belonging to the pod.
+                                        Init containers are executed in order prior to containers being started. If any
+                                        init container fails, the pod is considered to have failed and is handled according
+                                        to its restartPolicy. The name for an init container or normal container must be
+                                        unique among all containers.
+                                        Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                        The resourceRequirements of an init container are taken into account during scheduling
+                                        by finding the highest request/limit for each resource type, and then using the max of
+                                        of that value or the sum of the normal containers. Limits are applied to init containers
+                                        in a similar fashion.
+                                        Init containers cannot currently be added or removed.
+                                        Cannot be updated.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                                      items:
+                                        description: A single application container that you want to run within a pod.
+                                        properties:
+                                          args:
+                                            description: |-
+                                              Arguments to the entrypoint.
+                                              The container image's CMD is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          command:
+                                            description: |-
+                                              Entrypoint array. Not executed within a shell.
+                                              The container image's ENTRYPOINT is used if this is not provided.
+                                              Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                              cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                              produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                              of whether the variable exists or not. Cannot be updated.
+                                              More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                            items:
+                                              type: string
+                                            type: array
+                                          env:
+                                            description: |-
+                                              List of environment variables to set in the container.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvVar represents an environment variable present in a Container.
+                                              properties:
+                                                name:
+                                                  description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                value:
+                                                  description: |-
+                                                    Variable references $(VAR_NAME) are expanded
+                                                    using the previously defined environment variables in the container and
+                                                    any service environment variables. If a variable cannot be resolved,
+                                                    the reference in the input string will be unchanged. Double $$ are reduced
+                                                    to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                                    "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                                    Escaped references will never be expanded, regardless of whether the variable
+                                                    exists or not.
+                                                    Defaults to "".
+                                                  type: string
+                                                valueFrom:
+                                                  description: Source for the environment variable's value. Cannot be used if value is not empty.
+                                                  properties:
+                                                    configMapKeyRef:
+                                                      description: Selects a key of a ConfigMap.
+                                                      properties:
+                                                        key:
+                                                          description: The key to select.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the ConfigMap or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    fieldRef:
+                                                      description: |-
+                                                        Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                        spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    secretKeyRef:
+                                                      description: Selects a key of a secret in the pod's namespace
+                                                      properties:
+                                                        key:
+                                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                                          type: string
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: Specify whether the Secret or its key must be defined
+                                                          type: boolean
+                                                      required:
+                                                      - key
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                              required:
+                                              - name
+                                              type: object
+                                            type: array
+                                          envFrom:
+                                            description: |-
+                                              List of sources to populate environment variables in the container.
+                                              The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                              will be reported as an event when the container is starting. When a key exists in multiple
+                                              sources, the value associated with the last source will take precedence.
+                                              Values defined by an Env with a duplicate key will take precedence.
+                                              Cannot be updated.
+                                            items:
+                                              description: EnvFromSource represents the source of a set of ConfigMaps
+                                              properties:
+                                                configMapRef:
+                                                  description: The ConfigMap to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the ConfigMap must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                prefix:
+                                                  description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                                  type: string
+                                                secretRef:
+                                                  description: The Secret to select from
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name of the referent.
+                                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                        TODO: Add other useful fields. apiVersion, kind, uid?
+                                                      type: string
+                                                    optional:
+                                                      description: Specify whether the Secret must be defined
+                                                      type: boolean
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              type: object
+                                            type: array
+                                          image:
+                                            description: |-
+                                              Container image name.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images
+                                              This field is optional to allow higher level config management to default or override
+                                              container images in workload controllers like Deployments and StatefulSets.
+                                            type: string
+                                          imagePullPolicy:
+                                            description: |-
+                                              Image pull policy.
+                                              One of Always, Never, IfNotPresent.
+                                              Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                            type: string
+                                          lifecycle:
+                                            description: |-
+                                              Actions that the management system should take in response to container lifecycle events.
+                                              Cannot be updated.
+                                            properties:
+                                              postStart:
+                                                description: |-
+                                                  PostStart is called immediately after a container is created. If the handler fails,
+                                                  the container is terminated and restarted according to its restart policy.
+                                                  Other management of the container blocks until the hook completes.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                              preStop:
+                                                description: |-
+                                                  PreStop is called immediately before a container is terminated due to an
+                                                  API request or management event such as liveness/startup probe failure,
+                                                  preemption, resource contention, etc. The handler is not called if the
+                                                  container crashes or exits. The Pod's termination grace period countdown begins before the
+                                                  PreStop hook is executed. Regardless of the outcome of the handler, the
+                                                  container will eventually terminate within the Pod's termination grace
+                                                  period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                                  or until the termination grace period is reached.
+                                                  More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                                properties:
+                                                  exec:
+                                                    description: Exec specifies the action to take.
+                                                    properties:
+                                                      command:
+                                                        description: |-
+                                                          Command is the command line to execute inside the container, the working directory for the
+                                                          command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                          not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                          a shell, you need to explicitly call out to that shell.
+                                                          Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                    type: object
+                                                  httpGet:
+                                                    description: HTTPGet specifies the http request to perform.
+                                                    properties:
+                                                      host:
+                                                        description: |-
+                                                          Host name to connect to, defaults to the pod IP. You probably want to set
+                                                          "Host" in httpHeaders instead.
+                                                        type: string
+                                                      httpHeaders:
+                                                        description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                        items:
+                                                          description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                          properties:
+                                                            name:
+                                                              description: |-
+                                                                The header field name.
+                                                                This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                              type: string
+                                                            value:
+                                                              description: The header field value
+                                                              type: string
+                                                          required:
+                                                          - name
+                                                          - value
+                                                          type: object
+                                                        type: array
+                                                      path:
+                                                        description: Path to access on the HTTP server.
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Name or number of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                      scheme:
+                                                        description: |-
+                                                          Scheme to use for connecting to the host.
+                                                          Defaults to HTTP.
+                                                        type: string
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                  sleep:
+                                                    description: Sleep represents the duration that the container should sleep before being terminated.
+                                                    properties:
+                                                      seconds:
+                                                        description: Seconds is the number of seconds to sleep.
+                                                        format: int64
+                                                        type: integer
+                                                    required:
+                                                    - seconds
+                                                    type: object
+                                                  tcpSocket:
+                                                    description: |-
+                                                      Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                                      for the backward compatibility. There are no validation of this field and
+                                                      lifecycle hooks will fail in runtime when tcp handler is specified.
+                                                    properties:
+                                                      host:
+                                                        description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                        type: string
+                                                      port:
+                                                        anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                        description: |-
+                                                          Number or name of the port to access on the container.
+                                                          Number must be in the range 1 to 65535.
+                                                          Name must be an IANA_SVC_NAME.
+                                                        x-kubernetes-int-or-string: true
+                                                    required:
+                                                    - port
+                                                    type: object
+                                                type: object
+                                            type: object
+                                          livenessProbe:
+                                            description: |-
+                                              Periodic probe of container liveness.
+                                              Container will be restarted if the probe fails.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          name:
+                                            description: |-
+                                              Name of the container specified as a DNS_LABEL.
+                                              Each container in a pod must have a unique name (DNS_LABEL).
+                                              Cannot be updated.
+                                            type: string
+                                          ports:
+                                            description: |-
+                                              List of ports to expose from the container. Not specifying a port here
+                                              DOES NOT prevent that port from being exposed. Any port which is
+                                              listening on the default "0.0.0.0" address inside a container will be
+                                              accessible from the network.
+                                              Modifying this array with strategic merge patch may corrupt the data.
+                                              For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                              Cannot be updated.
+                                            items:
+                                              description: ContainerPort represents a network port in a single container.
+                                              properties:
+                                                containerPort:
+                                                  description: |-
+                                                    Number of port to expose on the pod's IP address.
+                                                    This must be a valid port number, 0 < x < 65536.
+                                                  format: int32
+                                                  type: integer
+                                                hostIP:
+                                                  description: What host IP to bind the external port to.
+                                                  type: string
+                                                hostPort:
+                                                  description: |-
+                                                    Number of port to expose on the host.
+                                                    If specified, this must be a valid port number, 0 < x < 65536.
+                                                    If HostNetwork is specified, this must match ContainerPort.
+                                                    Most containers do not need this.
+                                                  format: int32
+                                                  type: integer
+                                                name:
+                                                  description: |-
+                                                    If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                                    named port in a pod must have a unique name. Name for the port that can be
+                                                    referred to by services.
+                                                  type: string
+                                                protocol:
+                                                  default: TCP
+                                                  description: |-
+                                                    Protocol for port. Must be UDP, TCP, or SCTP.
+                                                    Defaults to "TCP".
+                                                  type: string
+                                              required:
+                                              - containerPort
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-map-keys:
+                                            - containerPort
+                                            - protocol
+                                            x-kubernetes-list-type: map
+                                          readinessProbe:
+                                            description: |-
+                                              Periodic probe of container service readiness.
+                                              Container will be removed from service endpoints if the probe fails.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          resizePolicy:
+                                            description: Resources resize policy for the container.
+                                            items:
+                                              description: ContainerResizePolicy represents resource resize policy for the container.
+                                              properties:
+                                                resourceName:
+                                                  description: |-
+                                                    Name of the resource to which this resource resize policy applies.
+                                                    Supported values: cpu, memory.
+                                                  type: string
+                                                restartPolicy:
+                                                  description: |-
+                                                    Restart policy to apply when specified resource is resized.
+                                                    If not specified, it defaults to NotRequired.
+                                                  type: string
+                                              required:
+                                              - resourceName
+                                              - restartPolicy
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          resources:
+                                            description: |-
+                                              Compute Resources required by this container.
+                                              Cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                            properties:
+                                              claims:
+                                                description: |-
+                                                  Claims lists the names of resources, defined in spec.resourceClaims,
+                                                  that are used by this container.
+
+
+                                                  This is an alpha field and requires enabling the
+                                                  DynamicResourceAllocation feature gate.
+
+
+                                                  This field is immutable. It can only be set for containers.
+                                                items:
+                                                  description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        Name must match the name of one entry in pod.spec.resourceClaims of
+                                                        the Pod where this field is used. It makes that resource available
+                                                        inside a container.
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-map-keys:
+                                                - name
+                                                x-kubernetes-list-type: map
+                                              limits:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                              requests:
+                                                additionalProperties:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                type: object
+                                            type: object
+                                          restartPolicy:
+                                            description: |-
+                                              RestartPolicy defines the restart behavior of individual containers in a pod.
+                                              This field may only be set for init containers, and the only allowed value is "Always".
+                                              For non-init containers or when this field is not specified,
+                                              the restart behavior is defined by the Pod's restart policy and the container type.
+                                              Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                              this init container will be continually restarted on
+                                              exit until all regular containers have terminated. Once all regular
+                                              containers have completed, all init containers with restartPolicy "Always"
+                                              will be shut down. This lifecycle differs from normal init containers and
+                                              is often referred to as a "sidecar" container. Although this init
+                                              container still starts in the init container sequence, it does not wait
+                                              for the container to complete before proceeding to the next init
+                                              container. Instead, the next init container starts immediately after this
+                                              init container is started, or after any startupProbe has successfully
+                                              completed.
+                                            type: string
+                                          securityContext:
+                                            description: |-
+                                              SecurityContext defines the security options the container should be run with.
+                                              If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                              More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                            properties:
+                                              allowPrivilegeEscalation:
+                                                description: |-
+                                                  AllowPrivilegeEscalation controls whether a process can gain more
+                                                  privileges than its parent process. This bool directly controls if
+                                                  the no_new_privs flag will be set on the container process.
+                                                  AllowPrivilegeEscalation is true always when the container is:
+                                                  1) run as Privileged
+                                                  2) has CAP_SYS_ADMIN
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              capabilities:
+                                                description: |-
+                                                  The capabilities to add/drop when running containers.
+                                                  Defaults to the default set of capabilities granted by the container runtime.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  add:
+                                                    description: Added capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                  drop:
+                                                    description: Removed capabilities
+                                                    items:
+                                                      description: Capability represent POSIX capabilities type
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              privileged:
+                                                description: |-
+                                                  Run container in privileged mode.
+                                                  Processes in privileged containers are essentially equivalent to root on the host.
+                                                  Defaults to false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              procMount:
+                                                description: |-
+                                                  procMount denotes the type of proc mount to use for the containers.
+                                                  The default is DefaultProcMount which uses the container runtime defaults for
+                                                  readonly paths and masked paths.
+                                                  This requires the ProcMountType feature flag to be enabled.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: string
+                                              readOnlyRootFilesystem:
+                                                description: |-
+                                                  Whether this container has a read-only root filesystem.
+                                                  Default is false.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                type: boolean
+                                              runAsGroup:
+                                                description: |-
+                                                  The GID to run the entrypoint of the container process.
+                                                  Uses runtime default if unset.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              runAsNonRoot:
+                                                description: |-
+                                                  Indicates that the container must run as a non-root user.
+                                                  If true, the Kubelet will validate the image at runtime to ensure that it
+                                                  does not run as UID 0 (root) and fail to start the container if it does.
+                                                  If unset or false, no such validation will be performed.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                type: boolean
+                                              runAsUser:
+                                                description: |-
+                                                  The UID to run the entrypoint of the container process.
+                                                  Defaults to user specified in image metadata if unspecified.
+                                                  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                format: int64
+                                                type: integer
+                                              seLinuxOptions:
+                                                description: |-
+                                                  The SELinux context to be applied to the container.
+                                                  If unspecified, the container runtime will allocate a random SELinux context for each
+                                                  container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  level:
+                                                    description: Level is SELinux level label that applies to the container.
+                                                    type: string
+                                                  role:
+                                                    description: Role is a SELinux role label that applies to the container.
+                                                    type: string
+                                                  type:
+                                                    description: Type is a SELinux type label that applies to the container.
+                                                    type: string
+                                                  user:
+                                                    description: User is a SELinux user label that applies to the container.
+                                                    type: string
+                                                type: object
+                                              seccompProfile:
+                                                description: |-
+                                                  The seccomp options to use by this container. If seccomp options are
+                                                  provided at both the pod & container level, the container options
+                                                  override the pod options.
+                                                  Note that this field cannot be set when spec.os.name is windows.
+                                                properties:
+                                                  localhostProfile:
+                                                    description: |-
+                                                      localhostProfile indicates a profile defined in a file on the node should be used.
+                                                      The profile must be preconfigured on the node to work.
+                                                      Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                      Must be set if type is "Localhost". Must NOT be set for any other type.
+                                                    type: string
+                                                  type:
+                                                    description: |-
+                                                      type indicates which kind of seccomp profile will be applied.
+                                                      Valid options are:
+
+
+                                                      Localhost - a profile defined in a file on the node should be used.
+                                                      RuntimeDefault - the container runtime default profile should be used.
+                                                      Unconfined - no profile should be applied.
+                                                    type: string
+                                                required:
+                                                - type
+                                                type: object
+                                              windowsOptions:
+                                                description: |-
+                                                  The Windows specific settings applied to all containers.
+                                                  If unspecified, the options from the PodSecurityContext will be used.
+                                                  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                  Note that this field cannot be set when spec.os.name is linux.
+                                                properties:
+                                                  gmsaCredentialSpec:
+                                                    description: |-
+                                                      GMSACredentialSpec is where the GMSA admission webhook
+                                                      (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                      GMSA credential spec named by the GMSACredentialSpecName field.
+                                                    type: string
+                                                  gmsaCredentialSpecName:
+                                                    description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                                    type: string
+                                                  hostProcess:
+                                                    description: |-
+                                                      HostProcess determines if a container should be run as a 'Host Process' container.
+                                                      All of a Pod's containers must have the same effective HostProcess value
+                                                      (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                      In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                                    type: boolean
+                                                  runAsUserName:
+                                                    description: |-
+                                                      The UserName in Windows to run the entrypoint of the container process.
+                                                      Defaults to the user specified in image metadata if unspecified.
+                                                      May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                      PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                                    type: string
+                                                type: object
+                                            type: object
+                                          startupProbe:
+                                            description: |-
+                                              StartupProbe indicates that the Pod has successfully initialized.
+                                              If specified, no other probes are executed until this completes successfully.
+                                              If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                              This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                              when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                              This cannot be updated.
+                                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                            properties:
+                                              exec:
+                                                description: Exec specifies the action to take.
+                                                properties:
+                                                  command:
+                                                    description: |-
+                                                      Command is the command line to execute inside the container, the working directory for the
+                                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                      a shell, you need to explicitly call out to that shell.
+                                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                type: object
+                                              failureThreshold:
+                                                description: |-
+                                                  Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                                  Defaults to 3. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              grpc:
+                                                description: GRPC specifies an action involving a GRPC port.
+                                                properties:
+                                                  port:
+                                                    description: Port number of the gRPC service. Number must be in the range 1 to 65535.
+                                                    format: int32
+                                                    type: integer
+                                                  service:
+                                                    description: |-
+                                                      Service is the name of the service to place in the gRPC HealthCheckRequest
+                                                      (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                                      If this is not specified, the default behavior is defined by gRPC.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              httpGet:
+                                                description: HTTPGet specifies the http request to perform.
+                                                properties:
+                                                  host:
+                                                    description: |-
+                                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                                      "Host" in httpHeaders instead.
+                                                    type: string
+                                                  httpHeaders:
+                                                    description: Custom headers to set in the request. HTTP allows repeated headers.
+                                                    items:
+                                                      description: HTTPHeader describes a custom header to be used in HTTP probes
+                                                      properties:
+                                                        name:
+                                                          description: |-
+                                                            The header field name.
+                                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                          type: string
+                                                        value:
+                                                          description: The header field value
+                                                          type: string
+                                                      required:
+                                                      - name
+                                                      - value
+                                                      type: object
+                                                    type: array
+                                                  path:
+                                                    description: Path to access on the HTTP server.
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Name or number of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                  scheme:
+                                                    description: |-
+                                                      Scheme to use for connecting to the host.
+                                                      Defaults to HTTP.
+                                                    type: string
+                                                required:
+                                                - port
+                                                type: object
+                                              initialDelaySeconds:
+                                                description: |-
+                                                  Number of seconds after the container has started before liveness probes are initiated.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                              periodSeconds:
+                                                description: |-
+                                                  How often (in seconds) to perform the probe.
+                                                  Default to 10 seconds. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              successThreshold:
+                                                description: |-
+                                                  Minimum consecutive successes for the probe to be considered successful after having failed.
+                                                  Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                                format: int32
+                                                type: integer
+                                              tcpSocket:
+                                                description: TCPSocket specifies an action involving a TCP port.
+                                                properties:
+                                                  host:
+                                                    description: 'Optional: Host name to connect to, defaults to the pod IP.'
+                                                    type: string
+                                                  port:
+                                                    anyOf:
+                                                    - type: integer
+                                                    - type: string
+                                                    description: |-
+                                                      Number or name of the port to access on the container.
+                                                      Number must be in the range 1 to 65535.
+                                                      Name must be an IANA_SVC_NAME.
+                                                    x-kubernetes-int-or-string: true
+                                                required:
+                                                - port
+                                                type: object
+                                              terminationGracePeriodSeconds:
+                                                description: |-
+                                                  Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                                  The grace period is the duration in seconds after the processes running in the pod are sent
+                                                  a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                                  Set this value longer than the expected cleanup time for your process.
+                                                  If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                                  value overrides the value provided by the pod spec.
+                                                  Value must be non-negative integer. The value zero indicates stop immediately via
+                                                  the kill signal (no opportunity to shut down).
+                                                  This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                                  Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                                format: int64
+                                                type: integer
+                                              timeoutSeconds:
+                                                description: |-
+                                                  Number of seconds after which the probe times out.
+                                                  Defaults to 1 second. Minimum value is 1.
+                                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                                format: int32
+                                                type: integer
+                                            type: object
+                                          stdin:
+                                            description: |-
+                                              Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                              is not set, reads from stdin in the container will always result in EOF.
+                                              Default is false.
+                                            type: boolean
+                                          stdinOnce:
+                                            description: |-
+                                              Whether the container runtime should close the stdin channel after it has been opened by
+                                              a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                              sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                              first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                              at which time stdin is closed and remains closed until the container is restarted. If this
+                                              flag is false, a container processes that reads from stdin will never receive an EOF.
+                                              Default is false
+                                            type: boolean
+                                          terminationMessagePath:
+                                            description: |-
+                                              Optional: Path at which the file to which the container's termination message
+                                              will be written is mounted into the container's filesystem.
+                                              Message written is intended to be brief final status, such as an assertion failure message.
+                                              Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                              all containers will be limited to 12kb.
+                                              Defaults to /dev/termination-log.
+                                              Cannot be updated.
+                                            type: string
+                                          terminationMessagePolicy:
+                                            description: |-
+                                              Indicate how the termination message should be populated. File will use the contents of
+                                              terminationMessagePath to populate the container status message on both success and failure.
+                                              FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                              message file is empty and the container exited with an error.
+                                              The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                              Defaults to File.
+                                              Cannot be updated.
+                                            type: string
+                                          tty:
+                                            description: |-
+                                              Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                              Default is false.
+                                            type: boolean
+                                          volumeDevices:
+                                            description: volumeDevices is the list of block devices to be used by the container.
+                                            items:
+                                              description: volumeDevice describes a mapping of a raw block device within a container.
+                                              properties:
+                                                devicePath:
+                                                  description: devicePath is the path inside of the container that the device will be mapped to.
+                                                  type: string
+                                                name:
+                                                  description: name must match the name of a persistentVolumeClaim in the pod
+                                                  type: string
+                                              required:
+                                              - devicePath
+                                              - name
+                                              type: object
+                                            type: array
+                                          volumeMounts:
+                                            description: |-
+                                              Pod volumes to mount into the container's filesystem.
+                                              Cannot be updated.
+                                            items:
+                                              description: VolumeMount describes a mounting of a Volume within a container.
+                                              properties:
+                                                mountPath:
+                                                  description: |-
+                                                    Path within the container at which the volume should be mounted.  Must
+                                                    not contain ':'.
+                                                  type: string
+                                                mountPropagation:
+                                                  description: |-
+                                                    mountPropagation determines how mounts are propagated from the host
+                                                    to container and the other way around.
+                                                    When not set, MountPropagationNone is used.
+                                                    This field is beta in 1.10.
+                                                  type: string
+                                                name:
+                                                  description: This must match the Name of a Volume.
+                                                  type: string
+                                                readOnly:
+                                                  description: |-
+                                                    Mounted read-only if true, read-write otherwise (false or unspecified).
+                                                    Defaults to false.
+                                                  type: boolean
+                                                subPath:
+                                                  description: |-
+                                                    Path within the volume from which the container's volume should be mounted.
+                                                    Defaults to "" (volume's root).
+                                                  type: string
+                                                subPathExpr:
+                                                  description: |-
+                                                    Expanded path within the volume from which the container's volume should be mounted.
+                                                    Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                                    Defaults to "" (volume's root).
+                                                    SubPathExpr and SubPath are mutually exclusive.
+                                                  type: string
+                                              required:
+                                              - mountPath
+                                              - name
+                                              type: object
+                                            type: array
+                                          workingDir:
+                                            description: |-
+                                              Container's working directory.
+                                              If not specified, the container runtime's default will be used, which
+                                              might be configured in the container image.
+                                              Cannot be updated.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                    nodeName:
+                                      description: |-
+                                        NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                        the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                        requirements.
+                                      type: string
+                                    nodeSelector:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        NodeSelector is a selector which must be true for the pod to fit on a node.
+                                        Selector which must match a node's labels for the pod to be scheduled on that node.
+                                        More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    os:
+                                      description: |-
+                                        Specifies the OS of the containers in the pod.
+                                        Some pod and container fields are restricted if this is set.
+
+
+                                        If the OS field is set to linux, the following fields must be unset:
+                                        -securityContext.windowsOptions
+
+
+                                        If the OS field is set to windows, following fields must be unset:
+                                        - spec.hostPID
+                                        - spec.hostIPC
+                                        - spec.hostUsers
+                                        - spec.securityContext.seLinuxOptions
+                                        - spec.securityContext.seccompProfile
+                                        - spec.securityContext.fsGroup
+                                        - spec.securityContext.fsGroupChangePolicy
+                                        - spec.securityContext.sysctls
+                                        - spec.shareProcessNamespace
+                                        - spec.securityContext.runAsUser
+                                        - spec.securityContext.runAsGroup
+                                        - spec.securityContext.supplementalGroups
+                                        - spec.containers[*].securityContext.seLinuxOptions
+                                        - spec.containers[*].securityContext.seccompProfile
+                                        - spec.containers[*].securityContext.capabilities
+                                        - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                        - spec.containers[*].securityContext.privileged
+                                        - spec.containers[*].securityContext.allowPrivilegeEscalation
+                                        - spec.containers[*].securityContext.procMount
+                                        - spec.containers[*].securityContext.runAsUser
+                                        - spec.containers[*].securityContext.runAsGroup
+                                      properties:
+                                        name:
+                                          description: |-
+                                            Name is the name of the operating system. The currently supported values are linux and windows.
+                                            Additional value may be defined in future and can be one of:
+                                            https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                            Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                                          type: string
+                                      required:
+                                      - name
+                                      type: object
+                                    overhead:
+                                      additionalProperties:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: |-
+                                        Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                        This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                        the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                        The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                        set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                        defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                        More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                                      type: object
+                                    preemptionPolicy:
+                                      description: |-
+                                        PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                        One of Never, PreemptLowerPriority.
+                                        Defaults to PreemptLowerPriority if unset.
+                                      type: string
+                                    priority:
+                                      description: |-
+                                        The priority value. Various system components use this field to find the
+                                        priority of the pod. When Priority Admission Controller is enabled, it
+                                        prevents users from setting this field. The admission controller populates
+                                        this field from PriorityClassName.
+                                        The higher the value, the higher the priority.
+                                      format: int32
+                                      type: integer
+                                    priorityClassName:
+                                      description: |-
+                                        If specified, indicates the pod's priority. "system-node-critical" and
+                                        "system-cluster-critical" are two special keywords which indicate the
+                                        highest priorities with the former being the highest priority. Any other
+                                        name must be defined by creating a PriorityClass object with that name.
+                                        If not specified, the pod priority will be default or zero if there is no
+                                        default.
+                                      type: string
+                                    readinessGates:
+                                      description: |-
+                                        If specified, all readiness gates will be evaluated for pod readiness.
+                                        A pod is ready when all its containers are ready AND
+                                        all conditions specified in the readiness gates have status equal to "True"
+                                        More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                                      items:
+                                        description: PodReadinessGate contains the reference to a pod condition
+                                        properties:
+                                          conditionType:
+                                            description: ConditionType refers to a condition in the pod's condition list with matching type.
+                                            type: string
+                                        required:
+                                        - conditionType
+                                        type: object
+                                      type: array
+                                    resourceClaims:
+                                      description: |-
+                                        ResourceClaims defines which ResourceClaims must be allocated
+                                        and reserved before the Pod is allowed to start. The resources
+                                        will be made available to those containers which consume them
+                                        by name.
+
+
+                                        This is an alpha field and requires enabling the
+                                        DynamicResourceAllocation feature gate.
+
+
+                                        This field is immutable.
+                                      items:
+                                        description: |-
+                                          PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                          It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                          Containers that need access to the ResourceClaim reference it with this name.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name uniquely identifies this resource claim inside the pod.
+                                              This must be a DNS_LABEL.
+                                            type: string
+                                          source:
+                                            description: Source describes where to find the ResourceClaim.
+                                            properties:
+                                              resourceClaimName:
+                                                description: |-
+                                                  ResourceClaimName is the name of a ResourceClaim object in the same
+                                                  namespace as this pod.
+                                                type: string
+                                              resourceClaimTemplateName:
+                                                description: |-
+                                                  ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                                  object in the same namespace as this pod.
+
+
+                                                  The template will be used to create a new ResourceClaim, which will
+                                                  be bound to this pod. When this pod is deleted, the ResourceClaim
+                                                  will also be deleted. The pod name and resource name, along with a
+                                                  generated component, will be used to form a unique name for the
+                                                  ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                                  This field is immutable and no changes will be made to the
+                                                  corresponding ResourceClaim by the control plane after creating the
+                                                  ResourceClaim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    restartPolicy:
+                                      description: |-
+                                        Restart policy for all containers within the pod.
+                                        One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                        Default to Always.
+                                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                                      type: string
+                                    runtimeClassName:
+                                      description: |-
+                                        RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                        to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                        If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                        empty definition that uses the default runtime handler.
+                                        More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                                      type: string
+                                    schedulerName:
+                                      description: |-
+                                        If specified, the pod will be dispatched by specified scheduler.
+                                        If not specified, the pod will be dispatched by default scheduler.
+                                      type: string
+                                    schedulingGates:
+                                      description: |-
+                                        SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                        If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                        scheduler will not attempt to schedule the pod.
+
+
+                                        SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+
+
+                                        This is a beta feature enabled by the PodSchedulingReadiness feature gate.
+                                      items:
+                                        description: PodSchedulingGate is associated to a Pod to guard its scheduling.
+                                        properties:
+                                          name:
+                                            description: |-
+                                              Name of the scheduling gate.
+                                              Each scheduling gate must have a unique name field.
+                                            type: string
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - name
+                                      x-kubernetes-list-type: map
+                                    securityContext:
+                                      description: |-
+                                        SecurityContext holds pod-level security attributes and common container settings.
+                                        Optional: Defaults to empty.  See type description for default values of each field.
+                                      properties:
+                                        fsGroup:
+                                          description: |-
+                                            A special supplemental group that applies to all containers in a pod.
+                                            Some volume types allow the Kubelet to change the ownership of that volume
+                                            to be owned by the pod:
+
+
+                                            1. The owning GID will be the FSGroup
+                                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                            3. The permission bits are OR'd with rw-rw----
+
+
+                                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        fsGroupChangePolicy:
+                                          description: |-
+                                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                            before being exposed inside Pod. This field will only apply to
+                                            volume types which support fsGroup based ownership(and permissions).
+                                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                                            and emptydir.
+                                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          type: string
+                                        runAsGroup:
+                                          description: |-
+                                            The GID to run the entrypoint of the container process.
+                                            Uses runtime default if unset.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        runAsNonRoot:
+                                          description: |-
+                                            Indicates that the container must run as a non-root user.
+                                            If true, the Kubelet will validate the image at runtime to ensure that it
+                                            does not run as UID 0 (root) and fail to start the container if it does.
+                                            If unset or false, no such validation will be performed.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          type: boolean
+                                        runAsUser:
+                                          description: |-
+                                            The UID to run the entrypoint of the container process.
+                                            Defaults to user specified in image metadata if unspecified.
+                                            May also be set in SecurityContext.  If set in both SecurityContext and
+                                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                                            for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          format: int64
+                                          type: integer
+                                        seLinuxOptions:
+                                          description: |-
+                                            The SELinux context to be applied to all containers.
+                                            If unspecified, the container runtime will allocate a random SELinux context for each
+                                            container.  May also be set in SecurityContext.  If set in
+                                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                            takes precedence for that container.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            level:
+                                              description: Level is SELinux level label that applies to the container.
+                                              type: string
+                                            role:
+                                              description: Role is a SELinux role label that applies to the container.
+                                              type: string
+                                            type:
+                                              description: Type is a SELinux type label that applies to the container.
+                                              type: string
+                                            user:
+                                              description: User is a SELinux user label that applies to the container.
+                                              type: string
+                                          type: object
+                                        seccompProfile:
+                                          description: |-
+                                            The seccomp options to use by the containers in this pod.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          properties:
+                                            localhostProfile:
+                                              description: |-
+                                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                                The profile must be preconfigured on the node to work.
+                                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                                              type: string
+                                            type:
+                                              description: |-
+                                                type indicates which kind of seccomp profile will be applied.
+                                                Valid options are:
+
+
+                                                Localhost - a profile defined in a file on the node should be used.
+                                                RuntimeDefault - the container runtime default profile should be used.
+                                                Unconfined - no profile should be applied.
+                                              type: string
+                                          required:
+                                          - type
+                                          type: object
+                                        supplementalGroups:
+                                          description: |-
+                                            A list of groups applied to the first process run in each container, in addition
+                                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                                            defined in the container image for the uid of the container process. If unspecified,
+                                            no additional groups are added to any container. Note that group memberships
+                                            defined in the container image for the uid of the container process are still effective,
+                                            even if they are not included in this list.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            format: int64
+                                            type: integer
+                                          type: array
+                                        sysctls:
+                                          description: |-
+                                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                            sysctls (by the container runtime) might fail to launch.
+                                            Note that this field cannot be set when spec.os.name is windows.
+                                          items:
+                                            description: Sysctl defines a kernel parameter to be set
+                                            properties:
+                                              name:
+                                                description: Name of a property to set
+                                                type: string
+                                              value:
+                                                description: Value of a property to set
+                                                type: string
+                                            required:
+                                            - name
+                                            - value
+                                            type: object
+                                          type: array
+                                        windowsOptions:
+                                          description: |-
+                                            The Windows specific settings applied to all containers.
+                                            If unspecified, the options within a container's SecurityContext will be used.
+                                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            Note that this field cannot be set when spec.os.name is linux.
+                                          properties:
+                                            gmsaCredentialSpec:
+                                              description: |-
+                                                GMSACredentialSpec is where the GMSA admission webhook
+                                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                                GMSA credential spec named by the GMSACredentialSpecName field.
+                                              type: string
+                                            gmsaCredentialSpecName:
+                                              description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
+                                              type: string
+                                            hostProcess:
+                                              description: |-
+                                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                                All of a Pod's containers must have the same effective HostProcess value
+                                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                              type: boolean
+                                            runAsUserName:
+                                              description: |-
+                                                The UserName in Windows to run the entrypoint of the container process.
+                                                Defaults to the user specified in image metadata if unspecified.
+                                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                              type: string
+                                          type: object
+                                      type: object
+                                    serviceAccount:
+                                      description: |-
+                                        DeprecatedServiceAccount is a depreciated alias for ServiceAccountName.
+                                        Deprecated: Use serviceAccountName instead.
+                                      type: string
+                                    serviceAccountName:
+                                      description: |-
+                                        ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                        More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                                      type: string
+                                    setHostnameAsFQDN:
+                                      description: |-
+                                        If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                        In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                        In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                        If a pod does not have FQDN, this has no effect.
+                                        Default to false.
+                                      type: boolean
+                                    shareProcessNamespace:
+                                      description: |-
+                                        Share a single process namespace between all of the containers in a pod.
+                                        When this is set containers will be able to view and signal processes from other containers
+                                        in the same pod, and the first process in each container will not be assigned PID 1.
+                                        HostPID and ShareProcessNamespace cannot both be set.
+                                        Optional: Default to false.
+                                      type: boolean
+                                    subdomain:
+                                      description: |-
+                                        If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                        If not specified, the pod will not have a domainname at all.
+                                      type: string
+                                    terminationGracePeriodSeconds:
+                                      description: |-
+                                        Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                        Value must be non-negative integer. The value zero indicates stop immediately via
+                                        the kill signal (no opportunity to shut down).
+                                        If this value is nil, the default grace period will be used instead.
+                                        The grace period is the duration in seconds after the processes running in the pod are sent
+                                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                        Set this value longer than the expected cleanup time for your process.
+                                        Defaults to 30 seconds.
+                                      format: int64
+                                      type: integer
+                                    tolerations:
+                                      description: If specified, the pod's tolerations.
+                                      items:
+                                        description: |-
+                                          The pod this Toleration is attached to tolerates any taint that matches
+                                          the triple <key,value,effect> using the matching operator <operator>.
+                                        properties:
+                                          effect:
+                                            description: |-
+                                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                            type: string
+                                          key:
+                                            description: |-
+                                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              Operator represents a key's relationship to the value.
+                                              Valid operators are Exists and Equal. Defaults to Equal.
+                                              Exists is equivalent to wildcard for value, so that a pod can
+                                              tolerate all taints of a particular category.
+                                            type: string
+                                          tolerationSeconds:
+                                            description: |-
+                                              TolerationSeconds represents the period of time the toleration (which must be
+                                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                              negative values will be treated as 0 (evict immediately) by the system.
+                                            format: int64
+                                            type: integer
+                                          value:
+                                            description: |-
+                                              Value is the taint value the toleration matches to.
+                                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                            type: string
+                                        type: object
+                                      type: array
+                                    topologySpreadConstraints:
+                                      description: |-
+                                        TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                        domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                        All topologySpreadConstraints are ANDed.
+                                      items:
+                                        description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              LabelSelector is used to find matching pods.
+                                              Pods that match this label selector are counted to determine the number of pods
+                                              in their corresponding topology domain.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label key that the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                                              spreading will be calculated. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                                              to select the group of existing pods over which spreading will be calculated
+                                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                              Keys that don't exist in the incoming pod labels will
+                                              be ignored. A null or empty list means only match against labelSelector.
+
+
+                                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          maxSkew:
+                                            description: |-
+                                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                              between the number of matching pods in the target topology and the global minimum.
+                                              The global minimum is the minimum number of matching pods in an eligible domain
+                                              or zero if the number of eligible domains is less than MinDomains.
+                                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                              labelSelector spread as 2/2/1:
+                                              In this case, the global minimum is 1.
+                                              | zone1 | zone2 | zone3 |
+                                              |  P P  |  P P  |   P   |
+                                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                              violate MaxSkew(1).
+                                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                              to topologies that satisfy it.
+                                              It's a required field. Default value is 1 and 0 is not allowed.
+                                            format: int32
+                                            type: integer
+                                          minDomains:
+                                            description: |-
+                                              MinDomains indicates a minimum number of eligible domains.
+                                              When the number of eligible domains with matching topology keys is less than minDomains,
+                                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                              this value has no effect on scheduling.
+                                              As a result, when the number of eligible domains is less than minDomains,
+                                              scheduler won't schedule more than maxSkew Pods to those domains.
+                                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                              Valid values are integers greater than 0.
+                                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                              labelSelector spread as 2/2/2:
+                                              | zone1 | zone2 | zone3 |
+                                              |  P P  |  P P  |  P P  |
+                                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                              it will violate MaxSkew.
+
+
+                                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                                            format: int32
+                                            type: integer
+                                          nodeAffinityPolicy:
+                                            description: |-
+                                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                              when calculating pod topology spread skew. Options are:
+                                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                              If this value is nil, the behavior is equivalent to the Honor policy.
+                                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                            type: string
+                                          nodeTaintsPolicy:
+                                            description: |-
+                                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                              pod topology spread skew. Options are:
+                                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                              has a toleration, are included.
+                                              - Ignore: node taints are ignored. All nodes are included.
+
+
+                                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                            type: string
+                                          topologyKey:
+                                            description: |-
+                                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                                              and identical values are considered to be in the same topology.
+                                              We consider each <key, value> as a "bucket", and try to put balanced number
+                                              of pods into each bucket.
+                                              We define a domain as a particular instance of a topology.
+                                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                              nodeAffinityPolicy and nodeTaintsPolicy.
+                                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                              It's a required field.
+                                            type: string
+                                          whenUnsatisfiable:
+                                            description: |-
+                                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                              the spread constraint.
+                                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                                but giving higher precedence to topologies that would help reduce the
+                                                skew.
+                                              A constraint is considered "Unsatisfiable" for an incoming pod
+                                              if and only if every possible node assignment for that pod would violate
+                                              "MaxSkew" on some topology.
+                                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                              labelSelector spread as 3/1/1:
+                                              | zone1 | zone2 | zone3 |
+                                              | P P P |   P   |   P   |
+                                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                              won't make it *more* imbalanced.
+                                              It's a required field.
+                                            type: string
+                                        required:
+                                        - maxSkew
+                                        - topologyKey
+                                        - whenUnsatisfiable
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-map-keys:
+                                      - topologyKey
+                                      - whenUnsatisfiable
+                                      x-kubernetes-list-type: map
+                                    volumes:
+                                      description: |-
+                                        List of volumes that can be mounted by containers belonging to the pod.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volumes
+                                      items:
+                                        description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                                        properties:
+                                          awsElasticBlockStore:
+                                            description: |-
+                                              awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                              kubelet's host machine and then exposed to the pod.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type of the volume that you want to mount.
+                                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                                  TODO: how do we prevent errors in the filesystem from compromising the machine
+                                                type: string
+                                              partition:
+                                                description: |-
+                                                  partition is the partition in the volume that you want to mount.
+                                                  If omitted, the default is to mount by volume name.
+                                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                description: |-
+                                                  readOnly value true will force the readOnly setting in VolumeMounts.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                                type: boolean
+                                              volumeID:
+                                                description: |-
+                                                  volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          azureDisk:
+                                            description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                                            properties:
+                                              cachingMode:
+                                                description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                                type: string
+                                              diskName:
+                                                description: diskName is the Name of the data disk in the blob storage
+                                                type: string
+                                              diskURI:
+                                                description: diskURI is the URI of data disk in the blob storage
+                                                type: string
+                                              fsType:
+                                                description: |-
+                                                  fsType is Filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                type: string
+                                              kind:
+                                                description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                            required:
+                                            - diskName
+                                            - diskURI
+                                            type: object
+                                          azureFile:
+                                            description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                                            properties:
+                                              readOnly:
+                                                description: |-
+                                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              secretName:
+                                                description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                                type: string
+                                              shareName:
+                                                description: shareName is the azure share Name
+                                                type: string
+                                            required:
+                                            - secretName
+                                            - shareName
+                                            type: object
+                                          cephfs:
+                                            description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                                            properties:
+                                              monitors:
+                                                description: |-
+                                                  monitors is Required: Monitors is a collection of Ceph monitors
+                                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                                items:
+                                                  type: string
+                                                type: array
+                                              path:
+                                                description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                                type: boolean
+                                              secretFile:
+                                                description: |-
+                                                  secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                                type: string
+                                              secretRef:
+                                                description: |-
+                                                  secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              user:
+                                                description: |-
+                                                  user is optional: User is the rados user name, default is admin
+                                                  More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                                type: string
+                                            required:
+                                            - monitors
+                                            type: object
+                                          cinder:
+                                            description: |-
+                                              cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                                type: boolean
+                                              secretRef:
+                                                description: |-
+                                                  secretRef is optional: points to a secret object containing parameters used to connect
+                                                  to OpenStack.
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              volumeID:
+                                                description: |-
+                                                  volumeID used to identify the volume in cinder.
+                                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          configMap:
+                                            description: configMap represents a configMap that should populate this volume
+                                            properties:
+                                              defaultMode:
+                                                description: |-
+                                                  defaultMode is optional: mode bits used to set permissions on created files by default.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  Defaults to 0644.
+                                                  Directories within the path are not affected by this setting.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                description: |-
+                                                  items if unspecified, each key-value pair in the Data field of the referenced
+                                                  ConfigMap will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the ConfigMap,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                              name:
+                                                description: |-
+                                                  Name of the referent.
+                                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                  TODO: Add other useful fields. apiVersion, kind, uid?
+                                                type: string
+                                              optional:
+                                                description: optional specify whether the ConfigMap or its keys must be defined
+                                                type: boolean
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          csi:
+                                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                                            properties:
+                                              driver:
+                                                description: |-
+                                                  driver is the name of the CSI driver that handles this volume.
+                                                  Consult with your admin for the correct name as registered in the cluster.
+                                                type: string
+                                              fsType:
+                                                description: |-
+                                                  fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                                  If not provided, the empty value is passed to the associated CSI driver
+                                                  which will determine the default filesystem to apply.
+                                                type: string
+                                              nodePublishSecretRef:
+                                                description: |-
+                                                  nodePublishSecretRef is a reference to the secret object containing
+                                                  sensitive information to pass to the CSI driver to complete the CSI
+                                                  NodePublishVolume and NodeUnpublishVolume calls.
+                                                  This field is optional, and  may be empty if no secret is required. If the
+                                                  secret object contains more than one secret, all secret references are passed.
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              readOnly:
+                                                description: |-
+                                                  readOnly specifies a read-only configuration for the volume.
+                                                  Defaults to false (read/write).
+                                                type: boolean
+                                              volumeAttributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  volumeAttributes stores driver-specific properties that are passed to the CSI
+                                                  driver. Consult your driver's documentation for supported values.
+                                                type: object
+                                            required:
+                                            - driver
+                                            type: object
+                                          downwardAPI:
+                                            description: downwardAPI represents downward API about the pod that should populate this volume
+                                            properties:
+                                              defaultMode:
+                                                description: |-
+                                                  Optional: mode bits to use on created files by default. Must be a
+                                                  Optional: mode bits used to set permissions on created files by default.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  Defaults to 0644.
+                                                  Directories within the path are not affected by this setting.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                description: Items is a list of downward API volume file
+                                                items:
+                                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                  properties:
+                                                    fieldRef:
+                                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                      properties:
+                                                        apiVersion:
+                                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                          type: string
+                                                        fieldPath:
+                                                          description: Path of the field to select in the specified API version.
+                                                          type: string
+                                                      required:
+                                                      - fieldPath
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    mode:
+                                                      description: |-
+                                                        Optional: mode bits used to set permissions on this file, must be an octal value
+                                                        between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                      type: string
+                                                    resourceFieldRef:
+                                                      description: |-
+                                                        Selects a resource of the container: only resources limits and requests
+                                                        (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                      properties:
+                                                        containerName:
+                                                          description: 'Container name: required for volumes, optional for env vars'
+                                                          type: string
+                                                        divisor:
+                                                          anyOf:
+                                                          - type: integer
+                                                          - type: string
+                                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                          x-kubernetes-int-or-string: true
+                                                        resource:
+                                                          description: 'Required: resource to select'
+                                                          type: string
+                                                      required:
+                                                      - resource
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  required:
+                                                  - path
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          emptyDir:
+                                            description: |-
+                                              emptyDir represents a temporary directory that shares a pod's lifetime.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                            properties:
+                                              medium:
+                                                description: |-
+                                                  medium represents what type of storage medium should back this directory.
+                                                  The default is "" which means to use the node's default medium.
+                                                  Must be an empty string (default) or Memory.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                                type: string
+                                              sizeLimit:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                                  The size limit is also applicable for memory medium.
+                                                  The maximum usage on memory medium EmptyDir would be the minimum value between
+                                                  the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                                  The default is nil which means that the limit is undefined.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                            type: object
+                                          ephemeral:
+                                            description: |-
+                                              ephemeral represents a volume that is handled by a cluster storage driver.
+                                              The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                              and deleted when the pod is removed.
+
+
+                                              Use this if:
+                                              a) the volume is only needed while the pod runs,
+                                              b) features of normal volumes like restoring from snapshot or capacity
+                                                 tracking are needed,
+                                              c) the storage driver is specified through a storage class, and
+                                              d) the storage driver supports dynamic volume provisioning through
+                                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                                 information on the connection between this volume type
+                                                 and PersistentVolumeClaim).
+
+
+                                              Use PersistentVolumeClaim or one of the vendor-specific
+                                              APIs for volumes that persist for longer than the lifecycle
+                                              of an individual pod.
+
+
+                                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                              be used that way - see the documentation of the driver for
+                                              more information.
+
+
+                                              A pod can use both types of ephemeral volumes and
+                                              persistent volumes at the same time.
+                                            properties:
+                                              volumeClaimTemplate:
+                                                description: |-
+                                                  Will be used to create a stand-alone PVC to provision the volume.
+                                                  The pod in which this EphemeralVolumeSource is embedded will be the
+                                                  owner of the PVC, i.e. the PVC will be deleted together with the
+                                                  pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                                  `<volume name>` is the name from the `PodSpec.Volumes` array
+                                                  entry. Pod validation will reject the pod if the concatenated name
+                                                  is not valid for a PVC (for example, too long).
+
+
+                                                  An existing PVC with that name that is not owned by the pod
+                                                  will *not* be used for the pod to avoid using an unrelated
+                                                  volume by mistake. Starting the pod is then blocked until
+                                                  the unrelated PVC is removed. If such a pre-created PVC is
+                                                  meant to be used by the pod, the PVC has to updated with an
+                                                  owner reference to the pod once the pod exists. Normally
+                                                  this should not be necessary, but it may be useful when
+                                                  manually reconstructing a broken cluster.
+
+
+                                                  This field is read-only and no changes will be made by Kubernetes
+                                                  to the PVC after it has been created.
+
+
+                                                  Required, must not be nil.
+                                                properties:
+                                                  metadata:
+                                                    description: |-
+                                                      May contain labels and annotations that will be copied into the PVC
+                                                      when creating it. No other fields are allowed and will be rejected during
+                                                      validation.
+                                                    properties:
+                                                      annotations:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      finalizers:
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      labels:
+                                                        additionalProperties:
+                                                          type: string
+                                                        type: object
+                                                      name:
+                                                        type: string
+                                                      namespace:
+                                                        type: string
+                                                    type: object
+                                                  spec:
+                                                    description: |-
+                                                      The specification for the PersistentVolumeClaim. The entire content is
+                                                      copied unchanged into the PVC that gets created from this
+                                                      template. The same fields as in a PersistentVolumeClaim
+                                                      are also valid here.
+                                                    properties:
+                                                      accessModes:
+                                                        description: |-
+                                                          accessModes contains the desired access modes the volume should have.
+                                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                                        items:
+                                                          type: string
+                                                        type: array
+                                                      dataSource:
+                                                        description: |-
+                                                          dataSource field can be used to specify either:
+                                                          * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                          * An existing PVC (PersistentVolumeClaim)
+                                                          If the provisioner or an external controller can support the specified data source,
+                                                          it will create a new volume based on the contents of the specified data source.
+                                                          When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                          and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                          If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                                        properties:
+                                                          apiGroup:
+                                                            description: |-
+                                                              APIGroup is the group for the resource being referenced.
+                                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                              For any other third-party types, APIGroup is required.
+                                                            type: string
+                                                          kind:
+                                                            description: Kind is the type of resource being referenced
+                                                            type: string
+                                                          name:
+                                                            description: Name is the name of resource being referenced
+                                                            type: string
+                                                        required:
+                                                        - kind
+                                                        - name
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      dataSourceRef:
+                                                        description: |-
+                                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                          volume is desired. This may be any object from a non-empty API group (non
+                                                          core object) or a PersistentVolumeClaim object.
+                                                          When this field is specified, volume binding will only succeed if the type of
+                                                          the specified object matches some installed volume populator or dynamic
+                                                          provisioner.
+                                                          This field will replace the functionality of the dataSource field and as such
+                                                          if both fields are non-empty, they must have the same value. For backwards
+                                                          compatibility, when namespace isn't specified in dataSourceRef,
+                                                          both fields (dataSource and dataSourceRef) will be set to the same
+                                                          value automatically if one of them is empty and the other is non-empty.
+                                                          When namespace is specified in dataSourceRef,
+                                                          dataSource isn't set to the same value and must be empty.
+                                                          There are three important differences between dataSource and dataSourceRef:
+                                                          * While dataSource only allows two specific types of objects, dataSourceRef
+                                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                            preserves all values, and generates an error if a disallowed value is
+                                                            specified.
+                                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                                            in any namespaces.
+                                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                          (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                        properties:
+                                                          apiGroup:
+                                                            description: |-
+                                                              APIGroup is the group for the resource being referenced.
+                                                              If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                              For any other third-party types, APIGroup is required.
+                                                            type: string
+                                                          kind:
+                                                            description: Kind is the type of resource being referenced
+                                                            type: string
+                                                          name:
+                                                            description: Name is the name of resource being referenced
+                                                            type: string
+                                                          namespace:
+                                                            description: |-
+                                                              Namespace is the namespace of resource being referenced
+                                                              Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                              (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                            type: string
+                                                        required:
+                                                        - kind
+                                                        - name
+                                                        type: object
+                                                      resources:
+                                                        description: |-
+                                                          resources represents the minimum resources the volume should have.
+                                                          If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                          that are lower than previous value but must still be higher than capacity recorded in the
+                                                          status field of the claim.
+                                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                                        properties:
+                                                          limits:
+                                                            additionalProperties:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            description: |-
+                                                              Limits describes the maximum amount of compute resources allowed.
+                                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                            type: object
+                                                          requests:
+                                                            additionalProperties:
+                                                              anyOf:
+                                                              - type: integer
+                                                              - type: string
+                                                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                              x-kubernetes-int-or-string: true
+                                                            description: |-
+                                                              Requests describes the minimum amount of compute resources required.
+                                                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                            type: object
+                                                        type: object
+                                                      selector:
+                                                        description: selector is a label query over volumes to consider for binding.
+                                                        properties:
+                                                          matchExpressions:
+                                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                            items:
+                                                              description: |-
+                                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                relates the key and values.
+                                                              properties:
+                                                                key:
+                                                                  description: key is the label key that the selector applies to.
+                                                                  type: string
+                                                                operator:
+                                                                  description: |-
+                                                                    operator represents a key's relationship to a set of values.
+                                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                  type: string
+                                                                values:
+                                                                  description: |-
+                                                                    values is an array of string values. If the operator is In or NotIn,
+                                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                    the values array must be empty. This array is replaced during a strategic
+                                                                    merge patch.
+                                                                  items:
+                                                                    type: string
+                                                                  type: array
+                                                              required:
+                                                              - key
+                                                              - operator
+                                                              type: object
+                                                            type: array
+                                                          matchLabels:
+                                                            additionalProperties:
+                                                              type: string
+                                                            description: |-
+                                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                            type: object
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      storageClassName:
+                                                        description: |-
+                                                          storageClassName is the name of the StorageClass required by the claim.
+                                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                        type: string
+                                                      volumeAttributesClassName:
+                                                        description: |-
+                                                          volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                          If specified, the CSI driver will create or update the volume with the attributes defined
+                                                          in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                          it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                          will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                          If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                          will be set by the persistentvolume controller if it exists.
+                                                          If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                          set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                          exists.
+                                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                                          (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                                        type: string
+                                                      volumeMode:
+                                                        description: |-
+                                                          volumeMode defines what type of volume is required by the claim.
+                                                          Value of Filesystem is implied when not included in claim spec.
+                                                        type: string
+                                                      volumeName:
+                                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                                        type: string
+                                                    type: object
+                                                required:
+                                                - spec
+                                                type: object
+                                            type: object
+                                          fc:
+                                            description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  TODO: how do we prevent errors in the filesystem from compromising the machine
+                                                type: string
+                                              lun:
+                                                description: 'lun is Optional: FC target lun number'
+                                                format: int32
+                                                type: integer
+                                              readOnly:
+                                                description: |-
+                                                  readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              targetWWNs:
+                                                description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                                items:
+                                                  type: string
+                                                type: array
+                                              wwids:
+                                                description: |-
+                                                  wwids Optional: FC volume world wide identifiers (wwids)
+                                                  Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          flexVolume:
+                                            description: |-
+                                              flexVolume represents a generic volume resource that is
+                                              provisioned/attached using an exec based plugin.
+                                            properties:
+                                              driver:
+                                                description: driver is the name of the driver to use for this volume.
+                                                type: string
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                                type: string
+                                              options:
+                                                additionalProperties:
+                                                  type: string
+                                                description: 'options is Optional: this field holds extra command options if any.'
+                                                type: object
+                                              readOnly:
+                                                description: |-
+                                                  readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              secretRef:
+                                                description: |-
+                                                  secretRef is Optional: secretRef is reference to the secret object containing
+                                                  sensitive information to pass to the plugin scripts. This may be
+                                                  empty if no secret object is specified. If the secret object
+                                                  contains more than one secret, all secrets are passed to the plugin
+                                                  scripts.
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                            required:
+                                            - driver
+                                            type: object
+                                          flocker:
+                                            description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                                            properties:
+                                              datasetName:
+                                                description: |-
+                                                  datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                                  should be considered as deprecated
+                                                type: string
+                                              datasetUUID:
+                                                description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                                type: string
+                                            type: object
+                                          gcePersistentDisk:
+                                            description: |-
+                                              gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                              kubelet's host machine and then exposed to the pod.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is filesystem type of the volume that you want to mount.
+                                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                                  TODO: how do we prevent errors in the filesystem from compromising the machine
+                                                type: string
+                                              partition:
+                                                description: |-
+                                                  partition is the partition in the volume that you want to mount.
+                                                  If omitted, the default is to mount by volume name.
+                                                  Examples: For volume /dev/sda1, you specify the partition as "1".
+                                                  Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                                format: int32
+                                                type: integer
+                                              pdName:
+                                                description: |-
+                                                  pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                                  Defaults to false.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                                type: boolean
+                                            required:
+                                            - pdName
+                                            type: object
+                                          gitRepo:
+                                            description: |-
+                                              gitRepo represents a git repository at a particular revision.
+                                              DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                              EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                              into the Pod's container.
+                                            properties:
+                                              directory:
+                                                description: |-
+                                                  directory is the target directory name.
+                                                  Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                                  git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                                  the subdirectory with the given name.
+                                                type: string
+                                              repository:
+                                                description: repository is the URL
+                                                type: string
+                                              revision:
+                                                description: revision is the commit hash for the specified revision.
+                                                type: string
+                                            required:
+                                            - repository
+                                            type: object
+                                          glusterfs:
+                                            description: |-
+                                              glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                              More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                            properties:
+                                              endpoints:
+                                                description: |-
+                                                  endpoints is the endpoint name that details Glusterfs topology.
+                                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                                type: string
+                                              path:
+                                                description: |-
+                                                  path is the Glusterfs volume path.
+                                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                                  Defaults to false.
+                                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                                type: boolean
+                                            required:
+                                            - endpoints
+                                            - path
+                                            type: object
+                                          hostPath:
+                                            description: |-
+                                              hostPath represents a pre-existing file or directory on the host
+                                              machine that is directly exposed to the container. This is generally
+                                              used for system agents or other privileged things that are allowed
+                                              to see the host machine. Most containers will NOT need this.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                              ---
+                                              TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                              mount host directories as read/write.
+                                            properties:
+                                              path:
+                                                description: |-
+                                                  path of the directory on the host.
+                                                  If the path is a symlink, it will follow the link to the real path.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                                type: string
+                                              type:
+                                                description: |-
+                                                  type for HostPath Volume
+                                                  Defaults to ""
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                                type: string
+                                            required:
+                                            - path
+                                            type: object
+                                          iscsi:
+                                            description: |-
+                                              iscsi represents an ISCSI Disk resource that is attached to a
+                                              kubelet's host machine and then exposed to the pod.
+                                              More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                            properties:
+                                              chapAuthDiscovery:
+                                                description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                                type: boolean
+                                              chapAuthSession:
+                                                description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                                type: boolean
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type of the volume that you want to mount.
+                                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                                  TODO: how do we prevent errors in the filesystem from compromising the machine
+                                                type: string
+                                              initiatorName:
+                                                description: |-
+                                                  initiatorName is the custom iSCSI Initiator Name.
+                                                  If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                                  <target portal>:<volume name> will be created for the connection.
+                                                type: string
+                                              iqn:
+                                                description: iqn is the target iSCSI Qualified Name.
+                                                type: string
+                                              iscsiInterface:
+                                                description: |-
+                                                  iscsiInterface is the interface Name that uses an iSCSI transport.
+                                                  Defaults to 'default' (tcp).
+                                                type: string
+                                              lun:
+                                                description: lun represents iSCSI Target Lun number.
+                                                format: int32
+                                                type: integer
+                                              portals:
+                                                description: |-
+                                                  portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                                  is other than default (typically TCP ports 860 and 3260).
+                                                items:
+                                                  type: string
+                                                type: array
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                                  Defaults to false.
+                                                type: boolean
+                                              secretRef:
+                                                description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              targetPortal:
+                                                description: |-
+                                                  targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                                  is other than default (typically TCP ports 860 and 3260).
+                                                type: string
+                                            required:
+                                            - iqn
+                                            - lun
+                                            - targetPortal
+                                            type: object
+                                          name:
+                                            description: |-
+                                              name of the volume.
+                                              Must be a DNS_LABEL and unique within the pod.
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            type: string
+                                          nfs:
+                                            description: |-
+                                              nfs represents an NFS mount on the host that shares a pod's lifetime
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                            properties:
+                                              path:
+                                                description: |-
+                                                  path that is exported by the NFS server.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the NFS export to be mounted with read-only permissions.
+                                                  Defaults to false.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                                type: boolean
+                                              server:
+                                                description: |-
+                                                  server is the hostname or IP address of the NFS server.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                                type: string
+                                            required:
+                                            - path
+                                            - server
+                                            type: object
+                                          persistentVolumeClaim:
+                                            description: |-
+                                              persistentVolumeClaimVolumeSource represents a reference to a
+                                              PersistentVolumeClaim in the same namespace.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                            properties:
+                                              claimName:
+                                                description: |-
+                                                  claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly Will force the ReadOnly setting in VolumeMounts.
+                                                  Default false.
+                                                type: boolean
+                                            required:
+                                            - claimName
+                                            type: object
+                                          photonPersistentDisk:
+                                            description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                type: string
+                                              pdID:
+                                                description: pdID is the ID that identifies Photon Controller persistent disk
+                                                type: string
+                                            required:
+                                            - pdID
+                                            type: object
+                                          portworxVolume:
+                                            description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fSType represents the filesystem type to mount
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              volumeID:
+                                                description: volumeID uniquely identifies a Portworx volume
+                                                type: string
+                                            required:
+                                            - volumeID
+                                            type: object
+                                          projected:
+                                            description: projected items for all in one resources secrets, configmaps, and downward API
+                                            properties:
+                                              defaultMode:
+                                                description: |-
+                                                  defaultMode are the mode bits used to set permissions on created files by default.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                  Directories within the path are not affected by this setting.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              sources:
+                                                description: sources is the list of volume projections
+                                                items:
+                                                  description: Projection that may be projected along with other supported volume types
+                                                  properties:
+                                                    clusterTrustBundle:
+                                                      description: |-
+                                                        ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                        of ClusterTrustBundle objects in an auto-updating file.
+
+
+                                                        Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+                                                        ClusterTrustBundle objects can either be selected by name, or by the
+                                                        combination of signer name and a label selector.
+
+
+                                                        Kubelet performs aggressive normalization of the PEM contents written
+                                                        into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                        comments and block headers are stripped.  Certificates are deduplicated.
+                                                        The ordering of certificates within the file is arbitrary, and Kubelet
+                                                        may change the order over time.
+                                                      properties:
+                                                        labelSelector:
+                                                          description: |-
+                                                            Select all ClusterTrustBundles that match this label selector.  Only has
+                                                            effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                            interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                            everything".
+                                                          properties:
+                                                            matchExpressions:
+                                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                              items:
+                                                                description: |-
+                                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                                  relates the key and values.
+                                                                properties:
+                                                                  key:
+                                                                    description: key is the label key that the selector applies to.
+                                                                    type: string
+                                                                  operator:
+                                                                    description: |-
+                                                                      operator represents a key's relationship to a set of values.
+                                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                    type: string
+                                                                  values:
+                                                                    description: |-
+                                                                      values is an array of string values. If the operator is In or NotIn,
+                                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                                      the values array must be empty. This array is replaced during a strategic
+                                                                      merge patch.
+                                                                    items:
+                                                                      type: string
+                                                                    type: array
+                                                                required:
+                                                                - key
+                                                                - operator
+                                                                type: object
+                                                              type: array
+                                                            matchLabels:
+                                                              additionalProperties:
+                                                                type: string
+                                                              description: |-
+                                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                              type: object
+                                                          type: object
+                                                          x-kubernetes-map-type: atomic
+                                                        name:
+                                                          description: |-
+                                                            Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                            with signerName and labelSelector.
+                                                          type: string
+                                                        optional:
+                                                          description: |-
+                                                            If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                            aren't available.  If using name, then the named ClusterTrustBundle is
+                                                            allowed not to exist.  If using signerName, then the combination of
+                                                            signerName and labelSelector is allowed to match zero
+                                                            ClusterTrustBundles.
+                                                          type: boolean
+                                                        path:
+                                                          description: Relative path from the volume root to write the bundle.
+                                                          type: string
+                                                        signerName:
+                                                          description: |-
+                                                            Select all ClusterTrustBundles that match this signer name.
+                                                            Mutually-exclusive with name.  The contents of all selected
+                                                            ClusterTrustBundles will be unified and deduplicated.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                    configMap:
+                                                      description: configMap information about the configMap data to project
+                                                      properties:
+                                                        items:
+                                                          description: |-
+                                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                                            ConfigMap will be projected into the volume as a file whose name is the
+                                                            key and content is the value. If specified, the listed keys will be
+                                                            projected into the specified paths, and unlisted keys will not be
+                                                            present. If a key is specified which is not present in the ConfigMap,
+                                                            the volume setup will error unless it is marked optional. Paths must be
+                                                            relative and may not contain the '..' path or start with '..'.
+                                                          items:
+                                                            description: Maps a string key to a path within a volume.
+                                                            properties:
+                                                              key:
+                                                                description: key is the key to project.
+                                                                type: string
+                                                              mode:
+                                                                description: |-
+                                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                                  If not specified, the volume defaultMode will be used.
+                                                                  This might be in conflict with other options that affect the file
+                                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                description: |-
+                                                                  path is the relative path of the file to map the key to.
+                                                                  May not be an absolute path.
+                                                                  May not contain the path element '..'.
+                                                                  May not start with the string '..'.
+                                                                type: string
+                                                            required:
+                                                            - key
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: optional specify whether the ConfigMap or its keys must be defined
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    downwardAPI:
+                                                      description: downwardAPI information about the downwardAPI data to project
+                                                      properties:
+                                                        items:
+                                                          description: Items is a list of DownwardAPIVolume file
+                                                          items:
+                                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                                            properties:
+                                                              fieldRef:
+                                                                description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                                properties:
+                                                                  apiVersion:
+                                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                                    type: string
+                                                                  fieldPath:
+                                                                    description: Path of the field to select in the specified API version.
+                                                                    type: string
+                                                                required:
+                                                                - fieldPath
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                              mode:
+                                                                description: |-
+                                                                  Optional: mode bits used to set permissions on this file, must be an octal value
+                                                                  between 0000 and 0777 or a decimal value between 0 and 511.
+                                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                                  If not specified, the volume defaultMode will be used.
+                                                                  This might be in conflict with other options that affect the file
+                                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                                type: string
+                                                              resourceFieldRef:
+                                                                description: |-
+                                                                  Selects a resource of the container: only resources limits and requests
+                                                                  (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                                properties:
+                                                                  containerName:
+                                                                    description: 'Container name: required for volumes, optional for env vars'
+                                                                    type: string
+                                                                  divisor:
+                                                                    anyOf:
+                                                                    - type: integer
+                                                                    - type: string
+                                                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                                    x-kubernetes-int-or-string: true
+                                                                  resource:
+                                                                    description: 'Required: resource to select'
+                                                                    type: string
+                                                                required:
+                                                                - resource
+                                                                type: object
+                                                                x-kubernetes-map-type: atomic
+                                                            required:
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                      type: object
+                                                    secret:
+                                                      description: secret information about the secret data to project
+                                                      properties:
+                                                        items:
+                                                          description: |-
+                                                            items if unspecified, each key-value pair in the Data field of the referenced
+                                                            Secret will be projected into the volume as a file whose name is the
+                                                            key and content is the value. If specified, the listed keys will be
+                                                            projected into the specified paths, and unlisted keys will not be
+                                                            present. If a key is specified which is not present in the Secret,
+                                                            the volume setup will error unless it is marked optional. Paths must be
+                                                            relative and may not contain the '..' path or start with '..'.
+                                                          items:
+                                                            description: Maps a string key to a path within a volume.
+                                                            properties:
+                                                              key:
+                                                                description: key is the key to project.
+                                                                type: string
+                                                              mode:
+                                                                description: |-
+                                                                  mode is Optional: mode bits used to set permissions on this file.
+                                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                                  YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                                  If not specified, the volume defaultMode will be used.
+                                                                  This might be in conflict with other options that affect the file
+                                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                                format: int32
+                                                                type: integer
+                                                              path:
+                                                                description: |-
+                                                                  path is the relative path of the file to map the key to.
+                                                                  May not be an absolute path.
+                                                                  May not contain the path element '..'.
+                                                                  May not start with the string '..'.
+                                                                type: string
+                                                            required:
+                                                            - key
+                                                            - path
+                                                            type: object
+                                                          type: array
+                                                        name:
+                                                          description: |-
+                                                            Name of the referent.
+                                                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                            TODO: Add other useful fields. apiVersion, kind, uid?
+                                                          type: string
+                                                        optional:
+                                                          description: optional field specify whether the Secret or its key must be defined
+                                                          type: boolean
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    serviceAccountToken:
+                                                      description: serviceAccountToken is information about the serviceAccountToken data to project
+                                                      properties:
+                                                        audience:
+                                                          description: |-
+                                                            audience is the intended audience of the token. A recipient of a token
+                                                            must identify itself with an identifier specified in the audience of the
+                                                            token, and otherwise should reject the token. The audience defaults to the
+                                                            identifier of the apiserver.
+                                                          type: string
+                                                        expirationSeconds:
+                                                          description: |-
+                                                            expirationSeconds is the requested duration of validity of the service
+                                                            account token. As the token approaches expiration, the kubelet volume
+                                                            plugin will proactively rotate the service account token. The kubelet will
+                                                            start trying to rotate the token if the token is older than 80 percent of
+                                                            its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                            and must be at least 10 minutes.
+                                                          format: int64
+                                                          type: integer
+                                                        path:
+                                                          description: |-
+                                                            path is the path relative to the mount point of the file to project the
+                                                            token into.
+                                                          type: string
+                                                      required:
+                                                      - path
+                                                      type: object
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          quobyte:
+                                            description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                                            properties:
+                                              group:
+                                                description: |-
+                                                  group to map volume access to
+                                                  Default is no group
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                                  Defaults to false.
+                                                type: boolean
+                                              registry:
+                                                description: |-
+                                                  registry represents a single or multiple Quobyte Registry services
+                                                  specified as a string as host:port pair (multiple entries are separated with commas)
+                                                  which acts as the central registry for volumes
+                                                type: string
+                                              tenant:
+                                                description: |-
+                                                  tenant owning the given Quobyte volume in the Backend
+                                                  Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                                type: string
+                                              user:
+                                                description: |-
+                                                  user to map volume access to
+                                                  Defaults to serivceaccount user
+                                                type: string
+                                              volume:
+                                                description: volume is a string that references an already created Quobyte volume by name.
+                                                type: string
+                                            required:
+                                            - registry
+                                            - volume
+                                            type: object
+                                          rbd:
+                                            description: |-
+                                              rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                              More info: https://examples.k8s.io/volumes/rbd/README.md
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type of the volume that you want to mount.
+                                                  Tip: Ensure that the filesystem type is supported by the host operating system.
+                                                  Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                                  TODO: how do we prevent errors in the filesystem from compromising the machine
+                                                type: string
+                                              image:
+                                                description: |-
+                                                  image is the rados image name.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                type: string
+                                              keyring:
+                                                description: |-
+                                                  keyring is the path to key ring for RBDUser.
+                                                  Default is /etc/ceph/keyring.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                type: string
+                                              monitors:
+                                                description: |-
+                                                  monitors is a collection of Ceph monitors.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                items:
+                                                  type: string
+                                                type: array
+                                              pool:
+                                                description: |-
+                                                  pool is the rados pool name.
+                                                  Default is rbd.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly here will force the ReadOnly setting in VolumeMounts.
+                                                  Defaults to false.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                type: boolean
+                                              secretRef:
+                                                description: |-
+                                                  secretRef is name of the authentication secret for RBDUser. If provided
+                                                  overrides keyring.
+                                                  Default is nil.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              user:
+                                                description: |-
+                                                  user is the rados user name.
+                                                  Default is admin.
+                                                  More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                                type: string
+                                            required:
+                                            - image
+                                            - monitors
+                                            type: object
+                                          scaleIO:
+                                            description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs".
+                                                  Default is "xfs".
+                                                type: string
+                                              gateway:
+                                                description: gateway is the host address of the ScaleIO API Gateway.
+                                                type: string
+                                              protectionDomain:
+                                                description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly Defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              secretRef:
+                                                description: |-
+                                                  secretRef references to the secret for ScaleIO user and other
+                                                  sensitive information. If this is not provided, Login operation will fail.
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              sslEnabled:
+                                                description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                                type: boolean
+                                              storageMode:
+                                                description: |-
+                                                  storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                                  Default is ThinProvisioned.
+                                                type: string
+                                              storagePool:
+                                                description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                                type: string
+                                              system:
+                                                description: system is the name of the storage system as configured in ScaleIO.
+                                                type: string
+                                              volumeName:
+                                                description: |-
+                                                  volumeName is the name of a volume already created in the ScaleIO system
+                                                  that is associated with this volume source.
+                                                type: string
+                                            required:
+                                            - gateway
+                                            - secretRef
+                                            - system
+                                            type: object
+                                          secret:
+                                            description: |-
+                                              secret represents a secret that should populate this volume.
+                                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                            properties:
+                                              defaultMode:
+                                                description: |-
+                                                  defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                                  Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                  YAML accepts both octal and decimal values, JSON requires decimal values
+                                                  for mode bits. Defaults to 0644.
+                                                  Directories within the path are not affected by this setting.
+                                                  This might be in conflict with other options that affect the file
+                                                  mode, like fsGroup, and the result can be other mode bits set.
+                                                format: int32
+                                                type: integer
+                                              items:
+                                                description: |-
+                                                  items If unspecified, each key-value pair in the Data field of the referenced
+                                                  Secret will be projected into the volume as a file whose name is the
+                                                  key and content is the value. If specified, the listed keys will be
+                                                  projected into the specified paths, and unlisted keys will not be
+                                                  present. If a key is specified which is not present in the Secret,
+                                                  the volume setup will error unless it is marked optional. Paths must be
+                                                  relative and may not contain the '..' path or start with '..'.
+                                                items:
+                                                  description: Maps a string key to a path within a volume.
+                                                  properties:
+                                                    key:
+                                                      description: key is the key to project.
+                                                      type: string
+                                                    mode:
+                                                      description: |-
+                                                        mode is Optional: mode bits used to set permissions on this file.
+                                                        Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                        YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                        If not specified, the volume defaultMode will be used.
+                                                        This might be in conflict with other options that affect the file
+                                                        mode, like fsGroup, and the result can be other mode bits set.
+                                                      format: int32
+                                                      type: integer
+                                                    path:
+                                                      description: |-
+                                                        path is the relative path of the file to map the key to.
+                                                        May not be an absolute path.
+                                                        May not contain the path element '..'.
+                                                        May not start with the string '..'.
+                                                      type: string
+                                                  required:
+                                                  - key
+                                                  - path
+                                                  type: object
+                                                type: array
+                                              optional:
+                                                description: optional field specify whether the Secret or its keys must be defined
+                                                type: boolean
+                                              secretName:
+                                                description: |-
+                                                  secretName is the name of the secret in the pod's namespace to use.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                                type: string
+                                            type: object
+                                          storageos:
+                                            description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is the filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                type: string
+                                              readOnly:
+                                                description: |-
+                                                  readOnly defaults to false (read/write). ReadOnly here will force
+                                                  the ReadOnly setting in VolumeMounts.
+                                                type: boolean
+                                              secretRef:
+                                                description: |-
+                                                  secretRef specifies the secret to use for obtaining the StorageOS API
+                                                  credentials.  If not specified, default values will be attempted.
+                                                properties:
+                                                  name:
+                                                    description: |-
+                                                      Name of the referent.
+                                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    type: string
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              volumeName:
+                                                description: |-
+                                                  volumeName is the human-readable name of the StorageOS volume.  Volume
+                                                  names are only unique within a namespace.
+                                                type: string
+                                              volumeNamespace:
+                                                description: |-
+                                                  volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                                  namespace is specified then the Pod's namespace will be used.  This allows the
+                                                  Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                                  Set VolumeName to any name to override the default behaviour.
+                                                  Set to "default" if you are not using namespaces within StorageOS.
+                                                  Namespaces that do not pre-exist within StorageOS will be created.
+                                                type: string
+                                            type: object
+                                          vsphereVolume:
+                                            description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                                            properties:
+                                              fsType:
+                                                description: |-
+                                                  fsType is filesystem type to mount.
+                                                  Must be a filesystem type supported by the host operating system.
+                                                  Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                                type: string
+                                              storagePolicyID:
+                                                description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                                type: string
+                                              storagePolicyName:
+                                                description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                                type: string
+                                              volumePath:
+                                                description: volumePath is the path that identifies vSphere volume vmdk
+                                                type: string
+                                            required:
+                                            - volumePath
+                                            type: object
+                                        required:
+                                        - name
+                                        type: object
+                                      type: array
+                                  required:
+                                  - containers
+                                  type: object
+                              type: object
+                            ttlSecondsAfterFinished:
+                              description: |-
+                                ttlSecondsAfterFinished limits the lifetime of a Job that has finished
+                                execution (either Complete or Failed). If this field is set,
+                                ttlSecondsAfterFinished after the Job finishes, it is eligible to be
+                                automatically deleted. When the Job is being deleted, its lifecycle
+                                guarantees (e.g. finalizers) will be honored. If this field is unset,
+                                the Job won't be automatically deleted. If this field is set to zero,
+                                the Job becomes eligible to be deleted immediately after it finishes.
+                              format: int32
+                              type: integer
+                          required:
+                          - template
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  - template
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              startupPolicy:
+                description: StartupPolicy, if set, configures in what order jobs must be started
+                properties:
+                  startupPolicyOrder:
+                    description: |-
+                      StartupPolicyOrder determines the startup order of the ReplicatedJobs.
+                      AnyOrder means to start replicated jobs in any order.
+                      InOrder means to start them as they are listed in the JobSet. A ReplicatedJob is started only
+                      when all the jobs of the previous one are ready.
+                    enum:
+                    - AnyOrder
+                    - InOrder
+                    type: string
+                required:
+                - startupPolicyOrder
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              successPolicy:
+                description: |-
+                  SuccessPolicy configures when to declare the JobSet as
+                  succeeded.
+                  The JobSet is always declared succeeded if all jobs in the set
+                  finished with status complete.
+                properties:
+                  operator:
+                    description: Operator determines either All or Any of the selected jobs should succeed to consider the JobSet successful
+                    enum:
+                    - All
+                    - Any
+                    type: string
+                  targetReplicatedJobs:
+                    description: |-
+                      TargetReplicatedJobs are the names of the replicated jobs the operator will apply to.
+                      A null or empty list will apply to all replicatedJobs.
+                    items:
+                      type: string
+                    type: array
+                    x-kubernetes-list-type: atomic
+                required:
+                - operator
+                type: object
+                x-kubernetes-validations:
+                - message: Value is immutable
+                  rule: self == oldSelf
+              suspend:
+                description: Suspend suspends all running child Jobs when set to true.
+                type: boolean
+              ttlSecondsAfterFinished:
+                description: |-
+                  TTLSecondsAfterFinished limits the lifetime of a JobSet that has finished
+                  execution (either Complete or Failed). If this field is set,
+                  TTLSecondsAfterFinished after the JobSet finishes, it is eligible to be
+                  automatically deleted. When the JobSet is being deleted, its lifecycle
+                  guarantees (e.g. finalizers) will be honored. If this field is unset,
+                  the JobSet won't be automatically deleted. If this field is set to zero,
+                  the JobSet becomes eligible to be deleted immediately after it finishes.
+                format: int32
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: JobSetStatus defines the observed state of JobSet
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current state of this API Resource.\n---\nThis struct is intended for direct use as an array at the field path .status.conditions.  For example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the observations of a foo's current state.\n\t    // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    // +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t    // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t    // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              replicatedJobsStatus:
+                description: ReplicatedJobsStatus track the number of JobsReady for each replicatedJob.
+                items:
+                  description: ReplicatedJobStatus defines the observed ReplicatedJobs Readiness.
+                  properties:
+                    active:
+                      description: |-
+                        Active is the number of child Jobs with at least 1 pod in a running or pending state
+                        which are not marked for deletion.
+                      format: int32
+                      type: integer
+                    failed:
+                      description: Failed is the number of failed child Jobs.
+                      format: int32
+                      type: integer
+                    name:
+                      description: Name of the ReplicatedJob.
+                      type: string
+                    ready:
+                      description: |-
+                        Ready is the number of child Jobs where the number of ready pods and completed pods
+                        is greater than or equal to the total expected pod count for the Job (i.e., the minimum
+                        of job.spec.parallelism and job.spec.completions).
+                      format: int32
+                      type: integer
+                    succeeded:
+                      description: Succeeded is the number of successfully completed child Jobs.
+                      format: int32
+                      type: integer
+                    suspended:
+                      description: Suspended is the number of child Jobs which are in a suspended state.
+                      format: int32
+                      type: integer
+                  required:
+                  - active
+                  - failed
+                  - name
+                  - ready
+                  - succeeded
+                  - suspended
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              restarts:
+                description: Restarts tracks the number of times the JobSet has restarted (i.e. recreated in case of RecreateAll policy).
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: serviceaccount
+    app.kubernetes.io/part-of: jobset
+  name: jobset-controller-manager
+  namespace: jobset-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: leader-election-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: role
+    app.kubernetes.io/part-of: jobset
+  name: jobset-leader-election-role
+  namespace: jobset-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: jobset-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/status
+  verbs:
+  - get
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: metrics-reader
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jobset
+  name: jobset-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: proxy-role
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrole
+    app.kubernetes.io/part-of: jobset
+  name: jobset-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: leader-election-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: rolebinding
+    app.kubernetes.io/part-of: jobset
+  name: jobset-leader-election-rolebinding
+  namespace: jobset-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jobset-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: jobset-controller-manager
+  namespace: jobset-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: manager-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: jobset
+  name: jobset-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jobset-manager-role
+subjects:
+- kind: ServiceAccount
+  name: jobset-controller-manager
+  namespace: jobset-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: proxy-rolebinding
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: clusterrolebinding
+    app.kubernetes.io/part-of: jobset
+  name: jobset-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jobset-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: jobset-controller-manager
+  namespace: jobset-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jobset-webhook-server-cert
+  namespace: jobset-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: kube-rbac-proxy
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: controller-manager-metrics-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: jobset
+    control-plane: controller-manager
+  name: jobset-controller-manager-metrics-service
+  namespace: jobset-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: webhook
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: webhook-service
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: service
+    app.kubernetes.io/part-of: jobset
+  name: jobset-webhook-service
+  namespace: jobset-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: manager
+    app.kubernetes.io/created-by: jobset
+    app.kubernetes.io/instance: controller-manager
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/name: deployment
+    app.kubernetes.io/part-of: jobset
+    control-plane: controller-manager
+  name: jobset-controller-manager
+  namespace: jobset-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+                - ppc64le
+                - s390x
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                - linux
+      containers:
+      - args:
+        - --zap-log-level=2
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        command:
+        - /manager
+        image: registry.k8s.io/jobset/jobset:v0.5.2
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 2
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: jobset-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: jobset-webhook-server-cert
+      tolerations:
+      - effect: NoSchedule
+        key: components.gke.io/gke-managed-components
+        operator: Equal
+        value: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: jobset-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: jobset-webhook-service
+      namespace: jobset-system
+      path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
+  failurePolicy: Fail
+  name: mjobset.kb.io
+  rules:
+  - apiGroups:
+    - jobset.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: jobset-webhook-service
+      namespace: jobset-system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: jobset.sigs.k8s.io/jobset-name
+      operator: Exists
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: jobset-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: jobset-webhook-service
+      namespace: jobset-system
+      path: /validate-jobset-x-k8s-io-v1alpha2-jobset
+  failurePolicy: Fail
+  name: vjobset.kb.io
+  rules:
+  - apiGroups:
+    - jobset.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: jobset-webhook-service
+      namespace: jobset-system
+      path: /validate--v1-pod
+  failurePolicy: Fail
+  name: vpod.kb.io
+  objectSelector:
+    matchExpressions:
+    - key: jobset.sigs.k8s.io/jobset-name
+      operator: Exists
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None

--- a/modules/management/kubectl-apply/manifests/kueue-v0.8.1.yaml
+++ b/modules/management/kubectl-apply/manifests/kueue-v0.8.1.yaml
@@ -1,0 +1,12735 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-system
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: admissionchecks.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: AdmissionCheck
+    listKind: AdmissionCheckList
+    plural: admissionchecks
+    singular: admissioncheck
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: AdmissionCheck is the Schema for the admissionchecks API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AdmissionCheckSpec defines the desired state of AdmissionCheck
+            properties:
+              controllerName:
+                description: |-
+                  controllerName identifies the controller that processes the AdmissionCheck,
+                  not necessarily a Kubernetes Pod or Deployment name. Cannot be empty.
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              parameters:
+                description: |-
+                  Parameters identifies a configuration with additional parameters for the
+                  check.
+                properties:
+                  apiGroup:
+                    description: ApiGroup is the group for the resource being referenced.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  kind:
+                    description: Kind is the type of the resource being referenced.
+                    maxLength: 63
+                    pattern: ^(?i)[a-z]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  name:
+                    description: Name is the name of the resource being referenced.
+                    maxLength: 63
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                required:
+                - apiGroup
+                - kind
+                - name
+                type: object
+              retryDelayMinutes:
+                default: 15
+                description: |-
+                  RetryDelayMinutes **deprecated** specifies how long to keep the workload suspended after
+                  a failed check (after it transitioned to False). When the delay period has passed, the check
+                  state goes to "Unknown". The default is 15 min.
+                  The default is 15 min.
+                format: int64
+                type: integer
+            required:
+            - controllerName
+            type: object
+          status:
+            description: AdmissionCheckStatus defines the observed state of AdmissionCheck
+            properties:
+              conditions:
+                description: |-
+                  conditions hold the latest available observations of the AdmissionCheck
+                  current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: clusterqueues.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: ClusterQueue
+    listKind: ClusterQueueList
+    plural: clusterqueues
+    shortNames:
+    - cq
+    singular: clusterqueue
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Cohort that this ClusterQueue belongs to
+      jsonPath: .spec.cohort
+      name: Cohort
+      type: string
+    - description: The queueing strategy used to prioritize workloads
+      jsonPath: .spec.queueingStrategy
+      name: Strategy
+      priority: 1
+      type: string
+    - description: Number of pending workloads
+      jsonPath: .status.pendingWorkloads
+      name: Pending Workloads
+      type: integer
+    - description: Number of admitted workloads that haven't finished yet
+      jsonPath: .status.admittedWorkloads
+      name: Admitted Workloads
+      priority: 1
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ClusterQueue is the Schema for the clusterQueue API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ClusterQueueSpec defines the desired state of ClusterQueue
+            properties:
+              admissionChecks:
+                description: |-
+                  admissionChecks lists the AdmissionChecks required by this ClusterQueue.
+                  Cannot be used along with AdmissionCheckStrategy.
+                items:
+                  type: string
+                type: array
+              admissionChecksStrategy:
+                description: |-
+                  admissionCheckStrategy defines a list of strategies to determine which ResourceFlavors require AdmissionChecks.
+                  This property cannot be used in conjunction with the 'admissionChecks' property.
+                properties:
+                  admissionChecks:
+                    description: admissionChecks is a list of strategies for AdmissionChecks
+                    items:
+                      description: AdmissionCheckStrategyRule defines rules for a
+                        single AdmissionCheck
+                      properties:
+                        name:
+                          description: name is an AdmissionCheck's name.
+                          type: string
+                        onFlavors:
+                          description: |-
+                            onFlavors is a list of ResourceFlavors' names that this AdmissionCheck should run for.
+                            If empty, the AdmissionCheck will run for all workloads submitted to the ClusterQueue.
+                          items:
+                            description: ResourceFlavorReference is the name of the
+                              ResourceFlavor.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          type: array
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              cohort:
+                description: |-
+                  cohort that this ClusterQueue belongs to. CQs that belong to the
+                  same cohort can borrow unused resources from each other.
+
+
+                  A CQ can be a member of a single borrowing cohort. A workload submitted
+                  to a queue referencing this CQ can borrow quota from any CQ in the cohort.
+                  Only quota for the [resource, flavor] pairs listed in the CQ can be
+                  borrowed.
+                  If empty, this ClusterQueue cannot borrow from any other ClusterQueue and
+                  vice versa.
+
+
+                  A cohort is a name that links CQs together, but it doesn't reference any
+                  object.
+
+
+                  Validation of a cohort name is equivalent to that of object names:
+                  subdomain in DNS (RFC 1123).
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+              fairSharing:
+                description: |-
+                  fairSharing defines the properties of the ClusterQueue when participating in fair sharing.
+                  The values are only relevant if fair sharing is enabled in the Kueue configuration.
+                properties:
+                  weight:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    default: 1
+                    description: |-
+                      weight gives a comparative advantage to this ClusterQueue when competing for unused
+                      resources in the cohort against other ClusterQueues.
+                      The share of a ClusterQueue is based on the dominant resource usage above nominal
+                      quotas for each resource, divided by the weight.
+                      Admission prioritizes scheduling workloads from ClusterQueues with the lowest share
+                      and preempting workloads from the ClusterQueues with the highest share.
+                      A zero weight implies infinite share value, meaning that this ClusterQueue will always
+                      be at disadvantage against other ClusterQueues.
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                type: object
+              flavorFungibility:
+                default: {}
+                description: |-
+                  flavorFungibility defines whether a workload should try the next flavor
+                  before borrowing or preempting in the flavor being evaluated.
+                properties:
+                  whenCanBorrow:
+                    default: Borrow
+                    description: |-
+                      whenCanBorrow determines whether a workload should try the next flavor
+                      before borrowing in current flavor. The possible values are:
+
+
+                      - `Borrow` (default): allocate in current flavor if borrowing
+                        is possible.
+                      - `TryNextFlavor`: try next flavor even if the current
+                        flavor has enough resources to borrow.
+                    enum:
+                    - Borrow
+                    - TryNextFlavor
+                    type: string
+                  whenCanPreempt:
+                    default: TryNextFlavor
+                    description: |-
+                      whenCanPreempt determines whether a workload should try the next flavor
+                      before borrowing in current flavor. The possible values are:
+
+
+                      - `Preempt`: allocate in current flavor if it's possible to preempt some workloads.
+                      - `TryNextFlavor` (default): try next flavor even if there are enough
+                        candidates for preemption in the current flavor.
+                    enum:
+                    - Preempt
+                    - TryNextFlavor
+                    type: string
+                type: object
+              namespaceSelector:
+                description: |-
+                  namespaceSelector defines which namespaces are allowed to submit workloads to
+                  this clusterQueue. Beyond this basic support for policy, a policy agent like
+                  Gatekeeper should be used to enforce more advanced policies.
+                  Defaults to null which is a nothing selector (no namespaces eligible).
+                  If set to an empty selector `{}`, then all namespaces are eligible.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements.
+                      The requirements are ANDed.
+                    items:
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies
+                            to.
+                          type: string
+                        operator:
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
+                            merge patch.
+                          items:
+                            type: string
+                          type: array
+                          x-kubernetes-list-type: atomic
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+                x-kubernetes-map-type: atomic
+              preemption:
+                default: {}
+                description: |-
+                  preemption describes policies to preempt Workloads from this ClusterQueue
+                  or the ClusterQueue's cohort.
+
+
+                  Preemption can happen in two scenarios:
+
+
+                  - When a Workload fits within the nominal quota of the ClusterQueue, but
+                    the quota is currently borrowed by other ClusterQueues in the cohort.
+                    Preempting Workloads in other ClusterQueues allows this ClusterQueue to
+                    reclaim its nominal quota.
+                  - When a Workload doesn't fit within the nominal quota of the ClusterQueue
+                    and there are admitted Workloads in the ClusterQueue with lower priority.
+
+
+                  The preemption algorithm tries to find a minimal set of Workloads to
+                  preempt to accomomdate the pending Workload, preempting Workloads with
+                  lower priority first.
+                properties:
+                  borrowWithinCohort:
+                    default: {}
+                    description: |-
+                      borrowWithinCohort provides configuration to allow preemption within
+                      cohort while borrowing.
+                    properties:
+                      maxPriorityThreshold:
+                        description: |-
+                          maxPriorityThreshold allows to restrict the set of workloads which
+                          might be preempted by a borrowing workload, to only workloads with
+                          priority less than or equal to the specified threshold priority.
+                          When the threshold is not specified, then any workload satisfying the
+                          policy can be preempted by the borrowing workload.
+                        format: int32
+                        type: integer
+                      policy:
+                        default: Never
+                        description: |-
+                          policy determines the policy for preemption to reclaim quota within cohort while borrowing.
+                          Possible values are:
+                          - `Never` (default): do not allow for preemption, in other
+                             ClusterQueues within the cohort, for a borrowing workload.
+                          - `LowerPriority`: allow preemption, in other ClusterQueues
+                             within the cohort, for a borrowing workload, but only if
+                             the preempted workloads are of lower priority.
+                        enum:
+                        - Never
+                        - LowerPriority
+                        type: string
+                    type: object
+                  reclaimWithinCohort:
+                    default: Never
+                    description: |-
+                      reclaimWithinCohort determines whether a pending Workload can preempt
+                      Workloads from other ClusterQueues in the cohort that are using more than
+                      their nominal quota. The possible values are:
+
+
+                      - `Never` (default): do not preempt Workloads in the cohort.
+                      - `LowerPriority`: if the pending Workload fits within the nominal
+                        quota of its ClusterQueue, only preempt Workloads in the cohort that have
+                        lower priority than the pending Workload.
+                      - `Any`: if the pending Workload fits within the nominal quota of its
+                        ClusterQueue, preempt any Workload in the cohort, irrespective of
+                        priority.
+                    enum:
+                    - Never
+                    - LowerPriority
+                    - Any
+                    type: string
+                  withinClusterQueue:
+                    default: Never
+                    description: |-
+                      withinClusterQueue determines whether a pending Workload that doesn't fit
+                      within the nominal quota for its ClusterQueue, can preempt active Workloads in
+                      the ClusterQueue. The possible values are:
+
+
+                      - `Never` (default): do not preempt Workloads in the ClusterQueue.
+                      - `LowerPriority`: only preempt Workloads in the ClusterQueue that have
+                        lower priority than the pending Workload.
+                      - `LowerOrNewerEqualPriority`: only preempt Workloads in the ClusterQueue that
+                        either have a lower priority than the pending workload or equal priority
+                        and are newer than the pending workload.
+                    enum:
+                    - Never
+                    - LowerPriority
+                    - LowerOrNewerEqualPriority
+                    type: string
+                type: object
+                x-kubernetes-validations:
+                - message: reclaimWithinCohort=Never and borrowWithinCohort.Policy!=Never
+                  rule: '!(self.reclaimWithinCohort == ''Never'' && has(self.borrowWithinCohort)
+                    &&  self.borrowWithinCohort.policy != ''Never'')'
+              queueingStrategy:
+                default: BestEffortFIFO
+                description: |-
+                  QueueingStrategy indicates the queueing strategy of the workloads
+                  across the queues in this ClusterQueue.
+                  Current Supported Strategies:
+
+
+                  - StrictFIFO: workloads are ordered strictly by creation time.
+                  Older workloads that can't be admitted will block admitting newer
+                  workloads even if they fit available quota.
+                  - BestEffortFIFO: workloads are ordered by creation time,
+                  however older workloads that can't be admitted will not block
+                  admitting newer workloads that fit existing quota.
+                enum:
+                - StrictFIFO
+                - BestEffortFIFO
+                type: string
+              resourceGroups:
+                description: |-
+                  resourceGroups describes groups of resources.
+                  Each resource group defines the list of resources and a list of flavors
+                  that provide quotas for these resources.
+                  Each resource and each flavor can only form part of one resource group.
+                  resourceGroups can be up to 16.
+                items:
+                  properties:
+                    coveredResources:
+                      description: |-
+                        coveredResources is the list of resources covered by the flavors in this
+                        group.
+                        Examples: cpu, memory, vendor.com/gpu.
+                        The list cannot be empty and it can contain up to 16 resources.
+                      items:
+                        description: ResourceName is the name identifying various
+                          resources in a ResourceList.
+                        type: string
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                    flavors:
+                      description: |-
+                        flavors is the list of flavors that provide the resources of this group.
+                        Typically, different flavors represent different hardware models
+                        (e.g., gpu models, cpu architectures) or pricing models (on-demand vs spot
+                        cpus).
+                        Each flavor MUST list all the resources listed for this group in the same
+                        order as the .resources field.
+                        The list cannot be empty and it can contain up to 16 flavors.
+                      items:
+                        properties:
+                          name:
+                            description: |-
+                              name of this flavor. The name should match the .metadata.name of a
+                              ResourceFlavor. If a matching ResourceFlavor does not exist, the
+                              ClusterQueue will have an Active condition set to False.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          resources:
+                            description: |-
+                              resources is the list of quotas for this flavor per resource.
+                              There could be up to 16 resources.
+                            items:
+                              properties:
+                                borrowingLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    borrowingLimit is the maximum amount of quota for the [flavor, resource]
+                                    combination that this ClusterQueue is allowed to borrow from the unused
+                                    quota of other ClusterQueues in the same cohort.
+                                    In total, at a given time, Workloads in a ClusterQueue can consume a
+                                    quantity of quota equal to nominalQuota+borrowingLimit, assuming the other
+                                    ClusterQueues in the cohort have enough unused quota.
+                                    If null, it means that there is no borrowing limit.
+                                    If not null, it must be non-negative.
+                                    borrowingLimit must be null if spec.cohort is empty.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                lendingLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    lendingLimit is the maximum amount of unused quota for the [flavor, resource]
+                                    combination that this ClusterQueue can lend to other ClusterQueues in the same cohort.
+                                    In total, at a given time, ClusterQueue reserves for its exclusive use
+                                    a quantity of quota equals to nominalQuota - lendingLimit.
+                                    If null, it means that there is no lending limit, meaning that
+                                    all the nominalQuota can be borrowed by other clusterQueues in the cohort.
+                                    If not null, it must be non-negative.
+                                    lendingLimit must be null if spec.cohort is empty.
+                                    This field is in alpha stage. To be able to use this field,
+                                    enable the feature gate LendingLimit, which is disabled by default.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                name:
+                                  description: name of this resource.
+                                  type: string
+                                nominalQuota:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: |-
+                                    nominalQuota is the quantity of this resource that is available for
+                                    Workloads admitted by this ClusterQueue at a point in time.
+                                    The nominalQuota must be non-negative.
+                                    nominalQuota should represent the resources in the cluster available for
+                                    running jobs (after discounting resources consumed by system components
+                                    and pods not managed by kueue). In an autoscaled cluster, nominalQuota
+                                    should account for resources that can be provided by a component such as
+                                    Kubernetes cluster-autoscaler.
+
+
+                                    If the ClusterQueue belongs to a cohort, the sum of the quotas for each
+                                    (flavor, resource) combination defines the maximum quantity that can be
+                                    allocated by a ClusterQueue in the cohort.
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - name
+                              - nominalQuota
+                              type: object
+                            maxItems: 16
+                            minItems: 1
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                        required:
+                        - name
+                        - resources
+                        type: object
+                      maxItems: 16
+                      minItems: 1
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - coveredResources
+                  - flavors
+                  type: object
+                  x-kubernetes-validations:
+                  - message: flavors must have the same number of resources as the
+                      coveredResources
+                    rule: self.flavors.all(x, size(x.resources) == size(self.coveredResources))
+                maxItems: 16
+                type: array
+                x-kubernetes-list-type: atomic
+              stopPolicy:
+                default: None
+                description: |-
+                  stopPolicy - if set to a value different from None, the ClusterQueue is considered Inactive, no new reservation being
+                  made.
+
+
+                  Depending on its value, its associated workloads will:
+
+
+                  - None - Workloads are admitted
+                  - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
+                  - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+                enum:
+                - None
+                - Hold
+                - HoldAndDrain
+                type: string
+            type: object
+            x-kubernetes-validations:
+            - message: borrowingLimit must be nil when cohort is empty
+              rule: '!has(self.cohort) && has(self.resourceGroups) ? self.resourceGroups.all(rg,
+                rg.flavors.all(f, f.resources.all(r, !has(r.borrowingLimit)))) : true'
+          status:
+            description: ClusterQueueStatus defines the observed state of ClusterQueue
+            properties:
+              admittedWorkloads:
+                description: |-
+                  admittedWorkloads is the number of workloads currently admitted to this
+                  clusterQueue and haven't finished yet.
+                format: int32
+                type: integer
+              conditions:
+                description: |-
+                  conditions hold the latest available observations of the ClusterQueue
+                  current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              fairSharing:
+                description: FairSharing contains the information about the current
+                  status of fair sharing.
+                properties:
+                  weightedShare:
+                    description: |-
+                      WeightedShare represent the maximum of the ratios of usage above nominal
+                      quota to the lendable resources in the cohort, among all the resources
+                      provided by the ClusterQueue, and divided by the weight.
+                      If zero, it means that the usage of the ClusterQueue is below the nominal quota.
+                      If the ClusterQueue has a weight of zero, this will return 9223372036854775807,
+                      the maximum possible share value.
+                    format: int64
+                    type: integer
+                required:
+                - weightedShare
+                type: object
+              flavorsReservation:
+                description: |-
+                  flavorsReservation are the reserved quotas, by flavor, currently in use by the
+                  workloads assigned to this ClusterQueue.
+                items:
+                  properties:
+                    name:
+                      description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    resources:
+                      description: resources lists the quota usage for the resources
+                        in this flavor.
+                      items:
+                        properties:
+                          borrowed:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Borrowed is quantity of quota that is borrowed from the cohort. In other
+                              words, it's the used quota that is over the nominalQuota.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          name:
+                            description: name of the resource
+                            type: string
+                          total:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              total is the total quantity of used quota, including the amount borrowed
+                              from the cohort.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - name
+                  - resources
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              flavorsUsage:
+                description: |-
+                  flavorsUsage are the used quotas, by flavor, currently in use by the
+                  workloads admitted in this ClusterQueue.
+                items:
+                  properties:
+                    name:
+                      description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    resources:
+                      description: resources lists the quota usage for the resources
+                        in this flavor.
+                      items:
+                        properties:
+                          borrowed:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              Borrowed is quantity of quota that is borrowed from the cohort. In other
+                              words, it's the used quota that is over the nominalQuota.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          name:
+                            description: name of the resource
+                            type: string
+                          total:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: |-
+                              total is the total quantity of used quota, including the amount borrowed
+                              from the cohort.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - name
+                  - resources
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              pendingWorkloads:
+                description: |-
+                  pendingWorkloads is the number of workloads currently waiting to be
+                  admitted to this clusterQueue.
+                format: int32
+                type: integer
+              pendingWorkloadsStatus:
+                description: |-
+                  PendingWorkloadsStatus contains the information exposed about the current
+                  status of the pending workloads in the cluster queue.
+                properties:
+                  clusterQueuePendingWorkload:
+                    description: Head contains the list of top pending workloads.
+                    items:
+                      description: |-
+                        ClusterQueuePendingWorkload contains the information identifying a pending workload
+                        in the cluster queue.
+                      properties:
+                        name:
+                          description: Name indicates the name of the pending workload.
+                          type: string
+                        namespace:
+                          description: Namespace indicates the name of the pending
+                            workload.
+                          type: string
+                      required:
+                      - name
+                      - namespace
+                      type: object
+                    type: array
+                    x-kubernetes-list-type: atomic
+                  lastChangeTime:
+                    description: LastChangeTime indicates the time of the last change
+                      of the structure.
+                    format: date-time
+                    type: string
+                required:
+                - lastChangeTime
+                type: object
+              reservingWorkloads:
+                description: |-
+                  reservingWorkloads is the number of workloads currently reserving quota in this
+                  clusterQueue.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: localqueues.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: LocalQueue
+    listKind: LocalQueueList
+    plural: localqueues
+    shortNames:
+    - queue
+    - queues
+    - lq
+    singular: localqueue
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Backing ClusterQueue
+      jsonPath: .spec.clusterQueue
+      name: ClusterQueue
+      type: string
+    - description: Number of pending workloads
+      jsonPath: .status.pendingWorkloads
+      name: Pending Workloads
+      type: integer
+    - description: Number of admitted workloads that haven't finished yet.
+      jsonPath: .status.admittedWorkloads
+      name: Admitted Workloads
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: LocalQueue is the Schema for the localQueues API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LocalQueueSpec defines the desired state of LocalQueue
+            properties:
+              clusterQueue:
+                description: clusterQueue is a reference to a clusterQueue that backs
+                  this localQueue.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+                x-kubernetes-validations:
+                - message: field is immutable
+                  rule: self == oldSelf
+              stopPolicy:
+                default: None
+                description: |-
+                  stopPolicy - if set to a value different from None, the LocalQueue is considered Inactive,
+                  no new reservation being made.
+
+
+                  Depending on its value, its associated workloads will:
+
+
+                  - None - Workloads are admitted
+                  - HoldAndDrain - Admitted workloads are evicted and Reserving workloads will cancel the reservation.
+                  - Hold - Admitted workloads will run to completion and Reserving workloads will cancel the reservation.
+                enum:
+                - None
+                - Hold
+                - HoldAndDrain
+                type: string
+            type: object
+          status:
+            description: LocalQueueStatus defines the observed state of LocalQueue
+            properties:
+              admittedWorkloads:
+                description: |-
+                  admittedWorkloads is the number of workloads in this LocalQueue
+                  admitted to a ClusterQueue and that haven't finished yet.
+                format: int32
+                type: integer
+              conditions:
+                description: |-
+                  Conditions hold the latest available observations of the LocalQueue
+                  current state.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              flavorUsage:
+                description: |-
+                  flavorsUsage are the used quotas, by flavor currently in use by the
+                  workloads assigned to this LocalQueue.
+                items:
+                  properties:
+                    name:
+                      description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    resources:
+                      description: resources lists the quota usage for the resources
+                        in this flavor.
+                      items:
+                        properties:
+                          name:
+                            description: name of the resource.
+                            type: string
+                          total:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: total is the total quantity of used quota.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - name
+                  - resources
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              flavorsReservation:
+                description: |-
+                  flavorsReservation are the reserved quotas, by flavor currently in use by the
+                  workloads assigned to this LocalQueue.
+                items:
+                  properties:
+                    name:
+                      description: name of the flavor.
+                      maxLength: 253
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                    resources:
+                      description: resources lists the quota usage for the resources
+                        in this flavor.
+                      items:
+                        properties:
+                          name:
+                            description: name of the resource.
+                            type: string
+                          total:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            description: total is the total quantity of used quota.
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                        required:
+                        - name
+                        type: object
+                      maxItems: 16
+                      type: array
+                      x-kubernetes-list-map-keys:
+                      - name
+                      x-kubernetes-list-type: map
+                  required:
+                  - name
+                  - resources
+                  type: object
+                maxItems: 16
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              pendingWorkloads:
+                description: PendingWorkloads is the number of Workloads in the LocalQueue
+                  not yet admitted to a ClusterQueue
+                format: int32
+                type: integer
+              reservingWorkloads:
+                description: |-
+                  reservingWorkloads is the number of workloads in this LocalQueue
+                  reserving quota in a ClusterQueue and that haven't finished yet.
+                format: int32
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: multikueueclusters.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: MultiKueueCluster
+    listKind: MultiKueueClusterList
+    plural: multikueueclusters
+    singular: multikueuecluster
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MultiKueueCluster is the Schema for the multikueue API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              kubeConfig:
+                description: Information how to connect to the cluster.
+                properties:
+                  location:
+                    description: |-
+                      Location of the KubeConfig.
+
+
+                      If LocationType is Secret then Location is the name of the secret inside the namespace in
+                      which the kueue controller manager is running. The config should be stored in the "kubeconfig" key.
+                    type: string
+                  locationType:
+                    default: Secret
+                    description: Type of the KubeConfig location.
+                    enum:
+                    - Secret
+                    - Path
+                    type: string
+                required:
+                - location
+                - locationType
+                type: object
+            required:
+            - kubeConfig
+            type: object
+          status:
+            properties:
+              conditions:
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: multikueueconfigs.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: MultiKueueConfig
+    listKind: MultiKueueConfigList
+    plural: multikueueconfigs
+    singular: multikueueconfig
+  scope: Cluster
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: MultiKueueConfig is the Schema for the multikueue API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: MultiKueueConfigSpec defines the desired state of MultiKueueConfig
+            properties:
+              clusters:
+                description: List of MultiKueueClusters names where the workloads
+                  from the ClusterQueue should be distributed.
+                items:
+                  type: string
+                maxItems: 10
+                minItems: 1
+                type: array
+                x-kubernetes-list-type: set
+            required:
+            - clusters
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: provisioningrequestconfigs.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: ProvisioningRequestConfig
+    listKind: ProvisioningRequestConfigList
+    plural: provisioningrequestconfigs
+    singular: provisioningrequestconfig
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ProvisioningRequestConfig is the Schema for the provisioningrequestconfig
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProvisioningRequestConfigSpec defines the desired state of
+              ProvisioningRequestConfig
+            properties:
+              managedResources:
+                description: |-
+                  managedResources contains the list of resources managed by the autoscaling.
+
+
+                  If empty, all resources are considered managed.
+
+
+                  If not empty, the ProvisioningRequest will contain only the podsets that are
+                  requesting at least one of them.
+
+
+                  If none of the workloads podsets is requesting at least a managed resource,
+                  the workload is considered ready.
+                items:
+                  description: ResourceName is the name identifying various resources
+                    in a ResourceList.
+                  type: string
+                maxItems: 100
+                type: array
+                x-kubernetes-list-type: set
+              parameters:
+                additionalProperties:
+                  description: Parameter is limited to 255 characters.
+                  maxLength: 255
+                  type: string
+                description: Parameters contains all other parameters classes may
+                  require.
+                maxProperties: 100
+                type: object
+              provisioningClassName:
+                description: |-
+                  ProvisioningClassName describes the different modes of provisioning the resources.
+                  Check autoscaling.x-k8s.io ProvisioningRequestSpec.ProvisioningClassName for details.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+            required:
+            - provisioningClassName
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: resourceflavors.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: ResourceFlavor
+    listKind: ResourceFlavorList
+    plural: resourceflavors
+    shortNames:
+    - flavor
+    - flavors
+    - rf
+    singular: resourceflavor
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ResourceFlavor is the Schema for the resourceflavors API.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ResourceFlavorSpec defines the desired state of the ResourceFlavor
+            properties:
+              nodeLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  nodeLabels are labels that associate the ResourceFlavor with Nodes that
+                  have the same labels.
+                  When a Workload is admitted, its podsets can only get assigned
+                  ResourceFlavors whose nodeLabels match the nodeSelector and nodeAffinity
+                  fields.
+                  Once a ResourceFlavor is assigned to a podSet, the ResourceFlavor's
+                  nodeLabels should be injected into the pods of the Workload by the
+                  controller that integrates with the Workload object.
+
+
+                  nodeLabels can be up to 8 elements.
+                maxProperties: 8
+                type: object
+                x-kubernetes-map-type: atomic
+              nodeTaints:
+                description: |-
+                  nodeTaints are taints that the nodes associated with this ResourceFlavor
+                  have.
+                  Workloads' podsets must have tolerations for these nodeTaints in order to
+                  get assigned this ResourceFlavor during admission.
+
+
+                  An example of a nodeTaint is
+                  cloud.provider.com/preemptible="true":NoSchedule
+
+
+                  nodeTaints can be up to 8 elements.
+                items:
+                  description: |-
+                    The node this Taint is attached to has the "effect" on
+                    any pod that does not tolerate the Taint.
+                  properties:
+                    effect:
+                      description: |-
+                        Required. The effect of the taint on pods
+                        that do not tolerate the taint.
+                        Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Required. The taint key to be applied to a node.
+                      type: string
+                    timeAdded:
+                      description: |-
+                        TimeAdded represents the time at which the taint was added.
+                        It is only written for NoExecute taints.
+                      format: date-time
+                      type: string
+                    value:
+                      description: The taint value corresponding to the taint key.
+                      type: string
+                  required:
+                  - effect
+                  - key
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: self.all(x, x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
+              tolerations:
+                description: |-
+                  tolerations are extra tolerations that will be added to the pods admitted in
+                  the quota associated with this resource flavor.
+
+
+                  An example of a toleration is
+                  cloud.provider.com/preemptible="true":NoSchedule
+
+
+                  tolerations can be up to 8 elements.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-type: atomic
+                x-kubernetes-validations:
+                - message: operator must be Exists when 'key' is empty, which means
+                    'match all values and all keys'
+                  rule: 'self.all(x, !has(x.key) ? x.operator == ''Exists'' : true)'
+                - message: effect must be 'NoExecute' when 'tolerationSeconds' is
+                    set
+                  rule: 'self.all(x, has(x.tolerationSeconds) ? x.effect == ''NoExecute''
+                    : true)'
+                - message: 'supported toleration values: ''Equal''(default), ''Exists'''
+                  rule: self.all(x, !has(x.operator) || x.operator in ['Equal', 'Exists'])
+                - message: a value must be empty when 'operator' is 'Exists'
+                  rule: 'self.all(x, has(x.operator) && x.operator == ''Exists'' ?
+                    !has(x.value) : true)'
+                - message: 'supported taint effect values: ''NoSchedule'', ''PreferNoSchedule'',
+                    ''NoExecute'''
+                  rule: self.all(x, !has(x.effect) || x.effect in ['NoSchedule', 'PreferNoSchedule',
+                    'NoExecute'])
+            type: object
+        type: object
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: workloadpriorityclasses.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: WorkloadPriorityClass
+    listKind: WorkloadPriorityClassList
+    plural: workloadpriorityclasses
+    singular: workloadpriorityclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: Value of workloadPriorityClass's Priority
+      jsonPath: .value
+      name: Value
+      type: integer
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: WorkloadPriorityClass is the Schema for the workloadPriorityClass
+          API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          description:
+            description: |-
+              description is an arbitrary string that usually provides guidelines on
+              when this workloadPriorityClass should be used.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          value:
+            description: |-
+              value represents the integer value of this workloadPriorityClass. This is the actual priority that workloads
+              receive when jobs have the name of this class in their workloadPriorityClass label.
+              Changing the value of workloadPriorityClass doesn't affect the priority of workloads that were already created.
+            format: int32
+            type: integer
+        required:
+        - value
+        type: object
+    served: true
+    storage: true
+    subresources: {}
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    controller-gen.kubebuilder.io/version: v0.15.0
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: workloads.kueue.x-k8s.io
+spec:
+  group: kueue.x-k8s.io
+  names:
+    kind: Workload
+    listKind: WorkloadList
+    plural: workloads
+    shortNames:
+    - wl
+    singular: workload
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: Name of the queue this workload was submitted to
+      jsonPath: .spec.queueName
+      name: Queue
+      type: string
+    - description: Name of the ClusterQueue where the workload is reserving quota
+      jsonPath: .status.admission.clusterQueue
+      name: Reserved in
+      type: string
+    - description: Admission status
+      jsonPath: .status.conditions[?(@.type=='Admitted')].status
+      name: Admitted
+      type: string
+    - description: Workload finished
+      jsonPath: .status.conditions[?(@.type=='Finished')].status
+      name: Finished
+      type: string
+    - description: Time this workload was created
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Workload is the Schema for the workloads API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: WorkloadSpec defines the desired state of Workload
+            properties:
+              active:
+                default: true
+                description: |-
+                  Active determines if a workload can be admitted into a queue.
+                  Changing active from true to false will evict any running workloads.
+                  Possible values are:
+
+
+                    - false: indicates that a workload should never be admitted and evicts running workloads
+                    - true: indicates that a workload can be evaluated for admission into it's respective queue.
+
+
+                  Defaults to true
+                type: boolean
+              podSets:
+                description: |-
+                  podSets is a list of sets of homogeneous pods, each described by a Pod spec
+                  and a count.
+                  There must be at least one element and at most 8.
+                  podSets cannot be changed.
+                items:
+                  properties:
+                    count:
+                      default: 1
+                      description: count is the number of pods for the spec.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    minCount:
+                      description: |-
+                        minCount is the minimum number of pods for the spec acceptable
+                        if the workload supports partial admission.
+
+
+                        If not provided, partial admission for the current PodSet is not
+                        enabled.
+
+
+                        Only one podSet within the workload can use this.
+
+
+                        This is an alpha field and requires enabling PartialAdmission feature gate.
+                      format: int32
+                      minimum: 1
+                      type: integer
+                    name:
+                      default: main
+                      description: name is the PodSet name.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                      type: string
+                    template:
+                      description: |-
+                        template is the Pod template.
+
+
+                        The only allowed fields in template.metadata are labels and annotations.
+
+
+                        If requests are omitted for a container or initContainer,
+                        they default to the limits if they are explicitly specified for the
+                        container or initContainer.
+
+
+                        During admission, the rules in nodeSelector and
+                        nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution that match
+                        the keys in the nodeLabels from the ResourceFlavors considered for this
+                        Workload are used to filter the ResourceFlavors that can be assigned to
+                        this podSet.
+                      properties:
+                        metadata:
+                          description: |-
+                            Standard object's metadata.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            finalizers:
+                              items:
+                                type: string
+                              type: array
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                            namespace:
+                              type: string
+                          type: object
+                        spec:
+                          description: |-
+                            Specification of the desired behavior of the pod.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+                          properties:
+                            activeDeadlineSeconds:
+                              description: |-
+                                Optional duration in seconds the pod may be active on the node relative to
+                                StartTime before the system will actively try to mark it failed and kill associated containers.
+                                Value must be a positive integer.
+                              format: int64
+                              type: integer
+                            affinity:
+                              description: If specified, the pod's scheduling constraints
+                              properties:
+                                nodeAffinity:
+                                  description: Describes node affinity scheduling
+                                    rules for the pod.
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: |-
+                                          An empty preferred scheduling term matches all objects with implicit weight 0
+                                          (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                        properties:
+                                          preference:
+                                            description: A node selector term, associated
+                                              with the corresponding weight.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          weight:
+                                            description: Weight associated with matching
+                                              the corresponding nodeSelectorTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - preference
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to an update), the system
+                                        may or may not try to eventually evict the pod from its node.
+                                      properties:
+                                        nodeSelectorTerms:
+                                          description: Required. A list of node selector
+                                            terms. The terms are ORed.
+                                          items:
+                                            description: |-
+                                              A null or empty node selector term matches no objects. The requirements of
+                                              them are ANDed.
+                                              The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                            properties:
+                                              matchExpressions:
+                                                description: A list of node selector
+                                                  requirements by node's labels.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchFields:
+                                                description: A list of node selector
+                                                  requirements by node's fields.
+                                                items:
+                                                  description: |-
+                                                    A node selector requirement is a selector that contains values, a key, and an operator
+                                                    that relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: The label key that
+                                                        the selector applies to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        Represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        An array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. If the operator is Gt or Lt, the values
+                                                        array must have a single element, which will be interpreted as an integer.
+                                                        This array is replaced during a strategic merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                      required:
+                                      - nodeSelectorTerms
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                podAffinity:
+                                  description: Describes pod affinity scheduling rules
+                                    (e.g. co-locate this pod in the same node, zone,
+                                    etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                                podAntiAffinity:
+                                  description: Describes pod anti-affinity scheduling
+                                    rules (e.g. avoid putting this pod in the same
+                                    node, zone, etc. as some other pod(s)).
+                                  properties:
+                                    preferredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        The scheduler will prefer to schedule pods to nodes that satisfy
+                                        the anti-affinity expressions specified by this field, but it may choose
+                                        a node that violates one or more of the expressions. The node that is
+                                        most preferred is the one with the greatest sum of weights, i.e.
+                                        for each node that meets all of the scheduling requirements (resource
+                                        request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                        compute a sum by iterating through the elements of this field and adding
+                                        "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                        node(s) with the highest sum are the most preferred.
+                                      items:
+                                        description: The weights of all of the matched
+                                          WeightedPodAffinityTerm fields are added
+                                          per-node to find the most preferred node(s)
+                                        properties:
+                                          podAffinityTerm:
+                                            description: Required. A pod affinity
+                                              term, associated with the corresponding
+                                              weight.
+                                            properties:
+                                              labelSelector:
+                                                description: |-
+                                                  A label query over a set of resources, in this case pods.
+                                                  If it's null, this PodAffinityTerm matches with no Pods.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              matchLabelKeys:
+                                                description: |-
+                                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                                  Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              mismatchLabelKeys:
+                                                description: |-
+                                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                                  be taken into consideration. The keys are used to lookup values from the
+                                                  incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                                  to select the group of existing pods which pods will be taken into consideration
+                                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                                  pod labels will be ignored. The default value is empty.
+                                                  The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                                  Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              namespaceSelector:
+                                                description: |-
+                                                  A label query over the set of namespaces that the term applies to.
+                                                  The term is applied to the union of the namespaces selected by this field
+                                                  and the ones listed in the namespaces field.
+                                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                                  An empty selector ({}) matches all namespaces.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              namespaces:
+                                                description: |-
+                                                  namespaces specifies a static list of namespace names that the term applies to.
+                                                  The term is applied to the union of the namespaces listed in this field
+                                                  and the ones selected by namespaceSelector.
+                                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              topologyKey:
+                                                description: |-
+                                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                                  selected pods is running.
+                                                  Empty topologyKey is not allowed.
+                                                type: string
+                                            required:
+                                            - topologyKey
+                                            type: object
+                                          weight:
+                                            description: |-
+                                              weight associated with matching the corresponding podAffinityTerm,
+                                              in the range 1-100.
+                                            format: int32
+                                            type: integer
+                                        required:
+                                        - podAffinityTerm
+                                        - weight
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    requiredDuringSchedulingIgnoredDuringExecution:
+                                      description: |-
+                                        If the anti-affinity requirements specified by this field are not met at
+                                        scheduling time, the pod will not be scheduled onto the node.
+                                        If the anti-affinity requirements specified by this field cease to be met
+                                        at some point during pod execution (e.g. due to a pod label update), the
+                                        system may or may not try to eventually evict the pod from its node.
+                                        When there are multiple elements, the lists of nodes corresponding to each
+                                        podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                      items:
+                                        description: |-
+                                          Defines a set of pods (namely those matching the labelSelector
+                                          relative to the given namespace(s)) that this pod should be
+                                          co-located (affinity) or not co-located (anti-affinity) with,
+                                          where co-located is defined as running on a node whose value of
+                                          the label with key <topologyKey> matches that of any node on which
+                                          a pod of the set of pods is running
+                                        properties:
+                                          labelSelector:
+                                            description: |-
+                                              A label query over a set of resources, in this case pods.
+                                              If it's null, this PodAffinityTerm matches with no Pods.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          matchLabelKeys:
+                                            description: |-
+                                              MatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                              Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          mismatchLabelKeys:
+                                            description: |-
+                                              MismatchLabelKeys is a set of pod label keys to select which pods will
+                                              be taken into consideration. The keys are used to lookup values from the
+                                              incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                              to select the group of existing pods which pods will be taken into consideration
+                                              for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                              pod labels will be ignored. The default value is empty.
+                                              The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                              Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                              This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          namespaceSelector:
+                                            description: |-
+                                              A label query over the set of namespaces that the term applies to.
+                                              The term is applied to the union of the namespaces selected by this field
+                                              and the ones listed in the namespaces field.
+                                              null selector and null or empty namespaces list means "this pod's namespace".
+                                              An empty selector ({}) matches all namespaces.
+                                            properties:
+                                              matchExpressions:
+                                                description: matchExpressions is a
+                                                  list of label selector requirements.
+                                                  The requirements are ANDed.
+                                                items:
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
+                                                  properties:
+                                                    key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
+                                                      type: string
+                                                    operator:
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                      type: string
+                                                    values:
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
+                                                        merge patch.
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                type: object
+                                            type: object
+                                            x-kubernetes-map-type: atomic
+                                          namespaces:
+                                            description: |-
+                                              namespaces specifies a static list of namespace names that the term applies to.
+                                              The term is applied to the union of the namespaces listed in this field
+                                              and the ones selected by namespaceSelector.
+                                              null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          topologyKey:
+                                            description: |-
+                                              This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                              the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                              whose value of the label with key topologyKey matches that of any node on which any of the
+                                              selected pods is running.
+                                              Empty topologyKey is not allowed.
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  type: object
+                              type: object
+                            automountServiceAccountToken:
+                              description: AutomountServiceAccountToken indicates
+                                whether a service account token should be automatically
+                                mounted.
+                              type: boolean
+                            containers:
+                              description: |-
+                                List of containers belonging to the pod.
+                                Containers cannot currently be added or removed.
+                                There must be at least one container in a Pod.
+                                Cannot be updated.
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  command:
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  env:
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  image:
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                    type: string
+                                  lifecycle:
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                                          container will eventually terminate within the Pod's termination grace
+                                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                          or until the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: |-
+                                      Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
+                                          type: string
+                                        restartPolicy:
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
+                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      this init container will be continually restarted on
+                                      exit until all regular containers have terminated. Once all regular
+                                      containers have completed, all init containers with restartPolicy "Always"
+                                      will be shut down. This lifecycle differs from normal init containers and
+                                      is often referred to as a "sidecar" container. Although this init
+                                      container still starts in the init container sequence, it does not wait
+                                      for the container to complete before proceeding to the next init
+                                      container. Instead, the next init container starts immediately after this
+                                      init container is started, or after any startupProbe has successfully
+                                      completed.
+                                    type: string
+                                  securityContext:
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      appArmorProfile:
+                                        description: |-
+                                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                          overrides the pod's appArmorProfile.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile loaded on the node that should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must match the loaded name of the profile.
+                                              Must be set if and only if type is "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of AppArmor profile will be applied.
+                                              Valid options are:
+                                                Localhost - a profile pre-loaded on the node.
+                                                RuntimeDefault - the container runtime's default profile.
+                                                Unconfined - no AppArmor enforcement.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      capabilities:
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                      This cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                      at which time stdin is closed and remains closed until the container is restarted. If this
+                                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                                      Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
+                                      Cannot be updated.
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
+                                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                      Defaults to File.
+                                      Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
+                                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                            (which defaults to None).
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          description: |-
+                                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                                            recursively.
+
+
+                                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                                            recursively read-only, if it is supported by the container runtime.  If this
+                                            field is set to Enabled, the mount is made recursively read-only if it is
+                                            supported by the container runtime, otherwise the pod will not be started and
+                                            an error will be generated to indicate the reason.
+
+
+                                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                            None (or be unspecified, which defaults to None).
+
+
+                                            If this field is not specified, it is treated as an equivalent of Disabled.
+                                          type: string
+                                        subPath:
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            dnsConfig:
+                              description: |-
+                                Specifies the DNS parameters of a pod.
+                                Parameters specified here will be merged to the generated DNS
+                                configuration based on DNSPolicy.
+                              properties:
+                                nameservers:
+                                  description: |-
+                                    A list of DNS name server IP addresses.
+                                    This will be appended to the base nameservers generated from DNSPolicy.
+                                    Duplicated nameservers will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                options:
+                                  description: |-
+                                    A list of DNS resolver options.
+                                    This will be merged with the base options generated from DNSPolicy.
+                                    Duplicated entries will be removed. Resolution options given in Options
+                                    will override those that appear in the base DNSPolicy.
+                                  items:
+                                    description: PodDNSConfigOption defines DNS resolver
+                                      options of a pod.
+                                    properties:
+                                      name:
+                                        description: Required.
+                                        type: string
+                                      value:
+                                        type: string
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                searches:
+                                  description: |-
+                                    A list of DNS search domains for host-name lookup.
+                                    This will be appended to the base search paths generated from DNSPolicy.
+                                    Duplicated search paths will be removed.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                            dnsPolicy:
+                              description: |-
+                                Set DNS policy for the pod.
+                                Defaults to "ClusterFirst".
+                                Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'.
+                                DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                To have DNS options set along with hostNetwork, you have to specify DNS policy
+                                explicitly to 'ClusterFirstWithHostNet'.
+                              type: string
+                            enableServiceLinks:
+                              description: |-
+                                EnableServiceLinks indicates whether information about services should be injected into pod's
+                                environment variables, matching the syntax of Docker links.
+                                Optional: Defaults to true.
+                              type: boolean
+                            ephemeralContainers:
+                              description: |-
+                                List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing
+                                pod to perform user-initiated actions such as debugging. This list cannot be specified when
+                                creating a pod, and it cannot be modified by updating the pod spec. In order to add an
+                                ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.
+                              items:
+                                description: |-
+                                  An EphemeralContainer is a temporary container that you may add to an existing Pod for
+                                  user-initiated activities such as debugging. Ephemeral containers have no resource or
+                                  scheduling guarantees, and they will not be restarted when they exit or when a Pod is
+                                  removed or restarted. The kubelet may evict a Pod if an ephemeral container causes the
+                                  Pod to exceed its resource allocation.
+
+
+                                  To add an ephemeral container, use the ephemeralcontainers subresource of an existing
+                                  Pod. Ephemeral containers may not be removed or restarted.
+                                properties:
+                                  args:
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  command:
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  env:
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  image:
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                    type: string
+                                  lifecycle:
+                                    description: Lifecycle is not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      postStart:
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                                          container will eventually terminate within the Pod's termination grace
+                                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                          or until the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name of the ephemeral container specified as a DNS_LABEL.
+                                      This name must be unique among all containers, init containers and ephemeral containers.
+                                    type: string
+                                  ports:
+                                    description: Ports are not allowed for ephemeral
+                                      containers.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
+                                          type: string
+                                        restartPolicy:
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: |-
+                                      Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources
+                                      already allocated to the pod.
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    description: |-
+                                      Restart policy for the container to manage the restart behavior of each
+                                      container within a pod.
+                                      This may only be set for init containers. You cannot set this field on
+                                      ephemeral containers.
+                                    type: string
+                                  securityContext:
+                                    description: |-
+                                      Optional: SecurityContext defines the security options the ephemeral container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      appArmorProfile:
+                                        description: |-
+                                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                          overrides the pod's appArmorProfile.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile loaded on the node that should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must match the loaded name of the profile.
+                                              Must be set if and only if type is "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of AppArmor profile will be applied.
+                                              Valid options are:
+                                                Localhost - a profile pre-loaded on the node.
+                                                RuntimeDefault - the container runtime's default profile.
+                                                Unconfined - no AppArmor enforcement.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      capabilities:
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: Probes are not allowed for ephemeral
+                                      containers.
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                      at which time stdin is closed and remains closed until the container is restarted. If this
+                                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                                      Default is false
+                                    type: boolean
+                                  targetContainerName:
+                                    description: |-
+                                      If set, the name of the container from PodSpec that this ephemeral container targets.
+                                      The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container.
+                                      If not set then the ephemeral container uses the namespaces configured in the Pod spec.
+
+
+                                      The container runtime must implement support for this feature. If the runtime does not
+                                      support namespace targeting then the result of setting this field is undefined.
+                                    type: string
+                                  terminationMessagePath:
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
+                                      Cannot be updated.
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
+                                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                      Defaults to File.
+                                      Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers.
+                                      Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
+                                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                            (which defaults to None).
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          description: |-
+                                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                                            recursively.
+
+
+                                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                                            recursively read-only, if it is supported by the container runtime.  If this
+                                            field is set to Enabled, the mount is made recursively read-only if it is
+                                            supported by the container runtime, otherwise the pod will not be started and
+                                            an error will be generated to indicate the reason.
+
+
+                                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                            None (or be unspecified, which defaults to None).
+
+
+                                            If this field is not specified, it is treated as an equivalent of Disabled.
+                                          type: string
+                                        subPath:
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            hostAliases:
+                              description: |-
+                                HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts
+                                file if specified.
+                              items:
+                                description: |-
+                                  HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the
+                                  pod's hosts file.
+                                properties:
+                                  hostnames:
+                                    description: Hostnames for the above IP address.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  ip:
+                                    description: IP address of the host file entry.
+                                    type: string
+                                required:
+                                - ip
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - ip
+                              x-kubernetes-list-type: map
+                            hostIPC:
+                              description: |-
+                                Use the host's ipc namespace.
+                                Optional: Default to false.
+                              type: boolean
+                            hostNetwork:
+                              description: |-
+                                Host networking requested for this pod. Use the host's network namespace.
+                                If this option is set, the ports that will be used must be specified.
+                                Default to false.
+                              type: boolean
+                            hostPID:
+                              description: |-
+                                Use the host's pid namespace.
+                                Optional: Default to false.
+                              type: boolean
+                            hostUsers:
+                              description: |-
+                                Use the host's user namespace.
+                                Optional: Default to true.
+                                If set to true or not present, the pod will be run in the host user namespace, useful
+                                for when the pod needs a feature only available to the host user namespace, such as
+                                loading a kernel module with CAP_SYS_MODULE.
+                                When set to false, a new userns is created for the pod. Setting false is useful for
+                                mitigating container breakout vulnerabilities even allowing users to run their
+                                containers as root without actually having root privileges on the host.
+                                This field is alpha-level and is only honored by servers that enable the UserNamespacesSupport feature.
+                              type: boolean
+                            hostname:
+                              description: |-
+                                Specifies the hostname of the Pod
+                                If not specified, the pod's hostname will be set to a system-defined value.
+                              type: string
+                            imagePullSecrets:
+                              description: |-
+                                ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec.
+                                If specified, these secrets will be passed to individual puller implementations for them to use.
+                                More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod
+                              items:
+                                description: |-
+                                  LocalObjectReference contains enough information to let you locate the
+                                  referenced object inside the same namespace.
+                                properties:
+                                  name:
+                                    default: ""
+                                    description: |-
+                                      Name of the referent.
+                                      This field is effectively required, but due to backwards compatibility is
+                                      allowed to be empty. Instances of this type with an empty value here are
+                                      almost certainly wrong.
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            initContainers:
+                              description: |-
+                                List of initialization containers belonging to the pod.
+                                Init containers are executed in order prior to containers being started. If any
+                                init container fails, the pod is considered to have failed and is handled according
+                                to its restartPolicy. The name for an init container or normal container must be
+                                unique among all containers.
+                                Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
+                                The resourceRequirements of an init container are taken into account during scheduling
+                                by finding the highest request/limit for each resource type, and then using the max of
+                                of that value or the sum of the normal containers. Limits are applied to init containers
+                                in a similar fashion.
+                                Init containers cannot currently be added or removed.
+                                Cannot be updated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+                              items:
+                                description: A single application container that you
+                                  want to run within a pod.
+                                properties:
+                                  args:
+                                    description: |-
+                                      Arguments to the entrypoint.
+                                      The container image's CMD is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  command:
+                                    description: |-
+                                      Entrypoint array. Not executed within a shell.
+                                      The container image's ENTRYPOINT is used if this is not provided.
+                                      Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                                      cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                                      to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                                      produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                                      of whether the variable exists or not. Cannot be updated.
+                                      More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  env:
+                                    description: |-
+                                      List of environment variables to set in the container.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvVar represents an environment
+                                        variable present in a Container.
+                                      properties:
+                                        name:
+                                          description: Name of the environment variable.
+                                            Must be a C_IDENTIFIER.
+                                          type: string
+                                        value:
+                                          description: |-
+                                            Variable references $(VAR_NAME) are expanded
+                                            using the previously defined environment variables in the container and
+                                            any service environment variables. If a variable cannot be resolved,
+                                            the reference in the input string will be unchanged. Double $$ are reduced
+                                            to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                            "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                            Escaped references will never be expanded, regardless of whether the variable
+                                            exists or not.
+                                            Defaults to "".
+                                          type: string
+                                        valueFrom:
+                                          description: Source for the environment
+                                            variable's value. Cannot be used if value
+                                            is not empty.
+                                          properties:
+                                            configMapKeyRef:
+                                              description: Selects a key of a ConfigMap.
+                                              properties:
+                                                key:
+                                                  description: The key to select.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    ConfigMap or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            fieldRef:
+                                              description: |-
+                                                Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                                spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            secretKeyRef:
+                                              description: Selects a key of a secret
+                                                in the pod's namespace
+                                              properties:
+                                                key:
+                                                  description: The key of the secret
+                                                    to select from.  Must be a valid
+                                                    secret key.
+                                                  type: string
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: Specify whether the
+                                                    Secret or its key must be defined
+                                                  type: boolean
+                                              required:
+                                              - key
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          type: object
+                                      required:
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - name
+                                    x-kubernetes-list-type: map
+                                  envFrom:
+                                    description: |-
+                                      List of sources to populate environment variables in the container.
+                                      The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                                      will be reported as an event when the container is starting. When a key exists in multiple
+                                      sources, the value associated with the last source will take precedence.
+                                      Values defined by an Env with a duplicate key will take precedence.
+                                      Cannot be updated.
+                                    items:
+                                      description: EnvFromSource represents the source
+                                        of a set of ConfigMaps
+                                      properties:
+                                        configMapRef:
+                                          description: The ConfigMap to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the ConfigMap
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        prefix:
+                                          description: An optional identifier to prepend
+                                            to each key in the ConfigMap. Must be
+                                            a C_IDENTIFIER.
+                                          type: string
+                                        secretRef:
+                                          description: The Secret to select from
+                                          properties:
+                                            name:
+                                              default: ""
+                                              description: |-
+                                                Name of the referent.
+                                                This field is effectively required, but due to backwards compatibility is
+                                                allowed to be empty. Instances of this type with an empty value here are
+                                                almost certainly wrong.
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
+                                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                              type: string
+                                            optional:
+                                              description: Specify whether the Secret
+                                                must be defined
+                                              type: boolean
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  image:
+                                    description: |-
+                                      Container image name.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images
+                                      This field is optional to allow higher level config management to default or override
+                                      container images in workload controllers like Deployments and StatefulSets.
+                                    type: string
+                                  imagePullPolicy:
+                                    description: |-
+                                      Image pull policy.
+                                      One of Always, Never, IfNotPresent.
+                                      Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                                    type: string
+                                  lifecycle:
+                                    description: |-
+                                      Actions that the management system should take in response to container lifecycle events.
+                                      Cannot be updated.
+                                    properties:
+                                      postStart:
+                                        description: |-
+                                          PostStart is called immediately after a container is created. If the handler fails,
+                                          the container is terminated and restarted according to its restart policy.
+                                          Other management of the container blocks until the hook completes.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                      preStop:
+                                        description: |-
+                                          PreStop is called immediately before a container is terminated due to an
+                                          API request or management event such as liveness/startup probe failure,
+                                          preemption, resource contention, etc. The handler is not called if the
+                                          container crashes or exits. The Pod's termination grace period countdown begins before the
+                                          PreStop hook is executed. Regardless of the outcome of the handler, the
+                                          container will eventually terminate within the Pod's termination grace
+                                          period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                                          or until the termination grace period is reached.
+                                          More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
+                                        properties:
+                                          exec:
+                                            description: Exec specifies the action
+                                              to take.
+                                            properties:
+                                              command:
+                                                description: |-
+                                                  Command is the command line to execute inside the container, the working directory for the
+                                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                                  a shell, you need to explicitly call out to that shell.
+                                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            type: object
+                                          httpGet:
+                                            description: HTTPGet specifies the http
+                                              request to perform.
+                                            properties:
+                                              host:
+                                                description: |-
+                                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                                  "Host" in httpHeaders instead.
+                                                type: string
+                                              httpHeaders:
+                                                description: Custom headers to set
+                                                  in the request. HTTP allows repeated
+                                                  headers.
+                                                items:
+                                                  description: HTTPHeader describes
+                                                    a custom header to be used in
+                                                    HTTP probes
+                                                  properties:
+                                                    name:
+                                                      description: |-
+                                                        The header field name.
+                                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                      type: string
+                                                    value:
+                                                      description: The header field
+                                                        value
+                                                      type: string
+                                                  required:
+                                                  - name
+                                                  - value
+                                                  type: object
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              path:
+                                                description: Path to access on the
+                                                  HTTP server.
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Name or number of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                              scheme:
+                                                description: |-
+                                                  Scheme to use for connecting to the host.
+                                                  Defaults to HTTP.
+                                                type: string
+                                            required:
+                                            - port
+                                            type: object
+                                          sleep:
+                                            description: Sleep represents the duration
+                                              that the container should sleep before
+                                              being terminated.
+                                            properties:
+                                              seconds:
+                                                description: Seconds is the number
+                                                  of seconds to sleep.
+                                                format: int64
+                                                type: integer
+                                            required:
+                                            - seconds
+                                            type: object
+                                          tcpSocket:
+                                            description: |-
+                                              Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                              for the backward compatibility. There are no validation of this field and
+                                              lifecycle hooks will fail in runtime when tcp handler is specified.
+                                            properties:
+                                              host:
+                                                description: 'Optional: Host name
+                                                  to connect to, defaults to the pod
+                                                  IP.'
+                                                type: string
+                                              port:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                description: |-
+                                                  Number or name of the port to access on the container.
+                                                  Number must be in the range 1 to 65535.
+                                                  Name must be an IANA_SVC_NAME.
+                                                x-kubernetes-int-or-string: true
+                                            required:
+                                            - port
+                                            type: object
+                                        type: object
+                                    type: object
+                                  livenessProbe:
+                                    description: |-
+                                      Periodic probe of container liveness.
+                                      Container will be restarted if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  name:
+                                    description: |-
+                                      Name of the container specified as a DNS_LABEL.
+                                      Each container in a pod must have a unique name (DNS_LABEL).
+                                      Cannot be updated.
+                                    type: string
+                                  ports:
+                                    description: |-
+                                      List of ports to expose from the container. Not specifying a port here
+                                      DOES NOT prevent that port from being exposed. Any port which is
+                                      listening on the default "0.0.0.0" address inside a container will be
+                                      accessible from the network.
+                                      Modifying this array with strategic merge patch may corrupt the data.
+                                      For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                                      Cannot be updated.
+                                    items:
+                                      description: ContainerPort represents a network
+                                        port in a single container.
+                                      properties:
+                                        containerPort:
+                                          description: |-
+                                            Number of port to expose on the pod's IP address.
+                                            This must be a valid port number, 0 < x < 65536.
+                                          format: int32
+                                          type: integer
+                                        hostIP:
+                                          description: What host IP to bind the external
+                                            port to.
+                                          type: string
+                                        hostPort:
+                                          description: |-
+                                            Number of port to expose on the host.
+                                            If specified, this must be a valid port number, 0 < x < 65536.
+                                            If HostNetwork is specified, this must match ContainerPort.
+                                            Most containers do not need this.
+                                          format: int32
+                                          type: integer
+                                        name:
+                                          description: |-
+                                            If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                            named port in a pod must have a unique name. Name for the port that can be
+                                            referred to by services.
+                                          type: string
+                                        protocol:
+                                          default: TCP
+                                          description: |-
+                                            Protocol for port. Must be UDP, TCP, or SCTP.
+                                            Defaults to "TCP".
+                                          type: string
+                                      required:
+                                      - containerPort
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - containerPort
+                                    - protocol
+                                    x-kubernetes-list-type: map
+                                  readinessProbe:
+                                    description: |-
+                                      Periodic probe of container service readiness.
+                                      Container will be removed from service endpoints if the probe fails.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  resizePolicy:
+                                    description: Resources resize policy for the container.
+                                    items:
+                                      description: ContainerResizePolicy represents
+                                        resource resize policy for the container.
+                                      properties:
+                                        resourceName:
+                                          description: |-
+                                            Name of the resource to which this resource resize policy applies.
+                                            Supported values: cpu, memory.
+                                          type: string
+                                        restartPolicy:
+                                          description: |-
+                                            Restart policy to apply when specified resource is resized.
+                                            If not specified, it defaults to NotRequired.
+                                          type: string
+                                      required:
+                                      - resourceName
+                                      - restartPolicy
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  resources:
+                                    description: |-
+                                      Compute Resources required by this container.
+                                      Cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims,
+                                          that are used by this container.
+
+
+                                          This is an alpha field and requires enabling the
+                                          DynamicResourceAllocation feature gate.
+
+
+                                          This field is immutable. It can only be set for containers.
+                                        items:
+                                          description: ResourceClaim references one
+                                            entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: |-
+                                                Name must match the name of one entry in pod.spec.resourceClaims of
+                                                the Pod where this field is used. It makes that resource available
+                                                inside a container.
+                                              type: string
+                                          required:
+                                          - name
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-map-keys:
+                                        - name
+                                        x-kubernetes-list-type: map
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                        type: object
+                                    type: object
+                                  restartPolicy:
+                                    description: |-
+                                      RestartPolicy defines the restart behavior of individual containers in a pod.
+                                      This field may only be set for init containers, and the only allowed value is "Always".
+                                      For non-init containers or when this field is not specified,
+                                      the restart behavior is defined by the Pod's restart policy and the container type.
+                                      Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                                      this init container will be continually restarted on
+                                      exit until all regular containers have terminated. Once all regular
+                                      containers have completed, all init containers with restartPolicy "Always"
+                                      will be shut down. This lifecycle differs from normal init containers and
+                                      is often referred to as a "sidecar" container. Although this init
+                                      container still starts in the init container sequence, it does not wait
+                                      for the container to complete before proceeding to the next init
+                                      container. Instead, the next init container starts immediately after this
+                                      init container is started, or after any startupProbe has successfully
+                                      completed.
+                                    type: string
+                                  securityContext:
+                                    description: |-
+                                      SecurityContext defines the security options the container should be run with.
+                                      If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+                                    properties:
+                                      allowPrivilegeEscalation:
+                                        description: |-
+                                          AllowPrivilegeEscalation controls whether a process can gain more
+                                          privileges than its parent process. This bool directly controls if
+                                          the no_new_privs flag will be set on the container process.
+                                          AllowPrivilegeEscalation is true always when the container is:
+                                          1) run as Privileged
+                                          2) has CAP_SYS_ADMIN
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      appArmorProfile:
+                                        description: |-
+                                          appArmorProfile is the AppArmor options to use by this container. If set, this profile
+                                          overrides the pod's appArmorProfile.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile loaded on the node that should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must match the loaded name of the profile.
+                                              Must be set if and only if type is "Localhost".
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of AppArmor profile will be applied.
+                                              Valid options are:
+                                                Localhost - a profile pre-loaded on the node.
+                                                RuntimeDefault - the container runtime's default profile.
+                                                Unconfined - no AppArmor enforcement.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      capabilities:
+                                        description: |-
+                                          The capabilities to add/drop when running containers.
+                                          Defaults to the default set of capabilities granted by the container runtime.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          add:
+                                            description: Added capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          drop:
+                                            description: Removed capabilities
+                                            items:
+                                              description: Capability represent POSIX
+                                                capabilities type
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      privileged:
+                                        description: |-
+                                          Run container in privileged mode.
+                                          Processes in privileged containers are essentially equivalent to root on the host.
+                                          Defaults to false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      procMount:
+                                        description: |-
+                                          procMount denotes the type of proc mount to use for the containers.
+                                          The default is DefaultProcMount which uses the container runtime defaults for
+                                          readonly paths and masked paths.
+                                          This requires the ProcMountType feature flag to be enabled.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: string
+                                      readOnlyRootFilesystem:
+                                        description: |-
+                                          Whether this container has a read-only root filesystem.
+                                          Default is false.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        type: boolean
+                                      runAsGroup:
+                                        description: |-
+                                          The GID to run the entrypoint of the container process.
+                                          Uses runtime default if unset.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      runAsNonRoot:
+                                        description: |-
+                                          Indicates that the container must run as a non-root user.
+                                          If true, the Kubelet will validate the image at runtime to ensure that it
+                                          does not run as UID 0 (root) and fail to start the container if it does.
+                                          If unset or false, no such validation will be performed.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                        type: boolean
+                                      runAsUser:
+                                        description: |-
+                                          The UID to run the entrypoint of the container process.
+                                          Defaults to user specified in image metadata if unspecified.
+                                          May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        format: int64
+                                        type: integer
+                                      seLinuxOptions:
+                                        description: |-
+                                          The SELinux context to be applied to the container.
+                                          If unspecified, the container runtime will allocate a random SELinux context for each
+                                          container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                                          PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          level:
+                                            description: Level is SELinux level label
+                                              that applies to the container.
+                                            type: string
+                                          role:
+                                            description: Role is a SELinux role label
+                                              that applies to the container.
+                                            type: string
+                                          type:
+                                            description: Type is a SELinux type label
+                                              that applies to the container.
+                                            type: string
+                                          user:
+                                            description: User is a SELinux user label
+                                              that applies to the container.
+                                            type: string
+                                        type: object
+                                      seccompProfile:
+                                        description: |-
+                                          The seccomp options to use by this container. If seccomp options are
+                                          provided at both the pod & container level, the container options
+                                          override the pod options.
+                                          Note that this field cannot be set when spec.os.name is windows.
+                                        properties:
+                                          localhostProfile:
+                                            description: |-
+                                              localhostProfile indicates a profile defined in a file on the node should be used.
+                                              The profile must be preconfigured on the node to work.
+                                              Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                              Must be set if type is "Localhost". Must NOT be set for any other type.
+                                            type: string
+                                          type:
+                                            description: |-
+                                              type indicates which kind of seccomp profile will be applied.
+                                              Valid options are:
+
+
+                                              Localhost - a profile defined in a file on the node should be used.
+                                              RuntimeDefault - the container runtime default profile should be used.
+                                              Unconfined - no profile should be applied.
+                                            type: string
+                                        required:
+                                        - type
+                                        type: object
+                                      windowsOptions:
+                                        description: |-
+                                          The Windows specific settings applied to all containers.
+                                          If unspecified, the options from the PodSecurityContext will be used.
+                                          If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                          Note that this field cannot be set when spec.os.name is linux.
+                                        properties:
+                                          gmsaCredentialSpec:
+                                            description: |-
+                                              GMSACredentialSpec is where the GMSA admission webhook
+                                              (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                              GMSA credential spec named by the GMSACredentialSpecName field.
+                                            type: string
+                                          gmsaCredentialSpecName:
+                                            description: GMSACredentialSpecName is
+                                              the name of the GMSA credential spec
+                                              to use.
+                                            type: string
+                                          hostProcess:
+                                            description: |-
+                                              HostProcess determines if a container should be run as a 'Host Process' container.
+                                              All of a Pod's containers must have the same effective HostProcess value
+                                              (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                              In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                            type: boolean
+                                          runAsUserName:
+                                            description: |-
+                                              The UserName in Windows to run the entrypoint of the container process.
+                                              Defaults to the user specified in image metadata if unspecified.
+                                              May also be set in PodSecurityContext. If set in both SecurityContext and
+                                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                            type: string
+                                        type: object
+                                    type: object
+                                  startupProbe:
+                                    description: |-
+                                      StartupProbe indicates that the Pod has successfully initialized.
+                                      If specified, no other probes are executed until this completes successfully.
+                                      If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                                      This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                                      when it might take a long time to load data or warm a cache, than during steady-state operation.
+                                      This cannot be updated.
+                                      More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                    properties:
+                                      exec:
+                                        description: Exec specifies the action to
+                                          take.
+                                        properties:
+                                          command:
+                                            description: |-
+                                              Command is the command line to execute inside the container, the working directory for the
+                                              command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                              not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                              a shell, you need to explicitly call out to that shell.
+                                              Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        type: object
+                                      failureThreshold:
+                                        description: |-
+                                          Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                                          Defaults to 3. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      grpc:
+                                        description: GRPC specifies an action involving
+                                          a GRPC port.
+                                        properties:
+                                          port:
+                                            description: Port number of the gRPC service.
+                                              Number must be in the range 1 to 65535.
+                                            format: int32
+                                            type: integer
+                                          service:
+                                            description: |-
+                                              Service is the name of the service to place in the gRPC HealthCheckRequest
+                                              (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+
+
+                                              If this is not specified, the default behavior is defined by gRPC.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      httpGet:
+                                        description: HTTPGet specifies the http request
+                                          to perform.
+                                        properties:
+                                          host:
+                                            description: |-
+                                              Host name to connect to, defaults to the pod IP. You probably want to set
+                                              "Host" in httpHeaders instead.
+                                            type: string
+                                          httpHeaders:
+                                            description: Custom headers to set in
+                                              the request. HTTP allows repeated headers.
+                                            items:
+                                              description: HTTPHeader describes a
+                                                custom header to be used in HTTP probes
+                                              properties:
+                                                name:
+                                                  description: |-
+                                                    The header field name.
+                                                    This will be canonicalized upon output, so case-variant names will be understood as the same header.
+                                                  type: string
+                                                value:
+                                                  description: The header field value
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          path:
+                                            description: Path to access on the HTTP
+                                              server.
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Name or number of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            description: |-
+                                              Scheme to use for connecting to the host.
+                                              Defaults to HTTP.
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      initialDelaySeconds:
+                                        description: |-
+                                          Number of seconds after the container has started before liveness probes are initiated.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                      periodSeconds:
+                                        description: |-
+                                          How often (in seconds) to perform the probe.
+                                          Default to 10 seconds. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      successThreshold:
+                                        description: |-
+                                          Minimum consecutive successes for the probe to be considered successful after having failed.
+                                          Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
+                                        format: int32
+                                        type: integer
+                                      tcpSocket:
+                                        description: TCPSocket specifies an action
+                                          involving a TCP port.
+                                        properties:
+                                          host:
+                                            description: 'Optional: Host name to connect
+                                              to, defaults to the pod IP.'
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: |-
+                                              Number or name of the port to access on the container.
+                                              Number must be in the range 1 to 65535.
+                                              Name must be an IANA_SVC_NAME.
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                      terminationGracePeriodSeconds:
+                                        description: |-
+                                          Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                                          The grace period is the duration in seconds after the processes running in the pod are sent
+                                          a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                          Set this value longer than the expected cleanup time for your process.
+                                          If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                                          value overrides the value provided by the pod spec.
+                                          Value must be non-negative integer. The value zero indicates stop immediately via
+                                          the kill signal (no opportunity to shut down).
+                                          This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                                          Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
+                                        format: int64
+                                        type: integer
+                                      timeoutSeconds:
+                                        description: |-
+                                          Number of seconds after which the probe times out.
+                                          Defaults to 1 second. Minimum value is 1.
+                                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
+                                        format: int32
+                                        type: integer
+                                    type: object
+                                  stdin:
+                                    description: |-
+                                      Whether this container should allocate a buffer for stdin in the container runtime. If this
+                                      is not set, reads from stdin in the container will always result in EOF.
+                                      Default is false.
+                                    type: boolean
+                                  stdinOnce:
+                                    description: |-
+                                      Whether the container runtime should close the stdin channel after it has been opened by
+                                      a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                                      sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                                      first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                                      at which time stdin is closed and remains closed until the container is restarted. If this
+                                      flag is false, a container processes that reads from stdin will never receive an EOF.
+                                      Default is false
+                                    type: boolean
+                                  terminationMessagePath:
+                                    description: |-
+                                      Optional: Path at which the file to which the container's termination message
+                                      will be written is mounted into the container's filesystem.
+                                      Message written is intended to be brief final status, such as an assertion failure message.
+                                      Will be truncated by the node if greater than 4096 bytes. The total message length across
+                                      all containers will be limited to 12kb.
+                                      Defaults to /dev/termination-log.
+                                      Cannot be updated.
+                                    type: string
+                                  terminationMessagePolicy:
+                                    description: |-
+                                      Indicate how the termination message should be populated. File will use the contents of
+                                      terminationMessagePath to populate the container status message on both success and failure.
+                                      FallbackToLogsOnError will use the last chunk of container log output if the termination
+                                      message file is empty and the container exited with an error.
+                                      The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                                      Defaults to File.
+                                      Cannot be updated.
+                                    type: string
+                                  tty:
+                                    description: |-
+                                      Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                                      Default is false.
+                                    type: boolean
+                                  volumeDevices:
+                                    description: volumeDevices is the list of block
+                                      devices to be used by the container.
+                                    items:
+                                      description: volumeDevice describes a mapping
+                                        of a raw block device within a container.
+                                      properties:
+                                        devicePath:
+                                          description: devicePath is the path inside
+                                            of the container that the device will
+                                            be mapped to.
+                                          type: string
+                                        name:
+                                          description: name must match the name of
+                                            a persistentVolumeClaim in the pod
+                                          type: string
+                                      required:
+                                      - devicePath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - devicePath
+                                    x-kubernetes-list-type: map
+                                  volumeMounts:
+                                    description: |-
+                                      Pod volumes to mount into the container's filesystem.
+                                      Cannot be updated.
+                                    items:
+                                      description: VolumeMount describes a mounting
+                                        of a Volume within a container.
+                                      properties:
+                                        mountPath:
+                                          description: |-
+                                            Path within the container at which the volume should be mounted.  Must
+                                            not contain ':'.
+                                          type: string
+                                        mountPropagation:
+                                          description: |-
+                                            mountPropagation determines how mounts are propagated from the host
+                                            to container and the other way around.
+                                            When not set, MountPropagationNone is used.
+                                            This field is beta in 1.10.
+                                            When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                            (which defaults to None).
+                                          type: string
+                                        name:
+                                          description: This must match the Name of
+                                            a Volume.
+                                          type: string
+                                        readOnly:
+                                          description: |-
+                                            Mounted read-only if true, read-write otherwise (false or unspecified).
+                                            Defaults to false.
+                                          type: boolean
+                                        recursiveReadOnly:
+                                          description: |-
+                                            RecursiveReadOnly specifies whether read-only mounts should be handled
+                                            recursively.
+
+
+                                            If ReadOnly is false, this field has no meaning and must be unspecified.
+
+
+                                            If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                            recursively read-only.  If this field is set to IfPossible, the mount is made
+                                            recursively read-only, if it is supported by the container runtime.  If this
+                                            field is set to Enabled, the mount is made recursively read-only if it is
+                                            supported by the container runtime, otherwise the pod will not be started and
+                                            an error will be generated to indicate the reason.
+
+
+                                            If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                            None (or be unspecified, which defaults to None).
+
+
+                                            If this field is not specified, it is treated as an equivalent of Disabled.
+                                          type: string
+                                        subPath:
+                                          description: |-
+                                            Path within the volume from which the container's volume should be mounted.
+                                            Defaults to "" (volume's root).
+                                          type: string
+                                        subPathExpr:
+                                          description: |-
+                                            Expanded path within the volume from which the container's volume should be mounted.
+                                            Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                            Defaults to "" (volume's root).
+                                            SubPathExpr and SubPath are mutually exclusive.
+                                          type: string
+                                      required:
+                                      - mountPath
+                                      - name
+                                      type: object
+                                    type: array
+                                    x-kubernetes-list-map-keys:
+                                    - mountPath
+                                    x-kubernetes-list-type: map
+                                  workingDir:
+                                    description: |-
+                                      Container's working directory.
+                                      If not specified, the container runtime's default will be used, which
+                                      might be configured in the container image.
+                                      Cannot be updated.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            nodeName:
+                              description: |-
+                                NodeName is a request to schedule this pod onto a specific node. If it is non-empty,
+                                the scheduler simply schedules this pod onto that node, assuming that it fits resource
+                                requirements.
+                              type: string
+                            nodeSelector:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                NodeSelector is a selector which must be true for the pod to fit on a node.
+                                Selector which must match a node's labels for the pod to be scheduled on that node.
+                                More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            os:
+                              description: |-
+                                Specifies the OS of the containers in the pod.
+                                Some pod and container fields are restricted if this is set.
+
+
+                                If the OS field is set to linux, the following fields must be unset:
+                                -securityContext.windowsOptions
+
+
+                                If the OS field is set to windows, following fields must be unset:
+                                - spec.hostPID
+                                - spec.hostIPC
+                                - spec.hostUsers
+                                - spec.securityContext.appArmorProfile
+                                - spec.securityContext.seLinuxOptions
+                                - spec.securityContext.seccompProfile
+                                - spec.securityContext.fsGroup
+                                - spec.securityContext.fsGroupChangePolicy
+                                - spec.securityContext.sysctls
+                                - spec.shareProcessNamespace
+                                - spec.securityContext.runAsUser
+                                - spec.securityContext.runAsGroup
+                                - spec.securityContext.supplementalGroups
+                                - spec.containers[*].securityContext.appArmorProfile
+                                - spec.containers[*].securityContext.seLinuxOptions
+                                - spec.containers[*].securityContext.seccompProfile
+                                - spec.containers[*].securityContext.capabilities
+                                - spec.containers[*].securityContext.readOnlyRootFilesystem
+                                - spec.containers[*].securityContext.privileged
+                                - spec.containers[*].securityContext.allowPrivilegeEscalation
+                                - spec.containers[*].securityContext.procMount
+                                - spec.containers[*].securityContext.runAsUser
+                                - spec.containers[*].securityContext.runAsGroup
+                              properties:
+                                name:
+                                  description: |-
+                                    Name is the name of the operating system. The currently supported values are linux and windows.
+                                    Additional value may be defined in future and can be one of:
+                                    https://github.com/opencontainers/runtime-spec/blob/master/config.md#platform-specific-configuration
+                                    Clients should expect to handle additional values and treat unrecognized values in this field as os: null
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            overhead:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: |-
+                                Overhead represents the resource overhead associated with running a pod for a given RuntimeClass.
+                                This field will be autopopulated at admission time by the RuntimeClass admission controller. If
+                                the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests.
+                                The RuntimeClass admission controller will reject Pod create requests which have the overhead already
+                                set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value
+                                defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/688-pod-overhead/README.md
+                              type: object
+                            preemptionPolicy:
+                              description: |-
+                                PreemptionPolicy is the Policy for preempting pods with lower priority.
+                                One of Never, PreemptLowerPriority.
+                                Defaults to PreemptLowerPriority if unset.
+                              type: string
+                            priority:
+                              description: |-
+                                The priority value. Various system components use this field to find the
+                                priority of the pod. When Priority Admission Controller is enabled, it
+                                prevents users from setting this field. The admission controller populates
+                                this field from PriorityClassName.
+                                The higher the value, the higher the priority.
+                              format: int32
+                              type: integer
+                            priorityClassName:
+                              description: |-
+                                If specified, indicates the pod's priority. "system-node-critical" and
+                                "system-cluster-critical" are two special keywords which indicate the
+                                highest priorities with the former being the highest priority. Any other
+                                name must be defined by creating a PriorityClass object with that name.
+                                If not specified, the pod priority will be default or zero if there is no
+                                default.
+                              type: string
+                            readinessGates:
+                              description: |-
+                                If specified, all readiness gates will be evaluated for pod readiness.
+                                A pod is ready when all its containers are ready AND
+                                all conditions specified in the readiness gates have status equal to "True"
+                                More info: https://git.k8s.io/enhancements/keps/sig-network/580-pod-readiness-gates
+                              items:
+                                description: PodReadinessGate contains the reference
+                                  to a pod condition
+                                properties:
+                                  conditionType:
+                                    description: ConditionType refers to a condition
+                                      in the pod's condition list with matching type.
+                                    type: string
+                                required:
+                                - conditionType
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            resourceClaims:
+                              description: |-
+                                ResourceClaims defines which ResourceClaims must be allocated
+                                and reserved before the Pod is allowed to start. The resources
+                                will be made available to those containers which consume them
+                                by name.
+
+
+                                This is an alpha field and requires enabling the
+                                DynamicResourceAllocation feature gate.
+
+
+                                This field is immutable.
+                              items:
+                                description: |-
+                                  PodResourceClaim references exactly one ResourceClaim through a ClaimSource.
+                                  It adds a name to it that uniquely identifies the ResourceClaim inside the Pod.
+                                  Containers that need access to the ResourceClaim reference it with this name.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name uniquely identifies this resource claim inside the pod.
+                                      This must be a DNS_LABEL.
+                                    type: string
+                                  source:
+                                    description: Source describes where to find the
+                                      ResourceClaim.
+                                    properties:
+                                      resourceClaimName:
+                                        description: |-
+                                          ResourceClaimName is the name of a ResourceClaim object in the same
+                                          namespace as this pod.
+                                        type: string
+                                      resourceClaimTemplateName:
+                                        description: |-
+                                          ResourceClaimTemplateName is the name of a ResourceClaimTemplate
+                                          object in the same namespace as this pod.
+
+
+                                          The template will be used to create a new ResourceClaim, which will
+                                          be bound to this pod. When this pod is deleted, the ResourceClaim
+                                          will also be deleted. The pod name and resource name, along with a
+                                          generated component, will be used to form a unique name for the
+                                          ResourceClaim, which will be recorded in pod.status.resourceClaimStatuses.
+
+
+                                          This field is immutable and no changes will be made to the
+                                          corresponding ResourceClaim by the control plane after creating the
+                                          ResourceClaim.
+                                        type: string
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            restartPolicy:
+                              description: |-
+                                Restart policy for all containers within the pod.
+                                One of Always, OnFailure, Never. In some contexts, only a subset of those values may be permitted.
+                                Default to Always.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
+                              type: string
+                            runtimeClassName:
+                              description: |-
+                                RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used
+                                to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run.
+                                If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an
+                                empty definition that uses the default runtime handler.
+                                More info: https://git.k8s.io/enhancements/keps/sig-node/585-runtime-class
+                              type: string
+                            schedulerName:
+                              description: |-
+                                If specified, the pod will be dispatched by specified scheduler.
+                                If not specified, the pod will be dispatched by default scheduler.
+                              type: string
+                            schedulingGates:
+                              description: |-
+                                SchedulingGates is an opaque list of values that if specified will block scheduling the pod.
+                                If schedulingGates is not empty, the pod will stay in the SchedulingGated state and the
+                                scheduler will not attempt to schedule the pod.
+
+
+                                SchedulingGates can only be set at pod creation time, and be removed only afterwards.
+                              items:
+                                description: PodSchedulingGate is associated to a
+                                  Pod to guard its scheduling.
+                                properties:
+                                  name:
+                                    description: |-
+                                      Name of the scheduling gate.
+                                      Each scheduling gate must have a unique name field.
+                                    type: string
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                            securityContext:
+                              description: |-
+                                SecurityContext holds pod-level security attributes and common container settings.
+                                Optional: Defaults to empty.  See type description for default values of each field.
+                              properties:
+                                appArmorProfile:
+                                  description: |-
+                                    appArmorProfile is the AppArmor options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile loaded on the node that should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must match the loaded name of the profile.
+                                        Must be set if and only if type is "Localhost".
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of AppArmor profile will be applied.
+                                        Valid options are:
+                                          Localhost - a profile pre-loaded on the node.
+                                          RuntimeDefault - the container runtime's default profile.
+                                          Unconfined - no AppArmor enforcement.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                fsGroup:
+                                  description: |-
+                                    A special supplemental group that applies to all containers in a pod.
+                                    Some volume types allow the Kubelet to change the ownership of that volume
+                                    to be owned by the pod:
+
+
+                                    1. The owning GID will be the FSGroup
+                                    2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                                    3. The permission bits are OR'd with rw-rw----
+
+
+                                    If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                fsGroupChangePolicy:
+                                  description: |-
+                                    fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                                    before being exposed inside Pod. This field will only apply to
+                                    volume types which support fsGroup based ownership(and permissions).
+                                    It will have no effect on ephemeral volume types such as: secret, configmaps
+                                    and emptydir.
+                                    Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  type: string
+                                runAsGroup:
+                                  description: |-
+                                    The GID to run the entrypoint of the container process.
+                                    Uses runtime default if unset.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                runAsNonRoot:
+                                  description: |-
+                                    Indicates that the container must run as a non-root user.
+                                    If true, the Kubelet will validate the image at runtime to ensure that it
+                                    does not run as UID 0 (root) and fail to start the container if it does.
+                                    If unset or false, no such validation will be performed.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                  type: boolean
+                                runAsUser:
+                                  description: |-
+                                    The UID to run the entrypoint of the container process.
+                                    Defaults to user specified in image metadata if unspecified.
+                                    May also be set in SecurityContext.  If set in both SecurityContext and
+                                    PodSecurityContext, the value specified in SecurityContext takes precedence
+                                    for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  format: int64
+                                  type: integer
+                                seLinuxOptions:
+                                  description: |-
+                                    The SELinux context to be applied to all containers.
+                                    If unspecified, the container runtime will allocate a random SELinux context for each
+                                    container.  May also be set in SecurityContext.  If set in
+                                    both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence for that container.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    level:
+                                      description: Level is SELinux level label that
+                                        applies to the container.
+                                      type: string
+                                    role:
+                                      description: Role is a SELinux role label that
+                                        applies to the container.
+                                      type: string
+                                    type:
+                                      description: Type is a SELinux type label that
+                                        applies to the container.
+                                      type: string
+                                    user:
+                                      description: User is a SELinux user label that
+                                        applies to the container.
+                                      type: string
+                                  type: object
+                                seccompProfile:
+                                  description: |-
+                                    The seccomp options to use by the containers in this pod.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  properties:
+                                    localhostProfile:
+                                      description: |-
+                                        localhostProfile indicates a profile defined in a file on the node should be used.
+                                        The profile must be preconfigured on the node to work.
+                                        Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                        Must be set if type is "Localhost". Must NOT be set for any other type.
+                                      type: string
+                                    type:
+                                      description: |-
+                                        type indicates which kind of seccomp profile will be applied.
+                                        Valid options are:
+
+
+                                        Localhost - a profile defined in a file on the node should be used.
+                                        RuntimeDefault - the container runtime default profile should be used.
+                                        Unconfined - no profile should be applied.
+                                      type: string
+                                  required:
+                                  - type
+                                  type: object
+                                supplementalGroups:
+                                  description: |-
+                                    A list of groups applied to the first process run in each container, in addition
+                                    to the container's primary GID, the fsGroup (if specified), and group memberships
+                                    defined in the container image for the uid of the container process. If unspecified,
+                                    no additional groups are added to any container. Note that group memberships
+                                    defined in the container image for the uid of the container process are still effective,
+                                    even if they are not included in this list.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  items:
+                                    format: int64
+                                    type: integer
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                sysctls:
+                                  description: |-
+                                    Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                                    sysctls (by the container runtime) might fail to launch.
+                                    Note that this field cannot be set when spec.os.name is windows.
+                                  items:
+                                    description: Sysctl defines a kernel parameter
+                                      to be set
+                                    properties:
+                                      name:
+                                        description: Name of a property to set
+                                        type: string
+                                      value:
+                                        description: Value of a property to set
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                windowsOptions:
+                                  description: |-
+                                    The Windows specific settings applied to all containers.
+                                    If unspecified, the options within a container's SecurityContext will be used.
+                                    If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                    Note that this field cannot be set when spec.os.name is linux.
+                                  properties:
+                                    gmsaCredentialSpec:
+                                      description: |-
+                                        GMSACredentialSpec is where the GMSA admission webhook
+                                        (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                        GMSA credential spec named by the GMSACredentialSpecName field.
+                                      type: string
+                                    gmsaCredentialSpecName:
+                                      description: GMSACredentialSpecName is the name
+                                        of the GMSA credential spec to use.
+                                      type: string
+                                    hostProcess:
+                                      description: |-
+                                        HostProcess determines if a container should be run as a 'Host Process' container.
+                                        All of a Pod's containers must have the same effective HostProcess value
+                                        (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                        In addition, if HostProcess is true then HostNetwork must also be set to true.
+                                      type: boolean
+                                    runAsUserName:
+                                      description: |-
+                                        The UserName in Windows to run the entrypoint of the container process.
+                                        Defaults to the user specified in image metadata if unspecified.
+                                        May also be set in PodSecurityContext. If set in both SecurityContext and
+                                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                                      type: string
+                                  type: object
+                              type: object
+                            serviceAccount:
+                              description: |-
+                                DeprecatedServiceAccount is a deprecated alias for ServiceAccountName.
+                                Deprecated: Use serviceAccountName instead.
+                              type: string
+                            serviceAccountName:
+                              description: |-
+                                ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                                More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                              type: string
+                            setHostnameAsFQDN:
+                              description: |-
+                                If true the pod's hostname will be configured as the pod's FQDN, rather than the leaf name (the default).
+                                In Linux containers, this means setting the FQDN in the hostname field of the kernel (the nodename field of struct utsname).
+                                In Windows containers, this means setting the registry value of hostname for the registry key HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters to FQDN.
+                                If a pod does not have FQDN, this has no effect.
+                                Default to false.
+                              type: boolean
+                            shareProcessNamespace:
+                              description: |-
+                                Share a single process namespace between all of the containers in a pod.
+                                When this is set containers will be able to view and signal processes from other containers
+                                in the same pod, and the first process in each container will not be assigned PID 1.
+                                HostPID and ShareProcessNamespace cannot both be set.
+                                Optional: Default to false.
+                              type: boolean
+                            subdomain:
+                              description: |-
+                                If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>".
+                                If not specified, the pod will not have a domainname at all.
+                              type: string
+                            terminationGracePeriodSeconds:
+                              description: |-
+                                Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request.
+                                Value must be non-negative integer. The value zero indicates stop immediately via
+                                the kill signal (no opportunity to shut down).
+                                If this value is nil, the default grace period will be used instead.
+                                The grace period is the duration in seconds after the processes running in the pod are sent
+                                a termination signal and the time when the processes are forcibly halted with a kill signal.
+                                Set this value longer than the expected cleanup time for your process.
+                                Defaults to 30 seconds.
+                              format: int64
+                              type: integer
+                            tolerations:
+                              description: If specified, the pod's tolerations.
+                              items:
+                                description: |-
+                                  The pod this Toleration is attached to tolerates any taint that matches
+                                  the triple <key,value,effect> using the matching operator <operator>.
+                                properties:
+                                  effect:
+                                    description: |-
+                                      Effect indicates the taint effect to match. Empty means match all taint effects.
+                                      When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                    type: string
+                                  key:
+                                    description: |-
+                                      Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                      If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      Operator represents a key's relationship to the value.
+                                      Valid operators are Exists and Equal. Defaults to Equal.
+                                      Exists is equivalent to wildcard for value, so that a pod can
+                                      tolerate all taints of a particular category.
+                                    type: string
+                                  tolerationSeconds:
+                                    description: |-
+                                      TolerationSeconds represents the period of time the toleration (which must be
+                                      of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                      it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                      negative values will be treated as 0 (evict immediately) by the system.
+                                    format: int64
+                                    type: integer
+                                  value:
+                                    description: |-
+                                      Value is the taint value the toleration matches to.
+                                      If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                    type: string
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologySpreadConstraints:
+                              description: |-
+                                TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                                domains. Scheduler will schedule pods in a way which abides by the constraints.
+                                All topologySpreadConstraints are ANDed.
+                              items:
+                                description: TopologySpreadConstraint specifies how
+                                  to spread matching pods among the given topology.
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      LabelSelector is used to find matching pods.
+                                      Pods that match this label selector are counted to determine the number of pods
+                                      in their corresponding topology domain.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                              x-kubernetes-list-type: atomic
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select the pods over which
+                                      spreading will be calculated. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are ANDed with labelSelector
+                                      to select the group of existing pods over which spreading will be calculated
+                                      for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      Keys that don't exist in the incoming pod labels will
+                                      be ignored. A null or empty list means only match against labelSelector.
+
+
+                                      This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  maxSkew:
+                                    description: |-
+                                      MaxSkew describes the degree to which pods may be unevenly distributed.
+                                      When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                                      between the number of matching pods in the target topology and the global minimum.
+                                      The global minimum is the minimum number of matching pods in an eligible domain
+                                      or zero if the number of eligible domains is less than MinDomains.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 2/2/1:
+                                      In this case, the global minimum is 1.
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |   P   |
+                                      - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                                      scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                                      violate MaxSkew(1).
+                                      - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                                      When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                                      to topologies that satisfy it.
+                                      It's a required field. Default value is 1 and 0 is not allowed.
+                                    format: int32
+                                    type: integer
+                                  minDomains:
+                                    description: |-
+                                      MinDomains indicates a minimum number of eligible domains.
+                                      When the number of eligible domains with matching topology keys is less than minDomains,
+                                      Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                                      And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                                      this value has no effect on scheduling.
+                                      As a result, when the number of eligible domains is less than minDomains,
+                                      scheduler won't schedule more than maxSkew Pods to those domains.
+                                      If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                                      Valid values are integers greater than 0.
+                                      When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                                      For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                                      labelSelector spread as 2/2/2:
+                                      | zone1 | zone2 | zone3 |
+                                      |  P P  |  P P  |  P P  |
+                                      The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                                      In this situation, new pod with the same labelSelector cannot be scheduled,
+                                      because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                                      it will violate MaxSkew.
+                                    format: int32
+                                    type: integer
+                                  nodeAffinityPolicy:
+                                    description: |-
+                                      NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                                      when calculating pod topology spread skew. Options are:
+                                      - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                                      - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+
+
+                                      If this value is nil, the behavior is equivalent to the Honor policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  nodeTaintsPolicy:
+                                    description: |-
+                                      NodeTaintsPolicy indicates how we will treat node taints when calculating
+                                      pod topology spread skew. Options are:
+                                      - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                                      has a toleration, are included.
+                                      - Ignore: node taints are ignored. All nodes are included.
+
+
+                                      If this value is nil, the behavior is equivalent to the Ignore policy.
+                                      This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                                    type: string
+                                  topologyKey:
+                                    description: |-
+                                      TopologyKey is the key of node labels. Nodes that have a label with this key
+                                      and identical values are considered to be in the same topology.
+                                      We consider each <key, value> as a "bucket", and try to put balanced number
+                                      of pods into each bucket.
+                                      We define a domain as a particular instance of a topology.
+                                      Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                                      nodeAffinityPolicy and nodeTaintsPolicy.
+                                      e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                                      And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                                      It's a required field.
+                                    type: string
+                                  whenUnsatisfiable:
+                                    description: |-
+                                      WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                                      the spread constraint.
+                                      - DoNotSchedule (default) tells the scheduler not to schedule it.
+                                      - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                        but giving higher precedence to topologies that would help reduce the
+                                        skew.
+                                      A constraint is considered "Unsatisfiable" for an incoming pod
+                                      if and only if every possible node assignment for that pod would violate
+                                      "MaxSkew" on some topology.
+                                      For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                                      labelSelector spread as 3/1/1:
+                                      | zone1 | zone2 | zone3 |
+                                      | P P P |   P   |   P   |
+                                      If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                                      to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                                      MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                                      won't make it *more* imbalanced.
+                                      It's a required field.
+                                    type: string
+                                required:
+                                - maxSkew
+                                - topologyKey
+                                - whenUnsatisfiable
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - topologyKey
+                              - whenUnsatisfiable
+                              x-kubernetes-list-type: map
+                            volumes:
+                              description: |-
+                                List of volumes that can be mounted by containers belonging to the pod.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes
+                              items:
+                                description: Volume represents a named volume in a
+                                  pod that may be accessed by any container in the
+                                  pod.
+                                properties:
+                                  awsElasticBlockStore:
+                                    description: |-
+                                      awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      partition:
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: |-
+                                          readOnly value true will force the readOnly setting in VolumeMounts.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        type: boolean
+                                      volumeID:
+                                        description: |-
+                                          volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  azureDisk:
+                                    description: azureDisk represents an Azure Data
+                                      Disk mount on the host and bind mount to the
+                                      pod.
+                                    properties:
+                                      cachingMode:
+                                        description: 'cachingMode is the Host Caching
+                                          mode: None, Read Only, Read Write.'
+                                        type: string
+                                      diskName:
+                                        description: diskName is the Name of the data
+                                          disk in the blob storage
+                                        type: string
+                                      diskURI:
+                                        description: diskURI is the URI of data disk
+                                          in the blob storage
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType is Filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      kind:
+                                        description: 'kind expected values are Shared:
+                                          multiple blob disks per storage account  Dedicated:
+                                          single blob disk per storage account  Managed:
+                                          azure managed data disk (only in managed
+                                          availability set). defaults to shared'
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                    required:
+                                    - diskName
+                                    - diskURI
+                                    type: object
+                                  azureFile:
+                                    description: azureFile represents an Azure File
+                                      Service mount on the host and bind mount to
+                                      the pod.
+                                    properties:
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretName:
+                                        description: secretName is the  name of secret
+                                          that contains Azure Storage Account Name
+                                          and Key
+                                        type: string
+                                      shareName:
+                                        description: shareName is the azure share
+                                          Name
+                                        type: string
+                                    required:
+                                    - secretName
+                                    - shareName
+                                    type: object
+                                  cephfs:
+                                    description: cephFS represents a Ceph FS mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      monitors:
+                                        description: |-
+                                          monitors is Required: Monitors is a collection of Ceph monitors
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      path:
+                                        description: 'path is Optional: Used as the
+                                          mounted root, rather than the full Ceph
+                                          tree, default is /'
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: boolean
+                                      secretFile:
+                                        description: |-
+                                          secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: string
+                                      secretRef:
+                                        description: |-
+                                          secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: |-
+                                          user is optional: User is the rados user name, default is admin
+                                          More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                                        type: string
+                                    required:
+                                    - monitors
+                                    type: object
+                                  cinder:
+                                    description: |-
+                                      cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is optional: points to a secret object containing parameters used to connect
+                                          to OpenStack.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeID:
+                                        description: |-
+                                          volumeID used to identify the volume in cinder.
+                                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  configMap:
+                                    description: configMap represents a configMap
+                                      that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode is optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  csi:
+                                    description: csi (Container Storage Interface)
+                                      represents ephemeral storage that is handled
+                                      by certain external CSI drivers (Beta feature).
+                                    properties:
+                                      driver:
+                                        description: |-
+                                          driver is the name of the CSI driver that handles this volume.
+                                          Consult with your admin for the correct name as registered in the cluster.
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                          If not provided, the empty value is passed to the associated CSI driver
+                                          which will determine the default filesystem to apply.
+                                        type: string
+                                      nodePublishSecretRef:
+                                        description: |-
+                                          nodePublishSecretRef is a reference to the secret object containing
+                                          sensitive information to pass to the CSI driver to complete the CSI
+                                          NodePublishVolume and NodeUnpublishVolume calls.
+                                          This field is optional, and  may be empty if no secret is required. If the
+                                          secret object contains more than one secret, all secret references are passed.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      readOnly:
+                                        description: |-
+                                          readOnly specifies a read-only configuration for the volume.
+                                          Defaults to false (read/write).
+                                        type: boolean
+                                      volumeAttributes:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          volumeAttributes stores driver-specific properties that are passed to the CSI
+                                          driver. Consult your driver's documentation for supported values.
+                                        type: object
+                                    required:
+                                    - driver
+                                    type: object
+                                  downwardAPI:
+                                    description: downwardAPI represents downward API
+                                      about the pod that should populate this volume
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          Optional: mode bits to use on created files by default. Must be a
+                                          Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: Items is a list of downward API
+                                          volume file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  emptyDir:
+                                    description: |-
+                                      emptyDir represents a temporary directory that shares a pod's lifetime.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                    properties:
+                                      medium:
+                                        description: |-
+                                          medium represents what type of storage medium should back this directory.
+                                          The default is "" which means to use the node's default medium.
+                                          Must be an empty string (default) or Memory.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                        type: string
+                                      sizeLimit:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: |-
+                                          sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                          The size limit is also applicable for memory medium.
+                                          The maximum usage on memory medium EmptyDir would be the minimum value between
+                                          the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                          The default is nil which means that the limit is undefined.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                    type: object
+                                  ephemeral:
+                                    description: |-
+                                      ephemeral represents a volume that is handled by a cluster storage driver.
+                                      The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                      and deleted when the pod is removed.
+
+
+                                      Use this if:
+                                      a) the volume is only needed while the pod runs,
+                                      b) features of normal volumes like restoring from snapshot or capacity
+                                         tracking are needed,
+                                      c) the storage driver is specified through a storage class, and
+                                      d) the storage driver supports dynamic volume provisioning through
+                                         a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                         information on the connection between this volume type
+                                         and PersistentVolumeClaim).
+
+
+                                      Use PersistentVolumeClaim or one of the vendor-specific
+                                      APIs for volumes that persist for longer than the lifecycle
+                                      of an individual pod.
+
+
+                                      Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                      be used that way - see the documentation of the driver for
+                                      more information.
+
+
+                                      A pod can use both types of ephemeral volumes and
+                                      persistent volumes at the same time.
+                                    properties:
+                                      volumeClaimTemplate:
+                                        description: |-
+                                          Will be used to create a stand-alone PVC to provision the volume.
+                                          The pod in which this EphemeralVolumeSource is embedded will be the
+                                          owner of the PVC, i.e. the PVC will be deleted together with the
+                                          pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                          `<volume name>` is the name from the `PodSpec.Volumes` array
+                                          entry. Pod validation will reject the pod if the concatenated name
+                                          is not valid for a PVC (for example, too long).
+
+
+                                          An existing PVC with that name that is not owned by the pod
+                                          will *not* be used for the pod to avoid using an unrelated
+                                          volume by mistake. Starting the pod is then blocked until
+                                          the unrelated PVC is removed. If such a pre-created PVC is
+                                          meant to be used by the pod, the PVC has to updated with an
+                                          owner reference to the pod once the pod exists. Normally
+                                          this should not be necessary, but it may be useful when
+                                          manually reconstructing a broken cluster.
+
+
+                                          This field is read-only and no changes will be made by Kubernetes
+                                          to the PVC after it has been created.
+
+
+                                          Required, must not be nil.
+                                        properties:
+                                          metadata:
+                                            description: |-
+                                              May contain labels and annotations that will be copied into the PVC
+                                              when creating it. No other fields are allowed and will be rejected during
+                                              validation.
+                                            properties:
+                                              annotations:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              finalizers:
+                                                items:
+                                                  type: string
+                                                type: array
+                                              labels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                              name:
+                                                type: string
+                                              namespace:
+                                                type: string
+                                            type: object
+                                          spec:
+                                            description: |-
+                                              The specification for the PersistentVolumeClaim. The entire content is
+                                              copied unchanged into the PVC that gets created from this
+                                              template. The same fields as in a PersistentVolumeClaim
+                                              are also valid here.
+                                            properties:
+                                              accessModes:
+                                                description: |-
+                                                  accessModes contains the desired access modes the volume should have.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                              dataSource:
+                                                description: |-
+                                                  dataSource field can be used to specify either:
+                                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                                  * An existing PVC (PersistentVolumeClaim)
+                                                  If the provisioner or an external controller can support the specified data source,
+                                                  it will create a new volume based on the contents of the specified data source.
+                                                  When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                                  and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                                  If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                                properties:
+                                                  apiGroup:
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              dataSourceRef:
+                                                description: |-
+                                                  dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                                  volume is desired. This may be any object from a non-empty API group (non
+                                                  core object) or a PersistentVolumeClaim object.
+                                                  When this field is specified, volume binding will only succeed if the type of
+                                                  the specified object matches some installed volume populator or dynamic
+                                                  provisioner.
+                                                  This field will replace the functionality of the dataSource field and as such
+                                                  if both fields are non-empty, they must have the same value. For backwards
+                                                  compatibility, when namespace isn't specified in dataSourceRef,
+                                                  both fields (dataSource and dataSourceRef) will be set to the same
+                                                  value automatically if one of them is empty and the other is non-empty.
+                                                  When namespace is specified in dataSourceRef,
+                                                  dataSource isn't set to the same value and must be empty.
+                                                  There are three important differences between dataSource and dataSourceRef:
+                                                  * While dataSource only allows two specific types of objects, dataSourceRef
+                                                    allows any non-core object, as well as PersistentVolumeClaim objects.
+                                                  * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                                    preserves all values, and generates an error if a disallowed value is
+                                                    specified.
+                                                  * While dataSource only allows local objects, dataSourceRef allows objects
+                                                    in any namespaces.
+                                                  (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                                  (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                properties:
+                                                  apiGroup:
+                                                    description: |-
+                                                      APIGroup is the group for the resource being referenced.
+                                                      If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                      For any other third-party types, APIGroup is required.
+                                                    type: string
+                                                  kind:
+                                                    description: Kind is the type
+                                                      of resource being referenced
+                                                    type: string
+                                                  name:
+                                                    description: Name is the name
+                                                      of resource being referenced
+                                                    type: string
+                                                  namespace:
+                                                    description: |-
+                                                      Namespace is the namespace of resource being referenced
+                                                      Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                                      (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                                    type: string
+                                                required:
+                                                - kind
+                                                - name
+                                                type: object
+                                              resources:
+                                                description: |-
+                                                  resources represents the minimum resources the volume should have.
+                                                  If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                                  that are lower than previous value but must still be higher than capacity recorded in the
+                                                  status field of the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                                properties:
+                                                  limits:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Limits describes the maximum amount of compute resources allowed.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                    type: object
+                                                  requests:
+                                                    additionalProperties:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    description: |-
+                                                      Requests describes the minimum amount of compute resources required.
+                                                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                                    type: object
+                                                type: object
+                                              selector:
+                                                description: selector is a label query
+                                                  over volumes to consider for binding.
+                                                properties:
+                                                  matchExpressions:
+                                                    description: matchExpressions
+                                                      is a list of label selector
+                                                      requirements. The requirements
+                                                      are ANDed.
+                                                    items:
+                                                      description: |-
+                                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                                        relates the key and values.
+                                                      properties:
+                                                        key:
+                                                          description: key is the
+                                                            label key that the selector
+                                                            applies to.
+                                                          type: string
+                                                        operator:
+                                                          description: |-
+                                                            operator represents a key's relationship to a set of values.
+                                                            Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                          type: string
+                                                        values:
+                                                          description: |-
+                                                            values is an array of string values. If the operator is In or NotIn,
+                                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                            the values array must be empty. This array is replaced during a strategic
+                                                            merge patch.
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                          x-kubernetes-list-type: atomic
+                                                      required:
+                                                      - key
+                                                      - operator
+                                                      type: object
+                                                    type: array
+                                                    x-kubernetes-list-type: atomic
+                                                  matchLabels:
+                                                    additionalProperties:
+                                                      type: string
+                                                    description: |-
+                                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                    type: object
+                                                type: object
+                                                x-kubernetes-map-type: atomic
+                                              storageClassName:
+                                                description: |-
+                                                  storageClassName is the name of the StorageClass required by the claim.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                                type: string
+                                              volumeAttributesClassName:
+                                                description: |-
+                                                  volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                                  If specified, the CSI driver will create or update the volume with the attributes defined
+                                                  in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                                  it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                                  will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                                  If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                                  will be set by the persistentvolume controller if it exists.
+                                                  If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                                  set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                                  exists.
+                                                  More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                                  (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
+                                                type: string
+                                              volumeMode:
+                                                description: |-
+                                                  volumeMode defines what type of volume is required by the claim.
+                                                  Value of Filesystem is implied when not included in claim spec.
+                                                type: string
+                                              volumeName:
+                                                description: volumeName is the binding
+                                                  reference to the PersistentVolume
+                                                  backing this claim.
+                                                type: string
+                                            type: object
+                                        required:
+                                        - spec
+                                        type: object
+                                    type: object
+                                  fc:
+                                    description: fc represents a Fibre Channel resource
+                                      that is attached to a kubelet's host machine
+                                      and then exposed to the pod.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      lun:
+                                        description: 'lun is Optional: FC target lun
+                                          number'
+                                        format: int32
+                                        type: integer
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      targetWWNs:
+                                        description: 'targetWWNs is Optional: FC target
+                                          worldwide names (WWNs)'
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      wwids:
+                                        description: |-
+                                          wwids Optional: FC volume world wide identifiers (wwids)
+                                          Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  flexVolume:
+                                    description: |-
+                                      flexVolume represents a generic volume resource that is
+                                      provisioned/attached using an exec based plugin.
+                                    properties:
+                                      driver:
+                                        description: driver is the name of the driver
+                                          to use for this volume.
+                                        type: string
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                        type: string
+                                      options:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'options is Optional: this field
+                                          holds extra command options if any.'
+                                        type: object
+                                      readOnly:
+                                        description: |-
+                                          readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is Optional: secretRef is reference to the secret object containing
+                                          sensitive information to pass to the plugin scripts. This may be
+                                          empty if no secret object is specified. If the secret object
+                                          contains more than one secret, all secrets are passed to the plugin
+                                          scripts.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - driver
+                                    type: object
+                                  flocker:
+                                    description: flocker represents a Flocker volume
+                                      attached to a kubelet's host machine. This depends
+                                      on the Flocker control service being running
+                                    properties:
+                                      datasetName:
+                                        description: |-
+                                          datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                          should be considered as deprecated
+                                        type: string
+                                      datasetUUID:
+                                        description: datasetUUID is the UUID of the
+                                          dataset. This is unique identifier of a
+                                          Flocker dataset
+                                        type: string
+                                    type: object
+                                  gcePersistentDisk:
+                                    description: |-
+                                      gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      partition:
+                                        description: |-
+                                          partition is the partition in the volume that you want to mount.
+                                          If omitted, the default is to mount by volume name.
+                                          Examples: For volume /dev/sda1, you specify the partition as "1".
+                                          Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        format: int32
+                                        type: integer
+                                      pdName:
+                                        description: |-
+                                          pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                        type: boolean
+                                    required:
+                                    - pdName
+                                    type: object
+                                  gitRepo:
+                                    description: |-
+                                      gitRepo represents a git repository at a particular revision.
+                                      DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                      EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                      into the Pod's container.
+                                    properties:
+                                      directory:
+                                        description: |-
+                                          directory is the target directory name.
+                                          Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                          git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                          the subdirectory with the given name.
+                                        type: string
+                                      repository:
+                                        description: repository is the URL
+                                        type: string
+                                      revision:
+                                        description: revision is the commit hash for
+                                          the specified revision.
+                                        type: string
+                                    required:
+                                    - repository
+                                    type: object
+                                  glusterfs:
+                                    description: |-
+                                      glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                                    properties:
+                                      endpoints:
+                                        description: |-
+                                          endpoints is the endpoint name that details Glusterfs topology.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: string
+                                      path:
+                                        description: |-
+                                          path is the Glusterfs volume path.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                                        type: boolean
+                                    required:
+                                    - endpoints
+                                    - path
+                                    type: object
+                                  hostPath:
+                                    description: |-
+                                      hostPath represents a pre-existing file or directory on the host
+                                      machine that is directly exposed to the container. This is generally
+                                      used for system agents or other privileged things that are allowed
+                                      to see the host machine. Most containers will NOT need this.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                      ---
+                                      TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                      mount host directories as read/write.
+                                    properties:
+                                      path:
+                                        description: |-
+                                          path of the directory on the host.
+                                          If the path is a symlink, it will follow the link to the real path.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        type: string
+                                      type:
+                                        description: |-
+                                          type for HostPath Volume
+                                          Defaults to ""
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  iscsi:
+                                    description: |-
+                                      iscsi represents an ISCSI Disk resource that is attached to a
+                                      kubelet's host machine and then exposed to the pod.
+                                      More info: https://examples.k8s.io/volumes/iscsi/README.md
+                                    properties:
+                                      chapAuthDiscovery:
+                                        description: chapAuthDiscovery defines whether
+                                          support iSCSI Discovery CHAP authentication
+                                        type: boolean
+                                      chapAuthSession:
+                                        description: chapAuthSession defines whether
+                                          support iSCSI Session CHAP authentication
+                                        type: boolean
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      initiatorName:
+                                        description: |-
+                                          initiatorName is the custom iSCSI Initiator Name.
+                                          If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                          <target portal>:<volume name> will be created for the connection.
+                                        type: string
+                                      iqn:
+                                        description: iqn is the target iSCSI Qualified
+                                          Name.
+                                        type: string
+                                      iscsiInterface:
+                                        description: |-
+                                          iscsiInterface is the interface Name that uses an iSCSI transport.
+                                          Defaults to 'default' (tcp).
+                                        type: string
+                                      lun:
+                                        description: lun represents iSCSI Target Lun
+                                          number.
+                                        format: int32
+                                        type: integer
+                                      portals:
+                                        description: |-
+                                          portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                        type: boolean
+                                      secretRef:
+                                        description: secretRef is the CHAP Secret
+                                          for iSCSI target and initiator authentication
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      targetPortal:
+                                        description: |-
+                                          targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                          is other than default (typically TCP ports 860 and 3260).
+                                        type: string
+                                    required:
+                                    - iqn
+                                    - lun
+                                    - targetPortal
+                                    type: object
+                                  name:
+                                    description: |-
+                                      name of the volume.
+                                      Must be a DNS_LABEL and unique within the pod.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    type: string
+                                  nfs:
+                                    description: |-
+                                      nfs represents an NFS mount on the host that shares a pod's lifetime
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                    properties:
+                                      path:
+                                        description: |-
+                                          path that is exported by the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the NFS export to be mounted with read-only permissions.
+                                          Defaults to false.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: boolean
+                                      server:
+                                        description: |-
+                                          server is the hostname or IP address of the NFS server.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                                        type: string
+                                    required:
+                                    - path
+                                    - server
+                                    type: object
+                                  persistentVolumeClaim:
+                                    description: |-
+                                      persistentVolumeClaimVolumeSource represents a reference to a
+                                      PersistentVolumeClaim in the same namespace.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                    properties:
+                                      claimName:
+                                        description: |-
+                                          claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Will force the ReadOnly setting in VolumeMounts.
+                                          Default false.
+                                        type: boolean
+                                    required:
+                                    - claimName
+                                    type: object
+                                  photonPersistentDisk:
+                                    description: photonPersistentDisk represents a
+                                      PhotonController persistent disk attached and
+                                      mounted on kubelets host machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      pdID:
+                                        description: pdID is the ID that identifies
+                                          Photon Controller persistent disk
+                                        type: string
+                                    required:
+                                    - pdID
+                                    type: object
+                                  portworxVolume:
+                                    description: portworxVolume represents a portworx
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fSType represents the filesystem type to mount
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      volumeID:
+                                        description: volumeID uniquely identifies
+                                          a Portworx volume
+                                        type: string
+                                    required:
+                                    - volumeID
+                                    type: object
+                                  projected:
+                                    description: projected items for all in one resources
+                                      secrets, configmaps, and downward API
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode are the mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      sources:
+                                        description: sources is the list of volume
+                                          projections
+                                        items:
+                                          description: Projection that may be projected
+                                            along with other supported volume types
+                                          properties:
+                                            clusterTrustBundle:
+                                              description: |-
+                                                ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                                of ClusterTrustBundle objects in an auto-updating file.
+
+
+                                                Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+
+                                                ClusterTrustBundle objects can either be selected by name, or by the
+                                                combination of signer name and a label selector.
+
+
+                                                Kubelet performs aggressive normalization of the PEM contents written
+                                                into the pod filesystem.  Esoteric PEM features such as inter-block
+                                                comments and block headers are stripped.  Certificates are deduplicated.
+                                                The ordering of certificates within the file is arbitrary, and Kubelet
+                                                may change the order over time.
+                                              properties:
+                                                labelSelector:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this label selector.  Only has
+                                                    effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                                    interpreted as "match nothing".  If set but empty, interpreted as "match
+                                                    everything".
+                                                  properties:
+                                                    matchExpressions:
+                                                      description: matchExpressions
+                                                        is a list of label selector
+                                                        requirements. The requirements
+                                                        are ANDed.
+                                                      items:
+                                                        description: |-
+                                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                                          relates the key and values.
+                                                        properties:
+                                                          key:
+                                                            description: key is the
+                                                              label key that the selector
+                                                              applies to.
+                                                            type: string
+                                                          operator:
+                                                            description: |-
+                                                              operator represents a key's relationship to a set of values.
+                                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                            type: string
+                                                          values:
+                                                            description: |-
+                                                              values is an array of string values. If the operator is In or NotIn,
+                                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                              the values array must be empty. This array is replaced during a strategic
+                                                              merge patch.
+                                                            items:
+                                                              type: string
+                                                            type: array
+                                                            x-kubernetes-list-type: atomic
+                                                        required:
+                                                        - key
+                                                        - operator
+                                                        type: object
+                                                      type: array
+                                                      x-kubernetes-list-type: atomic
+                                                    matchLabels:
+                                                      additionalProperties:
+                                                        type: string
+                                                      description: |-
+                                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                      type: object
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                name:
+                                                  description: |-
+                                                    Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                                    with signerName and labelSelector.
+                                                  type: string
+                                                optional:
+                                                  description: |-
+                                                    If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                                    aren't available.  If using name, then the named ClusterTrustBundle is
+                                                    allowed not to exist.  If using signerName, then the combination of
+                                                    signerName and labelSelector is allowed to match zero
+                                                    ClusterTrustBundles.
+                                                  type: boolean
+                                                path:
+                                                  description: Relative path from
+                                                    the volume root to write the bundle.
+                                                  type: string
+                                                signerName:
+                                                  description: |-
+                                                    Select all ClusterTrustBundles that match this signer name.
+                                                    Mutually-exclusive with name.  The contents of all selected
+                                                    ClusterTrustBundles will be unified and deduplicated.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                            configMap:
+                                              description: configMap information about
+                                                the configMap data to project
+                                              properties:
+                                                items:
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    ConfigMap will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the ConfigMap,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: optional specify whether
+                                                    the ConfigMap or its keys must
+                                                    be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            downwardAPI:
+                                              description: downwardAPI information
+                                                about the downwardAPI data to project
+                                              properties:
+                                                items:
+                                                  description: Items is a list of
+                                                    DownwardAPIVolume file
+                                                  items:
+                                                    description: DownwardAPIVolumeFile
+                                                      represents information to create
+                                                      the file containing the pod
+                                                      field
+                                                    properties:
+                                                      fieldRef:
+                                                        description: 'Required: Selects
+                                                          a field of the pod: only
+                                                          annotations, labels, name,
+                                                          namespace and uid are supported.'
+                                                        properties:
+                                                          apiVersion:
+                                                            description: Version of
+                                                              the schema the FieldPath
+                                                              is written in terms
+                                                              of, defaults to "v1".
+                                                            type: string
+                                                          fieldPath:
+                                                            description: Path of the
+                                                              field to select in the
+                                                              specified API version.
+                                                            type: string
+                                                        required:
+                                                        - fieldPath
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                      mode:
+                                                        description: |-
+                                                          Optional: mode bits used to set permissions on this file, must be an octal value
+                                                          between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: 'Required: Path
+                                                          is  the relative path name
+                                                          of the file to be created.
+                                                          Must not be absolute or
+                                                          contain the ''..'' path.
+                                                          Must be utf-8 encoded. The
+                                                          first item of the relative
+                                                          path must not start with
+                                                          ''..'''
+                                                        type: string
+                                                      resourceFieldRef:
+                                                        description: |-
+                                                          Selects a resource of the container: only resources limits and requests
+                                                          (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                                        properties:
+                                                          containerName:
+                                                            description: 'Container
+                                                              name: required for volumes,
+                                                              optional for env vars'
+                                                            type: string
+                                                          divisor:
+                                                            anyOf:
+                                                            - type: integer
+                                                            - type: string
+                                                            description: Specifies
+                                                              the output format of
+                                                              the exposed resources,
+                                                              defaults to "1"
+                                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                            x-kubernetes-int-or-string: true
+                                                          resource:
+                                                            description: 'Required:
+                                                              resource to select'
+                                                            type: string
+                                                        required:
+                                                        - resource
+                                                        type: object
+                                                        x-kubernetes-map-type: atomic
+                                                    required:
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              type: object
+                                            secret:
+                                              description: secret information about
+                                                the secret data to project
+                                              properties:
+                                                items:
+                                                  description: |-
+                                                    items if unspecified, each key-value pair in the Data field of the referenced
+                                                    Secret will be projected into the volume as a file whose name is the
+                                                    key and content is the value. If specified, the listed keys will be
+                                                    projected into the specified paths, and unlisted keys will not be
+                                                    present. If a key is specified which is not present in the Secret,
+                                                    the volume setup will error unless it is marked optional. Paths must be
+                                                    relative and may not contain the '..' path or start with '..'.
+                                                  items:
+                                                    description: Maps a string key
+                                                      to a path within a volume.
+                                                    properties:
+                                                      key:
+                                                        description: key is the key
+                                                          to project.
+                                                        type: string
+                                                      mode:
+                                                        description: |-
+                                                          mode is Optional: mode bits used to set permissions on this file.
+                                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                          YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                          If not specified, the volume defaultMode will be used.
+                                                          This might be in conflict with other options that affect the file
+                                                          mode, like fsGroup, and the result can be other mode bits set.
+                                                        format: int32
+                                                        type: integer
+                                                      path:
+                                                        description: |-
+                                                          path is the relative path of the file to map the key to.
+                                                          May not be an absolute path.
+                                                          May not contain the path element '..'.
+                                                          May not start with the string '..'.
+                                                        type: string
+                                                    required:
+                                                    - key
+                                                    - path
+                                                    type: object
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                                name:
+                                                  default: ""
+                                                  description: |-
+                                                    Name of the referent.
+                                                    This field is effectively required, but due to backwards compatibility is
+                                                    allowed to be empty. Instances of this type with an empty value here are
+                                                    almost certainly wrong.
+                                                    TODO: Add other useful fields. apiVersion, kind, uid?
+                                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                                    TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                                  type: string
+                                                optional:
+                                                  description: optional field specify
+                                                    whether the Secret or its key
+                                                    must be defined
+                                                  type: boolean
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            serviceAccountToken:
+                                              description: serviceAccountToken is
+                                                information about the serviceAccountToken
+                                                data to project
+                                              properties:
+                                                audience:
+                                                  description: |-
+                                                    audience is the intended audience of the token. A recipient of a token
+                                                    must identify itself with an identifier specified in the audience of the
+                                                    token, and otherwise should reject the token. The audience defaults to the
+                                                    identifier of the apiserver.
+                                                  type: string
+                                                expirationSeconds:
+                                                  description: |-
+                                                    expirationSeconds is the requested duration of validity of the service
+                                                    account token. As the token approaches expiration, the kubelet volume
+                                                    plugin will proactively rotate the service account token. The kubelet will
+                                                    start trying to rotate the token if the token is older than 80 percent of
+                                                    its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                    and must be at least 10 minutes.
+                                                  format: int64
+                                                  type: integer
+                                                path:
+                                                  description: |-
+                                                    path is the path relative to the mount point of the file to project the
+                                                    token into.
+                                                  type: string
+                                              required:
+                                              - path
+                                              type: object
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  quobyte:
+                                    description: quobyte represents a Quobyte mount
+                                      on the host that shares a pod's lifetime
+                                    properties:
+                                      group:
+                                        description: |-
+                                          group to map volume access to
+                                          Default is no group
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                          Defaults to false.
+                                        type: boolean
+                                      registry:
+                                        description: |-
+                                          registry represents a single or multiple Quobyte Registry services
+                                          specified as a string as host:port pair (multiple entries are separated with commas)
+                                          which acts as the central registry for volumes
+                                        type: string
+                                      tenant:
+                                        description: |-
+                                          tenant owning the given Quobyte volume in the Backend
+                                          Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                        type: string
+                                      user:
+                                        description: |-
+                                          user to map volume access to
+                                          Defaults to serivceaccount user
+                                        type: string
+                                      volume:
+                                        description: volume is a string that references
+                                          an already created Quobyte volume by name.
+                                        type: string
+                                    required:
+                                    - registry
+                                    - volume
+                                    type: object
+                                  rbd:
+                                    description: |-
+                                      rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type of the volume that you want to mount.
+                                          Tip: Ensure that the filesystem type is supported by the host operating system.
+                                          Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                          TODO: how do we prevent errors in the filesystem from compromising the machine
+                                        type: string
+                                      image:
+                                        description: |-
+                                          image is the rados image name.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      keyring:
+                                        description: |-
+                                          keyring is the path to key ring for RBDUser.
+                                          Default is /etc/ceph/keyring.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      monitors:
+                                        description: |-
+                                          monitors is a collection of Ceph monitors.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      pool:
+                                        description: |-
+                                          pool is the rados pool name.
+                                          Default is rbd.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly here will force the ReadOnly setting in VolumeMounts.
+                                          Defaults to false.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef is name of the authentication secret for RBDUser. If provided
+                                          overrides keyring.
+                                          Default is nil.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      user:
+                                        description: |-
+                                          user is the rados user name.
+                                          Default is admin.
+                                          More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                                        type: string
+                                    required:
+                                    - image
+                                    - monitors
+                                    type: object
+                                  scaleIO:
+                                    description: scaleIO represents a ScaleIO persistent
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs".
+                                          Default is "xfs".
+                                        type: string
+                                      gateway:
+                                        description: gateway is the host address of
+                                          the ScaleIO API Gateway.
+                                        type: string
+                                      protectionDomain:
+                                        description: protectionDomain is the name
+                                          of the ScaleIO Protection Domain for the
+                                          configured storage.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly Defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef references to the secret for ScaleIO user and other
+                                          sensitive information. If this is not provided, Login operation will fail.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sslEnabled:
+                                        description: sslEnabled Flag enable/disable
+                                          SSL communication with Gateway, default
+                                          false
+                                        type: boolean
+                                      storageMode:
+                                        description: |-
+                                          storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                          Default is ThinProvisioned.
+                                        type: string
+                                      storagePool:
+                                        description: storagePool is the ScaleIO Storage
+                                          Pool associated with the protection domain.
+                                        type: string
+                                      system:
+                                        description: system is the name of the storage
+                                          system as configured in ScaleIO.
+                                        type: string
+                                      volumeName:
+                                        description: |-
+                                          volumeName is the name of a volume already created in the ScaleIO system
+                                          that is associated with this volume source.
+                                        type: string
+                                    required:
+                                    - gateway
+                                    - secretRef
+                                    - system
+                                    type: object
+                                  secret:
+                                    description: |-
+                                      secret represents a secret that should populate this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                    properties:
+                                      defaultMode:
+                                        description: |-
+                                          defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                          Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                          YAML accepts both octal and decimal values, JSON requires decimal values
+                                          for mode bits. Defaults to 0644.
+                                          Directories within the path are not affected by this setting.
+                                          This might be in conflict with other options that affect the file
+                                          mode, like fsGroup, and the result can be other mode bits set.
+                                        format: int32
+                                        type: integer
+                                      items:
+                                        description: |-
+                                          items If unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its keys must be defined
+                                        type: boolean
+                                      secretName:
+                                        description: |-
+                                          secretName is the name of the secret in the pod's namespace to use.
+                                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                                        type: string
+                                    type: object
+                                  storageos:
+                                    description: storageOS represents a StorageOS
+                                      volume attached and mounted on Kubernetes nodes.
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is the filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      readOnly:
+                                        description: |-
+                                          readOnly defaults to false (read/write). ReadOnly here will force
+                                          the ReadOnly setting in VolumeMounts.
+                                        type: boolean
+                                      secretRef:
+                                        description: |-
+                                          secretRef specifies the secret to use for obtaining the StorageOS API
+                                          credentials.  If not specified, default values will be attempted.
+                                        properties:
+                                          name:
+                                            default: ""
+                                            description: |-
+                                              Name of the referent.
+                                              This field is effectively required, but due to backwards compatibility is
+                                              allowed to be empty. Instances of this type with an empty value here are
+                                              almost certainly wrong.
+                                              TODO: Add other useful fields. apiVersion, kind, uid?
+                                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Drop `kubebuilder:default` when controller-gen doesn't need it https://github.com/kubernetes-sigs/kubebuilder/issues/3896.
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      volumeName:
+                                        description: |-
+                                          volumeName is the human-readable name of the StorageOS volume.  Volume
+                                          names are only unique within a namespace.
+                                        type: string
+                                      volumeNamespace:
+                                        description: |-
+                                          volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                          namespace is specified then the Pod's namespace will be used.  This allows the
+                                          Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                          Set VolumeName to any name to override the default behaviour.
+                                          Set to "default" if you are not using namespaces within StorageOS.
+                                          Namespaces that do not pre-exist within StorageOS will be created.
+                                        type: string
+                                    type: object
+                                  vsphereVolume:
+                                    description: vsphereVolume represents a vSphere
+                                      volume attached and mounted on kubelets host
+                                      machine
+                                    properties:
+                                      fsType:
+                                        description: |-
+                                          fsType is filesystem type to mount.
+                                          Must be a filesystem type supported by the host operating system.
+                                          Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                        type: string
+                                      storagePolicyID:
+                                        description: storagePolicyID is the storage
+                                          Policy Based Management (SPBM) profile ID
+                                          associated with the StoragePolicyName.
+                                        type: string
+                                      storagePolicyName:
+                                        description: storagePolicyName is the storage
+                                          Policy Based Management (SPBM) profile name.
+                                        type: string
+                                      volumePath:
+                                        description: volumePath is the path that identifies
+                                          vSphere volume vmdk
+                                        type: string
+                                    required:
+                                    - volumePath
+                                    type: object
+                                required:
+                                - name
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                              - name
+                              x-kubernetes-list-type: map
+                          required:
+                          - containers
+                          type: object
+                      type: object
+                  required:
+                  - count
+                  - template
+                  type: object
+                  x-kubernetes-validations:
+                  - message: minCount should be positive and less or equal to count
+                    rule: 'has(self.minCount) ? self.minCount <= self.count : true'
+                maxItems: 8
+                minItems: 1
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              priority:
+                description: |-
+                  Priority determines the order of access to the resources managed by the
+                  ClusterQueue where the workload is queued.
+                  The priority value is populated from PriorityClassName.
+                  The higher the value, the higher the priority.
+                  If priorityClassName is specified, priority must not be null.
+                format: int32
+                type: integer
+              priorityClassName:
+                description: |-
+                  If specified, indicates the workload's priority.
+                  "system-node-critical" and "system-cluster-critical" are two special
+                  keywords which indicate the highest priorities with the former being
+                  the highest priority. Any other name must be defined by creating a
+                  PriorityClass object with that name. If not specified, the workload
+                  priority will be default or zero if there is no default.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+              priorityClassSource:
+                default: ""
+                description: |-
+                  priorityClassSource determines whether the priorityClass field refers to a pod PriorityClass or kueue.x-k8s.io/workloadpriorityclass.
+                  Workload's PriorityClass can accept the name of a pod priorityClass or a workloadPriorityClass.
+                  When using pod PriorityClass, a priorityClassSource field has the scheduling.k8s.io/priorityclass value.
+                enum:
+                - kueue.x-k8s.io/workloadpriorityclass
+                - scheduling.k8s.io/priorityclass
+                - ""
+                type: string
+              queueName:
+                description: |-
+                  queueName is the name of the LocalQueue the Workload is associated with.
+                  queueName cannot be changed while .status.admission is not null.
+                maxLength: 253
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                type: string
+            required:
+            - podSets
+            type: object
+            x-kubernetes-validations:
+            - message: priority should not be nil when priorityClassName is set
+              rule: 'has(self.priorityClassName) ? has(self.priority) : true'
+          status:
+            description: WorkloadStatus defines the observed state of Workload
+            properties:
+              admission:
+                description: |-
+                  admission holds the parameters of the admission of the workload by a
+                  ClusterQueue. admission can be set back to null, but its fields cannot be
+                  changed once set.
+                properties:
+                  clusterQueue:
+                    description: clusterQueue is the name of the ClusterQueue that
+                      admitted this workload.
+                    maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  podSetAssignments:
+                    description: PodSetAssignments hold the admission results for
+                      each of the .spec.podSets entries.
+                    items:
+                      properties:
+                        count:
+                          description: |-
+                            count is the number of pods taken into account at admission time.
+                            This field will not change in case of quota reclaim.
+                            Value could be missing for Workloads created before this field was added,
+                            in that case spec.podSets[*].count value will be used.
+                          format: int32
+                          minimum: 0
+                          type: integer
+                        flavors:
+                          additionalProperties:
+                            description: ResourceFlavorReference is the name of the
+                              ResourceFlavor.
+                            maxLength: 253
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                            type: string
+                          description: Flavors are the flavors assigned to the workload
+                            for each resource.
+                          type: object
+                        name:
+                          default: main
+                          description: Name is the name of the podSet. It should match
+                            one of the names in .spec.podSets.
+                          maxLength: 63
+                          pattern: ^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        resourceUsage:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            resourceUsage keeps track of the total resources all the pods in the podset need to run.
+
+
+                            Beside what is provided in podSet's specs, this calculation takes into account
+                            the LimitRange defaults and RuntimeClass overheads at the moment of admission.
+                            This field will not change in case of quota reclaim.
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    maxItems: 8
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                required:
+                - clusterQueue
+                - podSetAssignments
+                type: object
+              admissionChecks:
+                description: admissionChecks list all the admission checks required
+                  by the workload and the current status
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    name:
+                      description: name identifies the admission check.
+                      maxLength: 316
+                      type: string
+                    podSetUpdates:
+                      items:
+                        description: |-
+                          PodSetUpdate contains a list of pod set modifications suggested by AdmissionChecks.
+                          The modifications should be additive only - modifications of already existing keys
+                          or having the same key provided by multiple AdmissionChecks is not allowed and will
+                          result in failure during workload admission.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          name:
+                            description: Name of the PodSet to modify. Should match
+                              to one of the Workload's PodSets.
+                            type: string
+                          nodeSelector:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          tolerations:
+                            items:
+                              description: |-
+                                The pod this Toleration is attached to tolerates any taint that matches
+                                the triple <key,value,effect> using the matching operator <operator>.
+                              properties:
+                                effect:
+                                  description: |-
+                                    Effect indicates the taint effect to match. Empty means match all taint effects.
+                                    When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                  type: string
+                                key:
+                                  description: |-
+                                    Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                    If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    Operator represents a key's relationship to the value.
+                                    Valid operators are Exists and Equal. Defaults to Equal.
+                                    Exists is equivalent to wildcard for value, so that a pod can
+                                    tolerate all taints of a particular category.
+                                  type: string
+                                tolerationSeconds:
+                                  description: |-
+                                    TolerationSeconds represents the period of time the toleration (which must be
+                                    of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                    it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                    negative values will be treated as 0 (evict immediately) by the system.
+                                  format: int64
+                                  type: integer
+                                value:
+                                  description: |-
+                                    Value is the taint value the toleration matches to.
+                                    If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                  type: string
+                              type: object
+                            maxItems: 8
+                            type: array
+                            x-kubernetes-validations:
+                            - message: operator must be Exists when 'key' is empty,
+                                which means 'match all values and all keys'
+                              rule: 'self.all(x, !has(x.key) ? x.operator == ''Exists''
+                                : true)'
+                            - message: effect must be 'NoExecute' when 'tolerationSeconds'
+                                is set
+                              rule: 'self.all(x, has(x.tolerationSeconds) ? x.effect
+                                == ''NoExecute'' : true)'
+                            - message: 'supported toleration values: ''Equal''(default),
+                                ''Exists'''
+                              rule: self.all(x, !has(x.operator) || x.operator in
+                                ['Equal', 'Exists'])
+                            - message: a value must be empty when 'operator' is 'Exists'
+                              rule: 'self.all(x, has(x.operator) && x.operator ==
+                                ''Exists'' ? !has(x.value) : true)'
+                            - message: 'supported taint effect values: ''NoSchedule'',
+                                ''PreferNoSchedule'', ''NoExecute'''
+                              rule: self.all(x, !has(x.effect) || x.effect in ['NoSchedule',
+                                'PreferNoSchedule', 'NoExecute'])
+                        required:
+                        - name
+                        type: object
+                      maxItems: 8
+                      type: array
+                      x-kubernetes-list-type: atomic
+                    state:
+                      description: state of the admissionCheck, one of Pending, Ready,
+                        Retry, Rejected
+                      enum:
+                      - Pending
+                      - Ready
+                      - Retry
+                      - Rejected
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - name
+                  - state
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              conditions:
+                description: |-
+                  conditions hold the latest available observations of the Workload
+                  current state.
+
+
+                  The type of the condition could be:
+
+
+                  - Admitted: the Workload was admitted through a ClusterQueue.
+                  - Finished: the associated workload finished running (failed or succeeded).
+                  - PodsReady: at least `.spec.podSets[*].count` Pods are ready or have
+                  succeeded.
+                items:
+                  description: "Condition contains details for one aspect of the current
+                    state of this API Resource.\n---\nThis struct is intended for
+                    direct use as an array at the field path .status.conditions.  For
+                    example,\n\n\n\ttype FooStatus struct{\n\t    // Represents the
+                    observations of a foo's current state.\n\t    // Known .status.conditions.type
+                    are: \"Available\", \"Progressing\", and \"Degraded\"\n\t    //
+                    +patchMergeKey=type\n\t    // +patchStrategy=merge\n\t    // +listType=map\n\t
+                    \   // +listMapKey=type\n\t    Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                    patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`\n\n\n\t
+                    \   // other fields\n\t}"
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: |-
+                        type of condition in CamelCase or in foo.example.com/CamelCase.
+                        ---
+                        Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be
+                        useful (see .node.status.conditions), the ability to deconflict is important.
+                        The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              reclaimablePods:
+                description: |-
+                  reclaimablePods keeps track of the number pods within a podset for which
+                  the resource reservation is no longer needed.
+                items:
+                  properties:
+                    count:
+                      description: count is the number of pods for which the requested
+                        resources are no longer needed.
+                      format: int32
+                      minimum: 0
+                      type: integer
+                    name:
+                      description: name is the PodSet name.
+                      type: string
+                  required:
+                  - count
+                  - name
+                  type: object
+                maxItems: 8
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              requeueState:
+                description: |-
+                  requeueState holds the re-queue state
+                  when a workload meets Eviction with PodsReadyTimeout reason.
+                properties:
+                  count:
+                    description: |-
+                      count records the number of times a workload has been re-queued
+                      When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
+                      this count would be reset to null.
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  requeueAt:
+                    description: |-
+                      requeueAt records the time when a workload will be re-queued.
+                      When a deactivated (`.spec.activate`=`false`) workload is reactivated (`.spec.activate`=`true`),
+                      this time would be reset to null.
+                    format: date-time
+                    type: string
+                type: object
+            type: object
+        type: object
+        x-kubernetes-validations:
+        - message: podSetAssignments must have the same number of podSets as the spec
+          rule: 'has(self.status) && has(self.status.conditions) && self.status.conditions.exists(c,
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(self.status.admission)
+            ? size(self.spec.podSets) == size(self.status.admission.podSetAssignments)
+            : true'
+        - message: field is immutable
+          rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
+            c.type == ''QuotaReserved'' && c.status == ''True'')) ? (oldSelf.spec.priorityClassSource
+            == self.spec.priorityClassSource) : true'
+        - message: field is immutable
+          rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
+            c.type == ''QuotaReserved'' && c.status == ''True'') && has(oldSelf.spec.priorityClassName)
+            && has(self.spec.priorityClassName)) ? (oldSelf.spec.priorityClassName
+            == self.spec.priorityClassName) : true'
+        - message: field is immutable
+          rule: '(has(oldSelf.status) && has(oldSelf.status.conditions) && oldSelf.status.conditions.exists(c,
+            c.type == ''QuotaReserved'' && c.status == ''True'')) && (has(self.status)
+            && has(self.status.conditions) && self.status.conditions.exists(c, c.type
+            == ''QuotaReserved'' && c.status == ''True'')) && has(oldSelf.spec.queueName)
+            && has(self.spec.queueName) ? oldSelf.spec.queueName == self.spec.queueName
+            : true'
+    served: true
+    storage: true
+    subresources:
+      status: {}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-controller-manager
+  namespace: kueue-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-leader-election-role
+  namespace: kueue-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.kueue.x-k8s.io/batch-admin: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-batch-admin-role
+---
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.kueue.x-k8s.io/batch-user: "true"
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-batch-user-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-clusterqueue-editor-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-clusterqueue-viewer-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-job-editor-role
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-job-viewer-role
+rules:
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-jobset-editor-role
+rules:
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-jobset-viewer-role
+rules:
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-localqueue-editor-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-localqueue-viewer-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-manager-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - podtemplates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - autoscaling.x-k8s.io
+  resources:
+  - provisioningrequests
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - autoscaling.x-k8s.io
+  resources:
+  - provisioningrequests/status
+  verbs:
+  - get
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs/finalizers
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - batch
+  resources:
+  - jobs/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - flowschemas
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - flowschemas/status
+  verbs:
+  - patch
+- apiGroups:
+  - flowcontrol.apiserver.k8s.io
+  resources:
+  - prioritylevelconfigurations
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - jobset.x-k8s.io
+  resources:
+  - jobsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - admissionchecks/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - clusterqueues/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - localqueues/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - multikueueclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - multikueueclusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - multikueueconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - provisioningrequestconfigs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - resourceflavors
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - resourceflavors/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloadpriorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/finalizers
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-mpijob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-mpijob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mpijobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-mxjob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-mxjob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - mxjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-paddlejob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-paddlejob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - paddlejobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-pending-workloads-cq-viewer-role
+rules:
+- apiGroups:
+  - visibility.kueue.x-k8s.io
+  resources:
+  - clusterqueues/pendingworkloads
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-pending-workloads-lq-viewer-role
+rules:
+- apiGroups:
+  - visibility.kueue.x-k8s.io
+  resources:
+  - localqueues/pendingworkloads
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-proxy-role
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-pytorchjob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-pytorchjob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-raycluster-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-raycluster-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayclusters/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-rayjob-editor-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-rayjob-viewer-role
+rules:
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ray.io
+  resources:
+  - rayjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-resourceflavor-editor-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - resourceflavors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-resourceflavor-viewer-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - resourceflavors
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-tfjob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-tfjob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - tfjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+  name: kueue-workload-editor-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-workload-viewer-role
+rules:
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kueue.x-k8s.io
+  resources:
+  - workloads/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-xgboostjob-editor-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+    rbac.kueue.x-k8s.io/batch-admin: "true"
+    rbac.kueue.x-k8s.io/batch-user: "true"
+  name: kueue-xgboostjob-viewer-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - xgboostjobs/status
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-leader-election-rolebinding
+  namespace: kueue-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kueue-leader-election-role
+subjects:
+- kind: ServiceAccount
+  name: kueue-controller-manager
+  namespace: kueue-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-manager-role
+subjects:
+- kind: ServiceAccount
+  name: kueue-controller-manager
+  namespace: kueue-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-proxy-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: kueue-controller-manager
+  namespace: kueue-system
+---
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: config.kueue.x-k8s.io/v1beta1
+    kind: Configuration
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: :8080
+    # enableClusterQueueResources: true
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: c1f6bfd2.kueue.x-k8s.io
+    controller:
+      groupKindConcurrency:
+        Job.batch: 5
+        Pod: 5
+        Workload.kueue.x-k8s.io: 5
+        LocalQueue.kueue.x-k8s.io: 1
+        ClusterQueue.kueue.x-k8s.io: 1
+        ResourceFlavor.kueue.x-k8s.io: 1
+    clientConnection:
+      qps: 50
+      burst: 100
+    #pprofBindAddress: :8083
+    #waitForPodsReady:
+    #  enable: false
+    #  timeout: 5m
+    #  blockAdmission: false
+    #  requeuingStrategy:
+    #    timestamp: Eviction
+    #    backoffLimitCount: null # null indicates infinite requeuing
+    #    backoffBaseSeconds: 60
+    #    backoffMaxSeconds: 3600
+    #manageJobsWithoutQueueName: true
+    #internalCertManagement:
+    #  enable: false
+    #  webhookServiceName: ""
+    #  webhookSecretName: ""
+    integrations:
+      frameworks:
+      - "batch/job"
+      - "kubeflow.org/mpijob"
+      - "ray.io/rayjob"
+      - "ray.io/raycluster"
+      - "jobset.x-k8s.io/jobset"
+      - "kubeflow.org/mxjob"
+      - "kubeflow.org/paddlejob"
+      - "kubeflow.org/pytorchjob"
+      - "kubeflow.org/tfjob"
+      - "kubeflow.org/xgboostjob"
+    #  - "pod"
+    #  externalFrameworks:
+    #  - "Foo.v1.example.com"
+    #  podOptions:
+    #    namespaceSelector:
+    #      matchExpressions:
+    #        - key: kubernetes.io/metadata.name
+    #          operator: NotIn
+    #          values: [ kube-system, kueue-system ]
+    #fairSharing:
+    #  enable: true
+    #  preemptionStrategies: [LessThanOrEqualToFinalShare, LessThanInitialShare]
+    #resources:
+    #  excludeResourcePrefixes: []
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-manager-config
+  namespace: kueue-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-webhook-server-cert
+  namespace: kueue-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-controller-manager-metrics-service
+  namespace: kueue-system
+spec:
+  ports:
+  - name: https
+    port: 8443
+    protocol: TCP
+    targetPort: https
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-webhook-service
+  namespace: kueue-system
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-controller-manager
+  namespace: kueue-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: manager
+      labels:
+        control-plane: controller-manager
+    spec:
+      containers:
+      - args:
+        - --config=/controller_manager_config.yaml
+        - --zap-log-level=2
+        command:
+        - /manager
+        image: registry.k8s.io/kueue/kueue:v0.8.1
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        name: manager
+        ports:
+        - containerPort: 8082
+          name: visibility
+          protocol: TCP
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 500m
+            memory: 512Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        - mountPath: /controller_manager_config.yaml
+          name: manager-config
+          subPath: controller_manager_config.yaml
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+      securityContext:
+        runAsNonRoot: true
+      serviceAccountName: kueue-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: kueue-webhook-server-cert
+      - configMap:
+          name: kueue-manager-config
+        name: manager-config
+      tolerations:
+      - effect: NoSchedule
+        key: components.gke.io/gke-managed-components
+        operator: Equal
+        value: "true"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-mutating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate--v1-pod
+  failurePolicy: Fail
+  name: mpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kueue-system
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-batch-v1-job
+  failurePolicy: Fail
+  name: mjob.kb.io
+  rules:
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - jobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-jobset-x-k8s-io-v1alpha2-jobset
+  failurePolicy: Fail
+  name: mjobset.kb.io
+  rules:
+  - apiGroups:
+    - jobset.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    resources:
+    - jobsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v1-mxjob
+  failurePolicy: Fail
+  name: mmxjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - mxjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v1-paddlejob
+  failurePolicy: Fail
+  name: mpaddlejob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - paddlejobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v1-pytorchjob
+  failurePolicy: Fail
+  name: mpytorchjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pytorchjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v1-tfjob
+  failurePolicy: Fail
+  name: mtfjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - tfjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v1-xgboostjob
+  failurePolicy: Fail
+  name: mxgboostjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - xgboostjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kubeflow-org-v2beta1-mpijob
+  failurePolicy: Fail
+  name: mmpijob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v2beta1
+    operations:
+    - CREATE
+    resources:
+    - mpijobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-ray-io-v1-raycluster
+  failurePolicy: Fail
+  name: mraycluster.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - rayclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-ray-io-v1-rayjob
+  failurePolicy: Fail
+  name: mrayjob.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kueue-x-k8s-io-v1beta1-clusterqueue
+  failurePolicy: Fail
+  name: mclusterqueue.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - clusterqueues
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kueue-x-k8s-io-v1beta1-resourceflavor
+  failurePolicy: Fail
+  name: mresourceflavor.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - resourceflavors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /mutate-kueue-x-k8s-io-v1beta1-workload
+  failurePolicy: Fail
+  name: mworkload.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    resources:
+    - workloads
+  sideEffects: None
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/name: kueue
+    control-plane: controller-manager
+  name: kueue-validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate--v1-pod
+  failurePolicy: Fail
+  name: vpod.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values:
+      - kube-system
+      - kueue-system
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-batch-v1-job
+  failurePolicy: Fail
+  name: vjob.kb.io
+  rules:
+  - apiGroups:
+    - batch
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-jobset-x-k8s-io-v1alpha2-jobset
+  failurePolicy: Fail
+  name: vjobset.kb.io
+  rules:
+  - apiGroups:
+    - jobset.x-k8s.io
+    apiVersions:
+    - v1alpha2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - jobsets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v1-mxjob
+  failurePolicy: Fail
+  name: vmxjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mxjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v1-paddlejob
+  failurePolicy: Fail
+  name: vpaddlejob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - paddlejobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v1-pytorchjob
+  failurePolicy: Fail
+  name: vpytorchjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pytorchjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v1-tfjob
+  failurePolicy: Fail
+  name: vtfjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - tfjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v1-xgboostjob
+  failurePolicy: Fail
+  name: vxgboostjob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - xgboostjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kubeflow-org-v2beta1-mpijob
+  failurePolicy: Fail
+  name: vmpijob.kb.io
+  rules:
+  - apiGroups:
+    - kubeflow.org
+    apiVersions:
+    - v2beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - mpijobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-ray-io-v1-raycluster
+  failurePolicy: Fail
+  name: vraycluster.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-ray-io-v1-rayjob
+  failurePolicy: Fail
+  name: vrayjob.kb.io
+  rules:
+  - apiGroups:
+    - ray.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - rayjobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kueue-x-k8s-io-v1beta1-clusterqueue
+  failurePolicy: Fail
+  name: vclusterqueue.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - clusterqueues
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kueue-x-k8s-io-v1beta1-resourceflavor
+  failurePolicy: Fail
+  name: vresourceflavor.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - resourceflavors
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: kueue-webhook-service
+      namespace: kueue-system
+      path: /validate-kueue-x-k8s-io-v1beta1-workload
+  failurePolicy: Fail
+  name: vworkload.kb.io
+  rules:
+  - apiGroups:
+    - kueue.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - workloads
+    - workloads/status
+  sideEffects: None

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -36,3 +36,32 @@ variable "apply_manifests" {
   }))
   default = []
 }
+
+variable "kueue" {
+  description = "Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler."
+  type = object({
+    install     = optional(bool, false)
+    version     = optional(string, "v0.8.1")
+    config_path = optional(string, null)
+  })
+  default = {}
+
+  validation {
+    condition     = !var.kueue.install || contains(["v0.8.1"], var.kueue.version)
+    error_message = "Supported version of Kueue is v0.8.1"
+  }
+}
+
+variable "jobset" {
+  description = "Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit."
+  type = object({
+    install = optional(bool, false)
+    version = optional(string, "v0.5.2")
+  })
+  default = {}
+
+  validation {
+    condition     = !var.jobset.install || contains(["v0.5.2"], var.jobset.version)
+    error_message = "Supported version of Jobset is v0.5.2"
+  }
+}


### PR DESCRIPTION
Allows blueprint to install Kueue/Jobset for a GKE cluster which reduces the manual steps required by the user to configure these frameworks.

In this PR:
* Downloaded versions for kueue / jobset and updated the manifest to add tolerations for the system pool taint.

Testing 
* Manually tested that a3 high cluster comes up with kueue and jobset controllers

Example yaml in a blueprint

```yaml
- id: workload_component_install
    source: modules/management/kubectl-apply
    use: [gke_cluster]
    settings:
      kueue:
        install: true
        config_path: $(ghpc_stage("manifests/user-provided-kueue-config.yaml"))
      jobset:
        install: true
```

Future enhancements 
* Automatic basic configuration for Kueue

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
