### PR TITLE
Create default service account resource in controller only if service_account_email is null

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -25,7 +25,7 @@ locals {
     }
   ]
 
-  service_account_email = coalesce(var.service_account_email, data.google_compute_default_service_account.default.email)
+  service_account_email = (var.service_account_email == null || var.service_account_email == "") ? data.google_compute_default_service_account.default[0].email : var.service_account_email
 
   # can't rely on `email=null` as it's used to instantiate `cloudsql_secret_accessor`
   service_account = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
@@ -29,6 +29,8 @@ locals {
 }
 
 data "google_compute_default_service_account" "default" {
+  count = (var.service_account_email == null || var.service_account_email == "") ? 1 : 0
+
   project = var.project_id
 }
 


### PR DESCRIPTION
This PR limits the creation of the `google_compute_default_service_account` resource in the controller to only get created when `service_account_email` is null. 