### PR TITLE
Validate Reservations in GKE Blueprints

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -264,6 +264,7 @@ limitations under the License.
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_compute_reservation.specific_reservations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 
 ## Inputs
 

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -30,10 +30,8 @@ locals {
     effect = "NO_SCHEDULE"
   }] : []
 
-  autoscale_set                  = var.autoscaling_total_min_nodes != 0 || var.autoscaling_total_max_nodes != 1000
-  static_node_set                = var.static_node_count != null
-  reservation_resource_api_label = "compute.googleapis.com/reservation-name"
-  specific_reservations_count    = try(length(var.reservation_affinity.specific_reservations), 0)
+  autoscale_set   = var.autoscaling_total_min_nodes != 0 || var.autoscaling_total_max_nodes != 1000
+  static_node_set = var.static_node_count != null
 }
 
 data "google_compute_default_service_account" "default_sa" {
@@ -162,8 +160,8 @@ resource "google_container_node_pool" "node_pool" {
 
     reservation_affinity {
       consume_reservation_type = var.reservation_affinity.consume_reservation_type
-      key                      = local.specific_reservations_count != 1 ? null : local.reservation_resource_api_label
-      values                   = local.specific_reservations_count != 1 ? null : [for reservation in var.reservation_affinity.specific_reservations : reservation.name]
+      key                      = length(local.verified_specific_reservations) != 1 ? null : local.reservation_resource_api_label
+      values                   = length(local.verified_specific_reservations) != 1 ? null : [for r in local.verified_specific_reservations : "projects/${r.project}/reservations/${r.name}"]
     }
 
     dynamic "host_maintenance_policy" {
@@ -204,12 +202,24 @@ resource "google_container_node_pool" "node_pool" {
     }
     precondition {
       condition = (
-        (var.reservation_affinity.consume_reservation_type != "SPECIFIC_RESERVATION" && local.specific_reservations_count == 0) ||
-        (var.reservation_affinity.consume_reservation_type == "SPECIFIC_RESERVATION" && local.specific_reservations_count == 1)
+        (var.reservation_affinity.consume_reservation_type != "SPECIFIC_RESERVATION" && local.input_specific_reservations_count == 0) ||
+        (var.reservation_affinity.consume_reservation_type == "SPECIFIC_RESERVATION" && local.input_specific_reservations_count == 1)
       )
       error_message = <<-EOT
       When using NO_RESERVATION or ANY_RESERVATION as the `consume_reservation_type`, `specific_reservations` cannot be set.
       On the other hand, with SPECIFIC_RESERVATION you must set `specific_reservations`.
+      EOT
+    }
+    precondition {
+      condition = (
+        (local.input_specific_reservations_count == 0) ||
+        (local.input_specific_reservations_count == 1 && length(local.verified_specific_reservations) > 0 && length(local.specific_reservation_requirement_violations) == 0)
+      )
+      error_message = <<-EOT
+      Check if your reservation is configured correctly:
+      1. A reservation with the name must exist in the specified project and one of the specified zones
+      2. Its consumption type must be "specific"
+      3. Its VM Properties must match with those of the Node Pool; Machine type, Accelerators (GPU Type and count), Local SSD disk type and count
       EOT
     }
   }

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+data "google_compute_reservation" "specific_reservations" {
+  for_each = (
+    local.input_specific_reservations_count == 0 ?
+    {} :
+    {
+      for pair in flatten([
+        for zone in try(var.zones, []) : [
+          for reservation in try(var.reservation_affinity.specific_reservations, []) : {
+            key : "${coalesce(reservation.project, var.project_id)}/${zone}/${reservation.name}"
+            zone : zone
+            reservation_name : reservation.name
+            project : reservation.project == null ? var.project_id : reservation.project
+          }
+        ]
+      ]) :
+      pair.key => pair
+    }
+  )
+  name    = each.value.reservation_name
+  zone    = each.value.zone
+  project = each.value.project
+}
+
+locals {
+  reservation_resource_api_label    = "compute.googleapis.com/reservation-name"
+  input_specific_reservations_count = try(length(var.reservation_affinity.specific_reservations), 0)
+
+  # Filter specific reservations
+  verified_specific_reservations = [for k, v in data.google_compute_reservation.specific_reservations : v if(v.specific_reservation != null && v.specific_reservation_required == true)]
+
+  # Build two maps to be used to compare the VM properties between reservations and the node pool
+  reservation_vm_properties = [for r in local.verified_specific_reservations : {
+    "machine_type" : try(r.specific_reservation[0].instance_properties[0].machine_type, "")
+    "guest_accelerators" : { for acc in try(r.specific_reservation[0].instance_properties[0].guest_accelerators, []) : acc.accelerator_type => acc.accelerator_count },
+    "local_ssds" : {
+      "NVME" : length([for d in try(r.specific_reservation[0].instance_properties[0].local_ssds, []) : d if d.interface == "NVME"])
+      "SCSI" : length([for d in try(r.specific_reservation[0].instance_properties[0].local_ssds, []) : d if d.interface == "SCSI"])
+    }
+  }]
+  nodepool_vm_properties = {
+    "machine_type" : var.machine_type
+    "guest_accelerators" : { for acc in try(local.guest_accelerator, []) : coalesce(acc.type, try(local.generated_guest_accelerator[0].type, "")) => coalesce(acc.count, try(local.generated_guest_accelerator[0].count, 0)) },
+    "local_ssds" : {
+      "NVME" : coalesce(local.local_ssd_config.local_ssd_count_nvme_block, 0),
+      "SCSI" : coalesce(local.local_ssd_config.local_ssd_count_ephemeral_storage, 0)
+    }
+  }
+
+  # Compare two maps by counting the keys that mismatch.
+  # Know that in map comparison the order of keys does not matter. That is {NVME: x, SCSI: y} and {SCSI: y, NVME: x} are equal
+  # As of this writing, there is only one reservation supported by the Node Pool API. So, directly accessing it from the list
+  specific_reservation_requirement_violations = length(local.reservation_vm_properties) == 0 ? [] : [for k, v in local.nodepool_vm_properties : k if v != local.reservation_vm_properties[0][k]]
+}


### PR DESCRIPTION
### About
Validate GKE Node Pool Reservations

### Why
We want to ensure that the [requirements wrt consuming reservations](https://cloud.google.com/compute/docs/instances/reservations-overview#requirements) are identified early. Otherwise, the deployed Node Pool won’t consume reservations which would require troubleshooting. Essentially, validations will save users' time

### Testing
Existing integration tests will be modified as a follow-up. Before the test to create a reservation, deploy a cluster to use it, assert the consumption and destroy the reservation during clean up

### Submission Checklist

Please take the following actions before submitting this pull request.

* [x] Fork your PR branch from the Toolkit "develop" branch (not main)
* [x] Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* [x] Confirm that "make tests" passes all tests
* [x] Add or modify unit tests to cover code changes: __not applicable__
* [x] Ensure that unit test coverage remains above 80%: __not applicable__
* [x] Update all applicable documentation
* [x] Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)