### PR TITLE
Update zone for HCLS v5 (legacy) blueprint integration test

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hcls-v5-legacy.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls-v5-legacy.yml
@@ -19,7 +19,7 @@ deployment_name: "hcls-{{ build }}"
 # No non-alphanumerical characters in the slurm cluster name - they will be
 # removed by Cluster Toolkit slurm wrappers, which will break the playbook
 slurm_cluster_name: "hcls{{ build[0:6] }}"
-zone: europe-west1-d
+zone: europe-west1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/docs/videos/healthcare-and-life-sciences/hcls-blueprint-v5-legacy.yaml"
 network: "{{ test_name }}-net"


### PR DESCRIPTION
The PR for #3003 included an update to the zone for the HCLS v6 blueprint integration test as well as a reservation ensuring we have capacity for the GPU accelerators used in the test. This PR updates the legacy test to use that reservation.

### Submission Checklist

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
