### PR TITLE
Start daos-agent service in mount script

### DIFF
--- a/modules/file-system/parallelstore/main.tf
+++ b/modules/file-system/parallelstore/main.tf
@@ -30,14 +30,13 @@ locals {
   client_install_runner = {
     "type"        = "shell"
     "source"      = "${path.module}/scripts/install-daos-client.sh"
-    "args"        = "--access_points=\"${local.access_points}\""
     "destination" = "install_daos_client.sh"
   }
 
   mount_runner = {
     "type"        = "shell"
     "source"      = "${path.module}/scripts/mount-daos.sh"
-    "args"        = "--local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
+    "args"        = "--access_points=\"${local.access_points}\" --local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
     "destination" = "mount_daos.sh"
   }
 }

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -15,13 +15,6 @@
 
 set -e -o pipefail
 
-# Parse access_points.
-for arg in "$@"; do
-	if [[ $arg == --access_points=* ]]; then
-		access_points="${arg#*=}"
-	fi
-done
-
 OS_ID=$(awk -F '=' '/^ID=/ {print $2}' /etc/os-release | sed -e 's/"//g')
 OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g')
 OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
@@ -85,28 +78,6 @@ EOF
 		echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 		exit 1
 	fi
-fi
-
-# Edit agent config
-daos_config=/etc/daos/daos_agent.yml
-sed -i "s/#.*transport_config/transport_config/g" $daos_config
-sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
-sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
-
-# Start service
-if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
-	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
-	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
-	mkdir -p /var/log/daos_agent
-	chown daos_agent:daos_agent /var/log/daos_agent
-	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
-	systemctl start daos_agent.service
-elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
-	mkdir -p /var/run/daos_agent
-	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
-else
-	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
-	exit 1
 fi
 
 exit 0

--- a/modules/file-system/parallelstore/scripts/mount-daos.sh
+++ b/modules/file-system/parallelstore/scripts/mount-daos.sh
@@ -13,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -e -o pipefail
+
+OS_ID=$(awk -F '=' '/^ID=/ {print $2}' /etc/os-release | sed -e 's/"//g')
+OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g')
+OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
 
 # Parse local_mount, mount_options from argument.
 # Format mount-options string to be compatible to dfuse mount command.
 # e.g. "disable-wb-cache,eq-count=8" --> --disable-wb-cache --eq-count=8.
 for arg in "$@"; do
+	if [[ $arg == --access_points=* ]]; then
+		access_points="${arg#*=}"
+	fi
 	if [[ $arg == --local_mount=* ]]; then
 		local_mount="${arg#*=}"
 	fi
@@ -27,6 +34,28 @@ for arg in "$@"; do
 		mount_options="--${mount_options//,/ --}"
 	fi
 done
+
+# Edit agent config
+daos_config=/etc/daos/daos_agent.yml
+sed -i "s/#.*transport_config/transport_config/g" $daos_config
+sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
+sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
+
+# Start service
+if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
+	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
+	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+	mkdir -p /var/log/daos_agent
+	chown daos_agent:daos_agent /var/log/daos_agent
+	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
+	systemctl start daos_agent.service
+elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
+	mkdir -p /var/run/daos_agent
+	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
+else
+	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
+	exit 1
+fi
 
 # Mount parallelstore instance to client vm.
 mkdir -p "$local_mount"

--- a/modules/file-system/pre-existing-network-storage/outputs.tf
+++ b/modules/file-system/pre-existing-network-storage/outputs.tf
@@ -60,7 +60,7 @@ locals {
     "type"        = "shell"
     "content"     = lookup(local.install_scripts, var.fs_type, "echo 'skipping: client_install_runner not yet supported for ${var.fs_type}'")
     "destination" = "install_filesystem_client${replace(var.local_mount, "/", "_")}.sh"
-    "args"        = var.fs_type == "daos" ? "--access_points=\"${var.remote_mount}\"" : ""
+    "args"        = ""
   }
 
   mount_vanilla_supported_fstype = ["lustre", "nfs"]
@@ -85,7 +85,7 @@ locals {
   mount_runner_daos = {
     "type"        = "shell"
     "content"     = file("${path.module}/scripts/mount-daos.sh")
-    "args"        = "--local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
+    "args"        = "--access_points=\"${var.remote_mount}\" --local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
     "destination" = "mount_filesystem${replace(var.local_mount, "/", "_")}.sh"
   }
 

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -15,13 +15,6 @@
 
 set -e -o pipefail
 
-# Parse access_points.
-for arg in "$@"; do
-	if [[ $arg == --access_points=* ]]; then
-		access_points="${arg#*=}"
-	fi
-done
-
 OS_ID=$(awk -F '=' '/^ID=/ {print $2}' /etc/os-release | sed -e 's/"//g')
 OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g')
 OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
@@ -85,28 +78,6 @@ EOF
 		echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 		exit 1
 	fi
-fi
-
-# Edit agent config
-daos_config=/etc/daos/daos_agent.yml
-sed -i "s/#.*transport_config/transport_config/g" $daos_config
-sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
-sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
-
-# Start service
-if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
-	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
-	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
-	mkdir -p /var/log/daos_agent
-	chown daos_agent:daos_agent /var/log/daos_agent
-	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
-	systemctl start daos_agent.service
-elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
-	mkdir -p /var/run/daos_agent
-	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
-else
-	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
-	exit 1
 fi
 
 exit 0

--- a/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
@@ -13,12 +13,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -e -o pipefail
+
+OS_ID=$(awk -F '=' '/^ID=/ {print $2}' /etc/os-release | sed -e 's/"//g')
+OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g')
+OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
 
 # Parse local_mount, mount_options from argument.
 # Format mount-options string to be compatible to dfuse mount command.
 # e.g. "disable-wb-cache,eq-count=8" --> --disable-wb-cache --eq-count=8.
 for arg in "$@"; do
+	if [[ $arg == --access_points=* ]]; then
+		access_points="${arg#*=}"
+	fi
 	if [[ $arg == --local_mount=* ]]; then
 		local_mount="${arg#*=}"
 	fi
@@ -27,6 +34,28 @@ for arg in "$@"; do
 		mount_options="--${mount_options//,/ --}"
 	fi
 done
+
+# Edit agent config
+daos_config=/etc/daos/daos_agent.yml
+sed -i "s/#.*transport_config/transport_config/g" $daos_config
+sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
+sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
+
+# Start service
+if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ] || [ "${OS_VERSION_MAJOR}" = "9" ]; }; then
+	# TODO: Update script to change default log destination folder, after daos_agent user is supported in debian and ubuntu.
+	# Move agent log destination from /tmp/ (default) to /var/log/daos_agent/
+	mkdir -p /var/log/daos_agent
+	chown daos_agent:daos_agent /var/log/daos_agent
+	sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
+	systemctl start daos_agent.service
+elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
+	mkdir -p /var/run/daos_agent
+	daos_agent -o /etc/daos/daos_agent.yml >/dev/null 2>&1 &
+else
+	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
+	exit 1
+fi
 
 # Mount parallelstore instance to client vm.
 mkdir -p "$local_mount"


### PR DESCRIPTION
This PR moves the updating daos config and starting daos service logic inside mount daos script. 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
