### PR TITLE
support ghpc_stage function in kubectl-apply module

### DIFF
--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -30,10 +30,10 @@ This module simplifies applying Kubernetes manifests to GKE clusters. It provide
         metadata:
           name: my-namespace
     - source: "https://github.com/kubernetes-sigs/jobset/releases/download/v0.6.0/manifests.yaml"
-    - source: "./manifests/configmap1.yaml"
-    - source: "./manifests/configmap2.yaml.tftpl"
+    - source: $(ghpc_stage("manifests/configmap1.yaml"))
+    - source: $(ghpc_stage("manifests/configmap2.yaml.tftpl"))
       template_vars: {name: "dev-config", public: "false"}
-    - source: "./manifests/"
+    - source: $(ghpc_stage("manifests"))/
       template_vars: {name: "dev-config", public: "false"}
 ```
 

--- a/modules/management/kubectl-apply/kubectl/main.tf
+++ b/modules/management/kubectl-apply/kubectl/main.tf
@@ -24,10 +24,10 @@ locals {
   url         = startswith(local.null_safe_source, "http://") || startswith(local.null_safe_source, "https://") ? var.source_path : null
   url_content = local.url != null ? data.http.yaml_content[0].response_body : null
 
-  yaml_file         = local.url == null && endswith(lower(local.null_safe_source), ".yaml") ? abspath(var.source_path) : null
+  yaml_file         = local.url == null && length(regexall("\\.yaml(_.*)?$", lower(local.null_safe_source))) == 1 ? abspath(var.source_path) : null
   yaml_file_content = local.yaml_file != null ? file(local.yaml_file) : null
 
-  template_file         = local.url == null && endswith(lower(local.null_safe_source), ".tftpl") ? abspath(var.source_path) : null
+  template_file         = local.url == null && length(regexall("\\.tftpl(_.*)?$", lower(local.null_safe_source))) == 1 ? abspath(var.source_path) : null
   template_file_content = local.template_file != null ? templatefile(local.template_file, var.template_vars) : null
 
   yaml_body      = coalesce(local.content_yaml_body, local.url_content, local.yaml_file_content, local.template_file_content, " ")


### PR DESCRIPTION
### Added ghpc_stage function support in kubectl-apply module 
- The  kubectl-apply module now supports staged files.
- Relevant documents updated.

#### Manual tests:
- Different files types and directories containing yaml and templates files referenced using ghpc_function in blueprints
- Verified by checking applying manifests