### PR TITLE
SlurmGCP. Remove usage of `google_compute_default_service_account`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -244,8 +244,8 @@ limitations under the License.
 | [google_secret_manager_secret_version.cloudsql_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_storage_bucket_iam_binding.legacy_readers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
-| [google_compute_default_service_account.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+| [google_project.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -25,11 +25,10 @@ locals {
     }
   ]
 
-  service_account_email = (var.service_account_email == null || var.service_account_email == "") ? data.google_compute_default_service_account.default[0].email : var.service_account_email
+  synth_def_sa_email = "${data.google_project.this.number}-compute@developer.gserviceaccount.com"
 
-  # can't rely on `email=null` as it's used to instantiate `cloudsql_secret_accessor`
   service_account = {
-    email  = local.service_account_email
+    email  = coalesce(var.service_account_email, local.synth_def_sa_email)
     scopes = var.service_account_scopes
   }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/main.tf
@@ -28,10 +28,8 @@ locals {
   universe_domain = { "universe_domain" = var.universe_domain }
 }
 
-data "google_compute_default_service_account" "default" {
-  count = (var.service_account_email == null || var.service_account_email == "") ? 1 : 0
-
-  project = var.project_id
+data "google_project" "this" {
+  project_id = var.project_id
 }
 
 # See 


### PR DESCRIPTION
Synthesize it as `"${project_number}-compute@developer.gserviceaccount.com"` instead.

