### PR TITLE
Fix test-hpc-slurm-chromedesktop-v5-legacy to use valid reservation

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
@@ -19,7 +19,7 @@ deployment_name: "slm-crd-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.
 slurm_cluster_name: "slmcrd{{ build[0:4] }}"
-zone: europe-west1-d
+zone: europe-west1-c
 cli_deployment_vars:
   network_name: "{{ network }}"
   region: europe-west1


### PR DESCRIPTION
Update the test to use a valid reservation, w.r.t #3003 where we updated the zone with the reservation

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
