### PR TITLE
Fix multivpc missing region

### DIFF
--- a/modules/network/multivpc/main.tf
+++ b/modules/network/multivpc/main.tf
@@ -24,7 +24,7 @@ locals {
   maximum_subnetworks   = pow(2, local.subnetwork_new_bits)
   additional_networks = [
     for vpc in module.vpcs :
-    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_name, subnetwork_project = var.project_id })
+    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_self_link })
   ]
 }
 


### PR DESCRIPTION
This helps avoid errors like:
```
Error: cannot determine self_link for subnetwork "***": Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.
```

When just `use`-ing the generated networks.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
