### PR TITLE
Adding gcloud path override to wait-for-startup

### DIFF
--- a/community/modules/scripts/wait-for-startup/README.md
+++ b/community/modules/scripts/wait-for-startup/README.md
@@ -74,6 +74,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Directory of the gcloud executable to be used during cleanup | `string` | `""` | no |
 | <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the instance we are waiting for (can be null if 'instance\_names' is not empty) | `string` | `null` | no |
 | <a name="input_instance_names"></a> [instance\_names](#input\_instance\_names) | A list of instance names we are waiting for, in addition to the one mentioned in 'instance\_name' (if any) | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |

--- a/community/modules/scripts/wait-for-startup/main.tf
+++ b/community/modules/scripts/wait-for-startup/main.tf
@@ -37,6 +37,7 @@ resource "null_resource" "wait_for_startup" {
       ZONE          = var.zone
       PROJECT_ID    = var.project_id
       TIMEOUT       = var.timeout
+      GCLOUD_PATH   = var.gcloud_path_override
     }
   }
 

--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -30,6 +30,10 @@ if [[ -z "${TIMEOUT}" ]]; then
 	exit 1
 fi
 
+if [[ -n "${GCLOUD_PATH}" ]]; then
+	export PATH="$GCLOUD_PATH:$PATH"
+fi
+
 echo "Waiting for startup: instance_name='${INSTANCE_NAME}', zone='${ZONE}', project_id='${PROJECT_ID}', timeout_seconds='${TIMEOUT}'"
 
 # Wrapper around grep that swallows the error status code 1

--- a/community/modules/scripts/wait-for-startup/variables.tf
+++ b/community/modules/scripts/wait-for-startup/variables.tf
@@ -45,3 +45,10 @@ variable "timeout" {
     error_message = "The timeout should be non-negative"
   }
 }
+
+variable "gcloud_path_override" {
+  description = "Directory of the gcloud executable to be used during cleanup"
+  type        = string
+  default     = ""
+  nullable    = false
+}


### PR DESCRIPTION
If the version of gcloud does not have all the features needed (e.g. staging), it can break during use in a gcluster deployment.  This is a similar fix to the slurm compute cleanup script.

Testing is being done on another branch with the same edits, in a relevant environment.
