### PR TITLE
Provide explicit project information

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -174,6 +174,7 @@ data "google_compute_reservation" "reservation" {
 
 data "google_compute_machine_types" "machine_types_by_zone" {
   for_each = local.zones
+  project  = var.project_id
   filter   = format("name = \"%s\"", var.machine_type)
   zone     = each.value
 }

--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -82,6 +82,7 @@ No modules.
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to supporting resources. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to configure private service Access.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_prefix_length"></a> [prefix\_length](#input\_prefix\_length) | The prefix length of the IP range allocated for the private service access. | `number` | `16` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Private Service Access will be created. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/community/modules/network/private-service-access/main.tf
+++ b/community/modules/network/private-service-access/main.tf
@@ -26,6 +26,7 @@ resource "random_id" "resource_name_suffix" {
 resource "google_compute_global_address" "private_ip_alloc" {
   provider      = google-beta
   name          = "global-psconnect-ip-${random_id.resource_name_suffix.hex}"
+  project       = var.project_id
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"
   network       = var.network_id

--- a/community/modules/network/private-service-access/variables.tf
+++ b/community/modules/network/private-service-access/variables.tf
@@ -40,3 +40,8 @@ variable "prefix_length" {
   type        = number
   default     = 16
 }
+
+variable "project_id" {
+  description = "ID of project in which Private Service Access will be created."
+  type        = string
+}

--- a/modules/file-system/parallelstore/main.tf
+++ b/modules/file-system/parallelstore/main.tf
@@ -46,6 +46,7 @@ resource "random_id" "resource_name_suffix" {
 }
 
 resource "google_parallelstore_instance" "instance" {
+  project      = var.project_id
   instance_id  = local.id
   location     = var.zone
   capacity_gib = var.size_gb


### PR DESCRIPTION
### Submission Checklist
Explicitly provide project information, otherwise if environment doesn't set any project information, the plan/apply will fail with following error:
```
╷                                     
│ Error: Failed to retrieve project, pid: , err: project: required field is not set
│                                                                                                        
│   with module.ps-connect.google_compute_global_address.private_ip_alloc,
│   on modules/private-service-access-5f9b/main.tf line 26, in resource "google_compute_global_address" "private_ip_alloc":
│   26: resource "google_compute_global_address" "private_ip_alloc" {
│                                          

```

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
