### PR TITLE
Fix parallelstore installation script on RHEL and Rocky Linux

### DIFF
--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -52,7 +52,9 @@ EOF
 		fi
 
 		## TODO: Remove disable automatic update script after issue is fixed.
-		/usr/bin/google_disable_automatic_updates
+		if [ -x /usr/bin/google_disable_automatic_updates ]; then
+			/usr/bin/google_disable_automatic_updates
+		fi
 		dnf makecache
 
 		# 2) Install daos-client

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -52,7 +52,9 @@ EOF
 		fi
 
 		## TODO: Remove disable automatic update script after issue is fixed.
-		/usr/bin/google_disable_automatic_updates
+		if [ -x /usr/bin/google_disable_automatic_updates ]; then
+			/usr/bin/google_disable_automatic_updates
+		fi
 		dnf makecache
 
 		# 2) Install daos-client


### PR DESCRIPTION
### Submission Checklist

Base image of RHEL 9 and Rocky Linux 9 GCP Optimized do not provide `/usr/bin/google_disable_automatic_updates` so execute it only if it exists.

The only image that provides that is HPC Linux.

Related: #2986

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
