### PR TITLE
resource-policy module implemented

### DIFF
--- a/modules/README.md
+++ b/modules/README.md
@@ -49,6 +49,7 @@ Modules that are still in development and less stable are labeled with the
   Creates a dynamic nodeset to be used by the [schedmd-slurm-gcp-v6-partition] module and instance template.
 * **[gke-node-pool]** ![core-badge] ![experimental-badge] : Creates a
   Kubernetes node pool using GKE.
+* **[resource-policy]** ![core-badge] ![experimental-badge] : Create a resource policy for compute engines that can be applied to gke-node-pool's nodes.
 * **[gke-job-template]** ![core-badge] ![experimental-badge] : Creates a
   Kubernetes job file to be used with a [gke-node-pool].
 * **[htcondor-execute-point]** ![community-badge] ![experimental-badge] :
@@ -62,6 +63,7 @@ Modules that are still in development and less stable are labeled with the
 
 [vm-instance]: compute/vm-instance/README.md
 [gke-node-pool]: ../modules/compute/gke-node-pool/README.md
+[resource-policy]: ../modules/compute/resource-policy/README.md
 [gke-job-template]: ../modules/compute/gke-job-template/README.md
 [schedmd-slurm-gcp-v5-partition]: ../community/modules/compute/schedmd-slurm-gcp-v5-partition/README.md
 [schedmd-slurm-gcp-v5-node-group]: ../community/modules/compute/schedmd-slurm-gcp-v5-node-group/README.md

--- a/modules/compute/resource-policy/resource-policy/README.md
+++ b/modules/compute/resource-policy/resource-policy/README.md
@@ -46,7 +46,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_group_placement_max_distance"></a> [group\_placement\_max\_distance](#input\_group\_placement\_max\_distance) | The max distance for group placement policy to use for the node pool's nodes. If set it will add a compact group placement policy.<br>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. | `number` | `0` | no |
+| <a name="input_group_placement_max_distance"></a> [group\_placement\_max\_distance](#input\_group\_placement\_max\_distance) | The max distance for group placement policy to use for the node pool's nodes. If set it will add a compact group placement policy.<br/>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. | `number` | `0` | no |
 | <a name="input_name"></a> [name](#input\_name) | The resource policy's name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID for the resource policy. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region for the the resource policy. | `string` | n/a | yes |
@@ -55,5 +55,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_placement_policy"></a> [placement\_policy](#output\_placement\_policy) | Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.<br>It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.<br>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. |
+| <a name="output_placement_policy"></a> [placement\_policy](#output\_placement\_policy) | Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.<br/>It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.<br/>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/resource-policy/resource-policy/README.md
+++ b/modules/compute/resource-policy/resource-policy/README.md
@@ -1,8 +1,28 @@
 ## Description
 
-This modules create a resource policy for compute engines. This policy can be passed to a gke-node-pool module to apply the policy on the node-pool's nodes.
+This modules create a [resource policy for compute engines](https://cloud.google.com/compute/docs/instances/placement-policies-overview). This policy can be passed to a gke-node-pool module to apply the policy on the node-pool's nodes.
 
-Note: By default, you can't apply compact placement policies with a max distance value to A3 VMs. To request access to this feature, contact your Technical Account Manager (TAM) or the Sales team.
+Note: By default, you can't apply compact placement policies with a max distance value to A3 VMs. To request access to this feature, contact your [Technical Account Manager (TAM)](https://cloud.google.com/tam) or the [Sales team](https://cloud.google.com/contact).
+
+### Example
+
+The following example creates a group placement resource policy and applies it to a gke-node-pool.
+
+```yaml
+  - id: group_placement_1
+    source: modules/compute/resource-policy
+    settings:
+      name: gp-np-1
+      group_placement_max_distance: 2
+
+  - id: node_pool_1
+    source: modules/compute/gke-node-pool
+    use: [group_placement_1]
+    settings:
+      machine_type: e2-standard-8
+    outputs: [instructions]
+```
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2024 Google LLC

--- a/modules/compute/resource-policy/resource-policy/README.md
+++ b/modules/compute/resource-policy/resource-policy/README.md
@@ -23,7 +23,6 @@ The following example creates a group placement resource policy and applies it t
     outputs: [instructions]
 ```
 
-
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2024 Google LLC
 

--- a/modules/compute/resource-policy/resource-policy/README.md
+++ b/modules/compute/resource-policy/resource-policy/README.md
@@ -1,0 +1,59 @@
+## Description
+
+This modules create a resource policy for compute engines. This policy can be passed to a gke-node-pool module to apply the policy on the node-pool's nodes.
+
+Note: By default, you can't apply compact placement policies with a max distance value to A3 VMs. To request access to this feature, contact your Technical Account Manager (TAM) or the Sales team.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google-beta_google_compute_resource_policy.policy](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_resource_policy) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_group_placement_max_distance"></a> [group\_placement\_max\_distance](#input\_group\_placement\_max\_distance) | The max distance for group placement policy to use for the node pool's nodes. If set it will add a compact group placement policy.<br>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. | `number` | `0` | no |
+| <a name="input_name"></a> [name](#input\_name) | The resource policy's name. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID for the resource policy. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region for the the resource policy. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_placement_policy"></a> [placement\_policy](#output\_placement\_policy) | Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.<br>It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.<br>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/resource-policy/resource-policy/README.md
+++ b/modules/compute/resource-policy/resource-policy/README.md
@@ -75,5 +75,5 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_placement_policy"></a> [placement\_policy](#output\_placement\_policy) | Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.<br/>It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.<br/>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. |
+| <a name="output_placement_policy"></a> [placement\_policy](#output\_placement\_policy) | Group placement policy to use for placing VMs or GKE nodes placement. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.<br/>It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.<br/>Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/resource-policy/resource-policy/main.tf
+++ b/modules/compute/resource-policy/resource-policy/main.tf
@@ -1,0 +1,31 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+resource "google_compute_resource_policy" "policy" {
+  name     = var.name
+  region   = var.region
+  project  = var.project_id
+  provider = google-beta
+
+  dynamic "group_placement_policy" {
+    for_each = var.group_placement_max_distance > 0 ? [1] : []
+
+    content {
+      collocation  = "COLLOCATED"
+      max_distance = var.group_placement_max_distance
+    }
+  }
+}

--- a/modules/compute/resource-policy/resource-policy/metadata.yaml
+++ b/modules/compute/resource-policy/resource-policy/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2023 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - compute.googleapis.com

--- a/modules/compute/resource-policy/resource-policy/outputs.tf
+++ b/modules/compute/resource-policy/resource-policy/outputs.tf
@@ -16,7 +16,7 @@
 
 output "placement_policy" {
   description = <<-EOT
-  Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.
+  Group placement policy to use for placing VMs or GKE nodes placement. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.
   It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.
   Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions.
   EOT

--- a/modules/compute/resource-policy/resource-policy/outputs.tf
+++ b/modules/compute/resource-policy/resource-policy/outputs.tf
@@ -1,0 +1,28 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+output "placement_policy" {
+  description = <<-EOT
+  Group placement policy to use for the node pool's nodes. `COMPACT` is the only supported value for `type` currently. `name` is the name of the placement policy.
+  It is assumed that the specified policy exists. To create a placement policy refer to https://cloud.google.com/sdk/gcloud/reference/compute/resource-policies/create/group-placement.
+  Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions.
+  EOT
+
+  value = {
+    type = var.group_placement_max_distance > 0 ? "COMPACT" : null
+    name = var.group_placement_max_distance > 0 ? var.name : null
+  }
+}

--- a/modules/compute/resource-policy/resource-policy/variables.tf
+++ b/modules/compute/resource-policy/resource-policy/variables.tf
@@ -1,0 +1,40 @@
+/**
+  * Copyright 2024 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+variable "project_id" {
+  description = "The project ID for the resource policy."
+  type        = string
+}
+
+variable "region" {
+  description = "The region for the the resource policy."
+  type        = string
+}
+
+variable "name" {
+  description = "The resource policy's name."
+  type        = string
+}
+
+variable "group_placement_max_distance" {
+  description = <<-EOT
+  The max distance for group placement policy to use for the node pool's nodes. If set it will add a compact group placement policy.
+  Note: Placement policies have the [following](https://cloud.google.com/compute/docs/instances/placement-policies-overview#restrictions-compact-policies) restrictions.
+  EOT
+
+  type    = number
+  default = 0
+}

--- a/modules/compute/resource-policy/resource-policy/versions.tf
+++ b/modules/compute/resource-policy/resource-policy/versions.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:resource-policy/v1.37.2"
+  }
+
+  required_version = ">= 1.3"
+}


### PR DESCRIPTION
### Changes
resource-policy module implemented to create a resource policy for compute engines. This policy can be passed to a gke-node-pool module to apply the policy on the node-pool's nodes.

### Manual tests
- Created a new blueprint and added multiple resource-policy
- Verified their creation via gcloud commands