### PR TITLE
Improve `installing daos` script to be more non-interactive

### DIFF
--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -29,7 +29,7 @@ else
 	if [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; then
 		if [ "${OS_VERSION_MAJOR}" = "8" ]; then
 			# 1) Add the Parallelstore package repository
-			tee /etc/yum.repos.d/parallelstore-v2-6-el8.repo <<EOF
+			cat >/etc/yum.repos.d/parallelstore-v2-6-el8.repo <<EOF
 [parallelstore-v2-6-el8]
 name=Parallelstore EL8 v2.6
 baseurl=https://us-central1-yum.pkg.dev/projects/parallelstore-packages/v2-6-el8
@@ -38,7 +38,7 @@ repo_gpgcheck=0
 gpgcheck=0
 EOF
 		elif [ "${OS_VERSION_MAJOR}" -eq "9" ]; then
-			tee /etc/yum.repos.d/parallelstore-v2-6-el9.repo <<EOF
+			cat >/etc/yum.repos.d/parallelstore-v2-6-el9.repo <<EOF
 [parallelstore-v2-6-el9]
 name=Parallelstore EL9 v2.6
 baseurl=https://packages.daos.io/v2.6/EL9/packages/x86_64/
@@ -64,15 +64,17 @@ EOF
 
 	# For Ubuntu 22.04 and debian 12,
 	elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
+		# shellcheck disable=SC2034
+		DEBIAN_FRONTEND=noninteractive
 
 		# 1) Add the Parallelstore package repository
-		curl https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | apt-key add -
-		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
+		curl -o /etc/apt/trusted.gpg.d/us-central1-apt.pkg.dev.asc https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
+		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >>/etc/apt/sources.list.d/artifact-registry.list
 
-		apt update
+		apt-get update
 
 		# 2) Install daos-client
-		apt install -y daos-client
+		apt-get install -y daos-client
 
 	else
 		echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."

--- a/modules/file-system/parallelstore/scripts/mount-daos.sh
+++ b/modules/file-system/parallelstore/scripts/mount-daos.sh
@@ -65,7 +65,7 @@ chmod 777 "$local_mount"
 fuse_config=/etc/fuse.conf
 sed -i "s/#.*user_allow_other/user_allow_other/g" $fuse_config
 
-for i in {1..5}; do
+for i in {1..10}; do
 	# To parse mount_options as --disable-wb-cache --eq-count=8.
 	# shellcheck disable=SC2086
 	dfuse -m "$local_mount" --pool default-pool --container default-container --multi-user $mount_options && break

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -29,7 +29,7 @@ else
 	if [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; then
 		if [ "${OS_VERSION_MAJOR}" = "8" ]; then
 			# 1) Add the Parallelstore package repository
-			tee /etc/yum.repos.d/parallelstore-v2-6-el8.repo <<EOF
+			cat >/etc/yum.repos.d/parallelstore-v2-6-el8.repo <<EOF
 [parallelstore-v2-6-el8]
 name=Parallelstore EL8 v2.6
 baseurl=https://us-central1-yum.pkg.dev/projects/parallelstore-packages/v2-6-el8
@@ -38,7 +38,7 @@ repo_gpgcheck=0
 gpgcheck=0
 EOF
 		elif [ "${OS_VERSION_MAJOR}" -eq "9" ]; then
-			tee /etc/yum.repos.d/parallelstore-v2-6-el9.repo <<EOF
+			cat >/etc/yum.repos.d/parallelstore-v2-6-el9.repo <<EOF
 [parallelstore-v2-6-el9]
 name=Parallelstore EL9 v2.6
 baseurl=https://packages.daos.io/v2.6/EL9/packages/x86_64/
@@ -64,15 +64,17 @@ EOF
 
 	# For Ubuntu 22.04 and debian 12,
 	elif { [ "${OS_ID}" = "ubuntu" ] && [ "${OS_VERSION}" = "22.04" ]; } || { [ "${OS_ID}" = "debian" ] && [ "${OS_VERSION_MAJOR}" = "12" ]; }; then
+		# shellcheck disable=SC2034
+		DEBIAN_FRONTEND=noninteractive
 
 		# 1) Add the Parallelstore package repository
-		curl https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg | apt-key add -
-		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
+		curl -o /etc/apt/trusted.gpg.d/us-central1-apt.pkg.dev.asc https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
+		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >>/etc/apt/sources.list.d/artifact-registry.list
 
-		apt update
+		apt-get update
 
 		# 2) Install daos-client
-		apt install -y daos-client
+		apt-get install -y daos-client
 
 	else
 		echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."

--- a/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
@@ -65,7 +65,7 @@ chmod 777 "$local_mount"
 fuse_config=/etc/fuse.conf
 sed -i "s/#.*user_allow_other/user_allow_other/g" $fuse_config
 
-for i in {1..5}; do
+for i in {1..10}; do
 	# To parse mount_options as --disable-wb-cache --eq-count=8.
 	# shellcheck disable=SC2086
 	dfuse -m "$local_mount" --pool default-pool --container default-container --multi-user $mount_options && break


### PR DESCRIPTION
This PR does the following
* `tee` --> `cat`
* `apt` --> `apt-get` 
 * Increase retry.
* Updates logic in storing key since for using `apt-key` we observed, below failure. And `apt-key` is not recommended anymore.

```
Illegal status in __nss_next
```

After that, used a3mega blueprint and deployed PS instance. New parallelstore is mounted on a3mega node.

```
harshthakkar_google_com@har3a3-a3meganodeset-1:~$ df -H
Filesystem                   Size  Used Avail Use% Mounted on
udev                         990G     0  990G   0% /dev
tmpfs                        198G  2.0M  198G   1% /run
/dev/nvme0n1p1               212G   20G  184G  10% /
tmpfs                        990G     0  990G   0% /dev/shm
tmpfs                        5.3M     0  5.3M   0% /run/lock
/dev/nvme0n1p15              130M   13M  118M  10% /boot/efi
har3sha3mega-ps-9319ad5f     1.2P     0  1.2P   0% /gcs
har3a3-controller:/opt/apps  212G   20G  183G  10% /opt/apps
10.250.0.2:/nfsshare          11T     0   11T   0% /home
dfuse                         20T  108G   20T   1% /parallelstore
/dev/md127                   6.4T   29k  6.4T   1% /mnt/localssd
harshthakkar_google_com@har3a3-a3meganodeset-1:~$ 
```


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
