### PR TITLE
NeMo readme instructions for preloading gpt2 tokenizer

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/nemo-framework/README.md
+++ b/examples/machine-learning/a3-highgpu-8g/nemo-framework/README.md
@@ -25,6 +25,16 @@ README
 
 3. Run an example NeMo Framework Pre-Training
 
+   First, prepare the cache. This will download several files to the 
+   ~/.cache/huggingface folder which are needed to load the tokenizer for 
+   training.
+   
+   ```shell
+   pip install transformers
+   python -c "from transformers import AutoTokenizer; \
+       AutoTokenizer.from_pretrained('gpt2')"
+   ```
+
    This will run an example of training a 5B parameter GPT3 model for 10 steps
    using mock data as the input.
 
@@ -36,7 +46,7 @@ README
        stages=[training] \
        env_vars.TRANSFORMERS_OFFLINE=0 \
        container=../nemofw+tcpx-23.11.sqsh \
-       container_mounts='["/var/lib/tcpx/lib64","/run/tcpx-\${SLURM_JOB_ID}:/run/tcpx"]' \
+       container_mounts=[${HOME}/.cache,"/var/lib/tcpx/lib64","/run/tcpx-\${SLURM_JOB_ID}:/run/tcpx"] \
        cluster.srun_args=["--container-writable"] \
        training.model.data.data_impl=mock \
        training.model.data.data_prefix=[] \

--- a/examples/machine-learning/a3-megagpu-8g/nemo-framework/README.md
+++ b/examples/machine-learning/a3-megagpu-8g/nemo-framework/README.md
@@ -28,7 +28,10 @@ README
 
 3. Run an example NeMo Framework Pre-Training
 
-   First, prepare the cache. This will download several files to the ~/.cache/huggingface folder which are needed to load the tokenizer for training.
+   First, prepare the cache. This will download several files to the 
+   ~/.cache/huggingface folder which are needed to load the tokenizer for 
+   training.
+   
    ```shell
    pip install transformers
    python -c "from transformers import AutoTokenizer; \

--- a/examples/machine-learning/a3-megagpu-8g/nemo-framework/README.md
+++ b/examples/machine-learning/a3-megagpu-8g/nemo-framework/README.md
@@ -28,6 +28,13 @@ README
 
 3. Run an example NeMo Framework Pre-Training
 
+   First, prepare the cache. This will download several files to the ~/.cache/huggingface folder which are needed to load the tokenizer for training.
+   ```shell
+   pip install transformers
+   python -c "from transformers import AutoTokenizer; \
+       AutoTokenizer.from_pretrained('gpt2')"
+   ```
+
    This will run an example of training a 5B parameter GPT3 model for 10 steps
    using mock data as the input.
 
@@ -44,7 +51,7 @@ README
        training=gpt3/5b \
        env_vars.TRANSFORMERS_OFFLINE=0 \
        container=../nemofw+tcpxo-23.11.sqsh \
-       container_mounts='["/var/lib/tcpxo/lib64"]' \
+       container_mounts=[${HOME}/.cache,/var/lib/tcpxo/lib64] \
        cluster.srun_args=["--container-writable"] \
        training.model.data.data_impl=mock \
        training.model.data.data_prefix=[] \


### PR DESCRIPTION
Addresses error message:
```
ValueError: Unable to instantiate HuggingFace AUTOTOKENIZER for gpt2. Exception: [Errno 2] No such file or directory: '/home/<user>/.cache/huggingface/hub/models--gpt2/snapshots/607a30d783dfa663caf39e06633721c8d4cfcd7e/tokenizer.json'
```

Adding ${HOME}/.cache to container_mounts will download the tokenizer files on the first run but fail the run. The second run succeeds. \
We can preload the tokenizer files by creating an AutoTokenizer object in a short script, allowing the pre-training script to succeed on the first run.

