### PR TITLE
Update network_ip to use empty string

### DIFF
--- a/community/modules/network/rdma-vpc/main.tf
+++ b/community/modules/network/rdma-vpc/main.tf
@@ -116,7 +116,7 @@ locals {
       network            = null
       subnetwork         = subnet.self_link
       subnetwork_project = null # will populate from subnetwork_self_link
-      network_ip         = null
+      network_ip         = ""
       nic_type           = coalesce(var.nic_type, try(regex("IRDMA", local.profile_name), regex("MRDMA", local.profile_name), "RDMA"))
       stack_type         = null
       queue_count        = null


### PR DESCRIPTION
Enables compatibility with

https://github.com/GoogleCloudPlatform/slurm-gcp/blob/5b883492c8b99d8da5e7cc39c06a9d15b5700c85/terraform/slurm_cluster/modules/_instance_template/main.tf#L147

I will submit a PR to that repo to make the code treat `null` and empty string identically.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
