### PR TITLE
Improve GitHub workflows configuration

### DIFF
--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -28,7 +28,9 @@ on:
     - ready_for_review
     - unlocked
     branches:
+    - main
     - develop
+    - release-candidate
 
 jobs:
   pr-label-validation:

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -19,9 +19,8 @@ name: 'Use pre-commit to validate Pull Request'
 on:
   pull_request:
     types:
-    - edited
     - opened
-    - labeled
+    - reopened
     - synchronize
     branches:
     - main


### PR DESCRIPTION
This PR removes events that unnecessarily trigger pre-commit validation and enforces labels on PRs to the `main`, `develop`, and `release-candidate` branches.

While reviewing #3090, I noticed that the pre-commit validation was running even when modifying the labels on the PR.  Since this action does not change the underlying code, it's a waste of time and resources. Similar logic applies to the `edited` event which occurs when a PR title/description or base branch is modified.

I also noticed that the PR label validation was not running even though the merge to the `release-candidate` branch should include information for the release notes generated from labels.

https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request

There is a hard-to-see drop-down which selects different pull request events. Here is a deep link to the edited event.

https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=edited#pull_request

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
