### PR TITLE
Chrome Remote Desktop: increase resilience of apt operations

### DIFF
--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
@@ -28,8 +28,8 @@
       - xfce4-goodies
       state: present
     register: apt_result
-    retries: 6
-    delay: 10
+    retries: 10
+    delay: 30
     until: apt_result is success
 
   - name: Download and configure CRD
@@ -45,8 +45,8 @@
     environment:
       DEBIAN_FRONTEND: noninteractive
     register: apt_result
-    retries: 6
-    delay: 10
+    retries: 10
+    delay: 30
     until: apt_result is success
 
   - name: Configure CRD to use Xfce by default

--- a/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
+++ b/community/modules/remote-desktop/chrome-remote-desktop/scripts/configure-chrome-desktop.yml
@@ -16,6 +16,10 @@
 - name: Ensure Desktop OS and Chrome Remote Desktop is installed
   hosts: localhost
   become: true
+  module_defaults:
+    ansible.builtin.apt:
+      update_cache: true
+      cache_valid_time: 3600
   tasks:
   - name: Install desktop packages
     ansible.builtin.apt:
@@ -23,7 +27,6 @@
       - xfce4
       - xfce4-goodies
       state: present
-      update_cache: true
     register: apt_result
     retries: 6
     delay: 10


### PR DESCRIPTION
We have observed failures of this module when unattended-upgrades is running simultaneously to the installation of xfce4. There is no solution to this other than to wait. This increases the retry duration from 1 minute to 5 minutes and the number of retries from 6 to 10 (a total of 11 attempts). When we adopt ansible-core 2.12 or later, we should use the lock_timeout feature more directly:

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#parameter-lock_timeout

Additionally, this changes the behavior of the CRD Ansible playbook to update the apt cache only if it is stale (more than 1 hour old). In practice, the apt cache is unlikely to be stale in this playbook because Ansible was just installed by pip, which requires several packages to be installed. Thus forcing the cache update is both wasteful in time and increases the chance of an error.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
