### PR TITLE
Increase resume-timeout for TPU partition in blueprint

### DIFF
--- a/community/examples/hpc-slurm6-tpu.yaml
+++ b/community/examples/hpc-slurm6-tpu.yaml
@@ -49,6 +49,7 @@ deployment_groups:
     use: [tpu_nodeset]
     settings:
       partition_name: tpu
+      resume_timeout: 600
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login


### PR DESCRIPTION
TPU nodes take longer time to set up than compute nodes.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
