### PR TITLE
Do not trigger label validation on draft pull requests

### DIFF
--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   pr-label-validation:
-    if: github.repository == 'GoogleCloudPlatform/cluster-toolkit'
+    if: github.repository == 'GoogleCloudPlatform/cluster-toolkit' && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read


### PR DESCRIPTION
Problem: users (me) like to open draft PRs without expectation of full readiness for merging
Proposed Solution: only enforce labeling on PRs when they are ready for review

Draft PR with existing configuration (failure expected):

https://github.com/GoogleCloudPlatform/cluster-toolkit/actions/runs/11220327844?pr=3103

Draft PR with proposed configuration (skipped expected):

https://github.com/GoogleCloudPlatform/cluster-toolkit/actions/runs/11220350973?pr=3103

After marking PR ready for review without adding a label (failure expected):

https://github.com/GoogleCloudPlatform/cluster-toolkit/actions/runs/11220377069/job/31188407073?pr=3103

After adding a label to ready for review PR (success expected):

https://github.com/GoogleCloudPlatform/cluster-toolkit/actions/runs/11220416130/job/31188532923?pr=3103

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
