### PR TITLE
Retry `wait-for-startup` script on internal error

### DIFF
--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -60,14 +60,29 @@ FINISH_LINE="startup-script exit status"
 # Match string for failures on the new guest agent
 FINISH_LINE_ERR="Script.*failed with error:"
 
+NON_FATAL_ERRORS=(
+	"Internal error"
+)
+
 until [[ now -gt deadline ]]; do
 	ser_log=$(
 		set -o pipefail
 		${fetch_cmd} 2>"${error_file}" |
 			c1grep "${FINISH_LINE}\|${FINISH_LINE_ERR}"
 	) || {
-		cat "${error_file}"
-		exit 1
+		err=$(cat "${error_file}")
+		echo "$err"
+		fatal_error="true"
+		for e in "${NON_FATAL_ERRORS[@]}"; do
+			if [[ $err = *"$e"* ]]; then
+				fatal_error="false"
+				break
+			fi
+		done
+
+		if [[ $fatal_error = "true" ]]; then
+			exit 1
+		fi
 	}
 	if [[ -n "${ser_log}" ]]; then break; fi
 	echo "Could not detect end of startup script. Sleeping."


### PR DESCRIPTION
The command `gcloud compute instances get-serial-port-output` occasionally fails with an internal error, unrelated to the client's calling code.  An example of the error:
```
ERROR: (gcloud.compute.instances.get-serial-port-output) Could not fetch
serial port output: Internal error. Please try again or contact Google
Support. (Code: '623E40738DA88.30A0B2F.2313B7F8')

Error: exit status 1

Error: local-exec provisioner error

  with module.wait-for-instances.null_resource.wait_for_startup[0],
  on modules/embedded/community/modules/scripts/wait-for-startup/main.tf line 33, in resource "null_resource" "wait_for_startup":
  33:   provisioner "local-exec" {

Error running command '/bin/bash
modules/embedded/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh':
exit status 1
```

This PR adds error handling for what should be "non-fatal errors", and defines "Internal error" as one of them.