### PR TITLE
Added warning for v5 Slurm deployments

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -125,7 +125,25 @@ func expandOrDie(path string) (config.Blueprint, *config.YamlCtx) {
 	// Expand the blueprint
 	checkErr(bp.Expand(), ctx)
 	validateMaybeDie(bp, *ctx)
+	v5DeprecationWarning(bp)
+
 	return bp, ctx
+}
+
+// TODO: Remove this warning when v5 deprecation is complete
+func v5DeprecationWarning(bp config.Blueprint) {
+	alreadyContainsV5 := false
+	bp.WalkModulesSafe(func(mp config.ModulePath, m *config.Module) {
+		if strings.Contains(m.Source, "schedmd-slurm-gcp-v5-controller") && !alreadyContainsV5 {
+			logging.Info(boldYellow(
+				"We have been supporting slurm-gcp v5 since July 2022 and are now deprecating it, as we've launched slurm-gcp v6 in June 2024. \n" +
+					"Toolkit blueprints using Slurm-gcp v5 will be marked “deprecated” starting October 2024 and slurm-gcp v6 will be the default deployment. \n" +
+					"However we won't begin removing slurm-gcp v5 blueprints until January 6, 2025. Beginning on January 6, 2025, the Cluster Toolkit team will cease their support for Slurm-gcp v5. \n" +
+					"While this will not directly or immediately impact running clusters, we recommend replacing any v5 clusters with Slurm-gcp v6.",
+			))
+			alreadyContainsV5 = true // This is to avoid the logging message showing repeatedly for multiple v5 controllers
+		}
+	})
 }
 
 // TODO: move to expand.go


### PR DESCRIPTION
Added warning to to show for v5 deployments

Before:
```
Creating deployment folder "slurm-gcp-v5" ...
Initializing deployment group slurm-gcp-v5/primary
Testing if deployment group slurm-gcp-v5/primary requires adding or changing cloud infrastructure
Deployment group slurm-gcp-v5/primary requires adding or changing cloud infrastructure
Summary of proposed changes: Plan: 30 to add, 0 to change, 0 to destroy.
(D)isplay full proposed changes,
(A)pply proposed changes,
(S)top and exit,
(C)ontinue without applying
Please select an option [d,a,s,c]: 
```

After:
![3pVLcKirLfZJP5g](https://github.com/user-attachments/assets/b8c1d529-72ae-42a9-94f3-540661072ba8)


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
