### PR TITLE
Enable iteration over multi-VPC interface object

### DIFF
--- a/modules/network/multivpc/main.tf
+++ b/modules/network/multivpc/main.tf
@@ -24,7 +24,11 @@ locals {
   maximum_subnetworks   = pow(2, local.subnetwork_new_bits)
   additional_networks = [
     for vpc in module.vpcs :
-    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_self_link })
+    merge(var.network_interface_defaults, {
+      network            = vpc.network_name
+      subnetwork         = vpc.subnetwork_name
+      subnetwork_project = var.project_id
+    })
   ]
 }
 


### PR DESCRIPTION
f8c8fd6f avoided error messages that arise when the provider level project is not set or does not match the subnetwork when creating an instance template.

https://github.com/hashicorp/terraform-provider-google/blob/00a52318354fe60774305a53606a7c2f7ff6a9d3/google/services/compute/compute_instance_helpers.go#L466

However, this modified the additional_networks output so that one of its fields is only known after apply. Because its reasonable to expect to iterate over this field, we can alter the approach in f8c8fd6f to specify the project field separately.

The GKE functionality for multi-VPC is not as flexible for Shared VPCs and does not yet support specification of subnetworks outside the host project. It appears that the specification does not allow for identification of subnetwork by any other approach than resourcen name. So these solutions should align.

https://cloud.google.com/kubernetes-engine/docs/how-to/setup-multinetwork-support-for-pods

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
