### PR TITLE
Revert PR#3046 and add more line breaks for readability

### DIFF
--- a/modules/network/multivpc/main.tf
+++ b/modules/network/multivpc/main.tf
@@ -24,7 +24,11 @@ locals {
   maximum_subnetworks   = pow(2, local.subnetwork_new_bits)
   additional_networks = [
     for vpc in module.vpcs :
-    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_name, subnetwork_project = var.project_id })
+    merge(var.network_interface_defaults, {
+      network            = vpc.network_name
+      subnetwork         = vpc.subnetwork_name
+      subnetwork_project = var.project_id
+    })
   ]
 }
 

--- a/modules/network/multivpc/main.tf
+++ b/modules/network/multivpc/main.tf
@@ -24,7 +24,7 @@ locals {
   maximum_subnetworks   = pow(2, local.subnetwork_new_bits)
   additional_networks = [
     for vpc in module.vpcs :
-    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_self_link })
+    merge(var.network_interface_defaults, { network = vpc.network_name, subnetwork = vpc.subnetwork_name, subnetwork_project = var.project_id })
   ]
 }
 


### PR DESCRIPTION
Reverts https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3046 as that was causing GKE blueprints to fail.
Confirmed with @wiktorn that the revert is okay and does not break any functionality.

GKE blueprint error:

```
Error: Invalid count argument

  on modules/embedded/modules/management/kubectl-apply/kubectl/main.tf line 50, in data "kubectl_path_documents" "yamls":
  50:   count   = local.directory != null ? 1 : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

Theory is as follows:

vpc.subnetwork_name is know before apply and vpc.subnetwork_self_link is not known until after apply. If the name is an input then it should be determined prior to apply time.

If this is the case then there was a count (branching logic) that before change was known at apply but after change is unknown until vpc is applied


