### PR TITLE
Create and use non-default service accounts in GKE

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -40,6 +40,18 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gpunets
     source: modules/network/multivpc
     settings:
@@ -50,7 +62,7 @@ deployment_groups:
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gpunets]
+    use: [network1, gpunets, gke_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       master_authorized_networks:
@@ -60,7 +72,7 @@ deployment_groups:
 
   - id: a3_highgpu_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gpunets]
+    use: [gke_cluster, gpunets, gke_service_account]
     settings:
       machine_type: a3-highgpu-8g
       autoscaling_total_min_nodes: 2

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -40,6 +40,18 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gpunets
     source: modules/network/multivpc
     settings:
@@ -50,7 +62,7 @@ deployment_groups:
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gpunets]
+    use: [network1, gpunets, gke_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       master_authorized_networks:
@@ -60,7 +72,7 @@ deployment_groups:
 
   - id: a3_megagpu_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gpunets]
+    use: [gke_cluster, gpunets, gke_service_account]
     settings:
       machine_type: a3-megagpu-8g
       autoscaling_total_min_nodes: 2

--- a/examples/hpc-gke.yaml
+++ b/examples/hpc-gke.yaml
@@ -35,16 +35,28 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-service-account
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1]
+    use: [network1, gke_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
     outputs: [instructions]
 
   - id: compute_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, gke_service_account]
 
   - id: job-template
     source: modules/compute/gke-job-template

--- a/examples/ml-gke.yaml
+++ b/examples/ml-gke.yaml
@@ -40,19 +40,32 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1]
+    use: [network1, gke_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       master_authorized_networks:
       - display_name: deployment-machine
         cidr_block: $(vars.authorized_cidr)
+      configure_workload_identity_sa: true
     outputs: [instructions]
 
   - id: g2_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, gke_service_account]
     settings:
       disk_type: pd-balanced
       machine_type: g2-standard-4

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -38,9 +38,33 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: local_ssd_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: ssd-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1]
+    use: [network1, gke_service_account]
     settings:
       enable_filestore_csi: true
       enable_gcsfuse_csi: true
@@ -53,7 +77,7 @@ deployment_groups:
 
   - id: debug_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, gke_service_account]
     settings:
       name: debug
       zones: [$(vars.zone)]
@@ -118,7 +142,7 @@ deployment_groups:
 
   - id: local-ssd-pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, local_ssd_pool_service_account]
     settings:
       name: local-ssd
       machine_type: n2d-standard-2

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -268,16 +268,9 @@ limitations under the License.
 | Name | Type |
 |------|------|
 | [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
-| [google_project_iam_member.node_service_account_artifact_registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_log_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_resource_metadata_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [null_resource.enable_tcpx_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
 | [google_compute_reservation.specific_reservations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 
 ## Inputs

--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -131,14 +131,8 @@ limitations under the License.
 |------|------|
 | [google-beta_google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
 | [google-beta_google_container_node_pool.system_node_pools](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
-| [google_project_iam_member.node_service_account_artifact_registry](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_gcr](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_log_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_metric_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.node_service_account_resource_metadata_writer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
-| [google_compute_default_service_account.default_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_default_service_account) | data source |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -29,7 +29,8 @@ locals {
     security_group = var.authenticator_security_group
   }]
 
-  sa_email = var.service_account_email != null ? var.service_account_email : data.google_compute_default_service_account.default_sa.email
+  default_sa_email = "${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  sa_email         = coalesce(var.service_account_email, local.default_sa_email)
 
   # additional VPCs enable multi networking 
   derived_enable_multi_networking = coalesce(var.enable_multi_networking, length(var.additional_networks) > 0)
@@ -38,8 +39,8 @@ locals {
   derived_enable_dataplane_v2 = coalesce(var.enable_dataplane_v2, local.derived_enable_multi_networking)
 }
 
-data "google_compute_default_service_account" "default_sa" {
-  project = var.project_id
+data "google_project" "project" {
+  project_id = var.project_id
 }
 
 resource "google_container_cluster" "gke_cluster" {
@@ -267,45 +268,6 @@ resource "google_container_node_pool" "system_node_pools" {
   }
 }
 
-# For container logs to show up under Cloud Logging and GKE metrics to show up
-# on Cloud Monitoring console, some project level roles are needed for the
-# node_service_account
-resource "google_project_iam_member" "node_service_account_log_writer" {
-  project = var.project_id
-  role    = "roles/logging.logWriter"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
-resource "google_project_iam_member" "node_service_account_metric_writer" {
-  project = var.project_id
-  role    = "roles/monitoring.metricWriter"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
-resource "google_project_iam_member" "node_service_account_monitoring_viewer" {
-  project = var.project_id
-  role    = "roles/monitoring.viewer"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
-resource "google_project_iam_member" "node_service_account_resource_metadata_writer" {
-  project = var.project_id
-  role    = "roles/stackdriver.resourceMetadata.writer"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
-resource "google_project_iam_member" "node_service_account_gcr" {
-  project = var.project_id
-  role    = "roles/storage.objectViewer"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
-resource "google_project_iam_member" "node_service_account_artifact_registry" {
-  project = var.project_id
-  role    = "roles/artifactregistry.reader"
-  member  = "serviceAccount:${local.sa_email}"
-}
-
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
@@ -327,7 +289,7 @@ module "workload_identity" {
 
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [
-    data.google_compute_default_service_account.default_sa,
+    data.google_project.project,
     google_container_cluster.gke_cluster
   ]
 }

--- a/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -40,9 +40,21 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1]
+    use: [network1, gke_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       master_authorized_networks:
@@ -52,7 +64,7 @@ deployment_groups:
 
   - id: g2_latest_driver
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, gke_service_account]
     settings:
       name: g2-latest-driver
       machine_type: g2-standard-4
@@ -80,9 +92,21 @@ deployment_groups:
       ]
     outputs: [instructions]
 
+  - id: n1_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: n1-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: n1_pool_default
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, n1_service_account]
     settings:
       name: n1-pool-default
       disk_type: pd-balanced
@@ -108,9 +132,21 @@ deployment_groups:
       ]
     outputs: [instructions]
 
+  - id: n1_full_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: n1-full-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: n1_pool_full_spec
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, n1_full_service_account]
     settings:
       name: n1-pool-full-spec
       disk_type: pd-balanced
@@ -141,9 +177,21 @@ deployment_groups:
       ]
     outputs: [instructions]
 
+  - id: default_settings_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: ds-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
   - id: default_settings_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, default_settings_service_account]
     settings:
       name: default-settings-pool
 

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -16,6 +16,7 @@
 tags:
 - m.gke-cluster
 - m.gke-node-pool
+- m.service-account
 - m.vpc
 - m.multivpc
 - m.kubectl-apply

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -17,6 +17,7 @@ tags:
 - m.cloud-storage-bucket
 - m.filestore
 - m.gke-cluster
+- m.service-account
 - m.gke-job-template
 - m.gke-node-pool
 - m.gke-persistent-volume

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -17,6 +17,7 @@ tags:
 - m.gke-cluster
 - m.gke-job-template
 - m.gke-node-pool
+- m.service-account
 - m.vpc
 - gke
 

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -17,6 +17,7 @@ tags:
 - m.gke-cluster
 - m.gke-job-template
 - m.gke-node-pool
+- m.service-account
 - m.vpc
 - gke
 

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -17,6 +17,7 @@ tags:
 - m.gke-cluster
 - m.gke-job-template
 - m.gke-node-pool
+- m.service-account
 - m.vpc
 - gke
 


### PR DESCRIPTION
## Approach
- Allow user to create new SA from blueprint and use the same in cluster and node pool
- Do not fetch default SA from a data source, instead construct using project id
- User can pass a pre existing SA with appropriate permissions. Checking for the right permissions is not in the scope of this PR and will be covered in a follow up PR

## Testing
- [x] Deployed hpc-gke.yaml with non default new SA and verified provisioning and destruction, and that SA with appropriate roles was created. Verified all node pools used the SA specified
- [x] Deployed hpc-gke.yaml with non default pre-existing SA and verified provisioning and destruction, and that no new SA was created. Verified all node pools used the SA specified
- [x] Deployed hpc-gke.yaml with no SA passed. Verified default SA was used in all node pools
- [x] Verified all GKE integration tests passed
- [x] Verified logs are pushed from k8s pods and visible in GCP logging from Pantheon

## User Guide
### Create and use new SA (one per node pool) - recommended
Check updated example blueprints
### Use pre-existing SA
```
  - id: gke_cluster
    source: modules/scheduler/gke-cluster
    use: [network1]
    settings:
      enable_private_endpoint: false  # Allows for access from authorized public IPs
      service_account_email: ml-01-gke-sa@ns-playground-a.iam.gserviceaccount.com
    outputs: [instructions]

  - id: compute_pool
    source: modules/compute/gke-node-pool
    use: [gke_cluster]
    settings:
      service_account_email: ml-01-gke-sa@ns-playground-a.iam.gserviceaccount.com
```
### Use default SA
```
  - id: gke_cluster
    source: modules/scheduler/gke-cluster
    use: [network1]
    settings:
      enable_private_endpoint: false  # Allows for access from authorized public IPs
    outputs: [instructions]

  - id: compute_pool
    source: modules/compute/gke-node-pool
    use: [gke_cluster]
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
