### PR TITLE
Remove mention of `./[community/]modules` from docs and examples

### DIFF
--- a/community/examples/hpc-slurm-ramble-gromacs.yaml
+++ b/community/examples/hpc-slurm-ramble-gromacs.yaml
@@ -31,7 +31,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/vpc
 

--- a/community/examples/hpc-slurm-ubuntu2004-v5-legacy.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004-v5-legacy.yaml
@@ -34,7 +34,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/vpc
 

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -33,7 +33,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/vpc
 

--- a/community/examples/htc-slurm-v5-legacy.yaml
+++ b/community/examples/htc-slurm-v5-legacy.yaml
@@ -42,7 +42,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/pre-existing-vpc
   - id: network1
     source: modules/network/vpc
 

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -42,7 +42,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/pre-existing-vpc
   - id: network
     source: modules/network/vpc
 

--- a/community/examples/tutorial-starccm-slurm.yaml
+++ b/community/examples/tutorial-starccm-slurm.yaml
@@ -32,7 +32,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/vpc
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
@@ -17,7 +17,7 @@ be accessed as `tpu` partition.
 
 ```yaml
   - id: tpu_nodeset
-    source: ./community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu
     use: [network]
     settings:
       node_type: v2-8
@@ -27,7 +27,7 @@ be accessed as `tpu` partition.
       preserve_tpu: false
 
   - id: tpu_partition
-    source: ./community/modules/compute/schedmd-slurm-gcp-v6-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
     use: [tpu_nodeset]
     settings:
       partition_name: tpu

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid/README.md
@@ -73,7 +73,7 @@ The hybrid module can be added to a blueprint as follows:
 
 ```yaml
 - id: slurm-controller
-  source: ./community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid
+  source: community/modules/scheduler/schedmd-slurm-gcp-v5-hybrid
   use:
   - debug-partition
   - compute-partition

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -134,7 +134,7 @@ example:
 
 ```yaml
   - id: controller
-    source: ./community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use: [ network, partition ]
     settings:
       enable_slurm_gcp_plugins:

--- a/docs/hybrid-slurm-cluster/blueprints/create-networks.yaml
+++ b/docs/hybrid-slurm-cluster/blueprints/create-networks.yaml
@@ -28,7 +28,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network0
     source: modules/network/vpc
     settings:

--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -41,7 +41,7 @@ as shown below:
     settings: {local_mount: /home}
 
   - id: workstation
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, homefs]  # Note this line
 ```
 

--- a/docs/tutorials/hpc-slurm-qwiklabs.yaml
+++ b/docs/tutorials/hpc-slurm-qwiklabs.yaml
@@ -30,7 +30,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/vpc
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1730,10 +1730,9 @@ vars:
 deployment_groups:
 - group: groupName
   modules:
-
-  # Local source, prefixed with ./ (/ and ../ also accepted)
+  # Embedded module (part of the toolkit), prefixed with `modules/` or `community/modules`
   - id: <a unique id> # Required: Name of this module used to uniquely identify it.
-    source: ./modules/role/module-name # Required: Points to the module directory.
+    source: modules/role/module-name # Required
     kind: < terraform | packer > # Optional: Type of module, currently choose from terraform or packer. If not specified, `kind` will default to `terraform`
     # Optional: All configured settings for the module. For terraform, each
     # variable listed in variables.tf can be set here, and are mandatory if no
@@ -1747,14 +1746,18 @@ deployment_groups:
         key3a: value3a
         key3b: value3b
 
-  # Embedded module (part of the toolkit), prefixed with modules/
-  - source: modules/role/module-name
-
   # GitHub module over SSH, prefixed with git@github.com
-  - source: git@github.com:org/repo.git//modules/role/module-name
+  - source: git@github.com:org/repo.git//path/to/module
 
   # GitHub module over HTTPS, prefixed with github.com
-  - source: github.com/org/repo//modules/role/module-name
+  - source: github.com/org/repo//path/to/module
+
+  # Local absolute source, prefixed with / 
+  - source: /path/to/module
+
+  # Local relative (to current working directory) source, prefixed with ./ or ../
+  - source: ../path/to/module
+  # NOTE: Do not reference toolkit modules by local source, use embedded source instead.
 ```
 
 ## Writing an HPC Blueprint
@@ -1846,38 +1849,6 @@ file-system etc.).
 When possible, custom modules should use these roles so that they match other
 modules defined by the toolkit. If a custom module does not fit into these
 roles, a new role can be defined.
-
-A module's parent folder will define the module’s role if possible. Therefore,
-regardless of where the module is located, the module directory should be
-explicitly referenced at least 2 layers deep, where the top layer refers to the
-“role” of that module.
-
-If a module is not defined at least 2 layers deep and the `ghpc_role` label has
-not been explicitly set in settings, ghpc_role will default to `undefined`.
-
-Below we show some of the core modules and their roles (as parent folders).
-
-```text
-modules/
-└── <<ROLE>
-    └── <<MODULE_NAME>>
-
-modules/
-├── compute
-│   └── vm-instance
-├── file-system
-│   ├── pre-existing-network-storage
-│   └── filestore
-├── monitoring
-│   └── dashboard
-├── network
-│   ├── pre-existing-vpc
-│   └── vpc
-├── packer
-│   └── custom-image
-└── scripts
-    └── startup-script
-```
 
 ### Deployment Groups
 

--- a/examples/hpc-enterprise-slurm-v5-legacy.yaml
+++ b/examples/hpc-enterprise-slurm-v5-legacy.yaml
@@ -53,7 +53,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/pre-existing-vpc
 

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -46,7 +46,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/vpc
 

--- a/examples/hpc-slurm-v5-legacy.yaml
+++ b/examples/hpc-slurm-v5-legacy.yaml
@@ -30,7 +30,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/vpc
 

--- a/examples/hpc-slurm.yaml
+++ b/examples/hpc-slurm.yaml
@@ -30,7 +30,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/vpc
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -350,7 +350,7 @@ following module definition refers the local pre-existing-vpc modules.
 
 ```yaml
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 ```
 
 > **_NOTE:_** Relative paths (beginning with `.` or `..` must be relative to the

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -94,7 +94,7 @@ deployment_groups:
       source_image_project: cloud-hpc-image-public
 
   - id: batch-job
-    source: ./modules/scheduler/batch-job-template
+    source: modules/scheduler/batch-job-template
     settings:
       instance_template: $(batch-compute-template.self_link)
     outputs: [instructions]

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -29,12 +29,11 @@ Each runner receives the following attributes:
    not.
 - `source`: (Optional) A path to the file or data you want to upload. Must be
   defined if `content` is not. The source path is relative to the deployment
-  group directory. Scripts distributed as part of modules should start with
-  `modules/` followed by the name of the module used (not to be confused with
-  the module ID) and the path to the script. The format is shown below:
+  group directory. To ensure correctness of path use `ghpc_stage` function, that
+  would copy referenced file to the deployment group directory. For example:
 
-    ```text
-    source: ./modules/<<MODULE_NAME>>/<<SCRIPT_NAME>>
+    ```yaml
+    source: $(ghpc_stage("path/to/file"))
     ```
 
   For more examples with context, see the
@@ -188,7 +187,7 @@ For official documentation see troubleshooting docs:
 
 ```yaml
 - id: startup
-  source: ./modules/scripts/startup-script
+  source: modules/scripts/startup-script
   settings:
     runners:
       # Some modules such as filestore have runners as outputs for convenience:
@@ -212,7 +211,7 @@ For official documentation see troubleshooting docs:
         args: "bar.tgz 'Expanding file'"
 
 - id: compute-cluster
-  source: ./modules/compute/vm-instance
+  source: modules/compute/vm-instance
   use: [homefs, startup]
 ```
 
@@ -222,13 +221,13 @@ they are able to do so by using the `gcs_bucket_path` as shown in the below exam
 
 ```yaml
 - id: startup
-  source: ./modules/scripts/startup-script
+  source: modules/scripts/startup-script
   settings:
     gcs_bucket_path: gs://user-test-bucket/folder1/folder2
     install_stackdriver_agent: true
 
 - id: compute-cluster
-  source: ./modules/compute/vm-instance
+  source: modules/compute/vm-instance
   use: [startup]
 ```
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -537,9 +537,6 @@ func (s *zeroSuite) TestCheckMovedModules(c *C) {
 
 	// embedded moved
 	c.Check(checkMovedModule("community/modules/scheduler/cloud-batch-job"), NotNil)
-
-	// local moved
-	c.Assert(checkMovedModule("./community/modules/scheduler/cloud-batch-job"), NotNil)
 }
 
 func (s *zeroSuite) TestCheckStringLiteral(c *C) {

--- a/tools/cloud-build/daily-tests/validate_tests_metadata.py
+++ b/tools/cloud-build/daily-tests/validate_tests_metadata.py
@@ -42,7 +42,7 @@ def module_tag(src: str) -> Optional[str]:
     Remote sources are not supported (None).
     Ex: "modules/network/vpc" -> "m.vpc"
     """
-    if not src.startswith(("modules/", "community/modules/", "./modules/", "./community/modules/")):
+    if not src.startswith(("modules/", "community/modules/")):
         return None
     return f"m.{os.path.basename(src)}"
 

--- a/tools/validate_configs/golden_copies/configs/versioned_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/configs/versioned_blueprint.yaml
@@ -48,7 +48,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/vpc
 

--- a/tools/validate_configs/test_configs/2-network-interfaces.yaml
+++ b/tools/validate_configs/test_configs/2-network-interfaces.yaml
@@ -27,7 +27,6 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: default-network
     source: modules/network/pre-existing-vpc
 
@@ -52,7 +51,7 @@ deployment_groups:
 
   # Test adding a pre-existing network via "use"
   - id: one-used-existing-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - default-network
     settings:
@@ -61,7 +60,7 @@ deployment_groups:
 
   # Test adding a newly created network via "use"
   - id: one-used-new-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - new-network-1
     settings:
@@ -70,7 +69,7 @@ deployment_groups:
 
   # Test adding one pre-existing network via "network_interfaces"
   - id: one-explicit-existing-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     settings:
       name_prefix: one-explicit-existing-ni
       machine_type: n2-standard-2
@@ -88,7 +87,7 @@ deployment_groups:
 
   # Test adding one newly created network via "network_interfaces"
   - id: one-explicit-new-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     settings:
       name_prefix: one-explicit-new-ni
       machine_type: n2-standard-2
@@ -106,7 +105,7 @@ deployment_groups:
 
   # Test adding both a pre-existing network and a newly created network via "network_interfaces"
   - id: two-explicit-mixed-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     settings:
       name_prefix: two-explicit-mixed-ni
       network_interfaces:
@@ -136,7 +135,7 @@ deployment_groups:
 
   # Test adding two newly created networks via "network_interfaces"
   - id: two-explicit-new-ni
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     settings:
       name_prefix: two-explicit-new-ni
       network_interfaces:

--- a/tools/validate_configs/test_configs/2filestore-4instances.yaml
+++ b/tools/validate_configs/test_configs/2filestore-4instances.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: infrastructure
   modules:
   - id: network
-    source: ./modules/network/vpc
+    source: modules/network/vpc
 
   - id: homefs
     source: modules/file-system/filestore
@@ -38,7 +38,7 @@ deployment_groups:
         ghpc_role: storage-home
 
   - id: apps
-    source: ./modules/file-system/filestore
+    source: modules/file-system/filestore
     use: [network]
     settings:
       name: apps
@@ -47,7 +47,7 @@ deployment_groups:
         ghpc_role: storage-apps
 
   - id: license-server-1
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network, homefs]
     settings:
       name_prefix: ls1

--- a/tools/validate_configs/test_configs/apt-collision.yaml
+++ b/tools/validate_configs/test_configs/apt-collision.yaml
@@ -32,13 +32,12 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   ## Network
   - source: modules/network/vpc
     kind: terraform
     id: network1
 
-  - source: ./modules/scripts/startup-script
+  - source: modules/scripts/startup-script
     kind: terraform
     id: startup
     settings:

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: appsfs
     source: modules/file-system/filestore
@@ -42,7 +42,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 
@@ -58,7 +58,7 @@ deployment_groups:
         spack install cmake%gcc@10.3.0 target=x86_64
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       runners:
       - type: data
@@ -74,7 +74,7 @@ deployment_groups:
       - $(spack-execute.spack_runner)
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4

--- a/tools/validate_configs/test_configs/cloud-batch-cft-instance-template.yaml
+++ b/tools/validate_configs/test_configs/cloud-batch-cft-instance-template.yaml
@@ -59,7 +59,7 @@ deployment_groups:
       source_image_project: cloud-hpc-image-public
 
   - id: batch-job
-    source: ./modules/scheduler/batch-job-template
+    source: modules/scheduler/batch-job-template
     use: [network1, appfs, batch-startup-script]
     settings:
       runnable: "cat /sw/hello.txt"

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: appsfs
     source: modules/file-system/filestore
@@ -42,7 +42,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 
@@ -58,7 +58,7 @@ deployment_groups:
         spack install cmake%gcc@10.3.0 target=x86_64
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       runners:
       - type: data
@@ -74,7 +74,7 @@ deployment_groups:
       - $(spack-execute.spack_runner)
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4

--- a/tools/validate_configs/test_configs/exascaler-existing-vpc.yaml
+++ b/tools/validate_configs/test_configs/exascaler-existing-vpc.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: scratchfs
     source: community/modules/file-system/DDN-EXAScaler

--- a/tools/validate_configs/test_configs/exascaler-new-vpc.yaml
+++ b/tools/validate_configs/test_configs/exascaler-new-vpc.yaml
@@ -29,7 +29,7 @@ deployment_groups:
     source: modules/network/vpc
 
   - id: scratchfs
-    source: ./community/modules/file-system/DDN-EXAScaler
+    source: community/modules/file-system/DDN-EXAScaler
     use: [network1]
     settings:
       local_mount: /scratch

--- a/tools/validate_configs/test_configs/gpu-v5-legacy.yaml
+++ b/tools/validate_configs/test_configs/gpu-v5-legacy.yaml
@@ -62,12 +62,11 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/pre-existing-vpc
 
   - id: nogpu-n1
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - network1
     settings:
@@ -76,7 +75,7 @@ deployment_groups:
       instance_image: $(vars.instance_image_vm)
 
   - id: manual-n1
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - network1
     settings:

--- a/tools/validate_configs/test_configs/gpu.yaml
+++ b/tools/validate_configs/test_configs/gpu.yaml
@@ -62,12 +62,11 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network
     source: modules/network/pre-existing-vpc
 
   - id: nogpu-n1
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - network
     settings:
@@ -76,7 +75,7 @@ deployment_groups:
       instance_image: $(vars.instance_image_vm)
 
   - id: manual-n1
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use:
     - network
     settings:

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: appsfs
     source: modules/file-system/filestore
@@ -42,7 +42,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 
@@ -58,7 +58,7 @@ deployment_groups:
         spack install cmake%gcc@10.3.0 target=x86_64
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       runners:
       - type: data
@@ -74,7 +74,7 @@ deployment_groups:
       - $(spack-execute.spack_runner)
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4

--- a/tools/validate_configs/test_configs/instance-with-startup.yaml
+++ b/tools/validate_configs/test_configs/instance-with-startup.yaml
@@ -43,6 +43,6 @@ deployment_groups:
       machine_type: e2-standard-8
 
   - id: wait
-    source: ./community/modules/scripts/wait-for-startup
+    source: community/modules/scripts/wait-for-startup
     settings:
       instance_name: $(workstation.name[0])

--- a/tools/validate_configs/test_configs/new_project.yaml
+++ b/tools/validate_configs/test_configs/new_project.yaml
@@ -24,7 +24,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: project
-    source: ./community/modules/project/new-project
+    source: community/modules/project/new-project
     settings:
       folder_id: 334688113020  # random number
       billing_account: 111110-M2N704-854685  # random billing number

--- a/tools/validate_configs/test_configs/nfs-servers.yaml
+++ b/tools/validate_configs/test_configs/nfs-servers.yaml
@@ -37,7 +37,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: appsfs
-    source: ./community/modules/file-system/nfs-server
+    source: community/modules/file-system/nfs-server
     use: [network1]
     outputs: [network_storage]
     settings:
@@ -45,7 +45,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: multiple-local-mounts
-    source: ./community/modules/file-system/nfs-server
+    source: community/modules/file-system/nfs-server
     use: [network1]
     outputs: [network_storage]
     settings:

--- a/tools/validate_configs/test_configs/rocky-ss.yaml
+++ b/tools/validate_configs/test_configs/rocky-ss.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: appsfs
     source: modules/file-system/filestore
@@ -45,7 +45,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 
@@ -61,7 +61,7 @@ deployment_groups:
         spack install cmake%gcc@10.3.0 target=x86_64
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       runners:
       - type: data
@@ -77,7 +77,7 @@ deployment_groups:
       - $(spack-execute.spack_runner)
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4

--- a/tools/validate_configs/test_configs/simple-startup.yaml
+++ b/tools/validate_configs/test_configs/simple-startup.yaml
@@ -26,10 +26,10 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       runners:
       - type: data
@@ -44,12 +44,12 @@ deployment_groups:
         args: "foo.tgz 'Expanding the file'"
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup]
     settings:
       machine_type: e2-standard-4
 
   - id: waiter
-    source: ./community/modules/scripts/wait-for-startup
+    source: community/modules/scripts/wait-for-startup
     settings:
       instance_name: $(instance.name[0])

--- a/tools/validate_configs/test_configs/spack-buildcache.yaml
+++ b/tools/validate_configs/test_configs/spack-buildcache.yaml
@@ -29,7 +29,7 @@ deployment_groups:
     source: modules/network/pre-existing-vpc
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 

--- a/tools/validate_configs/test_configs/spack-environments.yaml
+++ b/tools/validate_configs/test_configs/spack-environments.yaml
@@ -29,7 +29,7 @@ deployment_groups:
     source: modules/network/pre-existing-vpc
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
       spack_url: https://github.com/spack/spack

--- a/tools/validate_configs/test_configs/startup-options.yaml
+++ b/tools/validate_configs/test_configs/startup-options.yaml
@@ -26,10 +26,10 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       ansible_virtualenv_path: /usr/local/ghpc
       runners:
@@ -48,7 +48,7 @@ deployment_groups:
         destination: empty_tasks.yaml
 
   - id: instance-explicit-startup
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1]
     settings:
       name_prefix: explicit
@@ -56,21 +56,21 @@ deployment_groups:
       startup_script: $(startup.startup_script)
 
   - id: instance-no-startup
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1]
     settings:
       name_prefix: no-startup
       machine_type: e2-standard-4
 
   - id: instance-use-startup
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup]
     settings:
       name_prefix: use-startup
       machine_type: e2-standard-4
 
   - id: instance-metadata-startup
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1]
     settings:
       name_prefix: metadata-startup

--- a/tools/validate_configs/test_configs/test_outputs.yaml
+++ b/tools/validate_configs/test_configs/test_outputs.yaml
@@ -47,7 +47,7 @@ deployment_groups:
     - install_nfs_client
 
   - id: nfs
-    source: ./community/modules/file-system/nfs-server
+    source: community/modules/file-system/nfs-server
     outputs:
     - network_storage
     - install_nfs_client
@@ -131,7 +131,7 @@ deployment_groups:
     - startup_script
 
   - id: lustre
-    source: ./community/modules/file-system/DDN-EXAScaler
+    source: community/modules/file-system/DDN-EXAScaler
     outputs:
     - private_addresses
     - ssh_console

--- a/tools/validate_configs/test_configs/threads_per_core.yaml
+++ b/tools/validate_configs/test_configs/threads_per_core.yaml
@@ -27,13 +27,12 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
-  # Example - ./modules/network/vpc
   - id: network1
     source: modules/network/pre-existing-vpc
     kind: terraform
 
   - id: n1-2-threads
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -43,7 +42,7 @@ deployment_groups:
       threads_per_core: 2
 
   - id: n1-1-thread
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -53,7 +52,7 @@ deployment_groups:
       threads_per_core: 1
 
   - id: n1-0-threads
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -63,7 +62,7 @@ deployment_groups:
       threads_per_core: 0
 
   - id: n1-null-threads
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -73,7 +72,7 @@ deployment_groups:
       threads_per_core: null
 
   - id: n2-2-threads
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -83,7 +82,7 @@ deployment_groups:
       threads_per_core: 2
 
   - id: n2-1-thread
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -93,7 +92,7 @@ deployment_groups:
       threads_per_core: 1
 
   - id: c2-2-threads
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -103,7 +102,7 @@ deployment_groups:
       threads_per_core: 2
 
   - id: c2-1-thread
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -113,7 +112,7 @@ deployment_groups:
       threads_per_core: 1
 
   - id: e2-medium-0-thread
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1
@@ -123,7 +122,7 @@ deployment_groups:
       threads_per_core: 0
 
   - id: e2-medium-null-thread
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     kind: terraform
     use:
     - network1

--- a/tools/validate_configs/test_configs/timeout_test.yaml
+++ b/tools/validate_configs/test_configs/timeout_test.yaml
@@ -32,21 +32,21 @@ deployment_groups:
     source: modules/network/vpc
 
   - id: gcs
-    source: ./modules/file-system/pre-existing-network-storage
+    source: modules/file-system/pre-existing-network-storage
     settings:
       remote_mount: hpc-toolkit-service-catalog-solutions
       local_mount: /catalog
       fs_type: gcsfuse
 
   - id: compute-hpc-image
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, gcs]
     settings:
       machine_type: n2-standard-2
       name_prefix: hpc-image
 
   - id: wait
-    source: ./community/modules/scripts/wait-for-startup
+    source: community/modules/scripts/wait-for-startup
     settings:
       instance_name: $(compute-hpc-image.name[0])
       timeout: 25

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -26,7 +26,7 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: appsfs
     source: modules/file-system/filestore
@@ -42,7 +42,7 @@ deployment_groups:
       auto_delete_disk: true
 
   - id: spack-setup
-    source: ./community/modules/scripts/spack-setup
+    source: community/modules/scripts/spack-setup
     settings:
       install_dir: /apps/spack
 
@@ -61,7 +61,7 @@ deployment_groups:
         spack install fftw%intel@18.0.5 target=skylake ^intel-mpi@2018.4.274%intel@18.0.5 target=x86_64
 
   - id: startup
-    source: ./modules/scripts/startup-script
+    source: modules/scripts/startup-script
     settings:
       install_stackdriver_agent: true
       runners:
@@ -78,7 +78,7 @@ deployment_groups:
       - $(spack-execute.spack_runner)
 
   - id: instance
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
       machine_type: e2-standard-4

--- a/tools/validate_configs/test_configs/vm-instance-local-ssd.yaml
+++ b/tools/validate_configs/test_configs/vm-instance-local-ssd.yaml
@@ -26,10 +26,10 @@ deployment_groups:
 - group: primary
   modules:
   - id: network1
-    source: ./modules/network/pre-existing-vpc
+    source: modules/network/pre-existing-vpc
 
   - id: multi-instance-multi-ssd
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1]
     settings:
       machine_type: n2-standard-16
@@ -37,7 +37,7 @@ deployment_groups:
       local_ssd_count: 2
 
   - id: instance-ssd-interface-defined
-    source: ./modules/compute/vm-instance
+    source: modules/compute/vm-instance
     use: [network1]
     settings:
       machine_type: n2-standard-16

--- a/tools/validate_configs/test_configs/vm.yaml
+++ b/tools/validate_configs/test_configs/vm.yaml
@@ -30,7 +30,7 @@ deployment_groups:
   - id: network1
     source: modules/network/pre-existing-vpc
 
-  - source: ./modules/compute/vm-instance
+  - source: modules/compute/vm-instance
     id: compute_instances_family
     use: [network1]
     settings:
@@ -47,7 +47,7 @@ deployment_groups:
         # project: $(vars.project_id)
         # family: myubuntu
 
-  - source: ./modules/compute/vm-instance
+  - source: modules/compute/vm-instance
     id: compute_instances_name
     use: [network1]
     settings:


### PR DESCRIPTION
* Remove mention of `./[community/]modules` from docs and examples;
* Added line about not using it with toolkit modules;
* Clean up outdated mentions of "role";
* Update recommendations for `startup-script.source` to use `ghpc_stage`.
