### PR TITLE
Include deployment name in Spack and Ramble bucket names (like startup-script)

### DIFF
--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -73,7 +73,7 @@ locals {
   }
 
   bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}"), 0, 8)
-  bucket_name = "ramble-scripts-${local.bucket_md5}"
+  bucket_name = "${var.deployment_name}-ramble-scripts-${local.bucket_md5}"
   runners     = [local.install_ramble_deps_runner, local.install_ramble_runner, local.python_reqs_runner]
 
   combined_runner = {

--- a/community/modules/scripts/ramble-setup/main.tf
+++ b/community/modules/scripts/ramble-setup/main.tf
@@ -72,8 +72,11 @@ locals {
     "destination" = "install_ramble.yml"
   }
 
-  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}"), 0, 8)
-  bucket_name = "${var.deployment_name}-ramble-scripts-${local.bucket_md5}"
+  bucket_md5 = substr(md5("${var.project_id}.${var.deployment_name}"), 0, 8)
+  # Max bucket name length is 63, so truncate deployment_name if necessary.
+  #   The string "-ramble-scripts-" is 16 characters and bucket_md5 is 8 characters,
+  #   leaving 63-16-8=39 chars for deployment_name.
+  bucket_name = "${substr(var.deployment_name, 0, 39)}-ramble-scripts-${local.bucket_md5}"
   runners     = [local.install_ramble_deps_runner, local.install_ramble_runner, local.python_reqs_runner]
 
   combined_runner = {

--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -79,8 +79,12 @@ locals {
     "destination" = "install_spack.yml"
   }
 
-  bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}.${local.script_content}"), 0, 8)
-  bucket_name = "${var.deployment_name}-spack-scripts-${local.bucket_md5}"
+  bucket_md5 = substr(md5("${var.project_id}.${var.deployment_name}.${local.script_content}"), 0, 8)
+  # Max bucket name length is 63, so truncate deployment_name if necessary.
+  #   The string "-spack-scripts-" is 15 characters and bucket_md5 is 8 characters,
+  #   leaving 63-15-8=40 chars for deployment_name.  Using 39 so it has the same prefix as the
+  #   ramble-setup module's GCS bucket.
+  bucket_name = "${substr(var.deployment_name, 0, 39)}-spack-scripts-${local.bucket_md5}"
   runners     = [local.install_spack_deps_runner, local.install_spack_runner]
 
   combined_runner = {

--- a/community/modules/scripts/spack-setup/main.tf
+++ b/community/modules/scripts/spack-setup/main.tf
@@ -80,7 +80,7 @@ locals {
   }
 
   bucket_md5  = substr(md5("${var.project_id}.${var.deployment_name}.${local.script_content}"), 0, 8)
-  bucket_name = "spack-scripts-${local.bucket_md5}"
+  bucket_name = "${var.deployment_name}-spack-scripts-${local.bucket_md5}"
   runners     = [local.install_spack_deps_runner, local.install_spack_runner]
 
   combined_runner = {


### PR DESCRIPTION
This will make it easier to know which buckets are tied to a deployment.