### PR TITLE
Remove the rdma_subnetwork_name_prefix output from rdma-vpc module

### DIFF
--- a/community/modules/network/rdma-vpc/main.tf
+++ b/community/modules/network/rdma-vpc/main.tf
@@ -126,12 +126,10 @@ locals {
     }
   ]
 
-  # FIX_ME(arajmane): There is a concern about this not working in a shared VPC environment. 
-  # To unblock experimental testing, we decided to go ahead with this.
   output_subnets_gke = [
-    for subnet in module.vpc.subnets : {
+    for i in range(length(module.vpc.subnets)) : {
       network            = local.network_name
-      subnetwork         = subnet.name
+      subnetwork         = local.template_subnetworks[i].subnet_name
       subnetwork_project = var.project_id
       network_ip         = ""
       nic_type           = coalesce(var.nic_type, try(regex("IRDMA", local.profile_name), regex("MRDMA", local.profile_name), "RDMA"))

--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -172,7 +172,6 @@ limitations under the License.
 | <a name="input_pods_ip_range_name"></a> [pods\_ip\_range\_name](#input\_pods\_ip\_range\_name) | The name of the secondary subnet ip range to use for pods. | `string` | `"pods"` | no |
 | <a name="input_prefix_with_deployment_name"></a> [prefix\_with\_deployment\_name](#input\_prefix\_with\_deployment\_name) | If true, cluster name will be prefixed by `deployment_name` (ex: <deployment\_name>-<name\_suffix>). | `bool` | `true` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the cluster in. | `string` | n/a | yes |
-| <a name="input_rdma_subnetwork_name_prefix"></a> [rdma\_subnetwork\_name\_prefix](#input\_rdma\_subnetwork\_name\_prefix) | Prefix of the RDMA subnetwork names | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region to host the cluster in. | `string` | n/a | yes |
 | <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`. | `string` | `"UNSPECIFIED"` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | DEPRECATED: use service\_account\_email and scopes. | <pre>object({<br/>    email  = string,<br/>    scopes = set(string)<br/>  })</pre> | `null` | no |

--- a/modules/scheduler/gke-cluster/variables.tf
+++ b/modules/scheduler/gke-cluster/variables.tf
@@ -328,12 +328,6 @@ variable "additional_networks" {
   }))
 }
 
-variable "rdma_subnetwork_name_prefix" {
-  description = "Prefix of the RDMA subnetwork names"
-  default     = null
-  type        = string
-}
-
 variable "cluster_reference_type" {
   description = "How the google_container_node_pool.system_node_pools refers to the cluster. Possible values are: {SELF_LINK, NAME}"
   default     = "SELF_LINK"


### PR DESCRIPTION
### About the Change
The [subnetwork names](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/658bbb1924ef0afcefba81ddd2049b6de468409b/community/modules/network/rdma-vpc/main.tf#L134) generated are known after terraform apply.

That means, the gke-cluster module for its kubectl-apply operations needs to depend on the [static prefix](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/658bbb1924ef0afcefba81ddd2049b6de468409b/modules/scheduler/gke-cluster/main.tf#L47) to avoid running into the issues like. 

```
Error: Invalid count argument

  on modules/embedded/modules/management/kubectl-apply/kubectl/main.tf line 50, in data "kubectl_path_documents" "yamls":
  50:   count   = local.directory != null ? 1 : 0
```

Alternatively, we could rely on [local.template_subnetworks[idx].subnet_name](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/658bbb1924ef0afcefba81ddd2049b6de468409b/community/modules/network/rdma-vpc/main.tf#L24) and obviate the output [subnetwork_name_prefix](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/658bbb1924ef0afcefba81ddd2049b6de468409b/community/modules/network/rdma-vpc/outputs.tf#L56) altogether. That avoids making assumptions about the names of the subnetworks generated by the rdma-vpc module.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
