### PR TITLE
Allow customization of Parallelstore mounts

### DIFF
--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -94,6 +94,30 @@ Here you can replace `import_gcs_bucket_uri` with the uri of sub folder within G
 bucket and `import_destination_path` with local directory within parallelstore
 instance.
 
+### Additional configuration for DAOS agent and dfuse
+Use `daos_agent_config` to provide additional configuration for `daos_agent`, for example:
+
+```yaml
+- id: parallelstorefs
+  source: modules/file-system/pre-existing-network-storage
+  settings:
+    daos_agent_config: |
+      credential_config:
+        cache_expiration: 1m
+```
+
+Use `dfuse_environment` to provide additional environment variables for `dfuse` process, for example:
+
+```yaml
+- id: parallelstorefs
+  source: modules/file-system/parallelstore
+  settings:
+    dfuse_environment:
+      D_LOG_FILE: /tmp/client.log
+      D_APPEND_PID_TO_LOG: 1
+      D_LOG_MASK: debug
+```
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2024 Google LLC
 
@@ -142,7 +166,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_daos_agent_config"></a> [daos\_agent\_config](#input\_daos\_agent\_config) | Additional configuration to be added to daos\_config.yml | `string` | `""` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. | `string` | n/a | yes |
+| <a name="input_dfuse_environment"></a> [dfuse\_environment](#input\_dfuse\_environment) | Additional environment variables for DFuse process | `map(string)` | `{}` | no |
 | <a name="input_directory_stripe"></a> [directory\_stripe](#input\_directory\_stripe) | The parallelstore stripe level for directories. | `string` | `"DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"` | no |
 | <a name="input_file_stripe"></a> [file\_stripe](#input\_file\_stripe) | The parallelstore stripe level for files. | `string` | `"FILE_STRIPE_LEVEL_UNSPECIFIED"` | no |
 | <a name="input_import_destination_path"></a> [import\_destination\_path](#input\_import\_destination\_path) | The name of local path to import data on parallelstore instance from GCS bucket. | `string` | `null` | no |

--- a/modules/file-system/parallelstore/main.tf
+++ b/modules/file-system/parallelstore/main.tf
@@ -34,10 +34,15 @@ locals {
   }
 
   mount_runner = {
-    "type"        = "shell"
-    "source"      = "${path.module}/scripts/mount-daos.sh"
-    "args"        = "--access_points=\"${local.access_points}\" --local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
-    "destination" = "mount_daos.sh"
+    "type" = "shell"
+    "content" = templatefile("${path.module}/templates/mount-daos.sh.tftpl", {
+      access_points     = local.access_points
+      daos_agent_config = var.daos_agent_config
+      dfuse_environment = var.dfuse_environment
+      local_mount       = var.local_mount
+      mount_options     = join(" ", [for opt in split(",", var.mount_options) : "--${opt}"])
+    })
+    "destination" = "mount_filesystem${replace(var.local_mount, "/", "_")}.sh"
   }
 }
 

--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -50,6 +50,7 @@ else
 		if [ -x /usr/bin/google_disable_automatic_updates ]; then
 			/usr/bin/google_disable_automatic_updates
 		fi
+		dnf clean all
 		dnf makecache
 
 		# 2) Install daos-client

--- a/modules/file-system/parallelstore/templates/mount-daos.sh.tftpl
+++ b/modules/file-system/parallelstore/templates/mount-daos.sh.tftpl
@@ -20,59 +20,48 @@ OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"/
 OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
 
 if ! {
-	{ [[ "${OS_ID}" = "rocky" ]] || [[ "${OS_ID}" = "rhel" ]]; } && { [[ "${OS_VERSION_MAJOR}" = "8" ]] || [[ "${OS_VERSION_MAJOR}" = "9" ]]; } ||
-		{ [[ "${OS_ID}" = "ubuntu" ]] && [[ "${OS_VERSION}" = "22.04" ]]; } ||
-		{ [[ "${OS_ID}" = "debian" ]] && [[ "${OS_VERSION_MAJOR}" = "12" ]]; }
+	{ [[ "$${OS_ID}" = "rocky" ]] || [[ "$${OS_ID}" = "rhel" ]]; } && { [[ "$${OS_VERSION_MAJOR}" = "8" ]] || [[ "$${OS_VERSION_MAJOR}" = "9" ]]; } ||
+		{ [[ "$${OS_ID}" = "ubuntu" ]] && [[ "$${OS_VERSION}" = "22.04" ]]; } ||
+		{ [[ "$${OS_ID}" = "debian" ]] && [[ "$${OS_VERSION_MAJOR}" = "12" ]]; }
 }; then
-	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
+	echo "Unsupported operating system $${OS_ID} $${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 	exit 1
 
 fi
 
-# Parse local_mount, mount_options from argument.
-# Format mount-options string to be compatible to dfuse mount command.
-# e.g. "disable-wb-cache,eq-count=8" --> --disable-wb-cache --eq-count=8.
-for arg in "$@"; do
-	if [[ $arg == --access_points=* ]]; then
-		access_points="${arg#*=}"
-	fi
-	if [[ $arg == --local_mount=* ]]; then
-		local_mount="${arg#*=}"
-	fi
-	if [[ $arg == --mount_options=* ]]; then
-		mount_options="${arg#*=}"
-		mount_options="--${mount_options//,/ --}"
-	fi
-done
-
 # Edit agent config
 daos_config=/etc/daos/daos_agent.yml
-sed -i "s/#.*transport_config/transport_config/g" $daos_config
-sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
-sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
+# rewrite $daos_config from scratch
+mv $${daos_config} $${daos_config}.orig
+
+exclude_fabric_ifaces=""
 # Get names of network interfaces not in first PCI slot
 # The first PCI slot is a standard network adapter while remaining interfaces
 # are typically network cards dedicated to GPU or workload communication
-if [[ "$OS_ID" == "debian" ]] || [[ "${OS_ID}" = "ubuntu" ]]; then
+if [[ "$${OS_ID}" == "debian" ]] || [[ "$${OS_ID}" = "ubuntu" ]]; then
 	extra_interfaces=$(find /sys/class/net/ -not -name 'enp0s*' -regextype posix-extended -regex '.*/enp[0-9]+s.*' -printf '"%f"\n' | paste -s -d ',')
-elif [[ "${OS_ID}" = "rocky" ]] || [[ "${OS_ID}" = "rhel" ]]; then
+elif [[ "$${OS_ID}" = "rocky" ]] || [[ "$${OS_ID}" = "rhel" ]]; then
 	extra_interfaces=$(find /sys/class/net/ -not -name eth0 -regextype posix-extended -regex '.*/eth[0-9]+' -printf '"%f"\n' | paste -s -d ',')
 fi
 
-if [[ -n "$extra_interfaces" ]]; then
-	exclude_fabric_ifaces="\"lo\",$extra_interfaces"
-	sed -i "s/#.*exclude_fabric_ifaces: \[.*/exclude_fabric_ifaces: [$exclude_fabric_ifaces]/" $daos_config
-fi
+cat > $daos_config <<EOF
+access_points: ${access_points}
+log_file: /var/log/daos_agent/daos_agent.log
+transport_config:
+  allow_insecure: true
+$exclude_fabric_ifaces
+${daos_agent_config}
 
-# reroute logs from /tmp (default) to daos_agent dedicated directory
+EOF
+
+
 mkdir -p /var/log/daos_agent
 chown daos_agent:daos_agent /var/log/daos_agent
-sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
 
 # Mount parallelstore instance to client vm.
-mkdir -p "$local_mount"
-chmod 777 "$local_mount"
+mkdir -p "${local_mount}"
+chmod 777 "${local_mount}"
 
 # Mount container for multi-user.
 fuse_config=/etc/fuse.conf
@@ -83,10 +72,10 @@ ulimit -n 1048576
 
 # Construct the service name with the local_mount suffix
 safe_mount_name=$(systemd-escape -p "${local_mount}")
-service_name="mount_parallelstore_${safe_mount_name}.service"
+service_name="mount_parallelstore_$${safe_mount_name}.service"
 
 # --- Begin: Add systemd service creation ---
-cat >/etc/systemd/system/"${service_name}" <<EOF
+cat >/etc/systemd/system/"$${service_name}" <<EOF
 [Unit]
 Description=DAOS Mount Service
 After=network-online.target daos_agent.service
@@ -100,8 +89,11 @@ User=root
 Group=root
 Restart=on-failure
 RestartSec=10
-ExecStart=/bin/dfuse -m $local_mount --pool default-pool --container default-container --multi-user $mount_options --foreground
-ExecStop=/usr/bin/fusermount3 -u $local_mount
+ExecStart=/bin/dfuse -m ${local_mount} --pool default-pool --container default-container --multi-user ${mount_options} --foreground
+ExecStop=fusermount3 -z -u '${local_mount}'
+%{ for env_key, env_value in dfuse_environment ~}
+Environment="${env_key}=${env_value}"
+%{ endfor ~}
 
 [Install]
 WantedBy=multi-user.target
@@ -111,8 +103,8 @@ EOF
 # brought in automatically by the mount units
 systemctl daemon-reload
 systemctl enable daos_agent.service
-systemctl enable "${service_name}"
-systemctl start "${service_name}"
+systemctl enable "$${service_name}"
+systemctl start "$${service_name}"
 # --- End: Add systemd service creation ---
 
 exit 0

--- a/modules/file-system/parallelstore/variables.tf
+++ b/modules/file-system/parallelstore/variables.tf
@@ -24,6 +24,20 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "daos_agent_config" {
+  description = "Additional configuration to be added to daos_config.yml"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "dfuse_environment" {
+  description = "Additional environment variables for DFuse process"
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
 variable "name" {
   description = "Name of parallelstore instance."
   type        = string

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -74,6 +74,38 @@ for `parallelstore` instance.
     mount_options: disable-wb-cache,thread-count=16,eq-count=8
 ```
 
+Parallelstore supports additional options for its mountpoints under `parallelstore_options` setting.
+Use `daos_agent_config` to provide additional configuration for `daos_agent`, for example:
+
+```yaml
+- id: parallelstorefs
+  source: modules/file-system/pre-existing-network-storage
+  settings:
+    fs_type: daos
+    remote_mount: "[10.246.99.2,10.246.99.3,10.246.99.4]"
+    mount_options: disable-wb-cache,thread-count=16,eq-count=8
+    parallelstore_options:
+      daos_agent_config: |
+        credential_config:
+          cache_expiration: 1m
+```
+
+Use `dfuse_environment` to provide additional environment variables for `dfuse` process, for example:
+
+```yaml
+- id: parallelstorefs
+  source: modules/file-system/pre-existing-network-storage
+  settings:
+    fs_type: daos
+    remote_mount: "[10.246.99.2,10.246.99.3,10.246.99.4]"
+    mount_options: disable-wb-cache,thread-count=16,eq-count=8
+    parallelstore_options:
+      dfuse_environment:
+        D_LOG_FILE: /tmp/client.log
+        D_APPEND_PID_TO_LOG: 1
+        D_LOG_MASK: debug
+```
+
 ### Mounting
 
 For the `fs_type` listed below, this module will provide `client_install_runner`
@@ -126,6 +158,7 @@ No resources.
 | <a name="input_fs_type"></a> [fs\_type](#input\_fs\_type) | Type of file system to be mounted (e.g., nfs, lustre) | `string` | `"nfs"` | no |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/mnt"` | no |
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Options describing various aspects of the file system. Consider adding setting to 'defaults,\_netdev,implicit\_dirs' when using gcsfuse. | `string` | `"defaults,_netdev"` | no |
+| <a name="input_parallelstore_options"></a> [parallelstore\_options](#input\_parallelstore\_options) | Parallelstore specific options | <pre>object({<br/>    daos_agent_config = optional(string, "")<br/>    dfuse_environment = optional(map(string), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_remote_mount"></a> [remote\_mount](#input\_remote\_mount) | Remote FS name or export. This is the exported directory for nfs, fs name for lustre, and bucket name (without gs://) for gcsfuse. | `string` | n/a | yes |
 | <a name="input_server_ip"></a> [server\_ip](#input\_server\_ip) | The device name as supplied to fs-tab, excluding remote fs-name(for nfs, that is the server IP, for lustre <MGS NID>[:<MGS NID>]). This can be omitted for gcsfuse. | `string` | `""` | no |
 

--- a/modules/file-system/pre-existing-network-storage/outputs.tf
+++ b/modules/file-system/pre-existing-network-storage/outputs.tf
@@ -83,9 +83,15 @@ locals {
   }
 
   mount_runner_daos = {
-    "type"        = "shell"
-    "content"     = file("${path.module}/scripts/mount-daos.sh")
-    "args"        = "--access_points=\"${var.remote_mount}\" --local_mount=\"${var.local_mount}\" --mount_options=\"${var.mount_options}\""
+    "type" = "shell"
+    "content" = templatefile("${path.module}/templates/mount-daos.sh.tftpl", {
+      access_points     = var.remote_mount
+      daos_agent_config = var.parallelstore_options.daos_agent_config
+      dfuse_environment = var.parallelstore_options.dfuse_environment
+      local_mount       = var.local_mount
+      # avoid passing "--" as mount option to dfuse
+      mount_options = length(var.mount_options) == 0 ? "" : join(" ", [for opt in split(",", var.mount_options) : "--${opt}"])
+    })
     "destination" = "mount_filesystem${replace(var.local_mount, "/", "_")}.sh"
   }
 

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -50,6 +50,7 @@ else
 		if [ -x /usr/bin/google_disable_automatic_updates ]; then
 			/usr/bin/google_disable_automatic_updates
 		fi
+		dnf clean all
 		dnf makecache
 
 		# 2) Install daos-client

--- a/modules/file-system/pre-existing-network-storage/templates/mount-daos.sh.tftpl
+++ b/modules/file-system/pre-existing-network-storage/templates/mount-daos.sh.tftpl
@@ -20,59 +20,48 @@ OS_VERSION=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"/
 OS_VERSION_MAJOR=$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')
 
 if ! {
-	{ [[ "${OS_ID}" = "rocky" ]] || [[ "${OS_ID}" = "rhel" ]]; } && { [[ "${OS_VERSION_MAJOR}" = "8" ]] || [[ "${OS_VERSION_MAJOR}" = "9" ]]; } ||
-		{ [[ "${OS_ID}" = "ubuntu" ]] && [[ "${OS_VERSION}" = "22.04" ]]; } ||
-		{ [[ "${OS_ID}" = "debian" ]] && [[ "${OS_VERSION_MAJOR}" = "12" ]]; }
+	{ [[ "$${OS_ID}" = "rocky" ]] || [[ "$${OS_ID}" = "rhel" ]]; } && { [[ "$${OS_VERSION_MAJOR}" = "8" ]] || [[ "$${OS_VERSION_MAJOR}" = "9" ]]; } ||
+		{ [[ "$${OS_ID}" = "ubuntu" ]] && [[ "$${OS_VERSION}" = "22.04" ]]; } ||
+		{ [[ "$${OS_ID}" = "debian" ]] && [[ "$${OS_VERSION_MAJOR}" = "12" ]]; }
 }; then
-	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
+	echo "Unsupported operating system $${OS_ID} $${OS_VERSION}. This script only supports Rocky Linux 8, Redhat 8, Redhat 9, Ubuntu 22.04, and Debian 12."
 	exit 1
 
 fi
 
-# Parse local_mount, mount_options from argument.
-# Format mount-options string to be compatible to dfuse mount command.
-# e.g. "disable-wb-cache,eq-count=8" --> --disable-wb-cache --eq-count=8.
-for arg in "$@"; do
-	if [[ $arg == --access_points=* ]]; then
-		access_points="${arg#*=}"
-	fi
-	if [[ $arg == --local_mount=* ]]; then
-		local_mount="${arg#*=}"
-	fi
-	if [[ $arg == --mount_options=* ]]; then
-		mount_options="${arg#*=}"
-		mount_options="--${mount_options//,/ --}"
-	fi
-done
-
 # Edit agent config
 daos_config=/etc/daos/daos_agent.yml
-sed -i "s/#.*transport_config/transport_config/g" $daos_config
-sed -i "s/#.*allow_insecure:.*false/  allow_insecure: true/g" $daos_config
-sed -i "s/.*access_points.*/access_points: $access_points/g" $daos_config
 
+# rewrite $daos_config from scratch
+mv $${daos_config} $${daos_config}.orig
+
+exclude_fabric_ifaces=""
 # Get names of network interfaces not in first PCI slot
 # The first PCI slot is a standard network adapter while remaining interfaces
 # are typically network cards dedicated to GPU or workload communication
-if [[ "$OS_ID" == "debian" ]] || [[ "${OS_ID}" = "ubuntu" ]]; then
+if [[ "$${OS_ID}" == "debian" ]] || [[ "$${OS_ID}" = "ubuntu" ]]; then
 	extra_interfaces=$(find /sys/class/net/ -not -name 'enp0s*' -regextype posix-extended -regex '.*/enp[0-9]+s.*' -printf '"%f"\n' | paste -s -d ',')
-elif [[ "${OS_ID}" = "rocky" ]] || [[ "${OS_ID}" = "rhel" ]]; then
+elif [[ "$${OS_ID}" = "rocky" ]] || [[ "$${OS_ID}" = "rhel" ]]; then
 	extra_interfaces=$(find /sys/class/net/ -not -name eth0 -regextype posix-extended -regex '.*/eth[0-9]+' -printf '"%f"\n' | paste -s -d ',')
 fi
 
-if [[ -n "$extra_interfaces" ]]; then
-	exclude_fabric_ifaces="\"lo\",$extra_interfaces"
-	sed -i "s/#.*exclude_fabric_ifaces: \[.*/exclude_fabric_ifaces: [$exclude_fabric_ifaces]/" $daos_config
-fi
+cat > $daos_config <<EOF
+access_points: ${access_points}
+log_file: /var/log/daos_agent/daos_agent.log
+transport_config:
+  allow_insecure: true
+$exclude_fabric_ifaces
+${daos_agent_config}
 
-# reroute logs from /tmp (default) to daos_agent dedicated directory
+EOF
+
+
 mkdir -p /var/log/daos_agent
 chown daos_agent:daos_agent /var/log/daos_agent
-sed -i "s/#.*log_file:.*/log_file: \/var\/log\/daos_agent\/daos_agent.log/g" $daos_config
 
 # Mount parallelstore instance to client vm.
-mkdir -p "$local_mount"
-chmod 777 "$local_mount"
+mkdir -p "${local_mount}"
+chmod 777 "${local_mount}"
 
 # Mount container for multi-user.
 fuse_config=/etc/fuse.conf
@@ -83,10 +72,10 @@ ulimit -n 1048576
 
 # Construct the service name with the local_mount suffix
 safe_mount_name=$(systemd-escape -p "${local_mount}")
-service_name="mount_parallelstore_${safe_mount_name}.service"
+service_name="mount_parallelstore_$${safe_mount_name}.service"
 
 # --- Begin: Add systemd service creation ---
-cat >/etc/systemd/system/"${service_name}" <<EOF
+cat >/etc/systemd/system/"$${service_name}" <<EOF
 [Unit]
 Description=DAOS Mount Service
 After=network-online.target daos_agent.service
@@ -100,8 +89,11 @@ User=root
 Group=root
 Restart=on-failure
 RestartSec=10
-ExecStart=/bin/dfuse -m $local_mount --pool default-pool --container default-container --multi-user $mount_options --foreground
-ExecStop=/usr/bin/fusermount3 -u $local_mount
+ExecStart=/bin/dfuse -m ${local_mount} --pool default-pool --container default-container --multi-user ${mount_options} --foreground
+ExecStop=fusermount3 -z -u '${local_mount}'
+%{ for env_key, env_value in dfuse_environment ~}
+Environment="${env_key}=${env_value}"
+%{ endfor ~}
 
 [Install]
 WantedBy=multi-user.target
@@ -111,8 +103,8 @@ EOF
 # brought in automatically by the mount units
 systemctl daemon-reload
 systemctl enable daos_agent.service
-systemctl enable "${service_name}"
-systemctl start "${service_name}"
+systemctl enable "$${service_name}"
+systemctl start "$${service_name}"
 # --- End: Add systemd service creation ---
 
 exit 0

--- a/modules/file-system/pre-existing-network-storage/variables.tf
+++ b/modules/file-system/pre-existing-network-storage/variables.tf
@@ -41,4 +41,14 @@ variable "mount_options" {
   description = "Options describing various aspects of the file system. Consider adding setting to 'defaults,_netdev,implicit_dirs' when using gcsfuse."
   type        = string
   default     = "defaults,_netdev"
+  nullable    = false
+}
+
+variable "parallelstore_options" {
+  description = "Parallelstore specific options"
+  type = object({
+    daos_agent_config = optional(string, "")
+    dfuse_environment = optional(map(string), {})
+  })
+  default = {}
 }

--- a/modules/scripts/startup-script/templates/startup-script-custom.tftpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tftpl
@@ -31,7 +31,7 @@ stdlib::runner() {
   stdlib::info "=== start executing runner: $object ==="
   case "$1" in
     ansible-local) stdlib::run_playbook "$destpath/$filename" "$args";;
-    shell) chmod u+x /$destpath/$filename && ./$destpath/$filename $args;;
+    shell) chmod u+x /$destpath/$filename && $destpath/$filename $args;;
   esac
   
   exit_code=$?

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -83,8 +83,8 @@ duplicates = [
         "modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh",
     ],
     [
-        "modules/file-system/parallelstore/scripts/mount-daos.sh",
-        "modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh",
+        "modules/file-system/parallelstore/templates/mount-daos.sh.tftpl",
+        "modules/file-system/pre-existing-network-storage/templates/mount-daos.sh.tftpl",
     ],
     [
         "modules/compute/vm-instance/compute_image.tf"


### PR DESCRIPTION
Add two customization options:
* daos_agent_config - to allow providing additional configuration in `/etc/daos/daos_agent.yml`
* dfuse_environment - to allow providing environment variables for `dfuse` process

## Topics for discussion:
* [x] whether using templates is proper approach here (it gives a lot of flexibility)
* [x] support for whitespaces in mount points (currently not supported, not sure if it was supported earlier)
* [x] handling of `/etc/daos/daos_agent.yml` - currently anyway everything is commented, and we just uncomment specific lines with `sed`. The other approach is either to create a new file (as implemnted), or just make sure that everything is commented, and just add configuration at the end. I think this aproach is cleaner in terms of what is expected result / file content.
* [x] usage of systemctl to start dfuse on first call. I did not implemented as such for now, as I didn't find a good way to fail `systemctl start` command if dfuse failed to start and this is current behavior
* [x] Adding `Restart=always` to systemd unit. With my testing, one needs to run first `umount $mount_point`, but if this indeed is necessary, this could be wrapped in script together with `$mount_command`, and this would make sure, that even if `dfuse` crashes, it will restart


## TODO
* [x] align those changes with `modules/file-system/pre-existing-network-storage`

This PR also addresses bug in startup-script module,
```
startup-script: Mon Dec 16 08:44:43 -0500 2024 Info [4589]: === start executing runner: early_run_hotfixes.sh-b383 ===
startup-script: /slurm/custom_scripts/controller.d/ghpc_daos_mount.sh: line 373: .//tmp/tmp.g1yoDyA6T5/early_run_hotfixes.sh: No such file or directory
startup-script: Mon Dec 16 08:44:43 -0500 2024 Info [4589]: === early_run_hotfixes.sh-b383 finished with exit_code=127 ===
startup-script: Mon Dec 16 08:44:43 -0500 2024 Error [4589]: === execution of early_run_hotfixes.sh-b383 failed, exiting ===


If re-running the script, using for example: DEBUG=1 google_metadata_script_runner startup
```