### PR TITLE
Add logging output during Packer failures

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -275,6 +275,7 @@ No resources.
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of persistent disk to provision | `string` | `"pd-balanced"` | no |
 | <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration (var.shielded\_instance\_config). | `bool` | `false` | no |
+| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Directory of the gcloud executable | `string` | `""` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |
 | <a name="input_image_storage_locations"></a> [image\_storage\_locations](#input\_image\_storage\_locations) | Storage location, either regional or multi-regional, where snapshot content is to be stored and only accepts 1 value.<br/>See https://developer.hashicorp.com/packer/plugins/builders/googlecompute#image_storage_locations | `list(string)` | `null` | no |

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -21,6 +21,9 @@ locals {
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
   image_name         = var.image_name != null ? var.image_name : local.image_name_default
 
+  # construct vm image name for use when getting logs
+  instance_name = "packer-${substr(uuidv4(), 0, 6)}"
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -96,6 +99,7 @@ source "googlecompute" "toolkit_image" {
   image_name                  = local.image_name
   image_family                = local.image_family
   image_labels                = local.labels
+  instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -189,12 +193,25 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
+  error-cleanup-provisioner "shell-local" {
+    environment_vars = [
+      "PRJ_ID=${var.project_id}",
+      "INST_NAME=${local.instance_name}",
+      "ZONE=${var.zone}",
+      "GCLOUD_PATH=${var.gcloud_path_override}",
+      "CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=https://www.googleapis.com/compute/v1/"
+    ]
     inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
+      "command -v gcloud > /dev/null || exit 0",
+      "if [[ -n \"$\\{GCLOUD_PATH\\}\" ]]; then export PATH=\"$GCLOUD_PATH:$PATH\"; fi",
+      "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
+      "echo 'Error building image try checking logs:'",
+      join(" ", ["echo \"gcloud logging --project $PRJ_ID read",
+        "'logName=(\\\"projects/$PRJ_ID/logs/GCEMetadataScripts\\\" OR \\\"projects/$PRJ_ID/logs/google_metadata_script_runner\\\") AND resource.labels.instance_id=$INST_ID'",
+        "--format=\\\"table(timestamp, resource.labels.instance_id, jsonPayload.message)\\\"",
+        "--order=asc\""
+        ]
+      )
     ]
   }
 }

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -274,3 +274,9 @@ variable "shielded_instance_config" {
     enable_integrity_monitoring = true
   }
 }
+
+variable "gcloud_path_override" {
+  description = "Directory of the gcloud executable"
+  type        = string
+  default     = ""
+}

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -21,6 +21,9 @@ locals {
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
   image_name         = var.image_name != null ? var.image_name : local.image_name_default
 
+  # construct vm image name for use when getting logs
+  instance_name = "packer-${substr(uuidv4(), 0, 6)}"
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -96,6 +99,7 @@ source "googlecompute" "toolkit_image" {
   image_name                  = local.image_name
   image_family                = local.image_family
   image_labels                = local.labels
+  instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -189,12 +193,25 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
+  error-cleanup-provisioner "shell-local" {
+    environment_vars = [
+      "PRJ_ID=${var.project_id}",
+      "INST_NAME=${local.instance_name}",
+      "ZONE=${var.zone}",
+      "GCLOUD_PATH=${var.gcloud_path_override}",
+      "CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=https://www.googleapis.com/compute/v1/"
+    ]
     inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
+      "command -v gcloud > /dev/null || exit 0",
+      "if [[ -n \"$\\{GCLOUD_PATH\\}\" ]]; then export PATH=\"$GCLOUD_PATH:$PATH\"; fi",
+      "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
+      "echo 'Error building image try checking logs:'",
+      join(" ", ["echo \"gcloud logging --project $PRJ_ID read",
+        "'logName=(\\\"projects/$PRJ_ID/logs/GCEMetadataScripts\\\" OR \\\"projects/$PRJ_ID/logs/google_metadata_script_runner\\\") AND resource.labels.instance_id=$INST_ID'",
+        "--format=\\\"table(timestamp, resource.labels.instance_id, jsonPayload.message)\\\"",
+        "--order=asc\""
+        ]
+      )
     ]
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
@@ -274,3 +274,9 @@ variable "shielded_instance_config" {
     enable_integrity_monitoring = true
   }
 }
+
+variable "gcloud_path_override" {
+  description = "Directory of the gcloud executable"
+  type        = string
+  default     = ""
+}

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -21,6 +21,9 @@ locals {
   image_name_default = "${local.image_family}-${formatdate("YYYYMMDD't'hhmmss'z'", timestamp())}"
   image_name         = var.image_name != null ? var.image_name : local.image_name_default
 
+  # construct vm image name for use when getting logs
+  instance_name = "packer-${substr(uuidv4(), 0, 6)}"
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -96,6 +99,7 @@ source "googlecompute" "toolkit_image" {
   image_name                  = local.image_name
   image_family                = local.image_family
   image_labels                = local.labels
+  instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
   accelerator_count           = var.accelerator_count
@@ -189,12 +193,25 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
+  error-cleanup-provisioner "shell-local" {
+    environment_vars = [
+      "PRJ_ID=${var.project_id}",
+      "INST_NAME=${local.instance_name}",
+      "ZONE=${var.zone}",
+      "GCLOUD_PATH=${var.gcloud_path_override}",
+      "CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=https://www.googleapis.com/compute/v1/"
+    ]
     inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
+      "command -v gcloud > /dev/null || exit 0",
+      "if [[ -n \"$\\{GCLOUD_PATH\\}\" ]]; then export PATH=\"$GCLOUD_PATH:$PATH\"; fi",
+      "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
+      "echo 'Error building image try checking logs:'",
+      join(" ", ["echo \"gcloud logging --project $PRJ_ID read",
+        "'logName=(\\\"projects/$PRJ_ID/logs/GCEMetadataScripts\\\" OR \\\"projects/$PRJ_ID/logs/google_metadata_script_runner\\\") AND resource.labels.instance_id=$INST_ID'",
+        "--format=\\\"table(timestamp, resource.labels.instance_id, jsonPayload.message)\\\"",
+        "--order=asc\""
+        ]
+      )
     ]
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
@@ -274,3 +274,9 @@ variable "shielded_instance_config" {
     enable_integrity_monitoring = true
   }
 }
+
+variable "gcloud_path_override" {
+  description = "Directory of the gcloud executable"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
This PR adds an output to the Packer module that prints a custom gcloud logging command of the format

`gcloud logging --project <project> read 'logName=("projects/<project>/logs/GCEMetadataScripts" OR "projects/<project>/logs/google_metadata_script_runner") AND resource.labels.instance_id=<instance #>' --format="table(timestamp, resource.labels.instance_id, jsonPayload.message)" --order=asc`

when Packer fails during the startup scripts.  It also updates packer to create a instance name variable for the instance so that can be more easily tracked in the module.  It varies from the command in the README in that it should not need the freshness option as it is specific to one instance.  It also does not look for `"^startup-script: "` as that can be a bit too specific of a query.

This PR also removes some redundant image name outputs, and updates the golden copies.

This was tested on a simple Packer blueprint that introduced an script that only ran `exit 1` and cause the Packer module to end with an error.  It was also tested with a clean build to confirm no new issues were introduced.