### PR TITLE
Improvements for CloudSQL

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -63,6 +63,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_bigquery_connection.connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_connection) | resource |
+| [google_compute_address.psc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_forwarding_rule.psc_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_forwarding_rule) | resource |
 | [google_sql_database.database](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
 | [google_sql_database_instance.instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
 | [google_sql_user.users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
@@ -74,19 +76,23 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | IP address ranges as authorized networks of the Cloud SQL for MySQL instances | `list(string)` | `[]` | no |
+| <a name="input_data_cache_enabled"></a> [data\_cache\_enabled](#input\_data\_cache\_enabled) | Whether data cache is enabled for the instance. Can be used with ENTERPRISE\_PLUS edition. | `bool` | `false` | no |
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
+| <a name="input_edition"></a> [edition](#input\_edition) | value | `string` | `"ENTERPRISE"` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |
-| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where SQL instance will be configured | `string` | n/a | yes |
 | <a name="input_sql_instance_name"></a> [sql\_instance\_name](#input\_sql\_instance\_name) | name given to the sql instance for ease of identificaion | `string` | n/a | yes |
 | <a name="input_sql_password"></a> [sql\_password](#input\_sql\_password) | Password for the SQL database. | `any` | `null` | no |
 | <a name="input_sql_username"></a> [sql\_username](#input\_sql\_username) | Username for the SQL database | `string` | `"slurm"` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Self link of the network where Cloud SQL instance PSC endpoint will be created | `string` | n/a | yes |
 | <a name="input_tier"></a> [tier](#input\_tier) | The machine type to use for the SQL instance | `string` | n/a | yes |
-| <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | Replication parameters that will be used for defined secrets | <pre>list(object({<br/>    location     = string<br/>    kms_key_name = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_use_psc_connection"></a> [use\_psc\_connection](#input\_use\_psc\_connection) | Create Private Service Connection instead of using Private Service Access peering | `bool` | `false` | no |
+| <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | Replication parameters that will be used for defined secrets | <pre>list(object({<br>    location     = string<br>    kms_key_name = optional(string)<br>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -80,20 +80,22 @@ No modules.
 | <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
+| <a name="input_disk_autoresize"></a> [disk\_autoresize](#input\_disk\_autoresize) | Set to false to disable automatic disk grow. | `bool` | `true` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of the database disk in GiB. | `number` | `null` | no |
 | <a name="input_edition"></a> [edition](#input\_edition) | value | `string` | `"ENTERPRISE"` | no |
 | <a name="input_enable_backups"></a> [enable\_backups](#input\_enable\_backups) | Set true to enable backups | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |
-| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region where SQL instance will be configured | `string` | n/a | yes |
 | <a name="input_sql_instance_name"></a> [sql\_instance\_name](#input\_sql\_instance\_name) | name given to the sql instance for ease of identificaion | `string` | n/a | yes |
 | <a name="input_sql_password"></a> [sql\_password](#input\_sql\_password) | Password for the SQL database. | `any` | `null` | no |
 | <a name="input_sql_username"></a> [sql\_username](#input\_sql\_username) | Username for the SQL database | `string` | `"slurm"` | no |
-| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Self link of the network where Cloud SQL instance PSC endpoint will be created | `string` | n/a | yes |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Self link of the network where Cloud SQL instance PSC endpoint will be created | `string` | `null` | no |
 | <a name="input_tier"></a> [tier](#input\_tier) | The machine type to use for the SQL instance | `string` | n/a | yes |
 | <a name="input_use_psc_connection"></a> [use\_psc\_connection](#input\_use\_psc\_connection) | Create Private Service Connection instead of using Private Service Access peering | `bool` | `false` | no |
-| <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | Replication parameters that will be used for defined secrets | <pre>list(object({<br>    location     = string<br>    kms_key_name = optional(string)<br>  }))</pre> | `[]` | no |
+| <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | Replication parameters that will be used for defined secrets | <pre>list(object({<br/>    location     = string<br/>    kms_key_name = optional(string)<br/>  }))</pre> | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -81,6 +81,7 @@ No modules.
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_edition"></a> [edition](#input\_edition) | value | `string` | `"ENTERPRISE"` | no |
+| <a name="input_enable_backups"></a> [enable\_backups](#input\_enable\_backups) | Set true to enable backups | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -47,9 +47,12 @@ resource "google_sql_database_instance" "instance" {
   database_version    = var.database_version
 
   settings {
-    user_labels = local.labels
-    edition     = var.edition
-    tier        = var.tier
+    disk_size       = var.disk_size_gb
+    disk_autoresize = var.disk_autoresize
+    edition         = var.edition
+    tier            = var.tier
+    user_labels     = local.labels
+
     dynamic "data_cache_config" {
       for_each = var.edition == "ENTERPRISE_PLUS" ? [""] : []
       content {
@@ -84,7 +87,15 @@ resource "google_sql_database_instance" "instance" {
       transaction_log_retention_days = 7
     }
   }
+  lifecycle {
+    precondition {
+      condition     = var.disk_autoresize && var.disk_size_gb == null || !var.disk_autoresize
+      error_message = "If setting disk_size_gb set disk_autorize to false to prevent re-provisioning of the instance after disk auto-expansion."
+    }
+  }
 }
+
+
 
 resource "google_compute_address" "psc" {
   count        = var.use_psc_connection ? 1 : 0

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -77,6 +77,12 @@ resource "google_sql_database_instance" "instance" {
         }
       }
     }
+
+    backup_configuration {
+      enabled = var.enable_backups
+      # to allow easy switching between ENTERPRISE and ENTERPRISE_PLUS
+      transaction_log_retention_days = 7
+    }
   }
 }
 

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -48,22 +48,58 @@ resource "google_sql_database_instance" "instance" {
 
   settings {
     user_labels = local.labels
+    edition     = var.edition
     tier        = var.tier
+    dynamic "data_cache_config" {
+      for_each = var.edition == "ENTERPRISE_PLUS" ? [""] : []
+      content {
+        data_cache_enabled = var.data_cache_enabled
+      }
+    }
     ip_configuration {
       ipv4_enabled                                  = false
-      private_network                               = var.network_id
+      private_network                               = var.use_psc_connection ? null : var.network_id
       enable_private_path_for_google_cloud_services = true
 
       dynamic "authorized_networks" {
-        for_each = var.authorized_networks
+        for_each = var.use_psc_connection ? [] : var.authorized_networks
         iterator = ip_range
 
         content {
           value = ip_range.value
         }
       }
+      dynamic "psc_config" {
+        for_each = var.use_psc_connection ? [""] : []
+        content {
+          psc_enabled               = true
+          allowed_consumer_projects = [var.project_id]
+        }
+      }
     }
   }
+}
+
+resource "google_compute_address" "psc" {
+  count        = var.use_psc_connection ? 1 : 0
+  project      = var.project_id
+  name         = local.sql_instance_name
+  address_type = "INTERNAL"
+  region       = var.region
+  subnetwork   = var.subnetwork_self_link
+  labels       = local.labels
+}
+
+resource "google_compute_forwarding_rule" "psc_consumer" {
+  count                 = var.use_psc_connection ? 1 : 0
+  name                  = local.sql_instance_name
+  project               = var.project_id
+  region                = var.region
+  subnetwork            = var.subnetwork_self_link
+  ip_address            = google_compute_address.psc[0].self_link
+  load_balancing_scheme = ""
+  recreate_closed_psc   = true
+  target                = google_sql_database_instance.instance.psc_service_attachment_link
 }
 
 resource "google_sql_database" "database" {

--- a/community/modules/database/slurm-cloudsql-federation/outputs.tf
+++ b/community/modules/database/slurm-cloudsql-federation/outputs.tf
@@ -18,7 +18,7 @@ output "cloudsql" {
   description = "Describes the cloudsql instance."
   sensitive   = true
   value = {
-    server_ip                = google_sql_database_instance.instance.ip_address[0].ip_address
+    server_ip                = var.use_psc_connection ? google_compute_address.psc[0].address : google_sql_database_instance.instance.ip_address[0].ip_address
     user                     = google_sql_user.users.name
     password                 = google_sql_user.users.password
     db_name                  = google_sql_database.database.name

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -42,6 +42,18 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "disk_autoresize" {
+  description = "Set to false to disable automatic disk grow."
+  type        = bool
+  default     = true
+}
+
+variable "disk_size_gb" {
+  description = "Size of the database disk in GiB."
+  type        = number
+  default     = null
+}
+
 variable "edition" {
   description = "value"
   type        = string
@@ -122,6 +134,7 @@ variable "private_vpc_connection_peering" {
 variable "subnetwork_self_link" {
   description = "Self link of the network where Cloud SQL instance PSC endpoint will be created"
   type        = string
+  default     = null
 }
 
 variable "user_managed_replication" {

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -26,14 +26,30 @@ variable "database_version" {
   type        = string
   default     = "MYSQL_5_7"
   validation {
-    condition     = var.database_version == "MYSQL_5_7" || var.database_version == "MYSQL_8_0"
-    error_message = "The database version must be either MYSQL_5_7 or MYSQL_8_0."
+    condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_4"], var.database_version)
+    error_message = "The database version must be either MYSQL_5_7, MYSQL_8_0 or MYSQL_8_4."
   }
+}
+
+variable "data_cache_enabled" {
+  description = "Whether data cache is enabled for the instance. Can be used with ENTERPRISE_PLUS edition."
+  type        = bool
+  default     = false
 }
 
 variable "deployment_name" {
   description = "The name of the current deployment"
   type        = string
+}
+
+variable "edition" {
+  description = "value"
+  type        = string
+  validation {
+    condition     = contains(["ENTERPRISE", "ENTERPRISE_PLUS"], var.edition)
+    error_message = "The database edition must be either ENTERPRISE or ENTERPRISE_PLUS"
+  }
+  default = "ENTERPRISE"
 }
 
 variable "project_id" {
@@ -97,6 +113,11 @@ variable "private_vpc_connection_peering" {
   default     = null
 }
 
+variable "subnetwork_self_link" {
+  description = "Self link of the network where Cloud SQL instance PSC endpoint will be created"
+  type        = string
+}
+
 variable "user_managed_replication" {
   type = list(object({
     location     = string
@@ -104,4 +125,10 @@ variable "user_managed_replication" {
   }))
   description = "Replication parameters that will be used for defined secrets"
   default     = []
+}
+
+variable "use_psc_connection" {
+  description = "Create Private Service Connection instead of using Private Service Access peering"
+  type        = bool
+  default     = false
 }

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -52,6 +52,12 @@ variable "edition" {
   default = "ENTERPRISE"
 }
 
+variable "enable_backups" {
+  description = "Set true to enable backups"
+  type        = bool
+  default     = false
+}
+
 variable "project_id" {
   description = "Project in which the HPC deployment will be created"
   type        = string


### PR DESCRIPTION
* add possibility to use Private Service Connect
* add 8.4 version of MySQL
* add possibility to choose CloudSQL edition
* add possibility to enable data caching

Supersedes: #2730 - compared to previous PR, this keeps PSA as default option and makes PSC an opt-in.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
