### PR TITLE
Remove redundant provisioner for printing image name

### DIFF
--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -193,15 +193,6 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
-    inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
-    ]
-  }
-
   # If there is an error during image creation, print out command for getting packer VM logs
   error-cleanup-provisioner "shell-local" {
     environment_vars = [

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -193,15 +193,6 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
-    inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
-    ]
-  }
-
   # If there is an error during image creation, print out command for getting packer VM logs
   error-cleanup-provisioner "shell-local" {
     environment_vars = [

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -193,15 +193,6 @@ build {
     }
   }
 
-  # if the jq command is present, this will print the image name to stdout
-  # if jq is not present, this exits silently with code 0
-  post-processor "shell-local" {
-    inline = [
-      "command -v jq > /dev/null || exit 0",
-      "echo \"Image built: $(jq -r '.builds[-1].artifact_id' ${var.manifest_file} | cut -d ':' -f2)\"",
-    ]
-  }
-
   # If there is an error during image creation, print out command for getting packer VM logs
   error-cleanup-provisioner "shell-local" {
     environment_vars = [


### PR DESCRIPTION
WIth updates to Packer, there is no longer a need for a provisioner to print out the new image name.  This PR removes this functionality to simplify the code base.
