### PR TITLE
Update IP address module within VPC module

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -172,7 +172,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | ~> 6.0 |
-| <a name="module_nat_ip_addresses"></a> [nat\_ip\_addresses](#module\_nat\_ip\_addresses) | terraform-google-modules/address/google | ~> 3.1 |
+| <a name="module_nat_ip_addresses"></a> [nat\_ip\_addresses](#module\_nat\_ip\_addresses) | terraform-google-modules/address/google | ~> 4.1 |
 | <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 9.0 |
 
 ## Resources
@@ -196,6 +196,7 @@ No resources.
 | <a name="input_firewall_log_config"></a> [firewall\_log\_config](#input\_firewall\_log\_config) | Firewall log configuration for Toolkit firewall rules (var.enable\_iap\_ssh\_ingress and others) | `string` | `"DISABLE_LOGGING"` | no |
 | <a name="input_firewall_rules"></a> [firewall\_rules](#input\_firewall\_rules) | List of firewall rules | `any` | `[]` | no |
 | <a name="input_ips_per_nat"></a> [ips\_per\_nat](#input\_ips\_per\_nat) | The number of IP addresses to allocate for each regional Cloud NAT (set to 0 to disable NAT) | `number` | `2` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to network resources that support labels. Key-value pairs of strings. | `map(string)` | `{}` | no |
 | <a name="input_mtu"></a> [mtu](#input\_mtu) | The network MTU (default: 8896). Recommended values: 0 (use Compute Engine default), 1460 (default outside HPC environments), 1500 (Internet default), or 8896 (for Jumbo packets). Allowed are all values in the range 1300 to 8896, inclusively. | `number` | `8896` | no |
 | <a name="input_network_address_range"></a> [network\_address\_range](#input\_network\_address\_range) | IP address range (CIDR) for global network | `string` | `"10.0.0.0/9"` | no |
 | <a name="input_network_description"></a> [network\_description](#input\_network\_description) | An optional description of this resource (changes will trigger resource destroy/create) | `string` | `""` | no |

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -15,6 +15,11 @@
 */
 
 locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "vpc", ghpc_role = "network" })
+}
+
+locals {
   autoname        = replace(var.deployment_name, "_", "-")
   network_name    = var.network_name == null ? "${local.autoname}-net" : var.network_name
   subnetwork_name = var.subnetwork_name == null ? "${local.autoname}-primary-subnet" : var.subnetwork_name
@@ -175,7 +180,7 @@ module "vpc" {
 # https://github.com/terraform-google-modules/terraform-google-address/blob/v3.1.1/outputs.tf
 module "nat_ip_addresses" {
   source  = "terraform-google-modules/address/google"
-  version = "~> 3.1"
+  version = "~> 4.1"
 
   for_each = toset(local.regions)
 
@@ -184,6 +189,7 @@ module "nat_ip_addresses" {
   # an external, regional (not global) IP address is suited for a regional NAT
   address_type = "EXTERNAL"
   global       = false
+  labels       = local.labels
   names        = [for idx in range(var.ips_per_nat) : "${local.network_name}-nat-ips-${each.value}-${idx}"]
 }
 

--- a/modules/network/vpc/variables.tf
+++ b/modules/network/vpc/variables.tf
@@ -19,6 +19,13 @@ variable "project_id" {
   type        = string
 }
 
+variable "labels" {
+  description = "Labels to add to network resources that support labels. Key-value pairs of strings."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
 variable "network_name" {
   description = "The name of the network to be created (if unsupplied, will default to \"{deployment_name}-net\")"
   type        = string

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -62,6 +62,7 @@ deployment_groups:
           deployment_name: ((var.deployment_name))
           enable_iap_rdp_ingress: true
           enable_iap_winrm_ingress: true
+          labels: ((var.labels))
           project_id: ((var.project_id))
           region: ((var.region))
       - source: modules/file-system/filestore

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/main.tf
@@ -19,6 +19,7 @@ module "network0" {
   deployment_name          = var.deployment_name
   enable_iap_rdp_ingress   = true
   enable_iap_winrm_ingress = true
+  labels                   = var.labels
   project_id               = var.project_id
   region                   = var.region
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -68,6 +68,7 @@ deployment_groups:
             sensitive: true
         settings:
           deployment_name: ((var.deployment_name))
+          labels: ((var.labels))
           project_id: ((var.project_id))
           region: ((var.region))
   - group: one

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/main.tf
@@ -24,6 +24,7 @@ terraform {
 module "network0" {
   source          = "./modules/embedded/modules/network/vpc"
   deployment_name = var.deployment_name
+  labels          = var.labels
   project_id      = var.project_id
   region          = var.region
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -57,6 +57,7 @@ deployment_groups:
         id: network
         settings:
           deployment_name: ((var.deployment_name))
+          labels: ((var.labels))
           project_id: ((var.project_id))
           region: ((var.region))
       - source: modules/file-system/filestore

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/main.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/main.tf
@@ -17,6 +17,7 @@
 module "network" {
   source          = "./modules/embedded/modules/network/vpc"
   deployment_name = var.deployment_name
+  labels          = var.labels
   project_id      = var.project_id
   region          = var.region
 }


### PR DESCRIPTION
- Support terraform-provider-google v6
- Adds support for labels on regional IP addresses

Without this update, any blueprint that uses the `vpc` module will default to TPG 5.44.2 instead of 6.8.0.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
