### PR TITLE
Add cluster and hostname as cloud ops labels

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -37,5 +37,10 @@ output "instructions" {
   value       = <<-EOT
     To SSH to the controller (may need to add '--tunnel-through-iap'):
       gcloud compute ssh ${google_compute_instance_from_template.controller.self_link}
+    
+    If you are using cloud ops agent with this deployment,
+    you can use the following command to see the logs for the entire cluster or any particular VM host:
+      gcloud logging read labels.cluster_name=${local.slurm_cluster_name}
+      gcloud logging read labels.hostname=${local.slurm_cluster_name}-controller
   EOT
 }


### PR DESCRIPTION
This PR adds an additional processor to slurm's cloud ops config and adds labels for hostname/cluster name.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
