### PR TITLE
Update MTU for a3 mega for GKE based on best practices 

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -33,6 +33,7 @@ deployment_groups:
     source: modules/network/vpc
     settings:
       subnetwork_name: gke-subnet-a3-highgpu
+      mtu: 8244
       secondary_ranges:
         gke-subnet-a3-highgpu:
         - range_name: pods
@@ -59,6 +60,7 @@ deployment_groups:
       global_ip_address_range: 192.169.0.0/16
       network_count: 4
       subnetwork_cidr_suffix: 24
+      mtu: 8244
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -33,6 +33,7 @@ deployment_groups:
     source: modules/network/vpc
     settings:
       subnetwork_name: gke-subnet-a3-mega
+      mtu: 8244
       secondary_ranges:
         gke-subnet-a3-mega:
         - range_name: pods
@@ -59,6 +60,7 @@ deployment_groups:
       global_ip_address_range: 192.169.0.0/16
       network_count: 8
       subnetwork_cidr_suffix: 24
+      mtu: 8244
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster


### PR DESCRIPTION
Based on the https://cloud.google.com/kubernetes-engine/docs/how-to/gpu-bandwidth-gpudirect-tcpx#create-vpcs-subnets, where the VPCs are created 

```
gcloud compute networks create PROJECT_ID-net-$N \
    --subnet-mode=custom \
    --mtu=8244

```