### PR TITLE
Add support for Filestore deletion protection

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -12,7 +12,7 @@ Toolkit, see the extended [Network Storage documentation](../../../docs/network_
 We recommend considering enabling [Filestore deletion protection][fdp]. Deletion
 protection will prevent unintentional deletion of an entire Filestore instance.
 It does not prevent deletion of files within the Filestore instance when mounted
-by a VM. It ss not available on some [tiers](#filestore-tiers), including the
+by a VM. It is not available on some [tiers](#filestore-tiers), including the
 default BASIC\_HDD tier or BASIC\_SSD tier. Follow the documentation link for
 up to date details.
 

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -7,6 +7,32 @@ mounted to one or more compute VMs.
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
 
+### Deletion protection
+
+We recommend considering enabling [Filestore deletion protection][fdp]. Deletion
+protection will prevent unintentional deletion of an entire Filestore instance.
+It does not prevent deletion of files within the Filestore instance when mounted
+by a VM. It ss not available on some [tiers](#filestore-tiers), including the
+default BASIC\_HDD tier or BASIC\_SSD tier. Follow the documentation link for
+up to date details.
+
+Usage can be enabled in a blueprint with, for example:
+
+```yaml
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network]
+    settings:
+      deletion_protection:
+        enabled: true
+        reason: Avoid data loss
+      filestore_tier: ZONAL
+      local_mount: /home
+      size_gb: 1024
+```
+
+[fdp]: https://cloud.google.com/filestore/docs/deletion-protection
+
 ### Filestore tiers
 
 At the time of writing, Filestore supports 5 [tiers of service][tiers] that are
@@ -149,14 +175,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.19 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.19 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.4 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -175,6 +201,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_connect_mode"></a> [connect\_mode](#input\_connect\_mode) | Used to select mode - supported values DIRECT\_PEERING and PRIVATE\_SERVICE\_ACCESS. | `string` | `"DIRECT_PEERING"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Configure Filestore instance deletion protection | <pre>object({<br/>    enabled = optional(bool, false)<br/>    reason  = optional(string)<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used as name of the filestore instance if no name is specified. | `string` | n/a | yes |
 | <a name="input_filestore_share_name"></a> [filestore\_share\_name](#input\_filestore\_share\_name) | Name of the file system share on the instance. | `string` | `"nfsshare"` | no |
 | <a name="input_filestore_tier"></a> [filestore\_tier](#input\_filestore\_tier) | The service tier of the instance. | `string` | `"BASIC_HDD"` | no |

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -56,6 +56,9 @@ resource "google_filestore_instance" "filestore_instance" {
   location = var.filestore_tier == "ENTERPRISE" ? var.region : var.zone
   tier     = var.filestore_tier
 
+  deletion_protection_enabled = var.deletion_protection.enabled
+  deletion_protection_reason  = var.deletion_protection.reason
+
   file_shares {
     capacity_gb = var.size_gb
     name        = var.filestore_share_name

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -147,3 +147,20 @@ variable "mount_options" {
   type        = string
   default     = "defaults,_netdev"
 }
+
+variable "deletion_protection" {
+  description = "Configure Filestore instance deletion protection"
+  type = object({
+    enabled = optional(bool, false)
+    reason  = optional(string)
+  })
+  default = {
+    enabled = false
+  }
+  nullable = false
+
+  validation {
+    condition     = !can(coalesce(var.deletion_protection.reason)) || var.deletion_protection.enabled
+    error_message = "Cannot set Filestore var.deletion_protection.reason unless var.deletion_protection.enabled is true"
+  }
+}

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.19"
+      version = ">= 6.4"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Filestore deletion protection ensures that instances are not unintentionally deleted. A typical lifecycle for a user will look like:

1. Deploy a blueprint with deletion protection enabled
2. Disable deletion protection in blueprint
3. Redeploy blueprint
4. Destroy deployment

In particular, enabling Filestore deletion protection does not prevent Terraform from destroying other resources. So a `gcluster destroy` command will destroy all resources except the Filestore and its dependencies. It will prevent modifications to a Filestore instance that require a destroy/create cycle.

We cannot yet add this to an integration test because we do not support tests that intentionally fail to destroy. Manual testing is described below:

1. Add extra settings to examples/hpc-slurm.yaml and deploy:

```yaml
  - id: homefs
    source: modules/file-system/filestore
    use: [network]
    settings:
      deletion_protection:
        enabled: true
        reason: Avoid data loss
      filestore_tier: ZONAL
      local_mount: /home
      size_gb: 1024
```

2. Remove the extra settings and attempt to deploy. It proposes the plan you'd expect (replace the Filestore due to change of tier):

```
-/+ resource "google_filestore_instance" "filestore_instance" {
      ~ create_time                 = "2024-11-12T22:03:13.633956077Z" -> (known after apply)
      ~ deletion_protection_enabled = true -> false
      - deletion_protection_reason  = "Avoid data loss" -> null
      + etag                        = (known after apply)
      ~ id                          = "projects/toolkit-demo-zero-e913/locations/us-central1-a/instances/hpc-slurm-f5d5ec9b" -> (known after apply)
        name                        = "hpc-slurm-f5d5ec9b"
      ~ tier                        = "ZONAL" -> "BASIC_HDD" # forces replacement
      + zone                        = (known after apply)
        # (6 unchanged attributes hidden)

      ~ networks {
          ~ ip_addresses      = [
              - "10.103.225.2",
            ] -> (known after apply)
          + reserved_ip_range = (known after apply)
            # (3 unchanged attributes hidden)
        }

        # (1 unchanged block hidden)
    }
```

This fails with an error message:

```
Error: exit status 1

Error: Error when reading or editing Instance: googleapi: Error 400: instance "projects/toolkit-demo-zero-e913/locations/us-central1-a/instances/hpc-
slurm-f5d5ec9b" is protected from deletion: Avoid data loss
```

It also prints an unhelpful stacktrace that I have reported at https://github.com/hashicorp/terraform-provider-google/issues/20311

If I then attempt to deliberately destroy the deployment with `gcluster destroy hpc-slurm`, it will progress through the destruction of non-Filestore infrastructure but leave the Filestore and its dependencies in place.

```
Summary of proposed changes: Plan: 0 to add, 0 to change, 46 to destroy.
...
Error: exit status 1

Error: Error when reading or editing Instance: googleapi: Error 400: instance "projects/toolkit-demo-zero-e913/locations/us-central1-a/instances/hpc-
slurm-f5d5ec9b" is protected from deletion: Avoid data loss
```

If I redeploy with a new blueprint that disables deletion protection:

```
module.homefs.google_filestore_instance.filestore_instance: Modifying... [id=projects/toolkit-demo-zero-e913/locations/us-central1-a/instances/hpc-slurm-f5d5ec9b]
...
module.homefs.google_filestore_instance.filestore_instance: Modifications complete after 11s [id=projects/toolkit-demo-zero-e913/locations/us-central1-a/instances/hpc-slurm-f5d5ec9b]
```

I can then run `gcluster destroy hpc-slurm` without difficulty.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
