### PR TITLE
update HTCondor modules to be compatible with TPG v6

### DIFF
--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -210,8 +210,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | 10.1.1 |
-| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | 10.1.1 |
+| <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 12.1 |
+| <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 12.1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | ../../../../modules/scripts/startup-script | n/a |
 
 ## Resources

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -132,7 +132,7 @@ module "startup_script" {
 
 module "execute_point_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "10.1.1"
+  version = "~> 12.1"
 
   name_prefix = local.name_prefix
   project_id  = var.project_id
@@ -160,7 +160,7 @@ module "execute_point_instance_template" {
 
 module "mig" {
   source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "10.1.1"
+  version = "~> 12.1"
 
   project_id                       = var.project_id
   region                           = var.region

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -120,8 +120,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_access_point_instance_template"></a> [access\_point\_instance\_template](#module\_access\_point\_instance\_template) | github.com/terraform-google-modules/terraform-google-vm//modules/instance_template | 73dc845 |
-| <a name="module_htcondor_ap"></a> [htcondor\_ap](#module\_htcondor\_ap) | terraform-google-modules/vm/google//modules/mig | 10.1.1 |
+| <a name="module_access_point_instance_template"></a> [access\_point\_instance\_template](#module\_access\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 12.1 |
+| <a name="module_htcondor_ap"></a> [htcondor\_ap](#module\_htcondor\_ap) | terraform-google-modules/vm/google//modules/mig | ~> 12.1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | ../../../../modules/scripts/startup-script | n/a |
 
 ## Resources

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -226,7 +226,8 @@ resource "google_compute_disk" "spool" {
 }
 
 module "access_point_instance_template" {
-  source = "github.com/terraform-google-modules/terraform-google-vm//modules/instance_template?ref=73dc845"
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 12.1"
 
   name_prefix = local.name_prefix
   project_id  = var.project_id
@@ -261,7 +262,7 @@ module "access_point_instance_template" {
 
 module "htcondor_ap" {
   source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "10.1.1"
+  version = "~> 12.1"
 
   project_id                       = var.project_id
   region                           = var.region

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -104,8 +104,8 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_central_manager_instance_template"></a> [central\_manager\_instance\_template](#module\_central\_manager\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | 10.1.1 |
-| <a name="module_htcondor_cm"></a> [htcondor\_cm](#module\_htcondor\_cm) | terraform-google-modules/vm/google//modules/mig | 10.1.1 |
+| <a name="module_central_manager_instance_template"></a> [central\_manager\_instance\_template](#module\_central\_manager\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 12.1 |
+| <a name="module_htcondor_cm"></a> [htcondor\_cm](#module\_htcondor\_cm) | terraform-google-modules/vm/google//modules/mig | ~> 12.1 |
 | <a name="module_startup_script"></a> [startup\_script](#module\_startup\_script) | ../../../../modules/scripts/startup-script | n/a |
 
 ## Resources

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -134,7 +134,7 @@ module "startup_script" {
 
 module "central_manager_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "10.1.1"
+  version = "~> 12.1"
 
   name_prefix = local.name_prefix
   project_id  = var.project_id
@@ -160,7 +160,7 @@ module "central_manager_instance_template" {
 
 module "htcondor_cm" {
   source  = "terraform-google-modules/vm/google//modules/mig"
-  version = "10.1.1"
+  version = "~> 12.1"
 
   project_id                       = var.project_id
   region                           = var.region


### PR DESCRIPTION
This pr updates the mig and instance_template submodule versions used in HTCondor to be the following:
``` 
source  = "terraform-google-modules/vm/google//modules/instance_template"
 version = "~> 12.1"
```
```
source  = "terraform-google-modules/vm/google//modules/mig"
 version = "~> 12.1"
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
