### PR TITLE
update Batch module to be compatible with TPG v6

### DIFF
--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -140,7 +140,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 10.1.1 |
+| <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 12.1 |
 | <a name="module_netstorage_startup_script"></a> [netstorage\_startup\_script](#module\_netstorage\_startup\_script) | github.com/GoogleCloudPlatform/hpc-toolkit//modules/scripts/startup-script | v1.39.0 |
 
 ## Resources

--- a/modules/scheduler/batch-job-template/main.tf
+++ b/modules/scheduler/batch-job-template/main.tf
@@ -90,7 +90,7 @@ locals {
 
 module "instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
-  version = "~> 10.1.1"
+  version = "~> 12.1"
 
   name_prefix        = var.instance_template == null ? "${var.job_id}-instance-template" : "unused-template"
   project_id         = var.project_id


### PR DESCRIPTION
This pr updates the instance_template submodule version used in Batch-job-template to be the following:
```
source  = "terraform-google-modules/vm/google//modules/instance_template"
  version = "~> 12.1"
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
