### PR TITLE
Standardizing the network naming for the integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml
@@ -20,7 +20,7 @@ test_name: gke-a3high
 deployment_name: gke-a3high-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-a3-highgpu.yaml"
-network: "gke-a3high-net-{{ build }}"
+network: "{{ deployment_name }}-net"
 region: us-west1
 zone: us-west1-a
 remote_node: "{{ deployment_name }}-remote-node-0"

--- a/tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml
@@ -20,7 +20,7 @@ test_name: gke-a3mega
 deployment_name: gke-a3mega-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-a3-megagpu.yaml"
-network: "gke-a3mega-net-{{ build }}"
+network: "{{ deployment_name }}-net"
 region: us-west4
 zone: us-west4-a
 remote_node: "{{ deployment_name }}-remote-node-0"

--- a/tools/cloud-build/daily-tests/tests/gke-storage.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-storage.yml
@@ -17,7 +17,7 @@ deployment_name: gke-storage-{{ build }}
 zone: us-central1-a  # for remote node
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/storage-gke.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 remote_node: "{{ deployment_name }}-0"
 post_deploy_tests: []
 cli_deployment_vars:

--- a/tools/cloud-build/daily-tests/tests/hcls-v5-legacy.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls-v5-legacy.yml
@@ -22,7 +22,7 @@ slurm_cluster_name: "hcls{{ build[0:6] }}"
 zone: europe-west1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/docs/videos/healthcare-and-life-sciences/hcls-blueprint-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 cli_deployment_vars:

--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
   gpu_zones: "[europe-west4-a,europe-west4-b,europe-west4-c]"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-slurm-chromedesktop.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
   zone: "{{ zone }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-chromedesktop-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/htc-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/htc-slurm.yml
@@ -15,7 +15,7 @@
 ---
 
 test_name: htc-slurm-v6
-deployment_name: htcv6{{ build }}
+deployment_name: htc-v6-{{ build }}
 slurm_cluster_name: "htcv6{{ build[0:5] }}"
 zone: us-west4-c
 
@@ -26,7 +26,7 @@ cli_deployment_vars:
 
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/htc-slurm.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -16,7 +16,7 @@
 
 test_name: ml-slurm-v6
 deployment_name: ml-slurm-v6-{{ build }}
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-debian.yml
@@ -29,7 +29,7 @@ cli_deployment_vars:
 zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-hpc-centos7.yml
@@ -28,7 +28,7 @@ cli_deployment_vars:
   zones: "[us-west4-a,us-west4-b,us-west4-c]"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-slurm-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-rocky8.yml
@@ -29,7 +29,7 @@ cli_deployment_vars:
 zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v5-ubuntu.yml
@@ -22,7 +22,7 @@ slurm_cluster_name: "ubunv5{{ build[0:4] }}"
 zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004-v5-legacy.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
@@ -29,7 +29,7 @@ cli_deployment_vars:
 zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
@@ -28,7 +28,7 @@ cli_deployment_vars:
 zone: us-central1-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-slurm.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml
@@ -22,7 +22,7 @@ slurm_cluster_name: "ssdv6{{ build[0:5] }}"
 zone: us-central1-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-local-ssd.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
@@ -22,7 +22,7 @@ slurm_cluster_name: "ubunv6{{ build[0:4] }}"
 zone: us-west4-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
+++ b/tools/cloud-build/daily-tests/tests/spack-gromacs.yml
@@ -20,7 +20,7 @@ slurm_cluster_name: "groma{{ build[0:5] }}"
 zone: us-central1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-gromacs.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 # Image name to be used to filter logs from /var/log/messages for startup script.
 image_name: "slurm-gcp-dev-hpc-rocky-linux-8-*"


### PR DESCRIPTION
A number of the integration tests fail with collisions, this is an attempt to standardize naming that uses the deployment name which always has the build number as part of it.  

There are a few other integration tests that use `default` as the network name that should also probably be updated, but I wasn't sure if they were done that way for a specific reason.