### PR TITLE
Adopt google Terraform plugin v6.10.0 and drop support for 5.x

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -199,11 +199,11 @@ func getDefaultGoogleProviders(bp Blueprint) map[string]TerraformProvider {
 	return map[string]TerraformProvider{
 		"google": {
 			Source:        "hashicorp/google",
-			Version:       ">= 5.44.2, < 6.10.0",
+			Version:       "~> 6.10.0",
 			Configuration: gglConf},
 		"google-beta": {
 			Source:        "hashicorp/google-beta",
-			Version:       ">= 5.44.2, < 6.10.0",
+			Version:       "~> 6.10.0",
 			Configuration: gglConf}}
 }
 

--- a/pkg/config/expand_test.go
+++ b/pkg/config/expand_test.go
@@ -93,10 +93,10 @@ func (s *zeroSuite) TestExpandProviders(c *C) {
 		c.Check(g.TerraformProviders, DeepEquals, map[string]PR{
 			"google": TerraformProvider{
 				Source:  "hashicorp/google",
-				Version: ">= 5.44.2, < 6.10.0"},
+				Version: "~> 6.10.0"},
 			"google-beta": TerraformProvider{
 				Source:  "hashicorp/google-beta",
-				Version: ">= 5.44.2, < 6.10.0"}})
+				Version: "~> 6.10.0"}})
 	}
 
 	{ // no def PR, group PR

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -38,14 +38,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -44,14 +44,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
@@ -80,14 +80,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -39,14 +39,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/.ghpc/artifacts/expanded_blueprint.yaml
@@ -47,14 +47,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 5.44.2, < 6.10.0'
+        version: ~> 6.10.0
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.44.2, < 6.10.0"
+      version = "~> 6.10.0"
     }
   }
 }


### PR DESCRIPTION
- TPG 5.x is no longer supported or maintained for anything except critical backports
- The filestore module will soon support only TPG 6.4 and above, effectively making most of our blueprints require TPG 6.4+

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
