### PR TITLE
Fix SSH issues with integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -93,7 +93,7 @@
       ansible.builtin.debug:
         var: remote_ip
 
-    ## Setup firewall for cloud build
+    # Setup firewall for cloud build
     - name: Create firewall rule
       register: fw_result
       changed_when: fw_result.rc == 0
@@ -132,8 +132,11 @@
         groups: [remote_host]
       when: remote_ip | ansible.utils.ipaddr
 
-    - name: Wait for cluster
-      ansible.builtin.wait_for_connection:
+    - name: Wait for host tasks
+      ansible.builtin.include_tasks: tasks/wait-for-host.yml
+      vars:
+        host_ip: "{{ remote_ip }}"
+        ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
 
     ## Cleanup and fail gracefully
     rescue:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -102,6 +102,11 @@
         - --ttl
         - 2h
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
+    - name: Wait for host tasks
+      ansible.builtin.include_tasks: tasks/wait-for-host.yml
+      vars:
+        host_ip: "{{ access_ip.stdout }}"
+        ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
     rescue:
     - name: Delete Firewall Rule
       register: fw_deleted
@@ -146,10 +151,6 @@
     vars:
       ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
     block:
-    - name: Wait until host is reachable
-      ansible.builtin.wait_for_connection:
-        delay: 60
-        timeout: 300
     - name: Gather facts
       ansible.builtin.setup:
     - name: Wait until HTCondor daemon is up

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -133,7 +133,7 @@
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
 
-    - name: 'Add SSH Keys to OS-Login'
+    - name: Add SSH Keys to OS-Login
       register: key_created
       changed_when: key_created.rc == 0
       ansible.builtin.command:
@@ -152,6 +152,12 @@
         hostname: "{{ login_ip }}"
         groups: [remote_host]
       when: login_ip | ansible.utils.ipaddr
+
+    - name: Wait for host tasks
+      ansible.builtin.include_tasks: tasks/wait-for-host.yml
+      vars:
+        host_ip: "{{ login_ip }}"
+        ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
 
     ## Cleanup and fail gracefully
     rescue:
@@ -186,14 +192,9 @@
   tasks:
   - name: Slurm Test Block
     vars:
-      ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
       ansible_remote_tmp: "/tmp/gcluster/"
+      ansible_ssh_private_key_file: "/builder/home/.ssh/id_rsa"
     block:
-    - name: Wait until host is reachable
-      ansible.builtin.wait_for_connection:
-        delay: 60
-        timeout: 300
-
     - name: Gather facts
       ansible.builtin.setup:
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-host.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-host.yml
@@ -1,0 +1,41 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - host_ip is defined
+
+- name: Wait for firewall to allow port 22 connection
+  ansible.builtin.wait_for:
+    host: "{{ host_ip }}"
+    port: 22
+    delay: 60
+    timeout: 300
+  delegate_to: localhost
+  ignore_errors: true
+  register: port_out
+
+- name: Check connection to remote host
+  ansible.builtin.wait_for_connection:
+    delay: 10
+  delegate_to: "{{ host_ip }}"
+  ignore_unreachable: true
+  register: connect_out
+
+- name: Fail on bad connections
+  ansible.builtin.fail:
+    msg: "Failed to connect to remote host {{ host_ip }}"
+  when: port_out is failed or connect_out is failed


### PR DESCRIPTION
A number of the integration tests have been failing lately due to a host being "UNREACHABLE" via ssh.  This PR creates a wait-for-host task that checks both the ansible connection and that port 22 is accessible from the builder.  

The PR should also resolve at least one issue where the playbook would completely halt because of an unreachable host and leave behind resources to be cleaned up.

This is being tested on the chrome-remote-desktop integration test.  I was able to reproduce the error by removing the firewall rule creation task in the test.