### PR TITLE
Adopt local SSD storage for A3 docker images

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
@@ -52,6 +52,7 @@ vars:
   enable_ops_agent: true
   # enable the NVIDIA DCGM daemon and integration into Cloud Ops Agent
   enable_nvidia_dcgm: true
+  localssd_mountpoint: /mnt/localssd
 
 deployment_groups:
 - group: cluster
@@ -114,8 +115,17 @@ deployment_groups:
       # Failure to do will result in VMs that lose data and do not automatically
       # mount local SSD filesystems
       local_ssd_filesystem:
-        mountpoint: /mnt/localssd
+        mountpoint: $(vars.localssd_mountpoint)
         permissions: "1777" # must quote numeric filesystem permissions!
+      # Docker was successfully installed in the image, this configures it
+      # to use the A3-specific local SSD volumes to store container images
+      docker:
+        enabled: true
+        world_writable: true
+        daemon_config: |
+          {
+            "data-root": "$(vars.localssd_mountpoint)/docker"
+          }
       runners:
       - type: ansible-local
         destination: enable_nvidia_dcgm.yml

--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-cluster.yaml
@@ -30,6 +30,7 @@ vars:
     project: $(vars.project_id)
   enable_login_public_ips: true
   enable_controller_public_ips: true
+  localssd_mountpoint: /mnt/localssd
 
 deployment_groups:
 - group: cluster
@@ -89,8 +90,17 @@ deployment_groups:
       # Failure to do will result in VMs that lose data and do not automatically
       # mount local SSD filesystems
       local_ssd_filesystem:
-        mountpoint: /mnt/localssd
+        mountpoint: $(vars.localssd_mountpoint)
         permissions: "1777" # must quote numeric filesystem permissions!
+      # Docker was successfully installed in the image, this configures it
+      # to use the A3-specific local SSD volumes to store container images
+      docker:
+        enabled: true
+        world_writable: true
+        daemon_config: |
+          {
+            "data-root": "$(vars.localssd_mountpoint)/docker"
+          }
       runners:
       - type: ansible-local
         destination: slurm_aperture.yml

--- a/modules/scripts/startup-script/files/install_docker.yml
+++ b/modules/scripts/startup-script/files/install_docker.yml
@@ -43,7 +43,10 @@
       dest: /etc/docker/daemon.json
       mode: '0644'
       content: '{{ docker_daemon_config }}'
-      validate: /usr/bin/dockerd --validate --config-file %s
+      # validate flag requires Docker server version 23.0 and above
+      # can add this back after private A3 DLVM image is deprecated
+      # this image comes with Docker version 20.10.17
+      # validate: /usr/bin/dockerd --validate --config-file %s
     when: docker_daemon_config
     notify:
     - Restart Docker


### PR DESCRIPTION
#3201 added support for custom Docker daemon configurations. One of the driving requirements was the ability to support storage of Docker image layers on performance local SSD disks. For large images with a high number of small files, the difference in `docker pull` can be a factor of several.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
