### PR TITLE
Update maintenance.py to support additional format

### DIFF
--- a/tools/maintenance/maintenance.py
+++ b/tools/maintenance/maintenance.py
@@ -35,6 +35,13 @@ UPC_MAINT_CMD = "gcloud alpha compute instances list --project={}" \
                 "upcomingMaintenance.startTimeWindow.earliest," \
                 "upcomingMaintenance.startTimeWindow.latest," \
                 "upcomingMaintenance.canReschedule,upcomingMaintenance.type)'"
+
+UPDATED_UPC_MAINT_CMD = "gcloud alpha compute instances list --project={}" \
+                " --filter='upcomingMaintenance:*' --format='value(name," \
+                "upcomingMaintenance.latestWindowStartTime," \
+                "upcomingMaintenance.windowEndTime," \
+                "upcomingMaintenance.canReschedule,upcomingMaintenance.type)'"
+
 PER_MAINT_CMD = "gcloud alpha compute instances list --project={}" \
                 " --filter=scheduling.maintenanceInterval:PERIODIC " \
                 " --format='value(name)'"
@@ -72,6 +79,9 @@ def get_upcoming_maintenance(project: str) -> List[str]:
     err_msg = "Error getting upcoming maintenance list"
     res = run_command(UPC_MAINT_CMD.format(project), err_msg)
 
+    # Check if all output was received. If length is 3, two of the filters failed since the maintenance output is using new format.
+    if len(res.stdout.split()) == 3:
+        res = run_command(UPDATED_UPC_MAINT_CMD.format(project), err_msg)
     upc_maint = [x.split() for x in res.stdout.split("\n")[:-1]]
 
     return upc_maint


### PR DESCRIPTION
This PR updates `maintenance.py` to support the additional upcomingMaintenance format. Ran a manual test with a node simulating maintenance with new version.

The new format:
```
$ gcloud compute instances describe testslurm-nodeset-0 --zone=us-central1-a | grep -A 6 upcomingMaintenance
  upcomingMaintenance:
    canReschedule: true
    latestWindowStartTime: '2024-11-01T22:43:52Z'
    maintenanceStatus: ONGOING
    type: SCHEDULED
    windowEndTime: '2024-11-02T02:43:46Z'
    windowStartTime: '2024-11-01T22:43:51Z'
```

After running maintenance.py:
```
$ python3 tools/maintenance/maintenance.py --project=dev-pool-prj3 --print_periodic_vms
No nodes with periodic maintenance

Upcoming maintenance:
Name                          Earliest Start                Latest Start                  Can Reschedule                Maintenance Type              
testslurm-nodeset-0           2024-11-01T22:43:52Z          2024-11-02T02:43:46Z          True                          SCHEDULED  
```  