### PR TITLE
Increasing ml-slurm test timeout to 5hr

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-slurm-v5-legacy.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm-v5-legacy.yaml
@@ -25,7 +25,7 @@ tags:
 - m.startup-script
 - slurm5
 
-timeout: 14400s  # 4hr
+timeout: 18000s  # 5hr
 steps:
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -24,7 +24,7 @@ tags:
 - m.startup-script
 - slurm6
 
-timeout: 14400s  # 4hr
+timeout: 18000s  # 5hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build


### PR DESCRIPTION
Increasing timeout due to recent failures. 