### PR TITLE
Support Extended Reservations

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -161,7 +161,7 @@ resource "google_container_node_pool" "node_pool" {
     reservation_affinity {
       consume_reservation_type = var.reservation_affinity.consume_reservation_type
       key                      = length(local.verified_specific_reservations) != 1 ? null : local.reservation_resource_api_label
-      values                   = length(local.verified_specific_reservations) != 1 ? null : [for r in local.verified_specific_reservations : "projects/${r.project}/reservations/${r.name}"]
+      values                   = length(local.verified_specific_reservations) != 1 ? null : [for i, r in local.verified_specific_reservations : "projects/${r.project}/reservations/${format("%s%s", r.name, local.input_reservation_suffixes[i])}"]
     }
 
     dynamic "host_maintenance_policy" {


### PR DESCRIPTION
### About the Change

Specific block of an extended reservation can be targeted with `exr-1/reservationBlocks/exr-1-block-1`. 

So, we are ensuring we query the data source with the reservation name only.

When we query the data source, we will split the input value on `/` to only pick the first segment; as that is the reservation name. And, in turn, re-attach the other segments (`/reservationBlocks/exr-1-block-1`) when pass the reservation affinity.

### Tests
Manually tested different scenarios:

- no reservation: terraform plan operation succeeds
- any reservation: terraform plan operation succeeds
- specific reservation: terraform plan operation succeeds
- extended reservation targeting a block: terraform plan and deploy operations succeed. Shared extended reservations are not supported yet by GKE.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
