### PR TITLE
Adding retries to a3mega image blueprint

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -83,6 +83,11 @@ deployment_groups:
               ansible.builtin.get_url:
                 url: "{{ package_url }}"
                 dest: "{{ package_filename }}"
+              retries: 3
+              delay: 60
+              register: result
+              until: result is success
+              failed_when: result is failure
             - name: Install kernel headers
               ansible.builtin.apt:
                 deb: "{{ package_filename }}"


### PR DESCRIPTION
The A3 Mega image creation blueprint has a transient failure on downloading the kernel headers within the Packer module.  This adds retries to the task and a delay of a minute to alleviate that issue.

Testing using the PR-test-ml-a3-megagpu-slurm integration test.
