### PR TITLE
Update commit hash; fixes b/377488571

### DIFF
--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -34,7 +34,7 @@ deployment_groups:
     settings:
       local_mount: /home
   - id: fluxfw-gcp
-    source: github.com/GoogleCloudPlatform/scientific-computing-examples//fluxfw-gcp/tf?ref=867e558
+    source: github.com/GoogleCloudPlatform/scientific-computing-examples//fluxfw-gcp/tf?ref=cb36377
     settings:
       compute_node_specs:
       - name_prefix: gfluxfw-compute


### PR DESCRIPTION
This pull request addresses the cluster-toolkit side of b/377488571.

It updates the commit hash to match the `fluxfw-gcp` commit for b/377488571