### PR TITLE
Updates network_storage.md with Parallelstore info

### DIFF
--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -7,7 +7,7 @@ The Toolkit contains modules that will **provision**:
 
 - [Filestore (GCP managed NFS)][filestore]
 - [DDN EXAScaler lustre][ddn-exascaler]
-- [Intel DAOS][intel-daos]
+- [Parallelstore][parallelstore]
 - [NFS server (non-GCP managed)][nfs-server]
 
 The Toolkit also provides a **[pre-existing-network-storage]** module to work
@@ -104,12 +104,12 @@ filestore | via USE | via USE | via USE | via USE | via STARTUP | via USE | via 
 nfs-server | via USE | via USE | via USE | via USE | via STARTUP | via USE | via USE
 cloud-storage-bucket (GCS)| via USE | via USE | via USE | via USE | via STARTUP | via USE | via USE
 DDN EXAScaler lustre | via USE | via USE | via USE | via USE | Needs Testing | via USE | via USE
-Intel DAOS** | Needs Testing | Needs Testing | Needs Testing | Needs Testing | Needs Testing | Needs Testing | Needs Testing
+Parallelstore | via USE | Needs Testing | Needs Testing | via USE | Needs Testing | Needs Testing | Needs Testing
   |  |   |   |   |   |   |  
 filestore (pre-existing) | via USE | via USE | via USE | via USE | via STARTUP | via USE | via USE
 nfs-server (pre-existing) | via USE | via USE | via USE | via USE | via STARTUP | via USE | via USE
 DDN EXAScaler lustre (pre-existing) | via USE | via USE | via USE | via USE | Needs Testing | via USE | via USE
-Intel DAOS (pre-existing) | Not Supported | Not Supported | Not Supported | Not Supported | Not Supported | Not Supported | Not Supported
+Parallelstore (pre-existing) | via USE | Needs Testing | Needs Testing | via USE | Needs Testing | Needs Testing | Needs Testing
 GCS FUSE (pre-existing) | via USE | via USE | via USE | via USE | via STARTUP | via USE | Needs Testing
 
 - **via USE:** Client installation and mounting occur automatically when
@@ -122,10 +122,9 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via USE | via STARTUP | 
 - **Not Supported:** This feature is not supported right now.
 
 \* only supported on CentOS 7\
-** DAOS has additional pre-req steps and does not yet support automatic mounting
 
 [filestore]: ../modules/file-system/filestore/README.md
 [pre-existing-network-storage]: ../modules/file-system/pre-existing-network-storage/README.md
 [ddn-exascaler]: ../community/modules/file-system/DDN-EXAScaler/README.md
-[intel-daos]: ../community/modules/file-system/Intel-DAOS/README.md
+[parallelstore]: ../modules/file-system/parallelstore/README.md
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md


### PR DESCRIPTION
This pr does the following:

- It removes all mentions of Intel Daos in `network_storage.md` as the toolkit no longer supports the use of the [external google cloud daos repository](https://github.com/daos-stack/google-cloud-daos/tree/main).
- It updates `network_storage.md` with Parallelstore information

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
