### PR TITLE
Add short build id to network to avoid resource alreadyExists error

### DIFF
--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -16,7 +16,7 @@
 
 test_name: ml-slurm-v6
 deployment_name: ml-slurm-v6-{{ build }}
-network: "{{ test_name }}-net"
+network: "{{ test_name }}-net-{{ build }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer


### PR DESCRIPTION
https://pantheon.corp.google.com/cloud-build/builds;region=global/fc85d545-5a35-42d0-b611-a127001721f4?e=13803378&mods=monitoring_api_prod&project=hpc-toolkit-dev

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
