### PR TITLE
Cleanup Always when SSH Fails

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -183,7 +183,6 @@
 
     - name: Run Integration tests for Cluster Toolkit
       ansible.builtin.include_tasks: "{{ test }}"
-      ignore_unreachable: false # end the play when the host is unreachable
       vars:
         remote_node: "{{ remote_node }}"
         deployment_name: "{{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -169,6 +169,7 @@
   vars:
     startup_timeout_seconds: 600  # 10 minutes
   gather_facts: false
+  ignore_unreachable: true  # ensure always block will run even if SSH fails
   tasks:
   - name: Remote Test Block
     vars:
@@ -182,6 +183,7 @@
 
     - name: Run Integration tests for Cluster Toolkit
       ansible.builtin.include_tasks: "{{ test }}"
+      ignore_unreachable: false # end the play when the host is unreachable
       vars:
         remote_node: "{{ remote_node }}"
         deployment_name: "{{ deployment_name }}"


### PR DESCRIPTION
### About the Change
Ansible has a way to ignore unreachable host errors and let the play continue: [ignore_unreachable: true](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_error_handling.html#ignoring-unreachable-host-errors). 

Slurm integration test is relying on the same: code [ref](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/b857af00ff4d5210bc49fb781264ebb1f671cb19/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml#L191)

Since, the ml-gke-e2e test uses the [base-integration-test.yml](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/develop/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml) playbook, this change is required therein. It will fix all tests that use this playbook ([github code search](https://github.com/search?q=repo%3AGoogleCloudPlatform%2Fcluster-toolkit+%22base-integration-test.yml%22+path%3Atools%2Fcloud-build%2Fdaily-tests&type=code))

### Testing
I am not sure how to test this. So, thinking if it is fine to merge the fix and see if this recurs in our daily tests.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
