### PR TITLE
Make gke-node-pool compatible with TPG 6.x

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1463,10 +1463,10 @@ guest_accelerator:
 - type: nvidia-l4
   count: 1
   gpu_sharing_config:
-  - max_shared_clients_per_gpu: 2
+    max_shared_clients_per_gpu: 2
     gpu_sharing_strategy: "TIME_SHARING"
   gpu_driver_installation_config:
-  - gpu_driver_version: "LATEST"
+    gpu_driver_version: "LATEST"
 ```
 
 * Configuration of the cluster using default drivers provided by GKE.

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -151,7 +151,7 @@ The following is an example of
       guest_accelerator:
       - gpu_partition_size: 1g.5gb
         gpu_sharing_config:
-        - gpu_sharing_strategy: TIME_SHARING
+          gpu_sharing_strategy: TIME_SHARING
           max_shared_clients_per_gpu: 3
 ```
 
@@ -181,9 +181,9 @@ The following is an example of using a GPU (with sharing config) attached to an 
       - type: nvidia-tesla-t4
         count: 2
         gpu_driver_installation_config:
-        - gpu_driver_version: "LATEST"
+          gpu_driver_version: "LATEST"
         gpu_sharing_config:
-        - max_shared_clients_per_gpu: 2
+          max_shared_clients_per_gpu: 2
           gpu_sharing_strategy: "TIME_SHARING"
 ```
 

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -279,16 +279,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | > 5 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 5 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | > 5 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 5 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
@@ -322,7 +322,7 @@ limitations under the License.
 | <a name="input_enable_gcfs"></a> [enable\_gcfs](#input\_enable\_gcfs) | Enable the Google Container Filesystem (GCFS). See [restrictions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#gcfs_config). | `bool` | `false` | no |
 | <a name="input_enable_secure_boot"></a> [enable\_secure\_boot](#input\_enable\_secure\_boot) | Enable secure boot for the nodes.  Keep enabled unless custom kernel modules need to be loaded. See [here](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot) for more info. | `bool` | `true` | no |
 | <a name="input_gke_version"></a> [gke\_version](#input\_gke\_version) | GKE version | `string` | n/a | yes |
-| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br/>    type  = optional(string)<br/>    count = optional(number, 0)<br/>    gpu_driver_installation_config = optional(list(object({<br/>      gpu_driver_version = string<br/>    })))<br/>    gpu_partition_size = optional(string)<br/>    gpu_sharing_config = optional(list(object({<br/>      gpu_sharing_strategy       = optional(string)<br/>      max_shared_clients_per_gpu = optional(number)<br/>    })))<br/>  }))</pre> | `null` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br/>    type  = optional(string)<br/>    count = optional(number, 0)<br/>    gpu_driver_installation_config = optional(object({<br/>      gpu_driver_version = string<br/>    }), { gpu_driver_version = "DEFAULT" })<br/>    gpu_partition_size = optional(string)<br/>    gpu_sharing_config = optional(object({<br/>      gpu_sharing_strategy       = string<br/>      max_shared_clients_per_gpu = number<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_host_maintenance_interval"></a> [host\_maintenance\_interval](#input\_host\_maintenance\_interval) | Specifies the frequency of planned maintenance events. | `string` | `""` | no |
 | <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The default image type used by NAP once a new node pool is being created. Use either COS\_CONTAINERD or UBUNTU\_CONTAINERD. | `string` | `"COS_CONTAINERD"` | no |
 | <a name="input_initial_node_count"></a> [initial\_node\_count](#input\_initial\_node\_count) | The initial number of nodes for the pool. In regional clusters, this is the number of nodes per zone. Changing this setting after node pool creation will not make any effect. It cannot be set with static\_node\_count and must be set to a value between autoscaling\_total\_min\_nodes and autoscaling\_total\_max\_nodes. | `number` | `null` | no |

--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -79,16 +79,32 @@ variable "guest_accelerator" {
   type = list(object({
     type  = optional(string)
     count = optional(number, 0)
-    gpu_driver_installation_config = optional(list(object({
+    gpu_driver_installation_config = optional(object({
       gpu_driver_version = string
-    })))
+    }), { gpu_driver_version = "DEFAULT" })
     gpu_partition_size = optional(string)
-    gpu_sharing_config = optional(list(object({
-      gpu_sharing_strategy       = optional(string)
-      max_shared_clients_per_gpu = optional(number)
-    })))
+    gpu_sharing_config = optional(object({
+      gpu_sharing_strategy       = string
+      max_shared_clients_per_gpu = number
+    }))
   }))
-  default = null
+  default  = []
+  nullable = false
+
+  validation {
+    condition     = alltrue([for ga in var.guest_accelerator : ga.count != null])
+    error_message = "var.guest_accelerator[*].count cannot be null"
+  }
+
+  validation {
+    condition     = alltrue([for ga in var.guest_accelerator : ga.count >= 0])
+    error_message = "var.guest_accelerator[*].count must never be negative"
+  }
+
+  validation {
+    condition     = alltrue([for ga in var.guest_accelerator : ga.gpu_driver_installation_config != null])
+    error_message = "var.guest_accelerator[*].gpu_driver_installation_config must not be null; leave unset to enable GKE to select default GPU driver installation"
+  }
 }
 
 variable "image_type" {

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = "> 5"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = "> 5"
     }
     null = {
       source  = "hashicorp/null"

--- a/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -70,9 +70,9 @@ deployment_groups:
       machine_type: g2-standard-4
       guest_accelerator:
       - gpu_driver_installation_config:
-        - gpu_driver_version: "LATEST"
+          gpu_driver_version: "LATEST"
         gpu_sharing_config:
-        - max_shared_clients_per_gpu: 2
+          max_shared_clients_per_gpu: 2
           gpu_sharing_strategy: "MPS"
 
   - id: job_template_g2_latest_driver
@@ -131,9 +131,9 @@ deployment_groups:
       - type: nvidia-tesla-t4
         count: 2
         gpu_driver_installation_config:
-        - gpu_driver_version: "LATEST"
+          gpu_driver_version: "LATEST"
         gpu_sharing_config:
-        - max_shared_clients_per_gpu: 2
+          max_shared_clients_per_gpu: 2
           gpu_sharing_strategy: "TIME_SHARING"
 
   - id: job_template_n1_pool_full_spec


### PR DESCRIPTION
    The gke-node-pool module uses older "attribute" syntax for the
    GPU-related arguments that has been removed in the google Terraform
    plugin 6.x. This commit replaces attribute syntax with block syntax.
    The key to understanding this change is that a dynamic block iterating
    over a list is equivalent to null when the list is empty (no dynamic
    blocks are inserted).

    The gpu_sharing_config and gpu_driver_installation_config settings are
    not (and never were) list(object) in the Terraform plugin. They could only
    ever taken on length 0 or 1. These are therefore being converted to object
    format as they are in the API.

    - https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_guest_accelerator
    - https://developer.hashicorp.com/terraform/language/attr-as-blocks

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
