### PR TITLE
Fix version constraint for resource-policy module

### DIFF
--- a/modules/compute/resource-policy/README.md
+++ b/modules/compute/resource-policy/README.md
@@ -43,13 +43,13 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 5.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 4.56.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 5.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 4.56.0 |
 
 ## Modules
 

--- a/modules/compute/resource-policy/versions.tf
+++ b/modules/compute/resource-policy/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.0"
+      version = "> 4.56.0"
     }
   }
 


### PR DESCRIPTION
Remove upper bound for best practices and impose correct lower bound

https://github.com/hashicorp/terraform-provider-google-beta/releases/tag/v4.56.0

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
