### PR TITLE
add integration tests for kueue for A3 high

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue-job.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue-job.yml
@@ -1,0 +1,46 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - region is defined
+    - custom_vars.project is defined
+
+- name: Get cluster credentials for kubectl
+  delegate_to: localhost
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+
+- name: Create the kueue job
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    array=({{ workspace }}/tools/cloud-build/daily-tests/blueprints/kueue-config-files/sample-kueue-job.yaml)
+    kubectl create -f ${array[0]}
+    echo ${array[0]}
+  args:
+    executable: /bin/bash
+  changed_when: False
+
+- name: Wait for job to complete
+  delegate_to: localhost
+  ansible.builtin.command: |
+    kubectl get job --field-selector  status.successful=3
+  register: job_completion
+  until: job_completion.stdout_lines | length > 1
+  retries: 50
+  delay: 5
+
+- name: Print job_completion debug output
+  ansible.builtin.debug:
+    var: job_completion.stdout_lines

--- a/tools/cloud-build/daily-tests/blueprints/a3high-gke-kueue.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a3high-gke-kueue.yaml
@@ -1,0 +1,94 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: a3high-gke-kueue
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: a3high-gke-kueue
+  region: us-west1
+  zone: us-west1-c
+
+  # Cidr block containing the IP of the machine calling terraform.
+  # The following line must be updated for this example to work.
+  authorized_cidr: 0.0.0.0/0
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network1
+    source: modules/network/vpc
+    settings:
+      subnetwork_name: gke-subnet-a3-highgpu
+      mtu: 8244
+      secondary_ranges:
+        gke-subnet-a3-highgpu:
+        - range_name: pods
+          ip_cidr_range: 10.4.0.0/14
+        - range_name: services
+          ip_cidr_range: 10.0.32.0/20
+
+  - id: gke_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: gpunets
+    source: modules/network/multivpc
+    settings:
+      network_name_prefix: $(vars.deployment_name)-gpunet
+      global_ip_address_range: 192.169.0.0/16
+      network_count: 4
+      subnetwork_cidr_suffix: 24
+      mtu: 8244
+
+  - id: gke_cluster
+    source: modules/scheduler/gke-cluster
+    use: [network1, gpunets, gke_service_account]
+    settings:
+      enable_private_endpoint: false  # Allows for access from authorized public IPs
+      master_authorized_networks:
+      - cidr_block: $(vars.authorized_cidr)  # Allows your machine run kubectl command. It's required for the multi-network setup.
+        display_name: "kubectl-access-network"
+    outputs: [instructions]
+
+  - id: a3_highgpu_pool
+    source: modules/compute/gke-node-pool
+    use: [gke_cluster, gpunets, gke_service_account]
+    settings:
+      machine_type: a3-highgpu-8g
+      autoscaling_total_min_nodes: 2
+      initial_node_count: 2
+      zones: [$(vars.zone)]
+    outputs: [instructions]
+
+  - id: workload_manager_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+        config_path: $(ghpc_stage("kueue-config-files"))/kueue-configuration.yaml.tftpl
+        config_template_vars: {num_chips: "32"}
+      jobset:
+        install: true

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/kueue-configuration.yaml.tftpl
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/kueue-configuration.yaml.tftpl
@@ -1,0 +1,73 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: gke-1xh100-mega-80gb-8
+spec:
+  nodeLabels:
+    cloud.google.com/gke-accelerator: system
+---
+
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  preemption:
+      reclaimWithinCohort: Never # Don't preempt other queues in the cohort.
+      withinClusterQueue: LowerPriority
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["nvidia.com/gpu"]
+    flavors:
+    - name: gke-1xh100-mega-80gb-8
+      resources:
+      - name: "nvidia.com/gpu"
+        nominalQuota: ${num_chips}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: default
+  name: multislice-queue
+spec:
+  clusterQueue: cluster-queue # Point to the ClusterQueue
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: very-low
+value: 100
+globalDefault: false
+description: "Very Low"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low
+value: 250
+globalDefault: false
+description: "Low"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: medium
+value: 500
+globalDefault: false
+description: "Medium"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high
+value: 750
+globalDefault: false
+description: "High"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: very-high
+value: 1000
+globalDefault: false
+description: "Very High"

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/sample-kueue-job.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/sample-kueue-job.yaml
@@ -1,0 +1,47 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  generateName: sample-kueue-job
+  annotations:
+    kueue.x-k8s.io/queue-name: multislice-queue
+spec:
+  ttlSecondsAfterFinished: 90 # Job will be deleted after 90 seconds
+  parallelism: 3 # This Job will have 3 replicas running at the same time
+  completions: 3 # This Job requires 3 completions
+  suspend: true # Set to true to allow Kueue to control the Job when it starts
+  template:
+    spec:
+      tolerations:
+      - key: "components.gke.io/gke-managed-components"
+        operator: "Equal"
+        value: "true"
+      - key: "user-workload"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      - key: "nvidia.com/gpu"
+        operator: "Equal"
+        value: "present"
+        effect: "NoSchedule"
+      nodeSelector:
+        cloud.google.com/gke-accelerator: nvidia-h100-80gb # Specify the GPU hardware
+      containers:
+      - name: dummy-job
+        image: ubuntu
+        command: ["sh", "-c", "echo Hello world!"]
+      restartPolicy: Never

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-kueue.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-kueue.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.gke-cluster
+- m.gke-node-pool
+- m.service-account
+- m.vpc
+- m.multivpc
+- m.kubectl-apply
+- gke
+
+timeout: 14400s  # 4hr
+steps:
+- id: gke-a3-highgpu-kueue-test
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    EXAMPLE_BP=tools/cloud-build/daily-tests/blueprints/a3high-gke-kueue.yaml
+
+    # Replacing the static subnet name to prevent collisions
+    sed  -i "s/gke-subnet-a3-high/gke-subnet-a3-high-$${BUILD_ID_SHORT}/" $${EXAMPLE_BP}
+    echo '  - id: remote-node'                           >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
+    echo '    use: [network1]'                           >> $${EXAMPLE_BP}
+    echo '    settings:'                                 >> $${EXAMPLE_BP}
+    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
+    echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-highgpu-kueue.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-a3-highgpu-kueue.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-highgpu-kueue.yml
@@ -1,0 +1,42 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined
+# in build file with --extra-vars flag!
+test_name: gke-a3high-kueue
+deployment_name: gke-a3high-kueue-{{ build }}
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a3high-gke-kueue.yaml"
+network: "gke-a3high-net-{{ build }}"
+region: us-west1
+zone: us-west1-a
+remote_node: "{{ deployment_name }}-remote-node-0"
+reservation_affinity:
+  consume_reservation_type: SPECIFIC_RESERVATION
+  specific_reservations:
+  - name: a3-reservation-0
+    project: "{{ project }}"
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  reservation_affinity: "{{ reservation_affinity }}"
+  autoscaling_total_max_nodes: 2
+  network_name: "{{ network }}"
+  local_ssd_count_nvme_block: 16
+custom_vars:
+  project: "{{ project }}"
+post_deploy_tests:
+- test-validation/test-gke-kueue-job.yml


### PR DESCRIPTION
- Added tests for integrating kueue and running kueue jobs on A3 high. 
- Ansible scripts for running kueue jobs is generic.
- Added a new blueprint for A3 high over using sed as multiple lines of kueue configuration were added.  

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
