### PR TITLE
Revert use of toolkit_modules_url in examples

### DIFF
--- a/community/examples/tutorial-starccm-slurm.yaml
+++ b/community/examples/tutorial-starccm-slurm.yaml
@@ -15,8 +15,6 @@
 ---
 
 blueprint_name: starccm-on-slurm
-toolkit_modules_url: github.com/GoogleCloudPlatform/cluster-toolkit
-toolkit_modules_version: v1.41.0
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/docs/hybrid-slurm-cluster/blueprints/hybrid-configuration.yaml
+++ b/docs/hybrid-slurm-cluster/blueprints/hybrid-configuration.yaml
@@ -15,8 +15,6 @@
 ---
 
 blueprint_name: hpc-cluster-hybrid-v5
-toolkit_modules_url: github.com/GoogleCloudPlatform/cluster-toolkit
-toolkit_modules_version: v1.41.0
 
 vars:
   project_id:  ## <<bursting project (Project B)>>


### PR DESCRIPTION
Versioned blueprints is a feature in development and should not yet be the default in our public examples. In particular, the use of an older Toolkit release blocks migration to TPG 6.x as our default (#3189)

This reverts commit 5cb64acebcfb136ddbeba2b6919e2677f1aab806.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
