### PR TITLE
Fix formatting of Docker config warning

### DIFF
--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -205,9 +205,9 @@ check "health_check" {
   assert {
     condition     = local.docker_config == {}
     error_message = <<-EOT
-      This message is only a warning. The Toolkit performs no validation of the Docker
-      daemon configuration. VM startup scripts will fail if the configuration file is
-      not a valid Docker JSON configuration. Please review the Docker documentation:
+      This message is only a warning. The Toolkit performs no validation of the
+      Docker daemon configuration. VM startup scripts will fail if the file is not
+      a valid Docker JSON configuration. Please review the Docker documentation:
 
       https://docs.docker.com/engine/daemon/
     EOT


### PR DESCRIPTION
This PR fixes the output from

```
This message is only a warning. The Toolkit performs no validation of the
Docker
daemon configuration. VM startup scripts will fail if the configuration file
is
not a valid Docker JSON configuration. Please review the Docker
documentation:

https://docs.docker.com/engine/daemon/
```

to

```
This message is only a warning. The Toolkit performs no validation of the
Docker daemon configuration. VM startup scripts will fail if the file is not
a valid Docker JSON configuration. Please review the Docker documentation:

https://docs.docker.com/engine/daemon/
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
