### PR TITLE
Don't install Lustre in A3 tests

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
@@ -82,7 +82,7 @@ deployment_groups:
             "reboot": false,
             "install_cuda": false,
             "install_gcsfuse": true,
-            "install_lustre": true,
+            "install_lustre": false,
             "install_ompi": true,
             "monitoring_agent": "cloud-ops",
             "nvidia_version": "latest",

--- a/examples/machine-learning/a3-highgpu-8g/v5-legacy/ml-slurm-a3-1-image-v5-legacy.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/v5-legacy/ml-slurm-a3-1-image-v5-legacy.yaml
@@ -82,7 +82,7 @@ deployment_groups:
             "install_cuda": false,
             "nvidia_version": "latest",
             "install_ompi": true,
-            "install_lustre": true,
+            "install_lustre": false,
             "install_gcsfuse": true,
             "monitoring_agent": "cloud-ops"
           }


### PR DESCRIPTION
Lustre clients do not seem to be available on their "latest" channel for Ubuntu 20.04, and this is causing integration test failures.

This PR is a temporary workaround to prevent failures while we debug the issue.