### PR TITLE
Remove CentOS 7 from list of supported images

### DIFF
--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -105,20 +105,9 @@ project and the new image name in the `instance_image` field discussed in
 
 ## Cluster Toolkit Supported Images
 
-### HPC CentOS 7
-
-The Cluster Toolkit has officially supported the [HPC CentOS 7 VM Image][hpcimage]
-as the primary VM image for HPC workloads on Google Cloud since it's release.
-Since the [HPC CentOS 7 VM Image][hpcimage] comes pre-tuned for optimal
-performance on typical HPC workloads, it is the default VM image in our modules,
-unless there is specific requirement for a different OS distribution.
-
-[hpcimage]: https://cloud.google.com/blog/topics/hpc/introducing-hpc-vm-images
-
 ### HPC Rocky Linux 8
 
-HPC Rocky Linux 8 is planned to become the primary supported VM image for HPC
-workloads on Google Cloud from 2024.
+HPC Rocky Linux 8 is the primary supported VM image for HPC workloads on Google Cloud.
 
 ### Debian 11
 
@@ -142,19 +131,18 @@ description of our support for Windows images.
   <th>Deployment Type/Scheduler</th>
   <th>Feature</th>
   <th></th>
-  <th>CentOS 7</th><th>Debian 11</th><th>Rocky Linux 8</th><th>Ubuntu 20.04</th>
+  <th>Debian 11</th><th>Rocky Linux 8</th><th>Ubuntu 20.04</th>
 </tr>
 <tr>
-  <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+  <td></td><td></td><td></td><td></td><td></td><td></td>
 </tr>
 
 <tr>
   <th rowspan="3">Cloud Batch</th>
   <th>Lustre</th>
   <th></th>
+  <td></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
-  <td></td>
-  <td></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
 </tr>
 <tr>
@@ -163,12 +151,10 @@ description of our support for Windows images.
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
-  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-lustre.yaml">✓</a></td>
 </tr>
 <tr>
   <th>Startup script</th>
   <th></th>
-  <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/batch-startup.yaml">✓</a></td>
@@ -178,7 +164,6 @@ description of our support for Windows images.
   <th rowspan="4">Slurm</th>
   <th>Chrome Remote Desktop</th>
   <th></th>
-  <td></td>
   <td><a href="../community/examples/hpc-slurm-chromedesktop-v5-legacy.yaml">✓</a></td>
   <td></td>
   <td></td>
@@ -186,15 +171,13 @@ description of our support for Windows images.
 <tr>
   <th>Lustre</th>
   <th></th>
-  <td><a href="../examples/hpc-enterprise-slurm.yaml">✓</a></td>
   <td></td>
-  <td>✓</td>
+  <td><a href="../examples/hpc-enterprise-slurm.yaml">✓</a></td>
   <td></td>
 </tr>
 <tr>
   <th>Shared filestore</th>
   <th></th>
-  <td>✓</td>
   <td>✓</td>
   <td><a href="../examples/hpc-slurm.yaml">✓</a></td>
   <td><a href="../community/examples/hpc-slurm-ubuntu2004.yaml">✓</a></td>
@@ -202,9 +185,8 @@ description of our support for Windows images.
 <tr>
   <th>Startup script</th>
   <th></th>
+  <td>✓</td>
   <td><a href="../community/examples/hpc-slurm-ramble-gromacs.yaml">✓</a></td>
-  <td>✓</td>
-  <td>✓</td>
   <td>✓</td>
 </tr>
 
@@ -212,7 +194,6 @@ description of our support for Windows images.
   <th rowspan="4">VM Instance</th>
   <th>Chrome Remote Desktop</th>
   <th></th>
-  <td></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-crd.yaml">✓</a></td>
   <td></td>
   <td><sup><b>*</b></sup></td>
@@ -220,7 +201,6 @@ description of our support for Windows images.
 <tr>
   <th>Lustre</th>
   <th></th>
-  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml">✓</a></td>
   <td></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-lustre.yaml">✓</a></td>
@@ -231,12 +211,10 @@ description of our support for Windows images.
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
-  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-filestore.yaml">✓</a></td>
 </tr>
 <tr>
   <th>Startup script</th>
   <th></th>
-  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-startup.yaml">✓</a></td>
@@ -245,7 +223,6 @@ description of our support for Windows images.
   <th rowspan="1">HTCondor</th>
   <th></th>
   <th></th>
-  <td>✓</td>
   <td></td>
   <td>✓</td>
   <td></td>
@@ -254,7 +231,6 @@ description of our support for Windows images.
   <th rowspan="1">Omnia</th>
   <th></th>
   <th></th>
-  <td></td>
   <td></td>
   <td>✓</td>
   <td></td>


### PR DESCRIPTION
CentOS 7 has been deprecated since July 2024.  This PR updates the list of supported VM images in the Cluster Toolkit documentation.