### PR TITLE
Revert "update a3 machines local ssd to use nvme instead of scsi for better performance"

### DIFF
--- a/modules/compute/gke-node-pool/disk_definitions.tf
+++ b/modules/compute/gke-node-pool/disk_definitions.tf
@@ -22,8 +22,8 @@
 locals {
 
   local_ssd_machines = {
-    "a3-highgpu-8g" = { local_ssd_count_ephemeral_storage = null, local_ssd_count_nvme_block = 16 },
-    "a3-megagpu-8g" = { local_ssd_count_ephemeral_storage = null, local_ssd_count_nvme_block = 16 },
+    "a3-highgpu-8g" = { local_ssd_count_ephemeral_storage = 16, local_ssd_count_nvme_block = null },
+    "a3-megagpu-8g" = { local_ssd_count_ephemeral_storage = 16, local_ssd_count_nvme_block = null },
   }
 
   generated_local_ssd_config = lookup(local.local_ssd_machines, var.machine_type, { local_ssd_count_ephemeral_storage = null, local_ssd_count_nvme_block = null })


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cluster-toolkit#3232

local_ssd_count_ephemeral_storage is also using NVMe interface, the assumption in reservation validation is wrong and we need to re-evaluate how validation should be done. Reverting this change for now to use the ephemeral ssd for A3 machines.