### PR TITLE
remove GKE reservation validation for local ssd NVMe/CSCI interface

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -235,6 +235,21 @@ resource "google_container_node_pool" "node_pool" {
       On the other hand, with SPECIFIC_RESERVATION you must set `specific_reservations`.
       EOT
     }
+    precondition {
+      condition = (
+        (local.input_specific_reservations_count == 0) ||
+        (local.input_specific_reservations_count == 1 && length(local.verified_specific_reservations) > 0 && length(local.specific_reservation_requirement_violations) == 0)
+      )
+      error_message = <<-EOT
+      Check if your reservation is configured correctly:
+      - A reservation with the name must exist in the specified project and one of the specified zones
+
+      - Its consumption type must be "specific"
+      %{for property in local.specific_reservation_requirement_violations}
+      - ${local.specific_reservation_requirement_violation_messages[property]}
+      %{endfor}
+      EOT
+    }
   }
 }
 

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -235,21 +235,6 @@ resource "google_container_node_pool" "node_pool" {
       On the other hand, with SPECIFIC_RESERVATION you must set `specific_reservations`.
       EOT
     }
-    precondition {
-      condition = (
-        (local.input_specific_reservations_count == 0) ||
-        (local.input_specific_reservations_count == 1 && length(local.verified_specific_reservations) > 0 && length(local.specific_reservation_requirement_violations) == 0)
-      )
-      error_message = <<-EOT
-      Check if your reservation is configured correctly:
-      - A reservation with the name must exist in the specified project and one of the specified zones
-
-      - Its consumption type must be "specific"
-      %{for property in local.specific_reservation_requirement_violations}
-      - ${local.specific_reservation_requirement_violation_messages[property]}
-      %{endfor}
-      EOT
-    }
   }
 }
 

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -43,39 +43,4 @@ locals {
 
   # Filter specific reservations
   verified_specific_reservations = [for k, v in data.google_compute_reservation.specific_reservations : v if(v.specific_reservation != null && v.specific_reservation_required == true)]
-
-  # Build two maps to be used to compare the VM properties between reservations and the node pool
-  reservation_vm_properties = [for r in local.verified_specific_reservations : {
-    "machine_type" : try(r.specific_reservation[0].instance_properties[0].machine_type, "")
-    "guest_accelerators" : { for acc in try(r.specific_reservation[0].instance_properties[0].guest_accelerators, []) : acc.accelerator_type => acc.accelerator_count },
-    "local_ssds" : {
-      "NVME" : length([for d in try(r.specific_reservation[0].instance_properties[0].local_ssds, []) : d if d.interface == "NVME"])
-      "SCSI" : length([for d in try(r.specific_reservation[0].instance_properties[0].local_ssds, []) : d if d.interface == "SCSI"])
-    }
-  }]
-  nodepool_vm_properties = {
-    "machine_type" : var.machine_type
-    "guest_accelerators" : { for acc in try(local.guest_accelerator, []) : coalesce(acc.type, try(local.generated_guest_accelerator[0].type, "")) => coalesce(acc.count, try(local.generated_guest_accelerator[0].count, 0)) },
-    "local_ssds" : {
-      "NVME" : coalesce(local.local_ssd_config.local_ssd_count_nvme_block, 0),
-      "SCSI" : coalesce(local.local_ssd_config.local_ssd_count_ephemeral_storage, 0)
-    }
-  }
-
-  # Compare two maps by counting the keys that mismatch.
-  # Know that in map comparison the order of keys does not matter. That is {NVME: x, SCSI: y} and {SCSI: y, NVME: x} are equal
-  # As of this writing, there is only one reservation supported by the Node Pool API. So, directly accessing it from the list
-  specific_reservation_requirement_violations = length(local.reservation_vm_properties) == 0 ? [] : [for k, v in local.nodepool_vm_properties : k if v != local.reservation_vm_properties[0][k]]
-
-  specific_reservation_requirement_violation_messages = {
-    "machine_type" : <<-EOT
-    The reservation has "${try(local.reservation_vm_properties[0].machine_type, "")}" machine type and the node pool has "${local.nodepool_vm_properties.machine_type}". Check the relevant node pool setting: "machine_type"
-    EOT
-    "guest_accelerators" : <<-EOT
-    The reservation has ${jsonencode(try(local.reservation_vm_properties[0].guest_accelerators, {}))} accelerators and the node pool has ${jsonencode(try(local.nodepool_vm_properties.guest_accelerators, {}))}. Check the relevant node pool setting: "guest_accelerator". When unspecified, for the machine_type=${var.machine_type}, the default is guest_accelerator=${jsonencode(try(local.generated_guest_accelerator, [{}]))}.
-    EOT
-    "local_ssds" : <<-EOT
-    The reservation has ${jsonencode(try(local.reservation_vm_properties[0].local_ssds, {}))} local SSDs and the node pool has ${jsonencode(try(local.nodepool_vm_properties.local_ssds, {}))}. Check the relevant node pool settings: {local_ssd_count_ephemeral_storage, local_ssd_count_nvme_block}. When unspecified, for the machine_type=${var.machine_type} the defaults are: {local_ssd_count_ephemeral_storage=${coalesce(local.generated_local_ssd_config.local_ssd_count_ephemeral_storage, 0)}, local_ssd_count_nvme_block=${coalesce(local.generated_local_ssd_config.local_ssd_count_nvme_block, 0)}}.
-    EOT
-  }
 }


### PR DESCRIPTION
[Toolkit reservation validation on disk interface](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/26fafe0d5a53138b807e490d4d6597544ad658d1/modules/compute/gke-node-pool/reservation_definitions.tf#L61) assume [local_ssd_count_ephemeral_storage -> ephemeral_storage_local_ssd_config](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/26fafe0d5a53138b807e490d4d6597544ad658d1/modules/compute/gke-node-pool/main.tf#L107-L112) is using SCSI interface, which is not true according to the [Terraform reference](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_ephemeral_storage_local_ssd_config) 

This would break the use case of A3* Reservation (use NVMe by default for its local ssd).

Synced with @ankitkinra and agree on removing this reservation for now to unblock critical use case.

We need to better understand if this validation is still needed, or how we should update it.