### PR TITLE
Update topology-scheduler-scripts.yaml

### DIFF
--- a/community/modules/compute/gke-topology-scheduler/manifests/topology-scheduler-scripts.yaml
+++ b/community/modules/compute/gke-topology-scheduler/manifests/topology-scheduler-scripts.yaml
@@ -83,13 +83,11 @@ data:
       node_labels = node['node_labels']
 
       if (
-          'cloud.google.com/gke-placement-group' in node_labels
-          and 'topology.gke.io/cluster' in node_labels
+          'topology.gke.io/cluster' in node_labels
           and 'topology.gke.io/rack' in node_labels
           and 'topology.gke.io/host' in node_labels
       ):
         return (
-            node_labels['cloud.google.com/gke-placement-group'],
             node_labels['topology.gke.io/cluster'],
             node_labels['topology.gke.io/rack'],
             node_labels['topology.gke.io/host'],
@@ -143,13 +141,6 @@ data:
       for node in nodes:
         node_name = node.metadata.name
         node_labels = node.metadata.labels
-
-        if 'cloud.google.com/gke-placement-group' not in node_labels:
-          print(
-              f'Skipping node {node_name} because it does not have topology'
-              ' metadata'
-          )
-          continue
 
         skip_node = False
         if node.spec.taints is not None:


### PR DESCRIPTION
Removing compact-placement check as it should no longer be required and DWS doesn't use this as well.

Without this change scheduling will be blocked in DWS nodes.

Longer term we need to align to: https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/416 which will consolidate an overall change

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
