### PR TITLE
Updating RDMA-VPC to use v9.3 CFT modules

### DIFF
--- a/community/modules/network/rdma-vpc/main.tf
+++ b/community/modules/network/rdma-vpc/main.tf
@@ -143,8 +143,7 @@ locals {
 }
 
 module "vpc" {
-  source = "./vpc-submodule"
-
+  source                                 = "./vpc-submodule"
   network_name                           = local.network_name
   project_id                             = var.project_id
   auto_create_subnetworks                = false

--- a/community/modules/network/rdma-vpc/vpc-submodule/README.md
+++ b/community/modules/network/rdma-vpc/vpc-submodule/README.md
@@ -36,9 +36,9 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | github.com/terraform-google-modules/terraform-google-network.git//modules/firewall-rules?depth=1&ref=v9.0.0 | n/a |
-| <a name="module_routes"></a> [routes](#module\_routes) | github.com/terraform-google-modules/terraform-google-network.git//modules/routes?depth=1&ref=v9.0.0 | n/a |
-| <a name="module_subnets"></a> [subnets](#module\_subnets) | github.com/terraform-google-modules/terraform-google-network.git//modules/subnets?depth=1&ref=v9.0.0 | n/a |
+| <a name="module_firewall_rules"></a> [firewall\_rules](#module\_firewall\_rules) | terraform-google-modules/network/google//modules/firewall-rules | ~> 9.3 |
+| <a name="module_routes"></a> [routes](#module\_routes) | terraform-google-modules/network/google//modules/routes | ~> 9.3 |
+| <a name="module_subnets"></a> [subnets](#module\_subnets) | terraform-google-modules/network/google//modules/subnets | ~> 9.3 |
 
 ## Resources
 

--- a/community/modules/network/rdma-vpc/vpc-submodule/main.tf
+++ b/community/modules/network/rdma-vpc/vpc-submodule/main.tf
@@ -46,7 +46,8 @@ resource "google_compute_shared_vpc_host_project" "shared_vpc_host" {
 	Subnet configuration
  *****************************************/
 module "subnets" {
-  source           = "github.com/terraform-google-modules/terraform-google-network.git//modules/subnets?depth=1&ref=v9.0.0"
+  source           = "terraform-google-modules/network/google//modules/subnets"
+  version          = "~> 9.3"
   project_id       = var.project_id
   network_name     = google_compute_network.network.name
   subnets          = var.subnets
@@ -57,7 +58,8 @@ module "subnets" {
 	Routes
  *****************************************/
 module "routes" {
-  source            = "github.com/terraform-google-modules/terraform-google-network.git//modules/routes?depth=1&ref=v9.0.0"
+  source            = "terraform-google-modules/network/google//modules/routes"
+  version           = "~> 9.3"
   project_id        = var.project_id
   network_name      = google_compute_network.network.name
   routes            = var.routes
@@ -88,7 +90,8 @@ locals {
 }
 
 module "firewall_rules" {
-  source        = "github.com/terraform-google-modules/terraform-google-network.git//modules/firewall-rules?depth=1&ref=v9.0.0"
+  source        = "terraform-google-modules/network/google//modules/firewall-rules"
+  version       = "~> 9.3"
   project_id    = var.project_id
   network_name  = google_compute_network.network.name
   rules         = local.rules

--- a/community/modules/network/rdma-vpc/vpc-submodule/versions.tf
+++ b/community/modules/network/rdma-vpc/vpc-submodule/versions.tf
@@ -28,6 +28,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-network/v9.3.0"
+    module_name = "blueprints/terraform/hpc-toolkit:rdma-vpc/experimental"
   }
 }

--- a/community/modules/network/rdma-vpc/vpc-submodule/versions.tf
+++ b/community/modules/network/rdma-vpc/vpc-submodule/versions.tf
@@ -28,6 +28,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-network/v9.1.0"
+    module_name = "blueprints/terraform/terraform-google-network/v9.3.0"
   }
 }


### PR DESCRIPTION
Enables compatibility with google/google-beta plugin providers v6.x. Tested using basic blueprint with just RDMA-VPC.

Used beta APIs for google-beta.