### PR TITLE
Updating Go version in Cluster Toolkit Dockerfile

### DIFF
--- a/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
+++ b/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
@@ -45,7 +45,7 @@ RUN wget -q "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PA
     rm packer.zip
 
 # Install Go
-ARG GO_VERSION=1.21.0
+ARG GO_VERSION=1.23.0
 RUN wget -q "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" -O go.tar.gz && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz

--- a/tools/cloud-build/images/cluster-toolkit-dockerfile/README.md
+++ b/tools/cloud-build/images/cluster-toolkit-dockerfile/README.md
@@ -15,7 +15,7 @@ The following build arguments can be used to customize the build process:
 * **`BASE_IMAGE`**: The base image to use for the build. Defaults to `gcr.io/google.com/cloudsdktool/google-cloud-cli:stable`.
 * **`TERRAFORM_VERSION`**: The version of Terraform to install. Defaults to `1.5.2`.
 * **`PACKER_VERSION`**: The version of Packer to install. Defaults to `1.8.6`.
-* **`GO_VERSION`**: The version of Go to install. Defaults to `1.21.0`.
+* **`GO_VERSION`**: The version of Go to install. Defaults to `1.23.0`.
 * **`CLUSTER_TOOLKIT_REF`**: The [Cluster Toolkit repository's](https://github.com/GoogleCloudPlatform/cluster-toolkit/releases) branch or tag from which to build Cluster Toolkit.  Defaults to the `main` branch, which is the latest official release.
 
 ## Build the Cluster Toolkit Docker Image


### PR DESCRIPTION
This PR updates the default go version in the Cluster Toolkit Dockerfile from v1.21 to v1.23.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
