### PR TITLE
Add Integration Test to Cluster Toolkit Dockerfile

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ctk-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/ctk-dockerfile.yaml
@@ -1,0 +1,75 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags: [dockerfile, m.pre-existing-vpc, m.vm-instance, vm]
+
+timeout: 3600s  # 1hr
+steps:
+## uses a pre-built Google Cloud image containing Docker CLI tool.
+- id: build-docker-image
+  name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcluster', 'tools/cloud-build/images/cluster-toolkit-dockerfile/']
+
+- id: create-deployment-folder
+  name: 'gcluster'
+  args:
+  - 'create'
+  - 'tools/cloud-build/daily-tests/blueprints/e2e.yaml'
+  - '--vars'
+  - 'project_id=$PROJECT_ID'
+  - '--vars'
+  - 'deployment_name=dockerfile-test'
+  - '--vars'
+  - 'region=us-central1'
+  - '--vars'
+  - 'zone=us-central1-a'
+  - '--out'
+  - '/workspace'
+
+- id: check-deployment-folder-exists
+  name: 'bash'
+  automapSubstitutions: true
+  script: |
+    #!/usr/bin/env bash
+    set -ex
+    folder_path="/workspace/dockerfile-test"
+
+    # Check if the folder exists
+    if [ -d "$folder_path" ]; then
+      echo "Folder exists: $folder_path"
+    else
+      echo "Folder does not exist: $folder_path"
+    fi
+
+- id: deploy-resources
+  name: 'gcluster'
+  args: ['deploy', '/workspace/dockerfile-test', '--auto-approve']
+
+- id: check-on-resources
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:slim'
+  automapSubstitutions: true
+  script: |
+    #!/usr/bin/env bash
+    set -ex
+
+    depl_name="dockerfile-test"
+    zone="us-central1-a"
+
+    # check instance was created
+    gcloud compute instances describe "${depl_name}-0" --project="$PROJECT_ID" --zone="$zone" >/dev/null
+
+- id: destroy-resources
+  name: 'gcluster'
+  args: ['destroy', '/workspace/dockerfile-test', '--auto-approve']

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -27,31 +27,10 @@ steps:
   args:
   - 'create'
   - 'tools/cloud-build/daily-tests/blueprints/e2e.yaml'
-  - '--vars'
-  - 'project_id=$PROJECT_ID'
-  - '--vars'
-  - 'deployment_name=dockerfile-test'
-  - '--vars'
-  - 'region=us-central1'
-  - '--vars'
-  - 'zone=us-central1-a'
   - '--out'
   - '/workspace'
-
-- id: check-deployment-folder-exists
-  name: 'bash'
-  automapSubstitutions: true
-  script: |
-    #!/usr/bin/env bash
-    set -ex
-    folder_path="/workspace/dockerfile-test"
-
-    # Check if the folder exists
-    if [ -d "$folder_path" ]; then
-      echo "Folder exists: $folder_path"
-    else
-      echo "Folder does not exist: $folder_path"
-    fi
+  - '--vars'
+  - 'project_id=$PROJECT_ID,deployment_name=dockerfile-test,region=us-central1,zone=us-central1-a'
 
 - id: deploy-resources
   name: 'gcluster'

--- a/tools/cloud-build/daily-tests/validate_tests_metadata.py
+++ b/tools/cloud-build/daily-tests/validate_tests_metadata.py
@@ -72,7 +72,7 @@ def get_blueprint(build_path: str) -> Optional[str]:
         f"{BUILDS_DIR}/ofe-deployment.yaml": None,
         f"{BUILDS_DIR}/chrome-remote-desktop.yaml": "tools/cloud-build/daily-tests/blueprints/crd-default.yaml",
         f"{BUILDS_DIR}/chrome-remote-desktop-ubuntu.yaml": "tools/cloud-build/daily-tests/blueprints/crd-ubuntu.yaml",
-        f"{BUILDS_DIR}/ctk-dockerfile.yaml": "tools/cloud-build/daily-tests/blueprints/e2e.yaml",
+        f"{BUILDS_DIR}/gcluster-dockerfile.yaml": "tools/cloud-build/daily-tests/blueprints/e2e.yaml",
     }
     if build_path in SPECIAL_CASES:
         return SPECIAL_CASES[build_path]

--- a/tools/cloud-build/daily-tests/validate_tests_metadata.py
+++ b/tools/cloud-build/daily-tests/validate_tests_metadata.py
@@ -33,7 +33,8 @@ CATEGORICAL_TAGS = frozenset([
     "slurm6", 
     "spack",
     "tpu", 
-    "vm", 
+    "vm",
+    "dockerfile", 
 ])
 
 def module_tag(src: str) -> Optional[str]:
@@ -71,6 +72,7 @@ def get_blueprint(build_path: str) -> Optional[str]:
         f"{BUILDS_DIR}/ofe-deployment.yaml": None,
         f"{BUILDS_DIR}/chrome-remote-desktop.yaml": "tools/cloud-build/daily-tests/blueprints/crd-default.yaml",
         f"{BUILDS_DIR}/chrome-remote-desktop-ubuntu.yaml": "tools/cloud-build/daily-tests/blueprints/crd-ubuntu.yaml",
+        f"{BUILDS_DIR}/ctk-dockerfile.yaml": "tools/cloud-build/daily-tests/blueprints/e2e.yaml",
     }
     if build_path in SPECIAL_CASES:
         return SPECIAL_CASES[build_path]


### PR DESCRIPTION
This PR adds an integration test to the [Cluster Toolkit Dockerfile](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/develop/tools/cloud-build/images/cluster-toolkit-dockerfile). The test does the following:

- Builds a Docker image from the Cluster Toolkit Dockerfile.
- Runs containers using the built Docker image that deploys a simple Toolkit blueprint([tools/cloud-build/daily-tests/blueprints/e2e.yaml](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/tools/cloud-build/daily-tests/blueprints/e2e.yaml)) executing gcluster create, gcluster deploy and gcluster destroy.

PR-test-gcluster-dockerfile (hpc-toolkit-dev) successfully passes.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
