### PR TITLE
Updating default vars for image to use managed-notebooks base image

### DIFF
--- a/community/modules/compute/notebook/variables.tf
+++ b/community/modules/compute/notebook/variables.tf
@@ -48,8 +48,8 @@ variable "instance_image" {
   description = "Instance Image"
   type        = map(string)
   default = {
-    project = "deeplearning-platform-release"
-    family  = "tf-latest-cpu"
+    project = "cloud-notebooks-managed"
+    family  = "workbench-instances"
     name    = null
   }
 


### PR DESCRIPTION
Updating the default Instance Image project & family to leverage the Images used by Vertex AI Workbench. 

The previous images were resulting in Jupyter not starting and the Notebook not making it out of the provisioning stage. 