### PR TITLE
SlurmGCP. Harden topology updates

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Iterable, Dict, Set
+from typing import List, Optional, Iterable, Dict, Set, Tuple
 from itertools import chain
 from collections import defaultdict
 import json
@@ -437,6 +437,10 @@ class TopologySummary:
 
 
     @classmethod
+    def path(cls, lkp: util.Lookup) -> Path:
+        return lkp.etc_dir / "cloud_topology.summary.json"
+
+    @classmethod
     def loads(cls, s: str) -> "TopologySummary":
         d = json.loads(s)
         return cls(
@@ -444,6 +448,13 @@ class TopologySummary:
             down_nodes=d.get("down_nodes"),
             tpu_nodes=d.get("tpu_nodes"),
         )
+    
+    @classmethod
+    def load(cls, lkp: util.Lookup) -> "TopologySummary":
+        p = cls.path(lkp)
+        if not p.exists():
+            return cls() # Return empty instance
+        return cls.loads(p.read_text())
     
     def dumps(self) -> str:
         return json.dumps(
@@ -453,6 +464,9 @@ class TopologySummary:
                 "tpu_nodes": list(self.tpu_nodes),
             },
             indent=2)
+    
+    def dump(self, lkp: util.Lookup) -> None:
+        TopologySummary.path(lkp).write_text(self.dumps())
     
     def _nodenames(self) -> Set[str]:
         return set(self.physical_host) | self.down_nodes | self.tpu_nodes
@@ -572,15 +586,13 @@ def gen_topology(lkp: util.Lookup) -> TopologyBuilder:
         add_nodeset_topology(ns, bldr, lkp)
     return bldr
 
-
-def gen_topology_conf(lkp: util.Lookup) -> bool:
+def gen_topology_conf(lkp: util.Lookup) -> Tuple[bool, TopologySummary]:
     """
     Generates slurm topology.conf.
     Returns whether the topology.conf got updated.
     """
     topo = gen_topology(lkp).compress()
     conf_file = lkp.etc_dir / "cloud_topology.conf"
-
 
     with open(conf_file, "w") as f:
         f.writelines(FILE_PREAMBLE + "\n")
@@ -589,13 +601,8 @@ def gen_topology_conf(lkp: util.Lookup) -> bool:
             f.write("\n")
         f.write("\n")
 
-    summary_file = lkp.etc_dir / "cloud_topology.summary.json"
-    prev_summary = TopologySummary()
-    if summary_file.exists():
-        prev_summary = TopologySummary.loads(summary_file.read_text())
-    summary_file.write_text(topo.summary.dumps())
-    
-    return topo.summary.requires_reconfigure(prev_summary)
+    prev_summary = TopologySummary.load(lkp)
+    return topo.summary.requires_reconfigure(prev_summary), topo.summary
 
 def install_topology_conf(lkp: util.Lookup) -> None:
     conf_file = lkp.etc_dir / "cloud_topology.conf"
@@ -619,5 +626,6 @@ def gen_controller_configs(lkp: util.Lookup) -> None:
     install_jobsubmit_lua(lkp)
 
     if topology_plugin(lkp) == TOPOLOGY_PLUGIN_TREE:
-        gen_topology_conf(lkp)
+        _, summary = gen_topology_conf(lkp)
+        summary.dump(lkp)
         install_topology_conf(lkp)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -446,10 +446,12 @@ def reconfigure_slurm():
 def update_topology(lkp: util.Lookup) -> None:
     if conf.topology_plugin(lkp) != conf.TOPOLOGY_PLUGIN_TREE:
         return
-    updated = conf.gen_topology_conf(lkp)
+    updated, summary = conf.gen_topology_conf(lkp)
     if updated:
-        log.debug("Topology configuration updated. Reconfiguring Slurm.")
+        log.info("Topology configuration updated. Reconfiguring Slurm.")
         util.scontrol_reconfigure(lkp)
+        # Safe summary only after Slurm got reconfigured, so summary reflects Slurm POV
+        summary.dump(lkp)
 
 
 def delete_reservation(lkp: util.Lookup, reservation_name: str) -> None:


### PR DESCRIPTION
**Problem example:**
```
# all good, single node (A) cluster
t0. nodes: [A] ; slurm_topo: [A]; topo_summary: [A]

# node B get added
t1. nodes: [A, B] ; slurm_topo: [A]; topo_summary: [A]

# slurmsync runs, detects change,  but fails to reconfigure slurmctld
t2. nodes: [A, B] ; slurm_topo: [A]; topo_summary: [A, B]

# slurmsync runs, no changes detected according to summary, does not attempt to reconfigure slurmctld
t3. nodes: [A, B] ; slurm_topo: [A]; topo_summary: [A, B]

# node B is not visible to Slurm topology-wise => can't be allocated
```

**Solution:**
Save topology summary only after Slurm got successfully reconfigure.  
This way `cloud_topology.summary.json` is a best effort representation of the current POV of Slurm.