### PR TITLE
Add NodeAction classes to subsitute NodeStatus Enum

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -21,13 +21,14 @@ import json
 import logging
 import re
 import sys
+import shlex
 from enum import Enum
 from itertools import chain
 from pathlib import Path
-import yaml
 import datetime as dt
 from datetime import datetime
-from typing import Dict, Tuple
+from dataclasses import dataclass
+from typing import Dict, Tuple, List, Optional, Protocol
 from functools import lru_cache
 
 import util
@@ -40,6 +41,7 @@ from util import (
     separate,
     to_hostlist_fast,
     NSDict,
+    NodeState,
     TPU,
     chunked,
     dirs,
@@ -54,21 +56,71 @@ log = logging.getLogger()
 TOT_REQ_CNT = 1000
 _MAINTENANCE_SBATCH_SCRIPT_PATH = dirs.custom_scripts / "perform_maintenance.sh"
 
-NodeStatus = Enum(
-    "NodeStatus",
-    (
-        "orphan",
-        "power_down",
-        "preempted",
-        "restore",
-        "resume",
-        "terminated",
-        "unbacked",
-        "unchanged",
-        "unknown",
-    ),
-)
+class NodeAction(Protocol):
+    def apply(self, nodes:List[str]) -> None:
+        ...
 
+    def __hash__(self):
+        ...
+
+@dataclass(frozen=True)
+class NodeActionPowerUp():
+    def apply(self, nodes:List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} instances to resume ({hostlist})")
+        run(f"{lookup().scontrol} update nodename={hostlist} state=power_up")
+
+@dataclass(frozen=True)
+class NodeActionIdle():
+    def apply(self, nodes:List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} nodes to idle ({hostlist})")
+        run(f"{lookup().scontrol} update nodename={hostlist} state=resume")
+
+@dataclass(frozen=True)
+class NodeActionPowerDown():
+    def apply(self, nodes:List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} instances to power down ({hostlist})")
+        run(f"{lookup().scontrol} update nodename={hostlist} state=power_down")
+
+@dataclass(frozen=True)
+class NodeActionDelete():
+    def apply(self, nodes:List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} instances to delete ({hostlist})")
+        delete_instances(nodes)
+
+@dataclass(frozen=True)
+class NodeActionPrempt():
+    def apply(self, nodes:List[str]) -> None:
+        NodeActionDown(reason="Preempted instance").apply(nodes)
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} instances restarted ({hostlist})")
+        start_instances(nodes)
+
+@dataclass(frozen=True)
+class NodeActionUnchanged():
+    def apply(self, nodes:List[str]) -> None:
+        pass
+
+@dataclass(frozen=True)
+class NodeActionDown():
+    reason: str
+
+    def apply(self, nodes: List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)
+        log.info(f"{len(nodes)} nodes set down ({hostlist}) with reason={self.reason}")
+        run(f"{lookup().scontrol} update nodename={hostlist} state=down reason={shlex.quote(self.reason)}")
+
+@dataclass(frozen=True)
+class NodeActionUnknown():
+    slurm_state: Optional[NodeState]
+    instance_state: Optional[str]
+
+    def apply(self, nodes:List[str]) -> None:
+        hostlist = util.to_hostlist_fast(nodes)    
+        log.error(f"{len(nodes)} nodes have unexpected {self.slurm_state} and instance state:{self.instance_state}, ({hostlist})")
 
 def start_instance_op(inst):
     return lookup().compute.instances().start(
@@ -94,14 +146,14 @@ def start_instances(node_list):
     execute_with_futures(start_tpu, tpu_start_data)
 
 
-def _find_dynamic_node_status() -> NodeStatus:
+def _find_dynamic_node_status() -> NodeAction:
     # TODO: cover more cases:
     # * delete dead dynamic nodes
     # * delete orhpaned instances
-    return NodeStatus.unchanged  # don't touch dynamic nodes
+    return NodeActionUnchanged()  # don't touch dynamic nodes
 
 
-def _find_tpu_node_status(nodename, state):
+def _find_tpu_node_action(nodename, state) -> NodeAction:
     ns = lookup().node_nodeset(nodename)
     tpuobj = TPU(ns)
     inst = tpuobj.get_node(nodename)
@@ -123,24 +175,24 @@ def _find_tpu_node_status(nodename, state):
             log.error(
                 f"More than one cloud tpu node for tpu group {nodelist}, there should be only one that should be {l_nodelist[0]}, but we have found {tpus_int}"
             )
-            return NodeStatus.unknown
+            return NodeActionUnknown(slurm_state=state, instance_state=None)
         if len(tpus_int) == 1:
             inst = tpuobj.get_node(tpus_int[0])
         # if len(tpus_int ==0) this case is not relevant as this would be the case always that a TPU group is not running
     if inst is None:
         if state.base == "DOWN" and "POWERED_DOWN" in state.flags:
-            return NodeStatus.restore
+            return NodeActionIdle()
         if "POWERING_DOWN" in state.flags:
-            return NodeStatus.restore
+            return NodeActionIdle()
         if "COMPLETING" in state.flags:
-            return NodeStatus.unbacked
+            return NodeActionDown(reason="Unbacked instance")
         if state.base != "DOWN" and not (
             set(("POWER_DOWN", "POWERING_UP", "POWERING_DOWN", "POWERED_DOWN"))
             & state.flags
         ):
-            return NodeStatus.unbacked
+            return NodeActionDown(reason="Unbacked instance")
         if lookup().is_static_node(nodename):
-            return NodeStatus.resume
+            return NodeActionPowerUp()
     elif (
         state is not None
         and "POWERED_DOWN" not in state.flags
@@ -148,20 +200,20 @@ def _find_tpu_node_status(nodename, state):
         and inst.state == TPU.State.STOPPED
     ):
         if tpuobj.preemptible:
-            return NodeStatus.preempted
+            return NodeActionPrempt()
         if state.base != "DOWN":
-            return NodeStatus.terminated
+            return NodeActionDown(reason="Instance terminated")
     elif (
         state is None or "POWERED_DOWN" in state.flags
     ) and inst.state == TPU.State.READY:
-        return NodeStatus.orphan
+        return NodeActionDelete()
     elif state is None:
         # if state is None here, the instance exists but it's not in Slurm
-        return NodeStatus.unknown
+        return NodeActionUnknown(slurm_state=state, instance_state=inst.status)
 
-    return NodeStatus.unchanged
+    return NodeActionUnchanged()
 
-def find_node_status(nodename):
+def get_node_action(nodename: str) -> NodeAction:
     """Determine node/instance status that requires action"""
     state = lookup().slurm_node(nodename)
 
@@ -169,7 +221,7 @@ def find_node_status(nodename):
         return _find_dynamic_node_status()
 
     if lookup().node_is_tpu(nodename):
-        return _find_tpu_node_status(nodename, state)
+        return _find_tpu_node_action(nodename, state)
 
     # split below is workaround for VMs whose hostname is FQDN
     inst = lookup().instance(nodename.split(".")[0])
@@ -179,19 +231,19 @@ def find_node_status(nodename):
 
     if inst is None:
         if "POWERING_UP" in state.flags:
-            return NodeStatus.unchanged
+            return NodeActionUnchanged()
         if state.base == "DOWN" and "POWERED_DOWN" in state.flags:
-            return NodeStatus.restore
+            return NodeActionIdle()
         if "POWERING_DOWN" in state.flags:
-            return NodeStatus.restore
+            return NodeActionIdle()
         if "COMPLETING" in state.flags:
-            return NodeStatus.unbacked
+            return NodeActionDown(reason="Unbacked instance")
         if state.base != "DOWN" and not power_flags:
-            return NodeStatus.unbacked
+            return NodeActionDown(reason="Unbacked instance")
         if state.base == "DOWN" and not power_flags:
-            return NodeStatus.power_down
+            return NodeActionPowerDown()
         if "POWERED_DOWN" in state.flags and lookup().is_static_node(nodename):
-            return NodeStatus.resume
+            return NodeActionPowerUp()
     elif (
         state is not None
         and "POWERED_DOWN" not in state.flags
@@ -199,9 +251,9 @@ def find_node_status(nodename):
         and inst.status == "TERMINATED"
     ):
         if inst.scheduling.preemptible:
-            return NodeStatus.preempted
+            return NodeActionPrempt()
         if state.base != "DOWN":
-            return NodeStatus.terminated
+            return NodeActionDown(reason="Instance terminated")
     elif (state is None or "POWERED_DOWN" in state.flags) and inst.status == "RUNNING":
         log.info("%s is potential orphan node", nodename)
         age_threshold_seconds = 90
@@ -214,13 +266,13 @@ def find_node_status(nodename):
                 age_threshold_seconds,
                 inst_seconds_old,
             )
-            return NodeStatus.unchanged
-        return NodeStatus.orphan
+            return NodeActionUnchanged()
+        return NodeActionDelete()
     elif state is None:
         # if state is None here, the instance exists but it's not in Slurm
-        return NodeStatus.unknown
+        return NodeActionUnknown(slurm_state=state, instance_state=inst.status)
 
-    return NodeStatus.unchanged
+    return NodeActionUnchanged()
 
 
 def _seconds_since_timestamp(timestamp):
@@ -234,69 +286,6 @@ def _seconds_since_timestamp(timestamp):
         timestamp = timestamp[:-3] + timestamp[-2:]
     creation_dt = datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%S.%f%z")
     return datetime.now().timestamp() - creation_dt.timestamp()
-
-
-def do_node_update(status, nodes):
-    """update node/instance based on node status"""
-    if status == NodeStatus.unchanged:
-        return
-    count = len(nodes)
-    hostlist = util.to_hostlist(nodes)
-
-    def nodes_down():
-        """down nodes"""
-        log.info(
-            f"{count} nodes set down due to node status '{status.name}' ({hostlist})"
-        )
-        run(
-            f"{lookup().scontrol} update nodename={hostlist} state=down reason='Instance stopped/deleted'"
-        )
-
-    def nodes_restart():
-        """start instances for nodes"""
-        log.info(f"{count} instances restarted ({hostlist})")
-        start_instances(nodes)
-
-    def nodes_idle():
-        """idle nodes"""
-        log.info(f"{count} nodes to idle ({hostlist})")
-        run(f"{lookup().scontrol} update nodename={hostlist} state=resume")
-
-    def nodes_resume():
-        """resume nodes via scontrol"""
-        log.info(f"{count} instances to resume ({hostlist})")
-        run(f"{lookup().scontrol} update nodename={hostlist} state=power_up")
-
-    def nodes_delete():
-        """delete instances for nodes"""
-        log.info(f"{count} instances to delete ({hostlist})")
-        delete_instances(nodes)
-
-    def nodes_power_down():
-        """power_down node in slurm"""
-        log.info(f"{count} instances to power down ({hostlist})")
-        run(f"{lookup().scontrol} update nodename={hostlist} state=power_down")
-
-    def nodes_unknown():
-        """Error status, nodes shouldn't get in this status"""
-        log.error(f"{count} nodes have unexpected status: ({hostlist})")
-        first = next(iter(nodes))
-        state = lookup().slurm_node(first)
-        state = "{}+{}".format(state.base, "+".join(state.flags)) if state else "None"
-        inst = lookup().instance(first)
-        log.error(f"{first} state: {state}, instance status:{inst.status}")
-
-    {
-        NodeStatus.orphan: nodes_delete,
-        NodeStatus.power_down: nodes_power_down,
-        NodeStatus.preempted: lambda: (nodes_down(), nodes_restart()),
-        NodeStatus.restore: nodes_idle,
-        NodeStatus.resume: nodes_resume,
-        NodeStatus.terminated: nodes_down,
-        NodeStatus.unbacked: nodes_down,
-        NodeStatus.unchanged: lambda: None,
-        NodeStatus.unknown: nodes_unknown,
-    }[status]()
 
 
 def delete_placement_groups(placement_groups):
@@ -393,18 +382,9 @@ def sync_slurm():
     log.debug(
         f"reconciling {len(compute_instances)} ({len(all_nodes)-len(compute_instances)}) GCP instances and {len(slurm_nodes)} Slurm nodes ({len(all_nodes)-len(slurm_nodes)})."
     )
-    node_statuses = {
-        k: list(v) for k, v in util.groupby_unsorted(all_nodes, find_node_status)
-    }
-    if log.isEnabledFor(logging.DEBUG):
-        status_nodelist = {
-            status.name: to_hostlist_fast(nodes)
-            for status, nodes in node_statuses.items()
-        }
-        log.debug(f"node statuses: \n{yaml.safe_dump(status_nodelist).rstrip()}")
 
-    for status, nodes in node_statuses.items():
-        do_node_update(status, nodes)
+    for action, nodes in util.groupby_unsorted(all_nodes, get_node_action):
+        action.apply(list(nodes))
 
 
 def reconfigure_slurm():

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1469,6 +1469,10 @@ class Job:
     job_state: Optional[str] = None
     duration: Optional[timedelta] = None
 
+@dataclass(frozen=True)
+class NodeState:
+    base: str
+    flags: frozenset
 
 class Lookup:
     """Wrapper class for cached data access"""
@@ -1645,15 +1649,14 @@ class Lookup:
 
     @lru_cache(maxsize=None)
     def slurm_nodes(self):
-        StateTuple = namedtuple("StateTuple", "base,flags")
 
         def make_node_tuple(node_line):
-            """turn node,state line to (node, StateTuple(state))"""
+            """turn node,state line to (node, NodeState(state))"""
             # state flags include: CLOUD, COMPLETING, DRAIN, FAIL, POWERED_DOWN,
             #   POWERING_DOWN
             node, fullstate = node_line.split(",")
             state = fullstate.split("+")
-            state_tuple = StateTuple(state[0], set(state[1:]))
+            state_tuple = NodeState(base=state[0], flags=frozenset(state[1:]))
             return (node, state_tuple)
 
         cmd = (


### PR DESCRIPTION
Instead of using NodeStatus Enum, added NodeAction classes so actions can be taken in bulk easily.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
