### PR TITLE
SlurmGCP. Improve `resume.py` performance for job arrays.

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -42,6 +42,7 @@ class TstPartition:
     partition_name: str = "euler"
     partition_nodeset: list[str] = field(default_factory=list)
     partition_nodeset_tpu: list[str] = field(default_factory=list)
+    enable_job_exclusive: bool = False
 
 @dataclass
 class TstCfg:


### PR DESCRIPTION
* Don't group nodes creation by non-exclusive jobs;
* Fix a bug, when multiple non-placements nodesets can not be provisioned due to overwrite by key (`placement == None`).