### PR TITLE
Add python test build files to daily-tests

### DIFF
--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -31,8 +31,4 @@ steps:
   - |
     set -x -e
     cd /workspace && make
-
-    # Install paramiko
-    pip3 install paramiko
-
-    python3 tools/python-integration-tests/slurm_simple_job_completion.py
+    python3 tools/python-integration-tests/slurm_reconfig_size.py

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -31,8 +31,4 @@ steps:
   - |
     set -x -e
     cd /workspace && make
-
-    # Install paramiko
-    pip3 install paramiko
-
-    python3 tools/python-integration-tests/slurm_reconfig_size.py
+    python3 tools/python-integration-tests/slurm_simple_job_completion.py

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -31,8 +31,4 @@ steps:
   - |
     set -x -e
     cd /workspace && make
-
-    # Install paramiko
-    pip3 install paramiko
-
     python3 tools/python-integration-tests/slurm_topology.py

--- a/tools/cloud-build/daily-tests/validate_tests_metadata.py
+++ b/tools/cloud-build/daily-tests/validate_tests_metadata.py
@@ -73,6 +73,9 @@ def get_blueprint(build_path: str) -> Optional[str]:
         f"{BUILDS_DIR}/chrome-remote-desktop.yaml": "tools/cloud-build/daily-tests/blueprints/crd-default.yaml",
         f"{BUILDS_DIR}/chrome-remote-desktop-ubuntu.yaml": "tools/cloud-build/daily-tests/blueprints/crd-ubuntu.yaml",
         f"{BUILDS_DIR}/gcluster-dockerfile.yaml": "tools/cloud-build/daily-tests/blueprints/e2e.yaml",
+        f"{BUILDS_DIR}/slurm-gcp-v6-reconfig-size.yaml": "tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml",
+        f"{BUILDS_DIR}/slurm-gcp-v6-simple-job-completion.yaml": "tools/python-integration-tests/blueprints/slurm-simple.yaml",
+        f"{BUILDS_DIR}/slurm-gcp-v6-topology.yaml": "tools/python-integration-tests/blueprints/topology-test.yaml",
     }
     if build_path in SPECIAL_CASES:
         return SPECIAL_CASES[build_path]

--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -44,6 +44,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/v5/scripts/requirements.txt && \
     pip install --no-cache-dir ansible && \
+    pip install --no-cache-dir paramiko && \
     rm -rf ~/.cache/pip/* && \
     cd /workspace && \
     # Add .terraformrc to $HOME to allow use of google-private


### PR DESCRIPTION
This PR:
- Adds `paramiko` to the dockerfile
- Moves the python test build files to `daily-tests`
- Includes the python test build files as a special case exception in `validate_tests_metadata.py` since they do not have an associated `yml` file.

Example of successful run:
```
----------------------------------------------------------------------
Ran 1 test in 506.801s

OK
gcloud storage cp gs://daily-tests-tf-state/topology-test/topology-test.tgz .
PUSH
DONE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
ID                                    CREATE_TIME                DURATION  SOURCE                                                                                         IMAGES  STATUS
2c83f046-6691-4527-b311-2e070e9416e8  2024-12-05T00:08:23+00:00  10M12S    gs://hpc-toolkit-dev_cloudbuild/source/1733357299.515849-1fe2440ea57a48e99f83cf575845a2f0.tgz  -       SUCCESS
```


