### PR TITLE
Address Parallelstore feature gaps

### DIFF
--- a/modules/file-system/parallelstore/scripts/install-daos-client.sh
+++ b/modules/file-system/parallelstore/scripts/install-daos-client.sh
@@ -71,7 +71,7 @@ EOF
 
 		# 1) Add the Parallelstore package repository
 		curl -o /etc/apt/trusted.gpg.d/us-central1-apt.pkg.dev.asc https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
-		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >>/etc/apt/sources.list.d/artifact-registry.list
+		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >/etc/apt/sources.list.d/artifact-registry.list
 
 		apt-get update
 

--- a/modules/file-system/parallelstore/scripts/mount-daos.sh
+++ b/modules/file-system/parallelstore/scripts/mount-daos.sh
@@ -52,7 +52,7 @@ elif [[ "$OS_ID_LIKE" =~ "rhel" ]]; then
 fi
 
 if [[ -n "$extra_interfaces" ]]; then
-	exclude_fabric_ifaces="lo,$extra_interfaces"
+	exclude_fabric_ifaces="\"lo\",$extra_interfaces"
 	sed -i "s/#.*exclude_fabric_ifaces: \[.*/exclude_fabric_ifaces: [$exclude_fabric_ifaces]/" $daos_config
 fi
 

--- a/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-daos-client.sh
@@ -71,7 +71,7 @@ EOF
 
 		# 1) Add the Parallelstore package repository
 		curl -o /etc/apt/trusted.gpg.d/us-central1-apt.pkg.dev.asc https://us-central1-apt.pkg.dev/doc/repo-signing-key.gpg
-		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >>/etc/apt/sources.list.d/artifact-registry.list
+		echo "deb https://us-central1-apt.pkg.dev/projects/parallelstore-packages v2-6-deb main" >/etc/apt/sources.list.d/artifact-registry.list
 
 		apt-get update
 

--- a/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/mount-daos.sh
@@ -52,7 +52,7 @@ elif [[ "$OS_ID_LIKE" =~ "rhel" ]]; then
 fi
 
 if [[ -n "$extra_interfaces" ]]; then
-	exclude_fabric_ifaces="lo,$extra_interfaces"
+	exclude_fabric_ifaces="\"lo\",$extra_interfaces"
 	sed -i "s/#.*exclude_fabric_ifaces: \[.*/exclude_fabric_ifaces: [$exclude_fabric_ifaces]/" $daos_config
 fi
 


### PR DESCRIPTION
This PR addresses 2 direct issues and simplifies the script in a couple respects.

## Minor quoting issues missed during review

A code change made locally during review of #3256 did not get synchronized with the branch that was actually merged. The change is inconsequential in terms of functionality but it is better to use the code I reviewed. When there is more than 1 NIC on the VM, it changes the text of /etc/daos/daos_agent.yaml from

```yaml
exclude_fabric_ifaces: [lo,"eth1"]
```

to

```yaml
exclude_fabric_ifaces: ["lo","eth1"]
```

by quoting `lo`. This is not strictly necessary in YAML and the `daos_agent.service` will start either way. Nevertheless, we should be consistent with the review process and I believe it's more aesthetically pleasing.
## Parallelstore mount units do not restart when DAOS restarts

Parallelstore mounting is strictly tied to whether the DAOS agent is active. The SystemD relationship that best describes this is "BindsTo"

https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#BindsTo=

This has the effect that the DAOS agent must always be active for the mounts to be active and additionally will trigger simultaneous (properly orderd with "After=") restarts of the mount units when the DAOS agent unit is restarted.

This change requires the addition of an explicit `daos_agent.service` on Debian-derived platforms along with explicit creation of the `daos_agent` user.

## Script fails early

Each DAOS/Parallelstore script now performs a single OS version comparison early in execution, allowing later stages to be simplified.

## Use indented heredocs
Using indented bash HEREDOC strings enables a better-formatted script.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
