### PR TITLE
Update python tests to throw errors

### DIFF
--- a/tools/python-integration-tests/slurm_reconfig_size.py
+++ b/tools/python-integration-tests/slurm_reconfig_size.py
@@ -20,28 +20,22 @@ import time
 
 class SlurmReconfigureSize(SlurmTest):
     # Class to test simple reconfiguration
-    def __init__(self, deployment, reconfig_blueprint):
-        super().__init__(deployment)
-        self.reconfig_blueprint = reconfig_blueprint
+    def __init__(self, deployment):
+        super().__init__(Deployment("tools/python-integration-tests/blueprints/slurm-simple.yaml"))
+        self.reconfig_blueprint = "tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml"
     
     def runTest(self):
-        hostname = self.get_login_node()
-        self.ssh(hostname)
-        self.check_node_size_reconfig()
-
-    def check_node_size_reconfig(self):
         # Check 5 nodes are available
         self.assert_equal(len(self.get_nodes()), 5)
         
         self.deployment = Deployment(self.reconfig_blueprint)
         self.deployment.deploy()
         
-        print("Wait 90 seconds for reconfig")
+        # Wait 90 seconds for reconfig
         time.sleep(90)
 
         # Check 3 nodes are available
         self.assert_equal(len(self.get_nodes()), 3)
 
 if __name__ == "__main__":
-    deployment = Deployment("tools/python-integration-tests/blueprints/slurm-simple.yaml")
-    unittest.TextTestRunner().run(SlurmReconfigureSize(deployment, "tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml")) 
+    unittest.main()

--- a/tools/python-integration-tests/slurm_simple_job_completion.py
+++ b/tools/python-integration-tests/slurm_simple_job_completion.py
@@ -22,15 +22,10 @@ import json
 class SlurmSimpleJobCompletionTest(SlurmTest):
     # Class to test simple slurm job completion
     def __init__(self, deployment):
-        super().__init__(deployment)
+        super().__init__(Deployment("tools/python-integration-tests/blueprints/slurm-simple.yaml"))
         self.job_list = {}
 
     def runTest(self):
-        hostname = self.get_login_node()
-        self.ssh(hostname)
-        self.check_simple_job_completion()
-
-    def check_simple_job_completion(self):
         # Submits 5 jobs and checks if they are successful.
         for i in range(5):
             self.submit_job('sbatch -N 1 --wrap "sleep 20"')
@@ -80,5 +75,4 @@ class SlurmSimpleJobCompletionTest(SlurmTest):
         self.job_list[jobID] = {}
 
 if __name__ == "__main__":
-    deployment = Deployment("tools/python-integration-tests/blueprints/slurm-simple.yaml")
-    unittest.TextTestRunner().run(SlurmSimpleJobCompletionTest(deployment)) 
+    unittest.main()

--- a/tools/python-integration-tests/slurm_topology.py
+++ b/tools/python-integration-tests/slurm_topology.py
@@ -21,12 +21,10 @@ import logging
 
 class SlurmTopologyTest(SlurmTest):
     # Class to test Slurm topology
-    def runTest(self):
-        hostname = self.get_login_node()
-        self.ssh(hostname)
-        self.check_topology()
+    def __init__(self, deployment):
+        super().__init__(Deployment("tools/python-integration-tests/blueprints/topology-test.yaml"))
 
-    def check_topology(self):
+    def runTest(self):
         # Checks isomorphism of last layer of nodes to determine topology.
         r_rack, s_rack = defaultdict(set), defaultdict(set)
         nodes = self.get_nodes()
@@ -58,5 +56,4 @@ class SlurmTopologyTest(SlurmTest):
         return switch_name
 
 if __name__ == "__main__":
-    deployment = Deployment("tools/python-integration-tests/blueprints/topology-test.yaml")
-    unittest.TextTestRunner().run(SlurmTopologyTest(deployment)) 
+    unittest.main()


### PR DESCRIPTION
This PR has some improvements:
- Simplifies to just call `unittest.main()` to run and makes the blueprint an embedded part of the class
- Updates `ssh.py` to close the ssh_client before the tunnel as well as ensures the tunnel is terminated.
- Updates to display stderr after unittest fails
- Moves `--ttl` flag to the `gcloud compute os-login ssh-keys add` cmd 

All three python tests were triggered manually and passed.