### PR TITLE
Add TTL to SSH key

### DIFF
--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -48,7 +48,7 @@ class SSHManager:
         key_path = os.path.expanduser("~/.ssh/google_compute_engine")
         os.makedirs(os.path.dirname(key_path), exist_ok=True)
 
-        cmd = ["ssh-keygen", "-t", "rsa", "-f", key_path, "-N", ""]
+        cmd = ["ssh-keygen", "-t", "rsa", "--ttl", "1h", "-f", key_path, "-N", ""]
         subprocess.run(cmd, capture_output=True, text=True, check=True)
 
         # Add the public key to OS Login


### PR DESCRIPTION
Add 1 hour TTL to os login keys to avoid:

```
ERROR: (gcloud.compute.os-login.ssh-keys.add) INVALID_ARGUMENT: Login profile size exceeds 32 KiB. Delete profile values to make additional space.
``` 