### PR TITLE
Remove use of basename from startup-script module

### DIFF
--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -178,7 +178,7 @@ locals {
       no_proxy   = var.http_no_proxy,
       runners = [
         for runner in local.runners : {
-          object      = google_storage_bucket_object.scripts[basename(runner["destination"])].output_name
+          object      = google_storage_bucket_object.scripts[runner["destination"]].output_name
           type        = runner["type"]
           destination = runner["destination"]
           args        = contains(keys(runner), "args") ? runner["args"] : ""
@@ -203,7 +203,7 @@ locals {
   stdlib = join("", local.stdlib_list)
 
   runners_map = { for runner in local.runners :
-    basename(runner["destination"]) => {
+    runner["destination"] => {
       content = lookup(runner, "content", null)
       source  = lookup(runner, "source", null)
     }


### PR DESCRIPTION
This allows the use of destinations with alternate paths but the same file name from being in the `destination` field for a startup-script runner:

```
  - id: example_startup_script
    source: modules/scripts/startup-script
    settings:
      runners:
      - type: data
        destination: /usr/pathA/pathA/t1.txt
        source: /home/user/cluster-toolkit/examples/file1.txt
      
      - type: data
        destination: /usr/pathA/pathB/t1.txt
        source: /home/user/cluster-toolkit/examples/file2.txt
```

Previously this functionality would not be allowed, note that if the destination paths are identical then an error is still thrown with the following:
```
**Error: exit status 1

Error: Invalid value for variable

  on main.tf line 31, in module "example_startup_script":
  31:   runners = [{
  32:     destination = "/usr/pathA/pathA/t1.txt"
  33:     source      = "/home/user/cluster-toolkit/examples/file1.txt"
  34:     type        = "data"
  35:     }, {
  36:     destination = "/usr/pathA/pathA/t1.txt"
  37:     source      = "/home/user/cluster-toolkit/examples/file2.txt"
  38:     type        = "data"
  39:   }]
    ├────────────────
    │ var.runners is list of map of string with 2 elements

All startup-script runners must have a unique destination.

This was checked by the validation rule at
modules/embedded/modules/scripts/startup-script/variables.tf:84,3-13.
**
```
This is a precursor to releasing an HPC Image blueprint since we make use of tuned profiles that maintain a specific path.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
