### PR TITLE
Update pinned provider in A3 Ultra preview Slurm blueprint

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -376,7 +376,6 @@ deployment_groups:
     - a3_ultra_partition
     - slurm_login
     - homefs
-    - parallelstore
     settings:
       enable_controller_public_ips: true
       instance_image_custom: true

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -44,7 +44,7 @@ vars:
 terraform_providers:
   google:
     source: hashicorp/google
-    version: 6.10.0
+    version: 6.13.0
     configuration:
       project: $(vars.project_id)
       region: $(vars.region)
@@ -52,7 +52,7 @@ terraform_providers:
 
   google-beta:
     source: hashicorp/google-beta
-    version: 6.12.99             # >= v6.12.99 required for A3U
+    version: 6.13.0
     configuration:
       project: $(vars.project_id)
       region: $(vars.region)


### PR DESCRIPTION
This PR updates the Terraform google/google-beta providers in our A3 Ultra Slurm blueprint to 6.13.0, which contains https://github.com/hashicorp/terraform-provider-google-beta/pull/8706, adding support for RDMA networking in Google Cloud.

Additionally, it removes an unused module.

It has been tested by provisioning the blueprint with the deployment file populated with project ID, region, etc and the cluster size set to 2.

```
tpdownes_google_com@a3utpd-controller:~$ sinfo
PARTITION AVAIL  TIMELIMIT  NODES  STATE NODELIST
a3ultra*     up   infinite      2   idle a3utpd-a3ultranodeset-[0-1]
tpdownes_google_com@a3utpd-controller:~$ srun -N2 hostname
a3utpd-a3ultranodeset-0
a3utpd-a3ultranodeset-1
tpdownes_google_com@a3utpd-controller:~$ srun -N2 --gpus-per-node=8 nvidia-smi
Mon Dec  9 23:42:12 2024
(EXPECTED OUTPUT OF 8 GPUS ON EACH NODE)
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
