### PR TITLE
Add NCCL plugin installation to A3 Ultra Slurm blueprint

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -40,6 +40,7 @@ vars:
     project: $(vars.project_id)
     family: $(vars.deployment_name)-u22
   disk_size_gb: 200
+  nccl_plugin_version: v1.0.2
 
 terraform_providers:
   google:
@@ -316,7 +317,45 @@ deployment_groups:
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
+      - type: ansible-local
+        destination: nccl_plugin.yml
+        content: |
+          ---
+          - name: Install NCCL plugin for A3 Ultra series
+            hosts: all
+            become: true
+            tasks:
+            - name: Add SystemD unit for NCCL plugin installation
+              ansible.builtin.copy:
+                dest: /etc/systemd/system/nccl-plugin@.service
+                mode: 0o0644
+                content: |
+                  [Unit]
+                  After=network-online.target
+                  Before=slurmd.service
 
+                  [Service]
+                  Type=oneshot
+                  ExecStartPre=/usr/bin/rm -rf /var/lib/gib
+                  ExecStartPre=/usr/bin/mkdir -p /var/lib/gib
+                  ExecStartPre=/snap/bin/gcloud auth configure-docker --quiet us-docker.pkg.dev
+                  ExecStart=/usr/bin/docker run --rm --name nccl-gib-installer --volume /var/lib/gib:/var/lib/gib \
+                      us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:%i install --install-nccl
+
+                  [Install]
+                  WantedBy=slurmd.service
+              notify:
+              - Reload SystemD
+            handlers:
+            - name: Reload SystemD
+              ansible.builtin.systemd:
+                daemon_reload: true
+            post_tasks:
+            - name: Enable NCCL plugin SystemD unit
+              ansible.builtin.service:
+                name: nccl-plugin@$(vars.nccl_plugin_version).service
+                state: started
+                enabled: true
   - id: a3_ultra_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [a3ultra-slurm-net-0, a3ultra_startup]


### PR DESCRIPTION
This PR adds installation of the NCCL plugin for A3 Ultra to our Slurm blueprint. The plugin and a copy of NCCL will be available under /var/lib/gib for A3 Ultra users. It is not automatically enabled for any workflow.

Users who want to select an alternative version of the plugin can follow

```
systemctl disable gib@v1.0.2.service
systemctl enable gib@vX.Y.Z.service
systemctl start gib@vX.Y.Z.service
```

Testing yields:

```
$ srun -N1 ls -lh /var/lib/gib
total 20K
drwxr-xr-x 2 root root 4.0K Nov 25 21:29 bin
drwxr-xr-x 2 root root 4.0K Nov 25 21:32 configs
drwxr-xr-x 4 root root 4.0K Nov 25 21:32 lib64
drwxr-xr-x 3 2666 dip  4.0K Nov 25 21:29 rdma-core
drwxr-xr-x 2 root root 4.0K Nov 25 21:26 scripts
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
