### PR TITLE
skip setting disk_labels if disk_type is local-ssd

### DIFF
--- a/community/modules/internal/slurm-gcp-v6/internal_instance_template/main.tf
+++ b/community/modules/internal/slurm-gcp-v6/internal_instance_template/main.tf
@@ -96,7 +96,7 @@ resource "google_compute_instance_template" "tpl" {
       source       = lookup(disk.value, "source", null)
       source_image = lookup(disk.value, "source_image", null)
       type         = lookup(disk.value, "disk_type", null) == "local-ssd" ? "SCRATCH" : "PERSISTENT"
-      labels       = lookup(disk.value, "disk_labels", null)
+      labels       = lookup(disk.value, "disk_type", null) == "local-ssd" ? null : lookup(disk.value, "disk_labels", null)
 
       dynamic "disk_encryption_key" {
         for_each = compact([var.disk_encryption_key == null ? null : 1])


### PR DESCRIPTION
Before when redeploying running instance with local-ssd with no labels:
```
~/cluster-toolkit$ ./gcluster deploy hpc-slurm/
Testing if deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Summary of proposed changes: Plan: 1 to add, 1 to change, 1 to destroy.
```

After:
```
~/cluster-toolkit$ ./gcluster deploy hpc-slurm/
Testing if deployment group hpc-slurm/primary requires adding or changing cloud infrastructure
Cloud infrastructure in deployment group hpc-slurm/primary is already applied
Collecting terraform outputs from hpc-slurm/primary
Deployment group primary contains no artifacts to export

###############################
Find instructions for cleanly destroying infrastructure and advanced manual
deployment instructions at:

hpc-slurm/instructions.txt
```
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
