### PR TITLE
Migrate `_slurm_instance` and `slurm_tpu_nodeset` modules from `slurm-gcp` repo

### DIFF
--- a/community/modules/internal/slurm-gcp-v6/instance/README.md
+++ b/community/modules/internal/slurm-gcp-v6/instance/README.md
@@ -1,0 +1,109 @@
+# Module: Slurm Instance
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=1 -->
+
+- [Module: Slurm Instance](#module-slurm-instance)
+  - [Overview](#overview)
+  - [Module API](#module-api)
+
+<!-- mdformat-toc end -->
+
+## Overview
+
+This module creates a [compute instance](../../../../docs/glossary.md#vm) from
+[instance template](../../../../docs/glossary.md#instance-template) for a
+[Slurm cluster](../slurm_cluster/README.md).
+
+> **NOTE:** This module is only intended to be used by Slurm modules. For
+> general usage, please consider using:
+>
+> - [terraform-google-modules/vm/google//modules/compute_instance](https://registry.terraform.io/modules/terraform-google-modules/vm/google/latest/submodules/compute_instance).
+> **WARNING:** The source image is not modified. Make sure to use a compatible
+> source image.
+
+## Module API
+
+For the terraform module API reference, please see
+[README_TF.md](./README_TF.md).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright (C) SchedMD LLC.
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.43 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.43 |
+| <a name="provider_local"></a> [local](#provider\_local) | ~> 2.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_compute_instance_from_template.slurm_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_from_template) | resource |
+| [null_resource.replace_trigger](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [google_compute_instance_template.base](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_template) | data source |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
+| [local_file.startup](https://registry.terraform.io/providers/hashicorp/local/latest/docs/data-sources/file) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_config"></a> [access\_config](#input\_access\_config) | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br/>    nat_ip       = string<br/>    network_tier = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_add_hostname_suffix"></a> [add\_hostname\_suffix](#input\_add\_hostname\_suffix) | Adds a suffix to the hostname | `bool` | `true` | no |
+| <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for GCE, if any. | <pre>list(object({<br/>    access_config = optional(list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    })), [])<br/>    alias_ip_range = optional(list(object({<br/>      ip_cidr_range         = string<br/>      subnetwork_range_name = string<br/>    })), [])<br/>    ipv6_access_config = optional(list(object({<br/>      network_tier = string<br/>    })), [])<br/>    network            = optional(string)<br/>    network_ip         = optional(string, "")<br/>    nic_type           = optional(string)<br/>    queue_count        = optional(number)<br/>    stack_type         = optional(string)<br/>    subnetwork         = optional(string)<br/>    subnetwork_project = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_hostname"></a> [hostname](#input\_hostname) | Hostname of instances | `string` | `""` | no |
+| <a name="input_hostname_suffix_separator"></a> [hostname\_suffix\_separator](#input\_hostname\_suffix\_separator) | Separator character to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
+| <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Instance template self\_link used to create compute instances | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels, provided as a map. Merged and takes precedence over labels on instance template | `map(string)` | `{}` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map | `map(string)` | `{}` | no |
+| <a name="input_network"></a> [network](#input\_network) | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances to create. This value is ignored if static\_ips is provided. | `number` | `1` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the instances should be created. | `string` | `null` | no |
+| <a name="input_replace_trigger"></a> [replace\_trigger](#input\_replace\_trigger) | Trigger value to replace the instances. | `string` | `""` | no |
+| <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming. | `string` | n/a | yes |
+| <a name="input_slurm_instance_role"></a> [slurm\_instance\_role](#input\_slurm\_instance\_role) | Slurm instance type. Must be one of: controller; login; compute. | `string` | `null` | no |
+| <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances | `list(string)` | `[]` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project that subnetwork belongs to | `string` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone where the instances should be created. If not specified, instances will be spread across available zones in the region. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_available_zones"></a> [available\_zones](#output\_available\_zones) | List of available zones in region |
+| <a name="output_instances_details"></a> [instances\_details](#output\_instances\_details) | List of all details for compute instances |
+| <a name="output_instances_self_links"></a> [instances\_self\_links](#output\_instances\_self\_links) | List of self-links for compute instances |
+| <a name="output_names"></a> [names](#output\_names) | List of available zones in region |
+| <a name="output_slurm_instances"></a> [slurm\_instances](#output\_slurm\_instances) | List of all resource objects for compute instances |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/internal/slurm-gcp-v6/instance/main.tf
+++ b/community/modules/internal/slurm-gcp-v6/instance/main.tf
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+##########
+# LOCALS #
+##########
+
+locals {
+  hostname      = var.hostname == "" ? "default" : var.hostname
+  num_instances = length(var.static_ips) == 0 ? var.num_instances : length(var.static_ips)
+
+  # local.static_ips is the same as var.static_ips with a dummy element appended
+  # at the end of the list to work around "list does not have any elements so cannot
+  # determine type" error when var.static_ips is empty
+  static_ips = concat(var.static_ips, ["NOT_AN_IP"])
+}
+
+#################
+# LOCALS: SLURM #
+#################
+
+locals {
+  network_interfaces = [for index in range(local.num_instances) :
+    concat([
+      {
+        access_config      = var.access_config
+        alias_ip_range     = []
+        ipv6_access_config = []
+        network            = var.network
+        network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, index)
+        nic_type           = null
+        queue_count        = null
+        stack_type         = null
+        subnetwork         = var.subnetwork
+        subnetwork_project = var.subnetwork_project
+      }
+      ],
+      var.additional_networks
+    )
+  ]
+
+  slurm_instance_role = lower(var.slurm_instance_role)
+
+}
+
+################
+# DATA SOURCES #
+################
+
+data "google_compute_zones" "available" {
+  project = var.project_id
+  region  = var.region
+}
+
+data "google_compute_instance_template" "base" {
+  project = var.project_id
+  name    = var.instance_template
+}
+
+data "local_file" "startup" {
+  filename = "${path.module}/../instance_template/files/startup_sh_unlinted"
+}
+
+#############
+# INSTANCES #
+#############
+resource "null_resource" "replace_trigger" {
+  triggers = {
+    trigger = var.replace_trigger
+  }
+}
+
+resource "google_compute_instance_from_template" "slurm_instance" {
+  count   = local.num_instances
+  name    = var.add_hostname_suffix ? format("%s%s%s", local.hostname, var.hostname_suffix_separator, format("%03d", count.index + 1)) : local.hostname
+  project = var.project_id
+  zone    = var.zone == null ? data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)] : var.zone
+
+  allow_stopping_for_update = true
+
+  dynamic "network_interface" {
+    for_each = local.network_interfaces[count.index]
+    iterator = nic
+    content {
+      dynamic "access_config" {
+        for_each = nic.value.access_config
+        content {
+          nat_ip       = access_config.value.nat_ip
+          network_tier = access_config.value.network_tier
+        }
+      }
+      dynamic "alias_ip_range" {
+        for_each = nic.value.alias_ip_range
+        content {
+          ip_cidr_range         = alias_ip_range.value.ip_cidr_range
+          subnetwork_range_name = alias_ip_range.value.subnetwork_range_name
+        }
+      }
+      dynamic "ipv6_access_config" {
+        for_each = nic.value.ipv6_access_config
+        iterator = access_config
+        content {
+          network_tier = access_config.value.network_tier
+        }
+      }
+      network            = nic.value.network
+      network_ip         = nic.value.network_ip
+      nic_type           = nic.value.nic_type
+      queue_count        = nic.value.queue_count
+      subnetwork         = nic.value.subnetwork
+      subnetwork_project = nic.value.subnetwork_project
+    }
+  }
+
+  source_instance_template = data.google_compute_instance_template.base.self_link
+
+  # Slurm
+  labels = merge(
+    data.google_compute_instance_template.base.labels,
+    var.labels,
+    {
+      slurm_cluster_name  = var.slurm_cluster_name
+      slurm_instance_role = local.slurm_instance_role
+    },
+  )
+  metadata = merge(
+    data.google_compute_instance_template.base.metadata,
+    var.metadata,
+    {
+      slurm_cluster_name  = var.slurm_cluster_name
+      slurm_instance_role = local.slurm_instance_role
+      startup-script      = data.local_file.startup.content
+    },
+  )
+
+  lifecycle {
+    replace_triggered_by = [null_resource.replace_trigger.id]
+  }
+}

--- a/community/modules/internal/slurm-gcp-v6/instance/outputs.tf
+++ b/community/modules/internal/slurm-gcp-v6/instance/outputs.tf
@@ -1,0 +1,41 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "slurm_instances" {
+  description = "List of all resource objects for compute instances"
+  value       = google_compute_instance_from_template.slurm_instance
+}
+
+output "instances_self_links" {
+  description = "List of self-links for compute instances"
+  value       = google_compute_instance_from_template.slurm_instance[*].self_link
+}
+
+output "instances_details" {
+  description = "List of all details for compute instances"
+  value       = google_compute_instance_from_template.slurm_instance[*]
+}
+
+output "available_zones" {
+  description = "List of available zones in region"
+  value       = data.google_compute_zones.available.names
+}
+
+output "names" {
+  description = "List of available zones in region"
+  value       = google_compute_instance_from_template.slurm_instance[*].name
+}

--- a/community/modules/internal/slurm-gcp-v6/instance/variables.tf
+++ b/community/modules/internal/slurm-gcp-v6/instance/variables.tf
@@ -1,0 +1,161 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID"
+  default     = null
+}
+
+variable "network" {
+  description = "Network to deploy to. Only one of network or subnetwork should be specified."
+  type        = string
+  default     = ""
+}
+
+variable "subnetwork" {
+  description = "Subnet to deploy to. Only one of network or subnetwork should be specified."
+  type        = string
+  default     = ""
+}
+
+variable "subnetwork_project" {
+  description = "The project that subnetwork belongs to"
+  type        = string
+  default     = null
+}
+
+variable "hostname" {
+  description = "Hostname of instances"
+  type        = string
+  default     = ""
+}
+
+variable "add_hostname_suffix" {
+  description = "Adds a suffix to the hostname"
+  type        = bool
+  default     = true
+}
+
+variable "additional_networks" {
+  description = "Additional network interface details for GCE, if any."
+  default     = []
+  type = list(object({
+    access_config = optional(list(object({
+      nat_ip       = string
+      network_tier = string
+    })), [])
+    alias_ip_range = optional(list(object({
+      ip_cidr_range         = string
+      subnetwork_range_name = string
+    })), [])
+    ipv6_access_config = optional(list(object({
+      network_tier = string
+    })), [])
+    network            = optional(string)
+    network_ip         = optional(string, "")
+    nic_type           = optional(string)
+    queue_count        = optional(number)
+    stack_type         = optional(string)
+    subnetwork         = optional(string)
+    subnetwork_project = optional(string)
+  }))
+  nullable = false
+}
+
+variable "static_ips" {
+  description = "List of static IPs for VM instances"
+  type        = list(string)
+  default     = []
+}
+
+variable "access_config" {
+  description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(object({
+    nat_ip       = string
+    network_tier = string
+  }))
+  default = []
+}
+
+variable "num_instances" {
+  description = "Number of instances to create. This value is ignored if static_ips is provided."
+  type        = number
+  default     = 1
+}
+
+variable "instance_template" {
+  description = "Instance template self_link used to create compute instances"
+  type        = string
+}
+
+variable "region" {
+  description = "Region where the instances should be created."
+  type        = string
+  default     = null
+}
+
+variable "zone" {
+  description = "Zone where the instances should be created. If not specified, instances will be spread across available zones in the region."
+  type        = string
+  default     = null
+}
+
+variable "hostname_suffix_separator" {
+  description = "Separator character to compose hostname when add_hostname_suffix is set to true."
+  type        = string
+  default     = "-"
+}
+
+variable "metadata" {
+  type        = map(string)
+  description = "Metadata, provided as a map"
+  default     = {}
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels, provided as a map. Merged and takes precedence over labels on instance template"
+  default     = {}
+}
+
+#########
+# SLURM #
+#########
+
+variable "slurm_instance_role" {
+  description = "Slurm instance type. Must be one of: controller; login; compute."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = contains(["controller", "login", "compute"], lower(var.slurm_instance_role))
+    error_message = "Must be one of: controller; login; compute."
+  }
+}
+
+variable "slurm_cluster_name" {
+  description = "Cluster name, used for resource naming."
+  type        = string
+}
+
+
+variable "replace_trigger" {
+  description = "Trigger value to replace the instances."
+  type        = string
+  default     = ""
+}

--- a/community/modules/internal/slurm-gcp-v6/instance/versions.tf
+++ b/community/modules/internal/slurm-gcp-v6/instance/versions.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.43"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/community/modules/internal/slurm-gcp-v6/nodeset_tpu/README.md
+++ b/community/modules/internal/slurm-gcp-v6/nodeset_tpu/README.md
@@ -1,0 +1,95 @@
+# Module: Slurm Nodeset (TPU)
+
+[FAQ](../../../../docs/faq.md) |
+[Troubleshooting](../../../../docs/troubleshooting.md) |
+[Glossary](../../../../docs/glossary.md)
+
+<!-- mdformat-toc start --slug=github --no-anchors --maxlevel=6 --minlevel=1 -->
+
+- [Module: Slurm Nodeset (TPU)](#module-slurm-nodeset-tpu)
+  - [Overview](#overview)
+  - [Module API](#module-api)
+
+<!-- mdformat-toc end -->
+
+## Overview
+
+This is a submodule of [slurm_cluster](../../../slurm_cluster/README.md). It
+creates a Slurm TPU nodeset for [slurm_partition](../slurm_partition/README.md).
+
+## Module API
+
+For the terraform module API reference, please see
+[README_TF.md](./README_TF.md).
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright (C) SchedMD LLC.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.53 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.53 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [null_resource.nodeset_tpu](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [google_compute_subnetwork.nodeset_subnetwork](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_accelerator_config"></a> [accelerator\_config](#input\_accelerator\_config) | Nodeset accelerator config, see https://cloud.google.com/tpu/docs/supported-tpu-configurations for details. | <pre>object({<br/>    topology = string<br/>    version  = string<br/>  })</pre> | <pre>{<br/>  "topology": "",<br/>  "version": ""<br/>}</pre> | no |
+| <a name="input_data_disks"></a> [data\_disks](#input\_data\_disks) | The data disks to include in the TPU node | `list(string)` | `[]` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-8-tf-<var.tf\_version> | `string` | `""` | no |
+| <a name="input_enable_public_ip"></a> [enable\_public\_ip](#input\_enable\_public\_ip) | Enables IP address to access the Internet. | `bool` | `false` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured on nodes. | <pre>list(object({<br/>    server_ip     = string,<br/>    remote_mount  = string,<br/>    local_mount   = string,<br/>    fs_type       = string,<br/>    mount_options = string,<br/>  }))</pre> | `[]` | no |
+| <a name="input_node_count_dynamic_max"></a> [node\_count\_dynamic\_max](#input\_node\_count\_dynamic\_max) | Maximum number of nodes allowed in this partition to be created dynamically. | `number` | `0` | no |
+| <a name="input_node_count_static"></a> [node\_count\_static](#input\_node\_count\_static) | Number of nodes to be statically created. | `number` | `0` | no |
+| <a name="input_node_type"></a> [node\_type](#input\_node\_type) | Specify a node type to base the vm configuration upon it. Not needed if you use accelerator\_config | `string` | `null` | no |
+| <a name="input_nodeset_name"></a> [nodeset\_name](#input\_nodeset\_name) | Name of Slurm nodeset. | `string` | n/a | yes |
+| <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Specify whether TPU-vms in this nodeset are preemtible, see https://cloud.google.com/tpu/docs/preemptible for details. | `bool` | `false` | no |
+| <a name="input_preserve_tpu"></a> [preserve\_tpu](#input\_preserve\_tpu) | Specify whether TPU-vms will get preserve on suspend, if set to true, on suspend vm is stopped, on false it gets deleted | `bool` | `true` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
+| <a name="input_reserved"></a> [reserved](#input\_reserved) | Specify whether TPU-vms in this nodeset are created under a reservation. | `bool` | `false` | no |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the TPU-vm.<br/>If none is given, the default service account and scopes will be used. | <pre>object({<br/>    email  = string<br/>    scopes = set(string)<br/>  })</pre> | `null` | no |
+| <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | The name of the subnetwork to attach the TPU-vm of this nodeset to. | `string` | n/a | yes |
+| <a name="input_tf_version"></a> [tf\_version](#input\_tf\_version) | Nodeset Tensorflow version, see https://cloud.google.com/tpu/docs/supported-tpu-configurations#tpu_vm for details. | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Nodes will only be created in this zone. Check https://cloud.google.com/tpu/docs/regions-zones to get zones with TPU-vm in it. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Nodeset details. |
+| <a name="output_nodeset_name"></a> [nodeset\_name](#output\_nodeset\_name) | Nodeset name. |
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account object, includes email and scopes. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/internal/slurm-gcp-v6/nodeset_tpu/main.tf
+++ b/community/modules/internal/slurm-gcp-v6/nodeset_tpu/main.tf
@@ -1,0 +1,121 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+###########
+# NODESET #
+###########
+
+locals {
+  node_conf_hw = {
+    Mem334CPU96 = {
+      CPUs           = 96
+      Boards         = 1
+      Sockets        = 2
+      CoresPerSocket = 24
+      ThreadsPerCore = 2
+      RealMemory     = 307200
+    }
+    Mem400CPU240 = {
+      CPUs           = 240
+      Boards         = 1
+      Sockets        = 2
+      CoresPerSocket = 60
+      ThreadsPerCore = 2
+      RealMemory     = 400000
+    }
+  }
+  node_conf_mappings = {
+    "v2" = local.node_conf_hw.Mem334CPU96
+    "v3" = local.node_conf_hw.Mem334CPU96
+    "v4" = local.node_conf_hw.Mem400CPU240
+  }
+  simple_nodes = ["v2-8", "v3-8", "v4-8"]
+}
+
+locals {
+  snetwork = data.google_compute_subnetwork.nodeset_subnetwork.name
+  region   = join("-", slice(split("-", var.zone), 0, 2))
+  tpu_fam  = var.accelerator_config.version != "" ? lower(var.accelerator_config.version) : split("-", var.node_type)[0]
+  #If subnetwork is specified and it does not have private_ip_google_access, we need to have public IPs on the TPU
+  #if no subnetwork is specified, the default one will be used, this does not have private_ip_google_access so we need public IPs too
+  pub_need    = !data.google_compute_subnetwork.nodeset_subnetwork.private_ip_google_access
+  can_preempt = var.node_type != null ? contains(local.simple_nodes, var.node_type) : false
+  nodeset_tpu = {
+    nodeset_name           = var.nodeset_name
+    node_conf              = local.node_conf_mappings[local.tpu_fam]
+    node_type              = var.node_type
+    accelerator_config     = var.accelerator_config
+    tf_version             = var.tf_version
+    preemptible            = local.can_preempt ? var.preemptible : false
+    reserved               = var.reserved
+    node_count_dynamic_max = var.node_count_dynamic_max
+    node_count_static      = var.node_count_static
+    enable_public_ip       = var.enable_public_ip
+    zone                   = var.zone
+    service_account        = var.service_account != null ? var.service_account : local.service_account
+    preserve_tpu           = local.can_preempt ? var.preserve_tpu : false
+    data_disks             = var.data_disks
+    docker_image           = var.docker_image != "" ? var.docker_image : "us-docker.pkg.dev/schedmd-slurm-public/tpu/slurm-gcp-6-8:tf-${var.tf_version}"
+    subnetwork             = local.snetwork
+    network_storage        = var.network_storage
+  }
+
+  service_account = {
+    email  = try(var.service_account.email, null)
+    scopes = try(var.service_account.scopes, ["https://www.googleapis.com/auth/cloud-platform"])
+  }
+}
+
+data "google_compute_subnetwork" "nodeset_subnetwork" {
+  name    = var.subnetwork
+  region  = local.region
+  project = var.project_id
+
+  self_link = (
+    length(regexall("/projects/([^/]*)", var.subnetwork)) > 0
+    && length(regexall("/regions/([^/]*)", var.subnetwork)) > 0
+    ? var.subnetwork
+    : null
+  )
+}
+
+resource "null_resource" "nodeset_tpu" {
+  triggers = {
+    nodeset = sha256(jsonencode(local.nodeset_tpu))
+  }
+  lifecycle {
+    precondition {
+      condition     = sum([var.node_count_dynamic_max, var.node_count_static]) > 0
+      error_message = "Sum of node_count_dynamic_max and node_count_static must be > 0."
+    }
+    precondition {
+      condition     = !(var.preemptible && var.reserved)
+      error_message = "Nodeset cannot be preemptible and reserved at the same time."
+    }
+    precondition {
+      condition     = !(var.subnetwork == null && !var.enable_public_ip)
+      error_message = "Using the default subnetwork for the TPU nodeset requires enable_public_ip set to true."
+    }
+    precondition {
+      condition     = !(var.subnetwork != null && (local.pub_need && !var.enable_public_ip))
+      error_message = "The subnetwork specified does not have Private Google Access enabled. This is required when enable_public_ip is set to false."
+    }
+    precondition {
+      condition     = !(var.node_type == null && (var.accelerator_config.topology == "" && var.accelerator_config.version == ""))
+      error_message = "Either a node type or an accelerator_config must be provided."
+    }
+  }
+}

--- a/community/modules/internal/slurm-gcp-v6/nodeset_tpu/outputs.tf
+++ b/community/modules/internal/slurm-gcp-v6/nodeset_tpu/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "nodeset_name" {
+  description = "Nodeset name."
+  value       = local.nodeset_tpu.nodeset_name
+}
+
+output "nodeset" {
+  description = "Nodeset details."
+  value       = local.nodeset_tpu
+}
+
+output "service_account" {
+  description = "Service account object, includes email and scopes."
+  value       = local.service_account
+}

--- a/community/modules/internal/slurm-gcp-v6/nodeset_tpu/variables.tf
+++ b/community/modules/internal/slurm-gcp-v6/nodeset_tpu/variables.tf
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "nodeset_name" {
+  description = "Name of Slurm nodeset."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z](?:[a-z0-9]{0,14})$", var.nodeset_name))
+    error_message = "Variable 'nodeset_name' must be a match of regex '^[a-z](?:[a-z0-9]{0,14})$'."
+  }
+}
+
+variable "node_type" {
+  description = "Specify a node type to base the vm configuration upon it. Not needed if you use accelerator_config"
+  type        = string
+  default     = null
+}
+
+variable "accelerator_config" {
+  description = "Nodeset accelerator config, see https://cloud.google.com/tpu/docs/supported-tpu-configurations for details."
+  type = object({
+    topology = string
+    version  = string
+  })
+  default = {
+    topology = ""
+    version  = ""
+  }
+  validation {
+    condition     = var.accelerator_config.version == "" ? true : contains(["V2", "V3", "V4"], upper(var.accelerator_config.version))
+    error_message = "accelerator_config.version must be one of [\"V2\", \"V3\", \"V4\"]"
+  }
+  validation {
+    condition     = var.accelerator_config.topology == "" ? true : can(regex("^[1-9]x[1-9](x[1-9])?$", var.accelerator_config.topology))
+    error_message = "accelerator_config.topology must be a valid topology, like 2x2 4x4x4 4x2x4 etc..."
+  }
+}
+
+variable "docker_image" {
+  description = "The gcp container registry id docker image to use in the TPU vms, it defaults to gcr.io/schedmd-slurm-public/tpu:slurm-gcp-6-8-tf-<var.tf_version>"
+  type        = string
+  default     = ""
+}
+
+variable "tf_version" {
+  description = "Nodeset Tensorflow version, see https://cloud.google.com/tpu/docs/supported-tpu-configurations#tpu_vm for details."
+  type        = string
+}
+
+variable "zone" {
+  description = "Nodes will only be created in this zone. Check https://cloud.google.com/tpu/docs/regions-zones to get zones with TPU-vm in it."
+  type        = string
+
+  validation {
+    condition     = can(coalesce(var.zone))
+    error_message = "Zone cannot be null or empty."
+  }
+}
+
+variable "preemptible" {
+  description = "Specify whether TPU-vms in this nodeset are preemtible, see https://cloud.google.com/tpu/docs/preemptible for details."
+  type        = bool
+  default     = false
+}
+
+variable "reserved" {
+  description = "Specify whether TPU-vms in this nodeset are created under a reservation."
+  type        = bool
+  default     = false
+}
+
+variable "preserve_tpu" {
+  description = "Specify whether TPU-vms will get preserve on suspend, if set to true, on suspend vm is stopped, on false it gets deleted"
+  type        = bool
+  default     = true
+}
+
+variable "node_count_static" {
+  description = "Number of nodes to be statically created."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.node_count_static >= 0
+    error_message = "Value must be >= 0."
+  }
+}
+
+variable "node_count_dynamic_max" {
+  description = "Maximum number of nodes allowed in this partition to be created dynamically."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.node_count_dynamic_max >= 0
+    error_message = "Value must be >= 0."
+  }
+}
+
+variable "enable_public_ip" {
+  description = "Enables IP address to access the Internet."
+  type        = bool
+  default     = false
+}
+
+variable "data_disks" {
+  type        = list(string)
+  description = "The data disks to include in the TPU node"
+  default     = []
+}
+
+variable "subnetwork" {
+  description = "The name of the subnetwork to attach the TPU-vm of this nodeset to."
+  type        = string
+}
+
+variable "service_account" {
+  type = object({
+    email  = string
+    scopes = set(string)
+  })
+  description = <<EOD
+Service account to attach to the TPU-vm.
+If none is given, the default service account and scopes will be used.
+EOD
+  default     = null
+}
+
+variable "project_id" {
+  type        = string
+  description = "Project ID to create resources in."
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured on nodes."
+  type = list(object({
+    server_ip     = string,
+    remote_mount  = string,
+    local_mount   = string,
+    fs_type       = string,
+    mount_options = string,
+  }))
+  default = []
+}

--- a/community/modules/internal/slurm-gcp-v6/nodeset_tpu/versions.tf
+++ b/community/modules/internal/slurm-gcp-v6/nodeset_tpu/versions.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright (C) SchedMD LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.53"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -263,10 +263,10 @@ limitations under the License.
 | <a name="module_nodeset_cleanup_tpu"></a> [nodeset\_cleanup\_tpu](#module\_nodeset\_cleanup\_tpu) | ./modules/cleanup_tpu | n/a |
 | <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | ../../internal/slurm-gcp-v6/instance_template | n/a |
 | <a name="module_slurm_files"></a> [slurm\_files](#module\_slurm\_files) | ./modules/slurm_files | n/a |
-| <a name="module_slurm_login_instance"></a> [slurm\_login\_instance](#module\_slurm\_login\_instance) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/_slurm_instance | 6.8.6 |
+| <a name="module_slurm_login_instance"></a> [slurm\_login\_instance](#module\_slurm\_login\_instance) | ../../internal/slurm-gcp-v6/instance | n/a |
 | <a name="module_slurm_login_template"></a> [slurm\_login\_template](#module\_slurm\_login\_template) | ../../internal/slurm-gcp-v6/instance_template | n/a |
 | <a name="module_slurm_nodeset_template"></a> [slurm\_nodeset\_template](#module\_slurm\_nodeset\_template) | ../../internal/slurm-gcp-v6/instance_template | n/a |
-| <a name="module_slurm_nodeset_tpu"></a> [slurm\_nodeset\_tpu](#module\_slurm\_nodeset\_tpu) | github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_nodeset_tpu | 6.8.6 |
+| <a name="module_slurm_nodeset_tpu"></a> [slurm\_nodeset\_tpu](#module\_slurm\_nodeset\_tpu) | ../../internal/slurm-gcp-v6/nodeset_tpu | n/a |
 
 ## Resources
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -56,7 +56,7 @@ module "slurm_login_template" {
 
 # INSTANCE
 module "slurm_login_instance" {
-  source   = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/_slurm_instance?ref=6.8.6"
+  source   = "../../internal/slurm-gcp-v6/instance"
   for_each = { for x in var.login_nodes : x.name_prefix => x }
 
   access_config       = each.value.access_config

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -104,7 +104,7 @@ locals {
 
 # NODESET TPU
 module "slurm_nodeset_tpu" {
-  source   = "github.com/GoogleCloudPlatform/slurm-gcp.git//terraform/slurm_cluster/modules/slurm_nodeset_tpu?ref=6.8.6"
+  source   = "../../internal/slurm-gcp-v6/nodeset_tpu"
   for_each = local.nodeset_tpu_map
 
   project_id             = var.project_id


### PR DESCRIPTION
Moved `_slurm_instance` and `slurm_tpu_nodeset` modules from slurm-gcp to toolkit. Updated terraform sources to point to new module location.

Modules are moved as is with exception of `_slurm_instance`'s `README.md` as it was failing pre-commits with due  MD027 violation (so removed a space), references to startup scripts are updated (and no longer uses absolute paths), and the `_slurm_instance` module itself has been renamed to `slurm_instance`

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
