### PR TITLE
TopologyAwareScheduling enabled by default for Kueue v0.9.1

### DIFF
--- a/modules/management/kubectl-apply/manifests/kueue-v0.9.1.yaml
+++ b/modules/management/kubectl-apply/manifests/kueue-v0.9.1.yaml
@@ -12331,6 +12331,7 @@ spec:
       - args:
         - --config=/controller_manager_config.yaml
         - --zap-log-level=2
+        - --feature-gates=TopologyAwareScheduling=true
         command:
         - /manager
         image: registry.k8s.io/kueue/kueue:v0.9.1
@@ -12394,11 +12395,6 @@ spec:
       - configMap:
           name: kueue-manager-config
         name: manager-config
-      tolerations:
-      - effect: NoSchedule
-        key: components.gke.io/gke-managed-components
-        operator: Equal
-        value: "true"
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService

--- a/modules/management/kubectl-apply/manifests/kueue-v0.9.1.yaml
+++ b/modules/management/kubectl-apply/manifests/kueue-v0.9.1.yaml
@@ -12395,6 +12395,11 @@ spec:
       - configMap:
           name: kueue-manager-config
         name: manager-config
+      tolerations:
+      - effect: NoSchedule
+        key: components.gke.io/gke-managed-components
+        operator: Equal
+        value: "true"
 ---
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService


### PR DESCRIPTION
This PR enables TopologyAwareScheduling by default for Kueue v0.9.1 installation.
It is already enabled for its v0.9.0.