### PR TITLE
SlurmGCP. Fix warning around `file_cache`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -373,6 +373,7 @@ def compute_service(version="beta"):
         requestBuilder=build_request,
         credentials=credentials,
         discoveryServiceUrl=disc_url,
+        cache_discovery=False, # See https://github.com/googleapis/google-api-python-client/issues/299
     )
 
 def storage_client() -> storage.Client:


### PR DESCRIPTION
Fix warning message `file_cache is only supported with oauth2client<4.0.0`

See https://github.com/googleapis/google-api-python-client/issues/299