### PR TITLE
update gcs storage solution design

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -135,6 +135,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the GCS bucket. | `string` | n/a | yes |
+| <a name="input_existing_gcs_bucket_name"></a> [existing\_gcs\_bucket\_name](#input\_existing\_gcs\_bucket\_name) | Name of the already existing GCS Bucket. | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | If true will destroy bucket with all objects stored within. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/mnt"` | no |

--- a/community/modules/file-system/cloud-storage-bucket/outputs.tf
+++ b/community/modules/file-system/cloud-storage-bucket/outputs.tf
@@ -65,5 +65,5 @@ output "gcs_bucket_path" {
 
 output "gcs_bucket_name" {
   description = "Bucket name."
-  value       = google_storage_bucket.bucket.name
+  value       = length(google_storage_bucket.bucket) != 0 ? google_storage_bucket.bucket[0].name : var.existing_gcs_bucket_name
 }

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -82,3 +82,9 @@ variable "viewers" {
     ])
   }
 }
+
+variable "existing_gcs_bucket_name" {
+  description = "Name of the already existing GCS Bucket."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Add support to allow customers to use already existing gcs buckets by leveraging `existing_gcs_bucket_name` and link it to Persistent Volume. In case gcs bucket isn't given as an input, we create a new one for the customer.


### Testing Details
- Created gcs bucket(cluster-toolkit-gcs-test)
- Updated storage-gke.yaml to include existing bucket details
```
 - id: data-bucket
    source: community/modules/file-system/cloud-storage-bucket
    settings:
      local_mount: /data
      random_suffix: true
      force_destroy: true
      existing_gcs_bucket_name: "cluster-toolkit-gcs-test"
```
- Deployed the storage-gke blueprint
- Ran `kubectl get pv`. Output:

```
NAME                          CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                                  STORAGECLASS   VOLUMEATTRIBUTESCLASS   REASON   AGE
cluster-toolkit-gcs-test-pv   5000Gi     RWX            Retain           Bound    default/cluster-toolkit-gcs-test-pvc                  <unset>                          20m
storage-gke-01-b32ed75c-pv    1Ti        RWX            Retain           Bound    default/storage-gke-01-b32ed75c-pvc                   <unset>                          20m
```

- Ran `kubectl describe pv cluster-toolkit-gcs-test-pv`. Output:
```
Name:            cluster-toolkit-gcs-test-pv
Labels:          ghpc_blueprint=storage-gke
                 ghpc_deployment=storage-gke-01
                 ghpc_module=gke-persistent-volume
                 ghpc_role=file-system
Annotations:     pv.kubernetes.io/bound-by-controller: yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    
Status:          Bound
Claim:           default/cluster-toolkit-gcs-test-pvc
Reclaim Policy:  Retain
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        5000Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            gcsfuse.csi.storage.gke.io
    FSType:            
    VolumeHandle:      cluster-toolkit-gcs-test
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
````


On provisioning without gcs_bucket. A new bucket gets created. Output of pv describe:
```
Name:            storage-gke-01-6960df25-pv
Labels:          ghpc_blueprint=storage-gke
                 ghpc_deployment=storage-gke-01
                 ghpc_module=gke-persistent-volume
                 ghpc_role=file-system
Annotations:     pv.kubernetes.io/bound-by-controller: yes
Finalizers:      [kubernetes.io/pv-protection]
StorageClass:    
Status:          Bound
Claim:           default/storage-gke-01-6960df25-pvc
Reclaim Policy:  Retain
Access Modes:    RWX
VolumeMode:      Filesystem
Capacity:        5000Gi
Node Affinity:   <none>
Message:         
Source:
    Type:              CSI (a Container Storage Interface (CSI) volume source)
    Driver:            gcsfuse.csi.storage.gke.io
    FSType:            
    VolumeHandle:      storage-gke-01-6960df25
    ReadOnly:          false
    VolumeAttributes:  <none>
Events:                <none>
``` 
