### PR TITLE
Allow mixing GPU and non-GPU partitions

### DIFF
--- a/community/modules/compute/htcondor-execute-point/gpu_definition.tf
+++ b/community/modules/compute/htcondor-execute-point/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v5-node-group/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-controller/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v5-login/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/gpu_definition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/modules/compute/gke-node-pool/gpu_definition.tf
+++ b/modules/compute/gke-node-pool/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }

--- a/modules/compute/vm-instance/gpu_definition.tf
+++ b/modules/compute/vm-instance/gpu_definition.tf
@@ -53,6 +53,12 @@ locals {
   # Select in priority order:
   # (1) var.guest_accelerator if not empty
   # (2) local.generated_guest_accelerator if not empty
-  # (3) default to empty list if both are empty
-  guest_accelerator = try(coalescelist(var.guest_accelerator, local.generated_guest_accelerator), [])
+  # (3) default to list with no-accelerator list entry to allow mixing GPU and non-GPU nodesets in one partition
+  guest_accelerator = try(
+    coalescelist(var.guest_accelerator, local.generated_guest_accelerator),
+    [{
+      type  = ""
+      count = 0
+    }]
+  )
 }


### PR DESCRIPTION
### Submission Checklist

Following blueprint:
```yaml
      - id: debug_nodeset
        source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
        use: [network]
        settings:
          machine_type: n2d-standard-2

      - id: debug_nodeset2
        source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
        use: [network]
        settings:
          machine_type: g2-standard-8

      - id: debug_partition
        source: community/modules/compute/schedmd-slurm-gcp-v6-partition
        use: 
          - debug_nodeset
          - debug_nodeset2
        settings:
          partition_name: debug

      - id: slurm_controller
        source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
        use:
          - network
          - debug_partition
```

Will throw an error:
```
╷
│ Error: Invalid value for input variable
│ 
│   on main.tf line 124, in module "debug_partition":
│  124:   nodeset        = flatten([module.debug_nodeset2.nodeset, flatten([module.debug_nodeset.nodeset])])
│ 
│ The given value is not suitable for module.debug_partition.var.nodeset declared at modules/embedded/community/modules/compute/schedmd-slurm-gcp-v6-partition/variables.tf:52,1-19: element types must all match for conversion to list.
```

This can be worked around by providing on non-GPU partitions:
```
      - id: debug_nodeset
        source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
        use: [network]
        settings:
          machine_type: n2d-standard-2
          guest_accelerator:
            - type: ""
              count: 0
```

With this change, one can mix gpu and non-gpu nodestes in one partition without extra steps.

This change was not tested with GKE or compute-vm