### PR TITLE
Fix clean_up placement policy bug

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -303,13 +303,11 @@ def _seconds_since_timestamp(timestamp):
 
 
 def delete_placement_groups(placement_groups):
-    def delete_placement_request(pg_name, region):
-        return lookup().compute.resourcePolicies().delete(
-            project=lookup().project, region=region, resourcePolicy=pg_name
-        )
-
     requests = {
-        pg.name: delete_placement_request(pg["name"], util.trim_self_link(pg["region"]))
+        pg["name"]: lookup().compute.resourcePolicies().delete(
+            project=lookup().project,
+            region=util.trim_self_link(pg["region"]),
+            resourcePolicy=pg["name"])
         for pg in placement_groups
     }
 


### PR DESCRIPTION
```sh
$ tail -f slurmsync.log
...
2024-12-17 20:36:28,922 INFO: deleted 1 of 1 placement groups (tst-slurmgcp-managed-exnodeset-1-0)
...
```