### PR TITLE
Integration test for Slurm A3U

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -16,6 +16,9 @@
 # This blueprint uses private preview functionality in limited availability,
 # see README.md for further information
 
+# This blueprint requires a Cluster Toolkit binary built from a
+# release >= 1.43.0
+
 blueprint_name: a3ultra-slurm
 
 vars:
@@ -25,16 +28,19 @@ vars:
   zone: # supply zone
   a3u_cluster_size: # supply cluster size
   a3u_reservation_name: # supply reservation name
+  # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
     family: ubuntu-accelerator-2204-amd64-with-nvidia-550
   image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.8.6
+  build_slurm_from_git_ref: 6.8.7
+  # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
-  filestore_ip_range: 192.168.32.0/24
+  # filestore_ip_range: 192.168.32.0/24
   net1_range: 192.168.64.0/18
   rdma_net_range: 192.168.128.0/18
+  # Cluster Settings
   local_ssd_mountpoint: /mnt/localssd
   instance_image:
     project: $(vars.project_id)
@@ -251,33 +257,55 @@ deployment_groups:
     settings:
       network_name: $(vars.deployment_name)-net-0
       mtu: 8896
+      enable_internal_traffic: false # Setting firewall below instead
       subnetworks:
       - subnet_name: $(vars.deployment_name)-sub-0
         subnet_region: $(vars.region)
         subnet_ip: $(vars.net0_range)
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-0
+        ranges: [$(vars.net0_range)]
+        allow:
+        - protocol: tcp
+        - protocol: udp
+        - protocol: icmp
 
   - id: a3ultra-slurm-net-1
     source: modules/network/vpc
     settings:
       network_name: $(vars.deployment_name)-net-1
       mtu: 8896
+      enable_internal_traffic: false # Setting firewall below instead
       subnetworks:
       - subnet_name: $(vars.deployment_name)-sub-1
         subnet_region: $(vars.region)
         subnet_ip: $(vars.net1_range)
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-1
+        ranges: [$(vars.net1_range)]
+        allow:
+        - protocol: tcp
+        - protocol: udp
+        - protocol: icmp
 
   - id: a3ultra-slurm-rdma-net
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//community/modules/network/rdma-vpc?ref=98c49fe
+    source: modules/network/gpu-rdma-vpc
     settings:
       network_name: $(vars.deployment_name)-rdma-net
       network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
       network_routing_mode: REGIONAL
-      nic_type: MRDMA
       subnetworks_template:
         name_prefix: $(vars.deployment_name)-mrdma-sub
         count: 8
         ip_range: $(vars.rdma_net_range)
         region: $(vars.region)
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-rdma
+        ranges: [$(vars.rdma_net_range)]
+        allow:
+        - protocol: tcp
+        - protocol: udp
+        - protocol: icmp
 
   - id: homefs
     source: modules/file-system/filestore
@@ -336,10 +364,10 @@ deployment_groups:
 
                   [Service]
                   Type=oneshot
-                  ExecStartPre=/usr/bin/rm -rf /var/lib/gib
-                  ExecStartPre=/usr/bin/mkdir -p /var/lib/gib
+                  ExecStartPre=/usr/bin/rm -rf /usr/local/gib
+                  ExecStartPre=/usr/bin/mkdir -p /usr/local/gib
                   ExecStartPre=/snap/bin/gcloud auth configure-docker --quiet us-docker.pkg.dev
-                  ExecStart=/usr/bin/docker run --rm --name nccl-gib-installer --volume /var/lib/gib:/var/lib/gib \
+                  ExecStart=/usr/bin/docker run --rm --name nccl-gib-installer --volume /usr/local/gib:/var/lib/gib \
                       us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:%i install --install-nccl
 
                   [Install]
@@ -356,6 +384,7 @@ deployment_groups:
                 name: nccl-plugin@$(vars.nccl_plugin_version).service
                 state: started
                 enabled: true
+
   - id: a3_ultra_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [a3ultra-slurm-net-0, a3ultra_startup]
@@ -408,6 +437,20 @@ deployment_groups:
       enable_login_public_ips: true
       machine_type: n2-standard-8
 
+  - id: controller_startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: stage_scripts.sh
+        content: |
+          #!/bin/bash
+          SLURM_ROOT=/opt/apps/adm/slurm
+          PARTITION_NAME=$(a3_ultra_partition.partitions[0].partition_name)
+          mkdir -m 0755 -p "${SLURM_ROOT}/scripts"
+          mkdir -p "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d"
+          ln -s "/slurm/scripts/tools/gpu-test" "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d/gpu-test.epilog_slurmd"
+
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
@@ -421,3 +464,5 @@ deployment_groups:
       disk_type: pd-extreme
       disk_size_gb: 300
       machine_type: n2-standard-80
+      controller_startup_script: $(controller_startup.startup_script)
+      enable_external_prolog_epilog: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/post-destroy-tasks/delete-image.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/post-destroy-tasks/delete-image.yml
@@ -1,0 +1,30 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - project is defined
+    - build is defined
+
+- name: Get Image Name
+  register: image_name
+  ansible.builtin.command: gcloud compute images list --project={{ project }} --no-standard-images --filter="labels.ghpc_deployment~{{ build }}" --format='get(name)' --limit=1
+  ignore_errors: yes
+
+- name: Delete Image
+  register: delete_image_result
+  changed_when: delete_image_result.rc == 0
+  ansible.builtin.command: gcloud compute images delete --project={{ project }} --quiet {{ image_name.stdout }}
+  when: image_name.rc == 0 and image_name.stdout != ""

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -1,0 +1,48 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.custom-image
+- m.startup-script
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+- id: ml-a3-highgpu-slurm-image
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    REGION=europe-west1
+    ZONE=europe-west1-b
+    BLUEPRINT="/workspace/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
+
+    sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
+    sed -i -e '/reason:/d' $${BLUEPRINT}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+        --user=sa_106486320838376751393 \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
@@ -1,0 +1,45 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined in build file with --extra-vars flag!
+test_name: a3u-slurm
+deployment_name: a3u-slurm-{{ build }}
+slurm_cluster_name: "a3u{{ build[0:4] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+region: europe-west1
+zone: europe-west1-b
+network: "{{ deployment_name }}-net-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+- test-validation/test-enroot.yml
+post_destroy_tasks:
+- post-destroy-tasks/delete-image.yml
+custom_vars:
+  partitions:
+  - a3ultra
+  mounts:
+  - /home
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+  disk_size_gb: 200
+  a3u_cluster_size: 2
+  a3u_reservation_name: slurm-dev-gcp-a3u-gsc


### PR DESCRIPTION
Tests 2 node Slurm Cluster on the A3Us

This has been tested successfully against a 1 node cluster in parts (image build from previous iteration, and then cluster portion tested)

This requires the A3U Slurm blueprint to be updated with the additional firewall settings (see internal repo)