### PR TITLE
Update Kueue TAS Test Definition and add Kueue v0.10.0 toleration

### DIFF
--- a/modules/management/kubectl-apply/manifests/kueue-v0.10.0.yaml
+++ b/modules/management/kubectl-apply/manifests/kueue-v0.10.0.yaml
@@ -12465,6 +12465,7 @@ spec:
       - configMap:
           name: kueue-manager-config
         name: manager-config
+      tolerations:
       - effect: NoSchedule
         key: components.gke.io/gke-managed-components
         operator: Equal

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
@@ -31,6 +31,10 @@ spec:
   nodeLabels:
     cloud.google.com/gke-nodepool: "a2-highgpu-2g-a2highgpupool"
   topologyName: "gke-default"
+  tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: NoSchedule
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: ClusterQueue
@@ -44,7 +48,7 @@ spec:
     - name: "tas-flavor"
       resources:
       - name: "nvidia.com/gpu"
-        nominalQuota: 12        # 6 nodes, 2 GPU each
+        nominalQuota: 10000000  # infinite quota
 ---
 apiVersion: kueue.x-k8s.io/v1beta1
 kind: LocalQueue


### PR DESCRIPTION
- Updated Kueue TAS queues definition to align with v0.10.0 implementation. The file changed is used for running kueue integration test.
- Add toleration to kueue manifest. This was missed in an earlier PR (#3417).
 
### Testing Details
- All integration tests for Kueue v0.10.0 are now passing.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
