### PR TITLE
Add terraform setup to github workflow config

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -41,6 +41,10 @@ jobs:
       with:
         go-version: '1.22'
         check-latest: true
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: "1.5.7"
+        terraform_wrapper: false
     - run: make install-dev-deps
     - uses: terraform-linters/setup-tflint@v4
       with:


### PR DESCRIPTION
`terraform_fmt` and `terraform validate` pre-commits were failing due to `terraform: command not found` it appears based on https://github.com/actions/runner-images/issues/10796#issuecomment-2417064348 that the suggest fix is to explicitly set up terraform since its not in the latest version of Ubuntu.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
