### PR TITLE
Update python test `deployment_name` to `BUILD_ID`

### DIFF
--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -31,4 +31,6 @@ steps:
   - |
     set -x -e
     cd /workspace && make
+    export BUILD_ID="${BUILD_ID}"
+
     python3 tools/python-integration-tests/slurm_reconfig_size.py

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -31,4 +31,6 @@ steps:
   - |
     set -x -e
     cd /workspace && make
+    export BUILD_ID="${BUILD_ID}"
+
     python3 tools/python-integration-tests/slurm_simple_job_completion.py

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -31,4 +31,6 @@ steps:
   - |
     set -x -e
     cd /workspace && make
+    export BUILD_ID="${BUILD_ID}"
+
     python3 tools/python-integration-tests/slurm_topology.py

--- a/tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml
+++ b/tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml
@@ -17,7 +17,7 @@ blueprint_name: slurm-test
 
 vars:
   project_id: ## Set GCP Project ID Here ##
-  deployment_name: slurm-test
+  deployment_name: ## Set Deployment Name Here ##
   region: us-central1
   zone: us-central1-a
 

--- a/tools/python-integration-tests/blueprints/slurm-simple.yaml
+++ b/tools/python-integration-tests/blueprints/slurm-simple.yaml
@@ -17,7 +17,7 @@ blueprint_name: slurm-test
 
 vars:
   project_id: ## Set GCP Project ID Here ##
-  deployment_name: slurm-test
+  deployment_name: ## Set Deployment Name Here ##
   region: us-central1
   zone: us-central1-a
 

--- a/tools/python-integration-tests/blueprints/topology-test.yaml
+++ b/tools/python-integration-tests/blueprints/topology-test.yaml
@@ -17,7 +17,7 @@ blueprint_name: topology-test
 
 vars:
   project_id: ## Set GCP Project ID Here ##
-  deployment_name: topology-test
+  deployment_name: ## Set Deployment Name Here ##
   region: us-central1
   zone: us-central1-a
 

--- a/tools/python-integration-tests/deployment.py
+++ b/tools/python-integration-tests/deployment.py
@@ -17,6 +17,7 @@ import shutil
 import os
 import subprocess
 import yaml
+import uuid
 
 class Deployment:
     def __init__(self, blueprint: str):
@@ -37,7 +38,6 @@ class Deployment:
     def parse_blueprint(self, file_path: str):
         with open(file_path, 'r') as file:
             content = yaml.safe_load(file)
-        self.deployment_name = content["vars"]["deployment_name"]
         self.zone = content["vars"]["zone"]
 
     def get_posixAccount_info(self):
@@ -50,8 +50,16 @@ class Deployment:
                 self.project_id = account['accountId']
                 self.username = account['username']
 
+    def generate_uniq_deployment_name(self):
+        BUILD_ID = os.environ.get('BUILD_ID')
+        if BUILD_ID:
+            return BUILD_ID[:6]
+        else:
+            return str(uuid.uuid4())[:6]
+
     def set_deployment_variables(self):
         self.workspace = os.path.abspath(os.getcwd().strip())
+        self.deployment_name = self.generate_uniq_deployment_name()
         self.parse_blueprint(self.blueprint_yaml)
         self.get_posixAccount_info()
         self.instance_name = self.deployment_name.replace("-", "")[:10] + "-slurm-login-001"


### PR DESCRIPTION
This PR updates the python test build files to export the `BUILD_ID` so it can be used as the `deployment_name` for the tests. Currently all tests use the same `deployment_name` causing them to share state.

Manually ran the three tests which all passed.

Example from successful test showing the deployment name was the shortened build id:
```
gcloud storage cp gs://daily-tests-tf-state/f4c987/f4c987.tgz .
PUSH
DONE
-----------------------------------------------------------------------------------------------------------------------------------------------------------------
ID                                    CREATE_TIME                DURATION  SOURCE                                                                                         IMAGES  STATUS
f4c98735-27e7-4645-8b9c-93cd078df94a  2024-12-19T03:41:37+00:00  8M5S      gs://hpc-toolkit-dev_cloudbuild/source/1734579691.841393-9e096ec8fdae4f80a8cca91a1a7fa669.tgz  -       SUCCESS
```

