### PR TITLE
[Cherry Pick] add reservations for kueue integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
@@ -20,7 +20,7 @@ vars:
   project_id: hpc-toolkit-dev ## Set GCP Project ID Here ##
   deployment_name: gke-a2-highgpu
   region: us-central1
-  zone: us-central1-c
+  zone: us-central1-f
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
@@ -84,6 +84,7 @@ deployment_groups:
       zones: [$(vars.zone)]
       image_type: UBUNTU_CONTAINERD
       placement_policy:
+        name: a2-highgpu-compact
         type: "COMPACT"
     outputs: [instructions]
 

--- a/tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue.yml
@@ -22,13 +22,19 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml"
 network: "gke-a2high-net-{{ build }}"
 region: us-central1
-zone: us-central1-c
+zone: us-central1-f
 remote_node: "{{ deployment_name }}-remote-node-0"
+reservation_affinity:
+  consume_reservation_type: SPECIFIC_RESERVATION
+  specific_reservations:
+  - name: a2-reservation-0
+    project: "{{ project }}"
 cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
   network_name: "{{ network }}"
-  local_ssd_count_nvme_block: 8
+  reservation_affinity: "{{ reservation_affinity }}"
+  local_ssd_count_nvme_block: 2
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:


### PR DESCRIPTION
Link the reservations required to run kueue tests. We are seeing a high occurence of stockout failures. This reservation is required to ensure the rate of failures for the integration tests reduces for the release-candidate too.
 
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
