### PR TITLE
Upgrade a3-ultra to use kueue v0.10.0

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -176,7 +176,7 @@ deployment_groups:
     settings:
       kueue:
         install: true
-        version: v0.9.1
+        version: v0.10.0
       jobset:
         install: true
         version: v0.7.1


### PR DESCRIPTION
[Kueue v0.10.0](https://github.com/kubernetes-sigs/kueue/releases/tag/v0.10.0) is the recommended TAS solution for cluster-toolkit. 

