### PR TITLE
Fix non-constant format string errors

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -91,7 +91,7 @@ func printAdvancedInstructionsMessage(deplDir string) {
 	logging.Info("Find instructions for cleanly destroying infrastructure and advanced manual")
 	logging.Info("deployment instructions at:")
 	logging.Info("")
-	logging.Info(modulewriter.InstructionsPath(deplDir))
+	logging.Info("%s", modulewriter.InstructionsPath(deplDir))
 }
 
 // TODO: move to expand.go
@@ -135,10 +135,10 @@ func v5DeprecationWarning(bp config.Blueprint) {
 	alreadyContainsV5 := false
 	bp.WalkModulesSafe(func(mp config.ModulePath, m *config.Module) {
 		if strings.Contains(m.Source, "schedmd-slurm-gcp-v5-controller") && !alreadyContainsV5 {
-			logging.Info(boldYellow(
-				"We have been supporting slurm-gcp v5 since July 2022 and are now deprecating it, as we've launched slurm-gcp v6 in June 2024. \n" +
-					"Toolkit blueprints using Slurm-gcp v5 will be marked “deprecated” starting October 2024 and slurm-gcp v6 will be the default deployment. \n" +
-					"However we won't begin removing slurm-gcp v5 blueprints until January 6, 2025. Beginning on January 6, 2025, the Cluster Toolkit team will cease their support for Slurm-gcp v5. \n" +
+			logging.Info("%s", boldYellow(
+				"We have been supporting slurm-gcp v5 since July 2022 and are now deprecating it, as we've launched slurm-gcp v6 in June 2024. \n"+
+					"Toolkit blueprints using Slurm-gcp v5 will be marked “deprecated” starting October 2024 and slurm-gcp v6 will be the default deployment. \n"+
+					"However we won't begin removing slurm-gcp v5 blueprints until January 6, 2025. Beginning on January 6, 2025, the Cluster Toolkit team will cease their support for Slurm-gcp v5. \n"+
 					"While this will not directly or immediately impact running clusters, we recommend replacing any v5 clusters with Slurm-gcp v6.",
 			))
 			alreadyContainsV5 = true // This is to avoid the logging message showing repeatedly for multiple v5 controllers
@@ -152,7 +152,7 @@ func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
 	if err == nil {
 		return
 	}
-	logging.Error(renderError(err, ctx))
+	logging.Error("%s", renderError(err, ctx))
 
 	logging.Error("One or more blueprint validators has failed. See messages above for suggested")
 	logging.Error("actions. General troubleshooting guidance and instructions for configuring")
@@ -169,12 +169,12 @@ func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
 	switch bp.ValidationLevel {
 	case config.ValidationWarning:
 		{
-			logging.Error(boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
+			logging.Error("%s", boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
 			logging.Error("")
 		}
 	case config.ValidationError:
 		{
-			logging.Fatal(boldRed("validation failed due to the issues listed above"))
+			logging.Fatal("%s", boldRed("validation failed due to the issues listed above"))
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -262,6 +262,6 @@ func checkErr(err error, ctx *config.YamlCtx) {
 		ctx = &config.YamlCtx{}
 	}
 	if err != nil {
-		logging.Fatal(renderError(err, *ctx))
+		logging.Fatal("%s", renderError(err, *ctx))
 	}
 }

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -136,7 +136,7 @@ func ReadHclAttributes(file string) (map[string]cty.Value, error) {
 		// work around ugly <nil> in error message missing d.Subject
 		// https://github.com/hashicorp/hcl2/blob/fb75b3253c80b3bc7ca99c4bfa2ad6743841b1af/hcl/diagnostic.go#L76-L78
 		if len(diags) == 1 {
-			return nil, fmt.Errorf(diags[0].Detail)
+			return nil, fmt.Errorf("%s", diags[0].Detail)
 		}
 		return nil, diags
 	}

--- a/pkg/modulereader/hcl_utils.go
+++ b/pkg/modulereader/hcl_utils.go
@@ -15,6 +15,7 @@
 package modulereader
 
 import (
+	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/sourcereader"
@@ -136,7 +137,7 @@ func ReadHclAttributes(file string) (map[string]cty.Value, error) {
 		// work around ugly <nil> in error message missing d.Subject
 		// https://github.com/hashicorp/hcl2/blob/fb75b3253c80b3bc7ca99c4bfa2ad6743841b1af/hcl/diagnostic.go#L76-L78
 		if len(diags) == 1 {
-			return nil, fmt.Errorf("%s", diags[0].Detail)
+			return nil, errors.New(diags[0].Detail)
 		}
 		return nil, diags
 	}


### PR DESCRIPTION
Fix `vet` error due to: https://github.com/golang/go/issues/60529
See https://tip.golang.org/doc/go1.24#:~:text=Vet%C2%B6,%2360529.

Go build on 1.22 and 1.23 are not blocked _per se_ as vet of the older golang doesn't check for the error, but it's nice-to-have fix anyway and makes the code forward-compatible with 1.24.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
