### PR TITLE
Relax validation around NIC types in gpu-rdma-vpc

### DIFF
--- a/modules/network/gpu-rdma-vpc/variables.tf
+++ b/modules/network/gpu-rdma-vpc/variables.tf
@@ -156,7 +156,7 @@ variable "nic_type" {
   default     = "MRDMA"
 
   validation {
-    condition     = contains(["MRDMA"], var.nic_type)
-    error_message = "The nic_type must be \"MRDMA\"."
+    condition     = contains(["MRDMA", "IRDMA"], var.nic_type)
+    error_message = "The nic_type must be \"MRDMA\" or \"IRDMA\"."
   }
 }


### PR DESCRIPTION
This is to allow the use of IRDMA `nic_types` in the module.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
