### PR TITLE
update a3mega nccl plugin to 1.0.7 and rxdm to 1.0.13_1

### DIFF
--- a/modules/compute/gke-node-pool/gpu_direct.tf
+++ b/modules/compute/gke-node-pool/gpu_direct.tf
@@ -43,11 +43,11 @@ locals {
     "a3-megagpu-8g" = {
       # Manifest to be installed for enabling TCPXO on a3-megagpu-8g machines
       gpu_direct_manifests = [
-        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.4 for tcpxo
-        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/fee883360a660f71ba07478db95d5c1325322f77/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/b324ec8994aa98ca320438dd2d01ff6d7f9165bb/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.7 for tcpxo
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/b324ec8994aa98ca320438dd2d01ff6d7f9165bb/nri_device_injector/nri-device-injector.yaml", # nri_plugin
       ]
       updated_workload_path   = replace(local.workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
-      rxdm_version            = "v1.0.10" # matching nccl-tcpxo-installer version v1.0.4
+      rxdm_version            = "v1.0.13_1" # matching nccl-tcpxo-installer version v1.0.7
       min_additional_networks = 8
       major_minor_version_acceptable_map = {
         "1.28" = "1.28.9-gke.1250000"


### PR DESCRIPTION
Update a3mega NCCL plugin to 1.0.7 and RxDM to 1.0.13_1

context: https://docs.google.com/document/d/1D5umT4-WDuNnYf3ieQ5SfLdmvGRPBQGLB662udzwz8I/edit?tab=t.0#bookmark=kix.bf6s41824t38