### PR TITLE
Pin A3U blueprint module with commit ref from develop branch

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -33,25 +33,42 @@ vars:
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
 
+terraform_providers:
+  google:
+    source: hashicorp/google
+    version: 6.13.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+  google-beta:
+    source: hashicorp/google-beta
+    version: 6.13.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+
 deployment_groups:
 - group: primary
   modules:
   - id: gke-a3-ultra-net-0
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/network/vpc?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/network/vpc?ref=e17bb15
     settings:
-      network_name: gke-a3-ultra-net-0
+      network_name: $(vars.deployment_name)-net-0
       subnetworks:
-      - subnet_name: gke-a3-ultra-sub-0
+      - subnet_name: $(vars.deployment_name)-sub-0
         subnet_region: $(vars.region)
         subnet_ip: 192.168.0.0/18
-      secondary_ranges:
-        gke-a3-ultra-sub-0:
+      secondary_ranges_list:
+      - subnetwork_name: $(vars.deployment_name)-sub-0
+        ranges:
         - range_name: pods
           ip_cidr_range: 10.4.0.0/14
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
       firewall_rules:
-      - name: gke-a3-ultra-internal-0
+      - name: $(vars.deployment_name)-internal-0
         ranges: [192.168.0.0/16]
         allow:
         - protocol: tcp
@@ -61,16 +78,16 @@ deployment_groups:
         - protocol: icmp
 
   - id: gke-a3-ultra-net-1
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/network/vpc?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/network/vpc?ref=e17bb15
     settings:
-      network_name: gke-a3-ultra-net-1
+      network_name: $(vars.deployment_name)-net-1
       mtu: $(vars.mtu_size)
       subnetworks:
-      - subnet_name: gke-a3-ultra-sub-1
+      - subnet_name: $(vars.deployment_name)-sub-1
         subnet_region: $(vars.region)
         subnet_ip: 192.168.64.0/18
       firewall_rules:
-      - name: gke-a3-ultra-internal-1
+      - name: $(vars.deployment_name)-internal-1
         ranges: [192.168.0.0/16]
         allow:
         - protocol: tcp
@@ -80,20 +97,20 @@ deployment_groups:
         - protocol: icmp
 
   - id: gke-a3-ultra-rdma-net
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//community/modules/network/rdma-vpc?ref=98c49fe
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/network/gpu-rdma-vpc?ref=e17bb15
     settings:
-      network_name: gke-a3-ultra-rdma-net
+      network_name: $(vars.deployment_name)-rdma-net
       mtu: $(vars.mtu_size)
       network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
       network_routing_mode: REGIONAL
       subnetworks_template:
-        name_prefix: gke-a3-ultra-rdma-sub
+        name_prefix: $(vars.deployment_name)-rdma-sub
         count: 8
         ip_range: 192.168.128.0/18
         region: $(vars.region)
 
   - id: a3-ultragpu-cluster
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/scheduler/gke-cluster?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/scheduler/gke-cluster?ref=e17bb15
     use: [gke-a3-ultra-net-0]
     settings:
       release_channel: RAPID
@@ -110,7 +127,7 @@ deployment_groups:
       - name: no-minor-or-node-upgrades-indefinite
         start_time: "2024-12-01T00:00:00Z"
         end_time: "2025-12-22T00:00:00Z"
-        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES      
+        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
       additional_networks:
         $(concat(
           [{
@@ -130,7 +147,7 @@ deployment_groups:
     outputs: [instructions]
 
   - id: a3-ultragpu-pool
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/compute/gke-node-pool?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/compute/gke-node-pool?ref=e17bb15
     use: [a3-ultragpu-cluster]
     settings:
       machine_type: a3-ultragpu-8g
@@ -167,16 +184,16 @@ deployment_groups:
     outputs: [instructions]
 
   - id: topology-aware-scheduler-install
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//community/modules/compute/gke-topology-scheduler?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//community/modules/compute/gke-topology-scheduler?ref=e17bb15
     use: [a3-ultragpu-cluster]
 
   - id: workload-manager-install
-    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/management/kubectl-apply?ref=e0c690b
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/management/kubectl-apply?ref=e17bb15
     use: [a3-ultragpu-cluster]
     settings:
       kueue:
         install: true
-        version: v0.9.1
+        version: v0.10.0
       jobset:
         install: true
         version: v0.7.1
@@ -185,7 +202,7 @@ deployment_groups:
       - source: $(vars.mglru_disable_path)
 
   - id: job-template
-    source: modules/compute/gke-job-template
+    source: github.com/GoogleCloudPlatform/cluster-toolkit.git//modules/compute/gke-job-template?ref=e17bb15
     use: [a3-ultragpu-pool]
     settings:
       image: nvidia/cuda:11.0.3-runtime-ubuntu20.04
@@ -194,19 +211,3 @@ deployment_groups:
       node_count: 2
       name: run-nvidia-smi
     outputs: [instructions]
-
-terraform_providers:
-  google:
-    source: hashicorp/google
-    version: 6.13.0
-    configuration:
-      project: $(vars.project_id)
-      region: $(vars.region)
-      zone: $(vars.zone)
-  google-beta:
-    source: hashicorp/google-beta
-    version: 6.13.0
-    configuration:
-      project: $(vars.project_id)
-      region: $(vars.region)
-      zone: $(vars.zone)

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -33,22 +33,6 @@ vars:
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
 
-terraform_providers:
-  google:
-    source: hashicorp/google
-    version: 6.13.0
-    configuration:
-      project: $(vars.project_id)
-      region: $(vars.region)
-      zone: $(vars.zone)
-  google-beta:
-    source: hashicorp/google-beta
-    version: 6.13.0
-    configuration:
-      project: $(vars.project_id)
-      region: $(vars.region)
-      zone: $(vars.zone)
-
 deployment_groups:
 - group: primary
   modules:


### PR DESCRIPTION
#### What changed ?
- Pinned A3U blueprint module to [e17bb15](https://github.com/GoogleCloudPlatform/cluster-toolkit/commit/e17bb153b36984a6dae6df9496928408f4db6a8e) commit hash from develop branch.

#### Why we require this change ?
- This change is required for A3U GA readiness.
- Prior plan of using `toolkit_modules_url` and `toolkit_modules_version` stalled, as we identified that we have no support for using commit hash (only works for branch and tag name).
- Its due to the hardcoding of git `depth` field in the current setup, while [expanding source path for each module](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/pkg/config/expand.go#L116-L121).

#### Why not pinned to latest [81e63e6](https://github.com/GoogleCloudPlatform/cluster-toolkit/commit/81e63e6be3defa2eab22988ebb649c0ea46ba80c) commit hash from develop branch?
- As it contain changes related to `gcluster` binary, which wont be available on main until next release.

#### How this has been tested ?
- Tested locally, using example A3U blueprint with diff, worked as expected.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
