### PR TITLE
Fix failures if not specifying stripe sizes for parallelstore

### DIFF
--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -169,8 +169,8 @@ No modules.
 | <a name="input_daos_agent_config"></a> [daos\_agent\_config](#input\_daos\_agent\_config) | Additional configuration to be added to daos\_config.yml | `string` | `""` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment. | `string` | n/a | yes |
 | <a name="input_dfuse_environment"></a> [dfuse\_environment](#input\_dfuse\_environment) | Additional environment variables for DFuse process | `map(string)` | `{}` | no |
-| <a name="input_directory_stripe"></a> [directory\_stripe](#input\_directory\_stripe) | The parallelstore stripe level for directories. | `string` | `"DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"` | no |
-| <a name="input_file_stripe"></a> [file\_stripe](#input\_file\_stripe) | The parallelstore stripe level for files. | `string` | `"FILE_STRIPE_LEVEL_UNSPECIFIED"` | no |
+| <a name="input_directory_stripe"></a> [directory\_stripe](#input\_directory\_stripe) | The parallelstore stripe level for directories. | `string` | `null` | no |
+| <a name="input_file_stripe"></a> [file\_stripe](#input\_file\_stripe) | The parallelstore stripe level for files. | `string` | `null` | no |
 | <a name="input_import_destination_path"></a> [import\_destination\_path](#input\_import\_destination\_path) | The name of local path to import data on parallelstore instance from GCS bucket. | `string` | `null` | no |
 | <a name="input_import_gcs_bucket_uri"></a> [import\_gcs\_bucket\_uri](#input\_import\_gcs\_bucket\_uri) | The name of the GCS bucket to import data from to parallelstore. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to parallel store instance. | `map(string)` | `{}` | no |

--- a/modules/file-system/parallelstore/variables.tf
+++ b/modules/file-system/parallelstore/variables.tf
@@ -109,9 +109,9 @@ variable "import_destination_path" {
 variable "file_stripe" {
   description = "The parallelstore stripe level for files."
   type        = string
-  default     = "FILE_STRIPE_LEVEL_UNSPECIFIED"
+  default     = null
   validation {
-    condition = contains([
+    condition = var.file_stripe == null ? true : contains([
       "FILE_STRIPE_LEVEL_UNSPECIFIED",
       "FILE_STRIPE_LEVEL_MIN",
       "FILE_STRIPE_LEVEL_BALANCED",
@@ -124,9 +124,9 @@ variable "file_stripe" {
 variable "directory_stripe" {
   description = "The parallelstore stripe level for directories."
   type        = string
-  default     = "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"
+  default     = null
   validation {
-    condition = contains([
+    condition = var.directory_stripe == null ? true : contains([
       "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED",
       "DIRECTORY_STRIPE_LEVEL_MIN",
       "DIRECTORY_STRIPE_LEVEL_BALANCED",


### PR DESCRIPTION
This fixes issues with non-empty and failing plan, if stripe sizes are not specified:
```
  # module.scratch-ps.google_parallelstore_instance.instance will be updated in-place
  ~ resource "google_parallelstore_instance" "instance" {
      + directory_stripe_level      = "DIRECTORY_STRIPE_LEVEL_UNSPECIFIED"
      + file_stripe_level           = "FILE_STRIPE_LEVEL_UNSPECIFIED"
        id                          = "projects/<redacted>/locations/us-central1-a/instances/<redacted>"
        name                        = "projects/<redacted>/locations/us-central1-a/instances/<redacted>"
        # (16 unchanged attributes hidden)
    }
```