### PR TITLE
Update reservation used by GKE A3 Ultra integration test

### DIFF
--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
@@ -24,7 +24,7 @@ network: "{{ deployment_name }}-net-0"
 region: europe-west1
 zone: europe-west1-b
 remote_node: "{{ deployment_name }}-remote-node-0"
-extended_reservation: slurm-dev-gcp-a3u-gsc
+extended_reservation: hpc-exfr-2
 static_node_count: 1
 cli_deployment_vars:
   region: "{{ region }}"


### PR DESCRIPTION
Migrate the A3 Ultra GKE integration test to a new reservation of A3 Ultra VMs.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
