### PR TITLE
Add blueprint name before build ID

### DIFF
--- a/tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml
+++ b/tools/python-integration-tests/blueprints/slurm-simple-reconfig.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: slurm-test
+blueprint_name: slurm-simple
 
 vars:
   project_id: ## Set GCP Project ID Here ##

--- a/tools/python-integration-tests/blueprints/slurm-simple.yaml
+++ b/tools/python-integration-tests/blueprints/slurm-simple.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: slurm-test
+blueprint_name: slurm-simple
 
 vars:
   project_id: ## Set GCP Project ID Here ##

--- a/tools/python-integration-tests/blueprints/topology-test.yaml
+++ b/tools/python-integration-tests/blueprints/topology-test.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: topology-test
+blueprint_name: topology
 
 vars:
   project_id: ## Set GCP Project ID Here ##

--- a/tools/python-integration-tests/deployment.py
+++ b/tools/python-integration-tests/deployment.py
@@ -21,13 +21,14 @@ import uuid
 
 class Deployment:
     def __init__(self, blueprint: str):
-        self.blueprint_yaml = blueprint
+        self.blueprint_file = blueprint
         self.state_bucket = "daily-tests-tf-state"
         self.project_id = None
         self.workspace = None
         self.instance_name = None
         self.username = None
         self.deployment_name = None
+        self.blueprint_name = None
         self.zone = None
 
     def run_command(self, cmd: str, err_msg: str = None) -> subprocess.CompletedProcess:
@@ -39,6 +40,7 @@ class Deployment:
         with open(file_path, 'r') as file:
             content = yaml.safe_load(file)
         self.zone = content["vars"]["zone"]
+        self.blueprint_name = content["blueprint_name"]
 
     def get_posixAccount_info(self):
         # Extract the username from posixAccounts
@@ -53,14 +55,14 @@ class Deployment:
     def generate_uniq_deployment_name(self):
         BUILD_ID = os.environ.get('BUILD_ID')
         if BUILD_ID:
-            return BUILD_ID[:6]
+            return "-".join([self.blueprint_name, str(BUILD_ID[:6])])
         else:
-            return str(uuid.uuid4())[:6]
+            return "-".join([self.blueprint_name, str(uuid.uuid4())[:6]])
 
     def set_deployment_variables(self):
         self.workspace = os.path.abspath(os.getcwd().strip())
+        self.parse_blueprint(self.blueprint_file)
         self.deployment_name = self.generate_uniq_deployment_name()
-        self.parse_blueprint(self.blueprint_yaml)
         self.get_posixAccount_info()
         self.instance_name = self.deployment_name.replace("-", "")[:10] + "-slurm-login-001"
 
@@ -70,7 +72,7 @@ class Deployment:
               "create",
               "-l",
               "ERROR",
-              self.blueprint_yaml,
+              self.blueprint_file,
               "--backend-config",
               f"bucket={self.state_bucket}",
               "--vars",


### PR DESCRIPTION
This PR updates the `deployment_name` to have the `blueprint_name` appended to the beginning. This solves the issue of the `deployment_name` not being recognized as an string when the build id starts with an int.