### PR TITLE
Enable hierarchical namespace support in cloud-storage-bucket module

### DIFF
--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -135,6 +135,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the GCS bucket. | `string` | n/a | yes |
+| <a name="input_enable_hierarchical_namespace"></a> [enable\_hierarchical\_namespace](#input\_enable\_hierarchical\_namespace) | If true, enables hierarchical namespace for the bucket. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | If true will destroy bucket with all objects stored within. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/mnt"` | no |

--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -109,6 +109,7 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -116,6 +117,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.13.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -126,7 +128,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google-beta_google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 

--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -109,7 +109,7 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.9.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -117,7 +117,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.13.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.9.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules

--- a/community/modules/file-system/cloud-storage-bucket/README.md
+++ b/community/modules/file-system/cloud-storage-bucket/README.md
@@ -137,7 +137,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the GCS bucket. | `string` | n/a | yes |
-| <a name="input_enable_hierarchical_namespace"></a> [enable\_hierarchical\_namespace](#input\_enable\_hierarchical\_namespace) | If true, enables hierarchical namespace for the bucket. | `bool` | `false` | no |
+| <a name="input_enable_hierarchical_namespace"></a> [enable\_hierarchical\_namespace](#input\_enable\_hierarchical\_namespace) | If true, enables hierarchical namespace for the bucket. This option must be configured during the initial creation of the bucket. | `bool` | `false` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | If true will destroy bucket with all objects stored within. | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the GCS bucket. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | The mount point where the contents of the device may be accessed after mounting. | `string` | `"/mnt"` | no |

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -41,8 +41,8 @@ resource "google_storage_bucket" "bucket" {
   storage_class               = "REGIONAL"
   labels                      = local.labels
   force_destroy               = var.force_destroy
-  hierarchical_namespace      = {
-                                enabled = var.enable_hierarchical_namespace
+  hierarchical_namespace {
+    enabled = var.enable_hierarchical_namespace
   }
 }
 

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -34,6 +34,7 @@ resource "random_id" "resource_name_suffix" {
 }
 
 resource "google_storage_bucket" "bucket" {
+  provider                    = google-beta
   project                     = var.project_id
   name                        = local.name
   uniform_bucket_level_access = true

--- a/community/modules/file-system/cloud-storage-bucket/main.tf
+++ b/community/modules/file-system/cloud-storage-bucket/main.tf
@@ -41,6 +41,9 @@ resource "google_storage_bucket" "bucket" {
   storage_class               = "REGIONAL"
   labels                      = local.labels
   force_destroy               = var.force_destroy
+  hierarchical_namespace      = {
+                                enabled = var.enable_hierarchical_namespace
+  }
 }
 
 resource "google_storage_bucket_iam_binding" "viewers" {

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -84,7 +84,7 @@ variable "viewers" {
 }
 
 variable "enable_hierarchical_namespace" {
-  description = "If true, enables hierarchical namespace for the bucket."
+  description = "If true, enables hierarchical namespace for the bucket. This option must be configured during the initial creation of the bucket."
   type        = bool
   default     = false
 }

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -85,6 +85,6 @@ variable "viewers" {
 
 variable "enable_hierarchical_namespace" {
   description = "If true, enables hierarchical namespace for the bucket."
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/community/modules/file-system/cloud-storage-bucket/variables.tf
+++ b/community/modules/file-system/cloud-storage-bucket/variables.tf
@@ -82,3 +82,9 @@ variable "viewers" {
     ])
   }
 }
+
+variable "enable_hierarchical_namespace" {
+  description = "If true, enables hierarchical namespace for the bucket."
+  type = bool
+  default = false
+}

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.13.0"
+      version = ">= 6.9.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -20,12 +20,19 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.83"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.13.0"
+    }
     random = {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
   }
   provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.44.0"
+  }
+  provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.44.0"
   }
   required_version = ">= 0.14.0"


### PR DESCRIPTION
Enable hierarchical namespace support in cloud-storage-bucket module. 
Boolean variable "enable_hierarchical_namespace" with default 'false', that links to this setting in the Terraform resource.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
