### PR TITLE
Update dependabot version update configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,16 @@ updates:
   target-branch: develop
   ignore:
   - dependency-name: "google.golang.org/api"
-
+  groups:
+  # group all Go minor/patch updates together and individual PRs for major updates
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates
+    go-minor-and-patch-updates:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: pip
   directory: /community/front-end/ofe/
   labels:
@@ -45,9 +54,16 @@ updates:
   reviewers:
   - ek-nag
   - mattstreet-nag
-  # Disable version updates, do security updates only
-  # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-  open-pull-requests-limit: 0
+  groups:
+    # group all OFE minor/patch updates together and individual PRs for major updates
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates
+    ofe-minor-and-patch-updates:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch
 - package-ecosystem: pip
   directory: /community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/
   labels:
@@ -55,11 +71,18 @@ updates:
   - python
   - release-chore
   schedule:
-    interval: weekly
+    interval: monthly
     day: monday
     time: "03:00"
     timezone: America/Los_Angeles
   target-branch: develop
-  # Disable version updates, do security updates only
-  # See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file
-  open-pull-requests-limit: 0
+  groups:
+    # group all Slurm minor/patch updates together and individual PRs for major updates
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates#example-3-individual-pull-requests-for-major-updates-and-grouped-for-minorpatch-updates
+    slurm-python-minor-and-patch-updates:
+      applies-to: version-updates
+      patterns:
+      - "*"
+      update-types:
+      - minor
+      - patch


### PR DESCRIPTION
We have disabled security updates at repository level because they are targeting the main branch and often produce PRs that are duplicative of work already performed on develop branch. Security alert notifications remain enabled. In its place, we are re-enabling monthly updates for all configured package ecosystems, but with minor and patch updates grouped together.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
