### PR TITLE
Bump jobset version to 0.7.2 and remove v0.7.1 as valid version

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -182,7 +182,7 @@ deployment_groups:
         version: v0.10.0
       jobset:
         install: true
-        version: v0.7.1
+        version: v0.7.2
       apply_manifests:
       - source: $(vars.nccl_installer_path)
       - source: $(vars.mglru_disable_path)

--- a/modules/management/kubectl-apply/manifests/jobset-v0.7.2.yaml
+++ b/modules/management/kubectl-apply/manifests/jobset-v0.7.2.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 "Google LLC"
+# Copyright 2025 "Google LLC"
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -8747,7 +8747,7 @@ spec:
         - --leader-elect
         command:
         - /manager
-        image: registry.k8s.io/jobset/jobset:v0.7.1
+        image: registry.k8s.io/jobset/jobset:v0.7.2
         livenessProbe:
           httpGet:
             path: /healthz

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -16,7 +16,7 @@
 
 locals {
   kueue_supported_versions  = ["v0.10.0", "v0.9.1", "v0.9.0", "v0.8.1"]
-  jobset_supported_versions = ["v0.7.1", "v0.5.2"]
+  jobset_supported_versions = ["v0.7.2", "v0.5.2"]
 }
 
 resource "terraform_data" "kueue_validations" {


### PR DESCRIPTION
Changes : 
* Jobset v0.7.1 had an issue as raised here https://github.com/kubernetes-sigs/jobset/issues/729 which has been fixed in v0.7.2 hence adding a new jobset version.
* Also removed v0.7.1 from valid set of versions to prevent installation of that version (also removed the manifest)
* Updated a3u blueprint to use the new jobset version