### PR TITLE
Update Filestore examples to use Private Service Access

### DIFF
--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -28,19 +28,23 @@ vars:
 deployment_groups:
 - group: primary
   modules:
-  - id: network1
+  - id: network
     source: modules/network/vpc
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
 
   ## Filesystems
   - id: appsfs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network, private_service_access]
     settings:
       local_mount: /sw
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 
@@ -93,7 +97,7 @@ deployment_groups:
 
   - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network1]
+    use: [network]
     settings:
       node_count_dynamic_max: 20
       bandwidth_tier: gvnic_enabled
@@ -108,14 +112,14 @@ deployment_groups:
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
-    use: [network1]
+    use: [network]
     settings:
       enable_login_public_ips: true
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
-    - network1
+    - network
     - compute_partition
     - slurm_login
     - homefs

--- a/community/examples/hpc-slurm-local-ssd.yaml
+++ b/community/examples/hpc-slurm-local-ssd.yaml
@@ -31,9 +31,13 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -33,18 +33,22 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local module, prefix with ./, ../ or /
-  - id: network1
+  - id: network
     source: modules/network/vpc
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network1]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 
   - id: debug_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network1]
+    use: [network]
     settings:
       instance_image: $(vars.slurm_image)
       enable_placement: false # the default is: true
@@ -61,7 +65,7 @@ deployment_groups:
 
   - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
-    use: [network1]
+    use: [network]
     settings:
       instance_image: $(vars.slurm_image)
       node_count_dynamic_max: 20
@@ -76,7 +80,7 @@ deployment_groups:
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use:
-    - network1
+    - network
     - slurm_login
     - debug_partition
     - compute_partition
@@ -87,7 +91,7 @@ deployment_groups:
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
-    use: [network1]
+    use: [network]
     settings:
       instance_image: $(vars.slurm_image)
       machine_type: n2-standard-4

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -45,15 +45,19 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       filestore_tier: HIGH_SCALE_SSD
       size_gb: 10240

--- a/examples/hcls-blueprint.yaml
+++ b/examples/hcls-blueprint.yaml
@@ -53,6 +53,10 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   ### Resource Monitoring ###
 
   - id: hpc-dash
@@ -62,14 +66,14 @@ deployment_groups:
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       filestore_share_name: homeshare
       local_mount: /home
 
   - id: appsfs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       filestore_share_name: appsshare
       local_mount: /apps

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -51,6 +51,10 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: controller_sa
     source: community/modules/project/service-account
     settings:
@@ -83,13 +87,13 @@ deployment_groups:
 
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 
   - id: projectsfs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       local_mount: /projects
 

--- a/examples/hpc-slurm.yaml
+++ b/examples/hpc-slurm.yaml
@@ -33,9 +33,13 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: homefs
     source: modules/file-system/filestore
-    use: [network]
+    use: [network, private_service_access]
     settings:
       local_mount: /home
 

--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -46,10 +46,13 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
   - id: homefs
     source: modules/file-system/filestore
-    use:
-    - network
+    use: [network, private_service_access]
     settings:
       local_mount: /home
       size_gb: 2560

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -18,6 +18,7 @@ tags:
 - m.cloud-storage-bucket
 - m.dashboard
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -18,6 +18,7 @@ tags:
 - m.DDN-EXAScaler
 - m.dashboard
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -16,6 +16,7 @@
 tags:
 - m.filestore
 - m.DDN-EXAScaler
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -16,6 +16,7 @@
 tags:
 - m.custom-image
 - m.filestore
+- m.private-service-access
 - m.vpc
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -15,6 +15,7 @@
 ---
 tags:
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -16,6 +16,7 @@
 tags:
 - slurm6
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -15,6 +15,7 @@
 ---
 tags:
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -15,6 +15,7 @@
 ---
 tags:
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -15,6 +15,7 @@
 ---
 tags:
 - m.filestore
+- m.private-service-access
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset


### PR DESCRIPTION
Update all examples that create new VPCs (with the modules/network/vpc module) to use Private Service Access. Do not update examples that use pre-existing-vpc module because it is not possible to use Terraform to manage Private Service Access in conflict with a pre-existing configuration.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
