### PR TITLE
Enable exclusive partition in A3 Ultra Slurm standard blueprint

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -408,6 +408,7 @@ deployment_groups:
       partition_name: a3ultra
       is_default: true
       partition_conf:
+        OverSubscribe: EXCLUSIVE
         ResumeTimeout: 900
         SuspendTimeout: 600
 


### PR DESCRIPTION
This PR aligns the EXCLUSIVE behavior of the A3 Ultra partition in our standard Slurm blueprint with the A3 High, A3 Mega, and A3 Ultra hypercompute solutions.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
