### PR TITLE
Update Minimum terraform version in Makefile from 1.2 to 1.5.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # PREAMBLE
 MIN_PACKER_VERSION=1.7.9 # for building images
-MIN_TERRAFORM_VERSION=1.2 # for deploying modules
+MIN_TERRAFORM_VERSION=1.5.7 # for deploying modules
 MIN_GOLANG_VERSION=1.18 # for building gcluster
 
 .PHONY: install install-user tests format install-dev-deps \


### PR DESCRIPTION
This PR updates the `MIN_TERRAFORM_VERSION` in Makefile from `v1.2` to `v1.5.7` as documented [here](https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies).
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
