### PR TITLE
Adding a note to use of Private Service Access module

### DIFF
--- a/community/examples/hpc-slurm-gromacs.yaml
+++ b/community/examples/hpc-slurm-gromacs.yaml
@@ -31,6 +31,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/community/examples/hpc-slurm-local-ssd.yaml
+++ b/community/examples/hpc-slurm-local-ssd.yaml
@@ -31,6 +31,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/community/examples/hpc-slurm-ubuntu2004.yaml
+++ b/community/examples/hpc-slurm-ubuntu2004.yaml
@@ -36,6 +36,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/community/examples/htc-slurm.yaml
+++ b/community/examples/htc-slurm.yaml
@@ -45,6 +45,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -23,6 +23,9 @@ It will automatically perform the following steps, as described in the
   - source: modules/network/vpc
     id: network
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - source: community/modules/network/private-service-access
     id: ps_connect
     use: [network]

--- a/examples/gke-managed-parallelstore.yaml
+++ b/examples/gke-managed-parallelstore.yaml
@@ -38,7 +38,11 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: private_service_access # required for parallelstore
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is required for all Parallelstore functionality.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
+  - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]
     settings:

--- a/examples/hcls-blueprint.yaml
+++ b/examples/hcls-blueprint.yaml
@@ -53,6 +53,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -51,6 +51,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/examples/hpc-slurm.yaml
+++ b/examples/hpc-slurm.yaml
@@ -33,6 +33,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-base.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-base.yaml
@@ -40,6 +40,13 @@ deployment_groups:
     outputs:
     - network_name
     - subnetwork_name
+
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use:

--- a/examples/ml-slurm.yaml
+++ b/examples/ml-slurm.yaml
@@ -46,6 +46,12 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is a best practice for Filestore instances, but can be optionally
+  # removed by deleting the private_service_access module and any references to
+  # the module by Filestore modules.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/examples/pfs-parallelstore.yaml
+++ b/examples/pfs-parallelstore.yaml
@@ -31,6 +31,10 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is required for all Parallelstore functionality.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/examples/ps-slurm.yaml
+++ b/examples/ps-slurm.yaml
@@ -39,6 +39,10 @@ deployment_groups:
   - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is required for all Parallelstore functionality.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/modules/file-system/gke-storage/README.md
+++ b/modules/file-system/gke-storage/README.md
@@ -15,6 +15,10 @@ then use them in a `gke-job-template` to dynamically provision the resource.
     settings:
       enable_parallelstore_csi: true
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is required for all Parallelstore functionality.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]

--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -40,6 +40,10 @@ for this newly created network.
  - id: network
     source: modules/network/vpc
 
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # PSA is required for all Parallelstore functionality.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
   - id: private_service_access
     source: community/modules/network/private-service-access
     use: [network]


### PR DESCRIPTION
This PR adds variations of the below note to examples that reference the `community/modules/network/private-service-access` module.

```
  # Private Service Access (PSA) requires the compute.networkAdmin role which is included in the Owner role, but not Editor
  # PSA is a best practice for Filestore instances, but can be optionally
  # removed by deleting the private_service_access module and any references to the module
  # by Filestore modules. PSA is required for all Parallelstore functionality.
  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
  - id: private_service_access
    source: community/modules/network/private-service-access
    use: [network]
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
