### PR TITLE
Fixing validation block error in Filestore module

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -190,7 +190,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -104,5 +104,10 @@ resource "google_filestore_instance" "filestore_instance" {
         BASIC_HDD or BASIC_SSD tiers. Otherwise the range size must be 24.
         EOT
     }
+
+    precondition {
+      condition     = !startswith(var.filestore_tier, "BASIC") || var.protocol != "NFS_V4_1"
+      error_message = "NFS_V4_1 is not supported on BASIC Filestore tiers."
+    }
   }
 }

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -92,6 +92,7 @@ variable "filestore_tier" {
       "BASIC_SSD",
       "HIGH_SCALE_SSD",
       "ZONAL",
+      "REGIONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
     error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -94,7 +94,7 @@ variable "filestore_tier" {
       "ZONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
-    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1beta1/Tier."
+    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
   }
 }
 

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -94,11 +94,7 @@ variable "filestore_tier" {
       "ZONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
-    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','HIGH_SCALE_SSD','ZONAL','ENTERPRISE'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1beta1/Tier."
-  }
-  validation {
-    condition     = !(var.protocol == "NFS_V4_1" && !contains(["HIGH_SCALE_SSD", "ZONAL", "REGIONAL", "ENTERPRISE"], var.filestore_tier))
-    error_message = "NFS_V4_1 is only supported with HIGH_SCALE_SSD, ZONAL, REGIONAL, or ENTERPRISE tiers."
+    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1beta1/Tier."
   }
 }
 

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.44.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = ">= 1.3.0"
 }


### PR DESCRIPTION
a validation block introduced in this [pr](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3418/files) causes an error during `terraform init` as a result of referencing another variable. In this PR, the validation block is replaced with a lifecycle precondition block.  

error:
```
'terraform init' failed, 'terraform validate' skipped: modules/file-system/filestore
Terraform encountered problems during initialisation, including problems
with the configuration, described below.

The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.
╷
│ Error: Invalid reference in variable validation
│ 
│   on variables.tf line 100, in variable "filestore_tier":
│  100:     condition     = !(var.protocol == "NFS_V4_1" && !contains(["HIGH_SCALE_SSD", "ZONAL", "REGIONAL", "ENTERPRISE"], var.filestore_tier))
│ 
│ The condition for variable "filestore_tier" can only refer to the variable
│ itself, using var.filestore_tier.
╵
```
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
