### PR TITLE
Improve dependency version coverage of Toolkit pre-commit

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -34,6 +34,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
+        # internal Python tests require Python 3.10
         python-version: '3.10'
         check-latest: true
         cache: 'pip'
@@ -44,6 +45,36 @@ jobs:
     - uses: hashicorp/setup-terraform@v3
       with:
         terraform_version: "1.5.7"
+        terraform_wrapper: false
+    - run: make install-dev-deps
+    - uses: terraform-linters/setup-tflint@v4
+      with:
+        tflint_version: v0.49.0
+    - run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --show-diff-on-failure --all-files
+  pre-commit-highest-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        # the slurm-files Python requirements.txt requires updating
+        # to enable 3.12+ compatibility
+        python-version: '3.11'
+        check-latest: true
+        cache: 'pip'
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.23'
+        check-latest: true
+    - uses: hashicorp/setup-terraform@v3
+      with:
+        terraform_version: latest
         terraform_wrapper: false
     - run: make install-dev-deps
     - uses: terraform-linters/setup-tflint@v4

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -15,4 +15,4 @@ grpcio-status==1.56.0
 httplib2==0.22.0
 more-executors==2.11.4
 pyyaml==6.0.2
-requests==2.32.0
+requests==2.32.3

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -11,7 +11,7 @@ google-cloud-tpu==1.10.0
 google-resumable-media==2.5.0
 googleapis-common-protos==1.59.1
 grpcio==1.56.2
-grpcio-status==1.56.0
+grpcio-status==1.56.2
 httplib2==0.22.0
 more-executors==2.11.4
 pyyaml==6.0.2

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -14,5 +14,5 @@ grpcio==1.56.2
 grpcio-status==1.56.0
 httplib2==0.22.0
 more-executors==2.11.4
-pyyaml==6.0
+pyyaml==6.0.2
 requests==2.32.0


### PR DESCRIPTION
Create a 2nd pre-commit job and refactor existing job such that:

1. 1 job runs against lowest supported versions of Go, Python, and Terraform. Reasoning: confirm our support claims.
2. The new 2nd job runs against latest releases of Go, Python, and Terraform. Reasoning: test against real-world user environments.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
