### PR TITLE
Update OFE virtualenv to address CVE-2024-53899

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -16,7 +16,7 @@ cryptography==43.0.1
 decorator==5.1.1
 defusedxml==0.7.1
 dill==0.3.6
-distlib==0.3.6
+distlib==0.3.7
 # django-revproxy==0.11.0 released but not yet in pypi
 git+https://github.com/jazzband/django-revproxy.git@d2234005135dc0771b7c4e0bb0465664ccfa5787
 Django==4.2.17
@@ -59,7 +59,7 @@ nodeenv==1.8.0
 oauthlib==3.2.2
 path==16.7.1
 pkgutil_resolve_name==1.3.10
-platformdirs==3.8.0
+platformdirs==3.9.1
 pre-commit==3.3.3
 proto-plus==1.22.3
 protobuf==4.23.3
@@ -94,7 +94,7 @@ typing_extensions==4.6.3
 uritemplate==4.1.1
 urllib3==1.26.19
 uvicorn==0.22.0
-virtualenv==20.23.1
+virtualenv==20.28.1
 wrapt==1.15.0
 xmltodict==0.13.0
 yq==3.2.2


### PR DESCRIPTION
Patch the upcoming v1.45.0 release branch to address security alert CVE-2024-53899.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
