### PR TITLE
Updating location for gke-managed-hyperdisk test

### DIFF
--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -16,8 +16,8 @@ blueprint_name: gke-managed-hyperdisk
 vars:
   project_id:  ## Set GCP Project ID Here ##
   deployment_name: gke-managed-hyperdisk
-  region: us-central1
-  zone: us-central1-c
+  region: europe-west1
+  zone: europe-west1-b
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -45,7 +45,7 @@ steps:
     echo '    use: [network]'                      >> $${SG_EXAMPLE}
     echo '    settings:'                           >> $${SG_EXAMPLE}
     echo '      machine_type: e2-standard-2'       >> $${SG_EXAMPLE}
-    echo '      zone: us-central1-a'               >> $${SG_EXAMPLE}
+    echo '      zone: europe-west1-b'               >> $${SG_EXAMPLE}
     # avoids conflict with other tests
     sed -i "s/gke-subnet/gke-subnet-$${BUILD_ID_SHORT}/" $${SG_EXAMPLE}
     IP=$(curl ifconfig.me)

--- a/tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml
@@ -14,8 +14,8 @@
 ---
 test_name: gke-managed-hyperdisk
 deployment_name: gke-managed-hyperdisk-{{ build }}
-zone: us-central1-a  # for remote node
-region: us-central1
+zone: europe-west1-b  # for remote node
+region: europe-west1
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-managed-hyperdisk.yaml"
 network: "{{ deployment_name }}-net"


### PR DESCRIPTION
This PR updates the location the gke-managed-hyperdisk integration test uses from us-central1 to europe-west1 for resource availability.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
