### PR TITLE
Updating A3 Ultra JBVM blueprint README documentation

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/README.md
+++ b/examples/machine-learning/a3-ultragpu-8g/README.md
@@ -1,16 +1,19 @@
 # A3 Ultra Blueprints
 
+## Slurm compute clusters
 For further information on deploying an A3 Ultra cluster with Slurm, please
 see:
 
 [Create A3 Ultra Slurm Cluster](https://cloud.google.com/ai-hypercomputer/docs/create/create-slurm-cluster)
 
-If you are unable to access these documents, please contact your
-[Technical Account Manager (TAM)](https://cloud.google.com/tam).
+## VMs without scheduler
 
-## Deploy A3 Ultra compute VM with custom startup-scripts
+To test workloads directly on A3 Ultra VMs, you can deploy the [a3ultra-vm.yaml]:
 
-Customers can deploy [a3ultra-vm.yaml] blueprint to deploy 2 A3 Ultra VMs. You
-can also specify custom startup-scripts to run in the blueprint.
+- A configurable number of A3 Ultra VMs (default N=2)
+- RDMA networking and GPU drivers pre-configured on our Ubuntu 22.04 Accelerator Image
+- Additional software environment customization can be achieved by adding to the example startup-script
+
+The VMs can be consumed from a reservation by modifying the `reservation_name` parameter in the `a3ultra-vms` module.
 
 [a3ultra-vm.yaml]: ./a3ultra-vm.yaml


### PR DESCRIPTION
This pr updates the A3 Ultra JBVM blueprint README documentation to explicitly highlight that there are 2 solutions in the folder:
- Slurm compute clusters
- VMs without scheduler

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
