### PR TITLE
Remove duplicative LimitNOFILE overrides

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
@@ -331,11 +331,6 @@ deployment_groups:
           * - cpu unlimited
           * - rtprio unlimited
       - type: data
-        destination: /etc/systemd/system/slurmd.service.d/file_ulimit.conf
-        content: |
-          [Service]
-          LimitNOFILE=infinity
-      - type: data
         destination: /etc/netplan/60-cloud-mrdma-init.yaml
         content: |
           network:

--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
@@ -110,11 +110,6 @@ deployment_groups:
           * - cpu unlimited
           * - rtprio unlimited
       - type: data
-        destination: /etc/systemd/system/slurmd.service.d/file_ulimit.conf
-        content: |
-          [Service]
-          LimitNOFILE=infinity
-      - type: data
         destination: /etc/systemd/system/delay-a3.service
         content: |
           [Unit]

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -97,11 +97,6 @@ deployment_groups:
           * - cpu unlimited
           * - rtprio unlimited
       - type: data
-        destination: /etc/systemd/system/slurmd.service.d/file_ulimit.conf
-        content: |
-          [Service]
-          LimitNOFILE=infinity
-      - type: data
         destination: /etc/netplan/60-cloud-mrdma-init.yaml
         content: |
           network:


### PR DESCRIPTION
The Slurm A3 series blueprints were patched to remove the limit on the number of open files by slurmd (and child processes including user workloads) but this override has also been present in the Slurm image building solution since tag 6.4.5.

https://github.com/GoogleCloudPlatform/slurm-gcp/pull/101

There is no downside to the override being present twice, but it is unnecessary and likely to lead to conflict if the desired value is changed. This PR removes the first file shown below which is winning the lexical prioritization by which SystemD processes drop-in files. 

```
tpdownes_google_com@a3ugcs-controller:~$ tail -v -n +1 /etc/systemd/system/slurmd.service.d/*.conf
==> /etc/systemd/system/slurmd.service.d/file_ulimit.conf <==
[Service]
LimitNOFILE=infinity

==> /etc/systemd/system/slurmd.service.d/overrides.conf <==
[Service]
LimitNOFILE=infinity
RestartSec=15s
Restart=on-failure

tpdownes_google_com@a3ugcs-controller:~$ sudo systemctl status slurmd.service
○ slurmd.service - Slurm node daemon
     Loaded: loaded (/lib/systemd/system/slurmd.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/slurmd.service.d
             └─file_ulimit.conf, overrides.conf
     Active: inactive (dead)
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
