### PR TITLE
Remove expanded blueprint from A3U Slurm solution

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -62,9 +62,6 @@ deployment_groups:
         enabled: true
       runners:
       - type: data
-        destination: /etc/cluster_toolkit/a3ultra-prod-slurm-image.yaml
-        source: ../.ghpc/artifacts/expanded_blueprint.yaml
-      - type: data
         destination: /var/tmp/slurm_vars.json
         content: |
           {


### PR DESCRIPTION
The placement of this file inside the cluster was primarily for development purposes and it is not being updated upon repeated invocations of `gcluster deploy`. We should remove the file in favor of an approach with guaranteed synchronization.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
