### PR TITLE
Remove netplan from A3 Ultra Slurm solution

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -93,47 +93,6 @@ deployment_groups:
           * - nofile 1048576
           * - cpu unlimited
           * - rtprio unlimited
-      - type: data
-        destination: /etc/netplan/60-cloud-mrdma-init.yaml
-        content: |
-          network:
-            ethernets:
-              primary:
-                match:
-                  name: enp0s*
-                  driver: gve
-                dhcp4: true
-                dhcp4-overrides:
-                  use-domains: true
-                dhcp6: true
-                dhcp6-overrides:
-                  use-domains: true
-                optional: true
-              secondary:
-                match:
-                  driver: gve
-                dhcp4: true
-                dhcp4-overrides:
-                  use-domains: false
-                  use-dns: false
-                  use-ntp: false
-                dhcp6: true
-                dhcp6-overrides:
-                  use-domains: false
-                  use-dns: false
-                  use-ntp: false
-                optional: true
-              mrdma_devices:
-                match:
-                  driver: mlx5_core
-                dhcp-identifier: mac
-                dhcp4: true
-                dhcp4-overrides:
-                  use-domains: true
-                  use-dns: false
-                  use-ntp: false
-                optional: true
-            version: 2
       - type: ansible-local
         destination: configure_gpu.yml
         content: |
@@ -194,10 +153,10 @@ deployment_groups:
                 state: stopped
                 enabled: false
       - type: ansible-local
-        destination: install_mellanox_drivers.yml
+        destination: install_ibverbs_utils.yml
         content: |
           ---
-          - name: Update Netplan and Install Network Utils
+          - name: Install ibverbs-utils
             hosts: all
             become: true
             tasks:
@@ -206,8 +165,6 @@ deployment_groups:
                 name:
                 - ibverbs-utils
                 state: present
-            - name: Apply netplan
-              ansible.builtin.command: netplan apply
 
 - group: image
   modules:


### PR DESCRIPTION
Updates to Guest OS packages obviate the need for an explict netplan on a3-ultragpu-8g VM types.

## Testing

1. Interfaces still come up cleanly (see below)
2. 2-node NCCL tests reports expected bandwidth

### Evidence

```
tpdownes_google_com@pr3556-a3ultranodeset-0:~$ ip link
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
2: enp0s19: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 42:01:c0:a8:00:04 brd ff:ff:ff:ff:ff:ff
3: enp192s20: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 42:01:c0:a8:40:02 brd ff:ff:ff:ff:ff:ff
4: enp145s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 3e:43:dd:9a:f7:01 brd ff:ff:ff:ff:ff:ff
5: enp146s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 12:8a:bf:ba:82:04 brd ff:ff:ff:ff:ff:ff
6: enp152s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 2a:57:30:28:5d:07 brd ff:ff:ff:ff:ff:ff
7: enp153s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 5a:9e:c5:c3:bb:0a brd ff:ff:ff:ff:ff:ff
8: enp198s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 76:54:c0:5e:02:0d brd ff:ff:ff:ff:ff:ff
9: enp199s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether 8e:b1:e8:2f:b9:10 brd ff:ff:ff:ff:ff:ff
10: enp205s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether a6:a3:c3:a3:60:13 brd ff:ff:ff:ff:ff:ff
11: enp206s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8896 qdisc mq state UP mode DEFAULT group default qlen 1000
    link/ether fa:63:60:61:3d:16 brd ff:ff:ff:ff:ff:ff
12: docker0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default
    link/ether 02:42:d2:d7:61:28 brd ff:ff:ff:ff:ff:ff
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
