### PR TITLE
Set correct go toolchain version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # PREAMBLE
 MIN_PACKER_VERSION=1.7.9 # for building images
 MIN_TERRAFORM_VERSION=1.5.7 # for deploying modules
-MIN_GOLANG_VERSION=1.18 # for building gcluster
+MIN_GOLANG_VERSION=1.22 # for building gcluster
 
 .PHONY: install install-user tests format install-dev-deps \
         warn-go-missing warn-terraform-missing warn-packer-missing \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hpc-toolkit
 
-go 1.22
+go 1.22.0
 
 require (
 	cloud.google.com/go/storage v1.41.0 // indirect

--- a/tools/cloud-build/provision/pr-go-build-test.tf
+++ b/tools/cloud-build/provision/pr-go-build-test.tf
@@ -14,6 +14,7 @@
 
 
 resource "google_cloudbuild_trigger" "pr_go_build_test" {
+  # NOTE: make sure that go.mod:go and Makefile:MIN_GOLANG_VERSION match lowest version.
   for_each = toset(["1.22", "1.23"])
 
   name        = "PR-Go-${replace(each.key, ".", "-")}-build-test"


### PR DESCRIPTION
> As of Go 1.21, toolchain versions must use the 1.N.P syntax.

* Update `go.mod:go` `1.22 -> 1.22.0`;
* Update Makefile go-version check, not breaking change, on older versions of go inconsequential warning message will be shown;
* Add reminder to keep go-versions consistent across multiple toolings.