### PR TITLE
Fix time parsing

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/base.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/base.py
@@ -1,0 +1,79 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List
+
+import addict
+from dataclasses import dataclass
+from datetime import datetime
+
+
+def parse_gcp_timestamp(s: str) -> datetime:
+  """
+  Parse timestamp strings returned by GCP API into datetime.
+  Works with both Zulu and non-Zulu timestamps.
+  """
+  # Requires Python >= 3.7
+  # TODO: Remove this "hack" of trimming the Z from timestamps once we move to Python 3.11 
+  # (context: https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220/30)
+  return datetime.fromisoformat(s.replace('Z', '+00:00'))
+
+
+@dataclass(frozen=True)
+class Instance:
+  name: str
+  status: str
+  creation_timestamp: datetime
+
+  # TODO: use proper InstanceResourceStatus class
+  resource_status: addict.Dict
+  # TODO: use proper InstanceScheduling class
+  scheduling: addict.Dict
+  # TODO: use proper UpcomingMaintenance class
+  upcoming_maintenance: Optional[addict.Dict] = None
+
+  @classmethod
+  def from_json(cls, jo: dict) -> "Instance":
+    return cls(
+      name=jo["name"],
+      status=jo["status"],
+      creation_timestamp=parse_gcp_timestamp(jo["creationTimestamp"]),
+      resource_status=addict.Dict(jo["resourceStatus"]),
+      scheduling=addict.Dict(jo["scheduling"]),
+      upcoming_maintenance=addict.Dict(jo["upcomingMaintenance"]) if "upcomingMaintenance" in jo else None
+    )
+  
+
+@dataclass(frozen=True)
+class ReservationDetails:
+    project: str
+    zone: str
+    name: str
+    policies: List[str] # names (not URLs) of resource policies
+    bulk_insert_name: str # name in format suitable for bulk insert (currently identical to user supplied name in long format)
+    deployment_type: Optional[str]
+
+    @property
+    def dense(self) -> bool:
+        return self.deployment_type == "DENSE"
+
+@dataclass(frozen=True)
+class FutureReservation:
+    project: str
+    zone: str
+    name: str
+    specific: bool
+    start_time: datetime
+    end_time: datetime
+    active_reservation: Optional[ReservationDetails]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -563,7 +563,7 @@ def add_nodeset_topology(
         except Exception:
             continue
     
-        phys_host = inst.resourceStatus.get("physicalHost", "")
+        phys_host = inst.resource_status.get("physicalHost", "")
         bldr.summary.physical_host[inst.name] = phys_host
         up_nodes.add(inst.name)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -43,6 +43,7 @@ from util import (
 )
 from util import lookup, NSDict
 import tpu
+from base import ReservationDetails
 
 log = logging.getLogger()
 
@@ -104,6 +105,7 @@ def instance_properties(nodeset:object, model:str, placement_group:Optional[str]
         update_reservation_props(reservation, props, placement_group)
 
     if (fr := lookup().future_reservation(nodeset)) and fr.specific:
+        assert fr.active_reservation
         update_reservation_props(fr.active_reservation, props, placement_group)
 
     if props.resourcePolicies:
@@ -119,7 +121,7 @@ def instance_properties(nodeset:object, model:str, placement_group:Optional[str]
     props.update(nodeset.get("instance_properties") or {})
     return props
 
-def update_reservation_props(reservation:object, props:object, placement_group:Optional[str]) -> None:
+def update_reservation_props(reservation:ReservationDetails, props:object, placement_group:Optional[str]) -> None:
     props.reservationAffinity = {
         "consumeReservationType": "SPECIFIC_RESERVATION",
         "key": f"compute.{util.universe_domain()}/reservation-name",

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -15,14 +15,20 @@
 from typing import Optional, Any
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime
+import addict
+
 
 SCRIPTS_DIR = "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts"
 if SCRIPTS_DIR not in sys.path:
     sys.path.append(SCRIPTS_DIR)  # TODO: make this more robust
 
 import util
+from base import Instance
 
 # TODO: use "real" classes once they are defined (instead of NSDict)
+
+SOME_TS = datetime.fromisoformat("2018-09-03T20:56:35.450686+00:00")
 
 @dataclass
 class Placeholder:
@@ -83,17 +89,17 @@ class TstMachineConf:
 class TstTemplateInfo:
     gpu: Optional[util.AcceleratorInfo]
 
-@dataclass
-class TstInstance:
-    name: str
-    region: str = "gondor"
-    zone: str = "anorien"
-    placementPolicyId: Optional[str] = None
-    physicalHost: Optional[str] = None
-
-    @property
-    def resourceStatus(self):
-        return {"physicalHost": self.physicalHost}
+def tstInstance(name: str, physical_host: Optional[str] = None):
+    return Instance(
+        name=name,
+        status="RUNNING",
+        creation_timestamp=SOME_TS,
+        resource_status=addict.Dict(
+            physicalHost = physical_host
+        ),
+        scheduling=addict.Dict(),
+        upcoming_maintenance=None,
+    )
 
 def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
     tbl = tbl or {}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
@@ -16,7 +16,7 @@ import pytest
 import json
 import mock
 from pytest_unordered import unordered
-from common import TstCfg, TstNodeset, TstTPU, TstInstance
+from common import TstCfg, TstNodeset, TstTPU, tstInstance
 import sort_nodes
 
 import util
@@ -62,13 +62,13 @@ def test_gen_topology_conf(tpu_mock):
     lkp = util.Lookup(cfg)
     lkp.instances = lambda: { n.name: n for n in [
         # nodeset blue
-        TstInstance("m22-blue-0"),  # no physicalHost
-        TstInstance("m22-blue-0", physicalHost="/a/a/a"),
-        TstInstance("m22-blue-1", physicalHost="/a/a/b"),
-        TstInstance("m22-blue-2", physicalHost="/a/b/a"),
-        TstInstance("m22-blue-3", physicalHost="/b/a/a"),
+        tstInstance("m22-blue-0"),  # no physicalHost
+        tstInstance("m22-blue-0", physical_host="/a/a/a"),
+        tstInstance("m22-blue-1", physical_host="/a/a/b"),
+        tstInstance("m22-blue-2", physical_host="/a/b/a"),
+        tstInstance("m22-blue-3", physical_host="/b/a/a"),
         # nodeset green
-        TstInstance("m22-green-3", physicalHost="/a/a/c"),
+        tstInstance("m22-green-3", physical_host="/a/a/c"),
     ]}
 
     uncompressed = conf.gen_topology(lkp)
@@ -173,19 +173,19 @@ def test_gen_topology_conf_update():
     # don't dump
 
     # set empty physicalHost - no reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == False
     # don't dump
 
     # set physicalHost - reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="/a/b/c")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="/a/b/c")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == True
     sum.dump(lkp)
 
     # change physicalHost - reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="/a/b/z")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="/a/b/z")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == True
     sum.dump(lkp)
@@ -203,6 +203,6 @@ def test_gen_topology_conf_update():
         (["z/n-0", "z/n-1", "z/n-2", "z/n-3", "z/n-4", "z/n-10"], ['n-0', 'n-1', 'n-2', 'n-3', 'n-4', 'n-10']),
         (["y/n-0", "z/n-1", "x/n-2", "x/n-3", "y/n-4", "g/n-10"], ['n-0', 'n-4', 'n-1', 'n-2', 'n-3', 'n-10']),
     ])
-def test_sort_nodes_order(paths: list[list[str]], expected: list[str]) -> None:
-    paths = [l.split("/") for l in paths]
-    assert sort_nodes.order(paths) == expected
+def test_sort_nodes_order(paths: list[str], expected: list[str]) -> None:
+    paths_expanded = [l.split("/") for l in paths]
+    assert sort_nodes.order(paths_expanded) == expected

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -16,11 +16,13 @@ from typing import Optional, Type
 
 import pytest
 from mock import Mock
+from datetime import datetime, timezone, timedelta
+
 from common import TstNodeset, TstCfg # needed to import util
 import util
 from util import NodeState, MachineType, AcceleratorInfo
-from datetime import timedelta
 from google.api_core.client_options import ClientOptions  # noqa: E402
+from base import parse_gcp_timestamp
 
 # Note: need to install pytest-mock
 
@@ -400,3 +402,18 @@ def test_node_state(node: str, state: Optional[NodeState], want: NodeState | Non
     ])
 def test_MachineType_from_json(jo: dict, want: MachineType):
     assert MachineType.from_json(jo) == want
+
+UTC, PST = timezone.utc, timezone(timedelta(hours=-8))
+
+@pytest.mark.parametrize(
+    "got,want",
+    [
+        # from instance.creationTimestamp: 
+        ("2024-11-30T12:47:51.676-08:00", datetime(2024, 11, 30, 12, 47, 51, 676000, tzinfo=PST)),
+        # from futureReservation.creationTimestamp
+        ("2024-11-05T15:23:33.702-08:00", datetime(2024, 11, 5, 15, 23, 33, 702000, tzinfo=PST)), 
+        # from futureReservation.timeWindow.endTime
+        ("2025-01-15T00:00:00Z", datetime(2025, 1, 15, 0, 0, tzinfo=UTC)),
+    ])
+def test_parse_gcp_timestamp(got: str, want: datetime):
+    assert parse_gcp_timestamp(got) == want


### PR DESCRIPTION
* Clean up time parsing
  * stop  using "to be deprecated" `datetime.utcnow`;
  * fix bug in "Zulu-hack", there is no guarantee that future reservation will always use Zulu-format;
  * Have just one function to parse timestamps from GCP.


* Add `Instance` dataclass for better type constraints;

```sh
$ mypy community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts --explicit-package-bases
# Before
Found 98 errors in 11 files (checked 16 source files)
# After
Found 80 errors in 11 files (checked 17 source files)
```

* Reduce number of fields to retrieve from aggregated list of VMs
Remove unused fields, on tested example cluster of 40 nodes, the reduction in resulting JSON size is X46 (1153KB -> 25KB)