### PR TITLE
enable queued provisioning on gke nodepool

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/README.md
+++ b/community/modules/file-system/DDN-EXAScaler/README.md
@@ -4,7 +4,7 @@ This module creates a DDN EXAScaler Cloud Lustre file system using
 [exascaler-cloud-terraform](https://github.com/DDNStorage/exascaler-cloud-terraform/tree/master/gcp).
 
 More information about the architecture can be found at
-[Architecture: Lustre file system in Google Cloud using DDN EXAScaler][architecture].
+[Overview of Lustre and EXAScaler Cloud][architecture].
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../../docs/network_storage.md).
@@ -22,7 +22,7 @@ Toolkit, see the extended [Network Storage documentation](../../../../docs/netwo
 
 [private-google-access]: https://cloud.google.com/vpc/docs/configure-private-google-access
 [marketplace]: https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
-[architecture]: https://cloud.google.com/architecture/lustre-architecture
+[architecture]: https://cloud.google.com/architecture/parallel-file-systems-for-hpc#overview_of_lustre_and_exascaler_cloud
 
 ## Mounting
 

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -279,16 +279,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | > 5 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | > 6.16 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 6.16 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | > 5 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 5 |
+| <a name="provider_google"></a> [google](#provider\_google) | > 6.16 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 6.16 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
@@ -314,6 +314,7 @@ limitations under the License.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for GKE, if any. Providing additional networks adds additional node networks to the node pool | <pre>list(object({<br/>    network            = string<br/>    subnetwork         = string<br/>    subnetwork_project = string<br/>    network_ip         = string<br/>    nic_type           = string<br/>    stack_type         = string<br/>    queue_count        = number<br/>    access_config = list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    }))<br/>    ipv6_access_config = list(object({<br/>      network_tier = string<br/>    }))<br/>    alias_ip_range = list(object({<br/>      ip_cidr_range         = string<br/>      subnetwork_range_name = string<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_auto_repair"></a> [auto\_repair](#input\_auto\_repair) | Whether the nodes will be automatically repaired. | `bool` | `true` | no |
 | <a name="input_auto_upgrade"></a> [auto\_upgrade](#input\_auto\_upgrade) | Whether the nodes will be automatically upgraded. | `bool` | `false` | no |
 | <a name="input_autoscaling_total_max_nodes"></a> [autoscaling\_total\_max\_nodes](#input\_autoscaling\_total\_max\_nodes) | Total maximum number of nodes in the NodePool. | `number` | `1000` | no |
 | <a name="input_autoscaling_total_min_nodes"></a> [autoscaling\_total\_min\_nodes](#input\_autoscaling\_total\_min\_nodes) | Total minimum number of nodes in the NodePool. | `number` | `0` | no |
@@ -322,6 +323,7 @@ limitations under the License.
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of disk for each node. | `number` | `100` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Disk type for each node. | `string` | `null` | no |
 | <a name="input_enable_gcfs"></a> [enable\_gcfs](#input\_enable\_gcfs) | Enable the Google Container Filesystem (GCFS). See [restrictions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#gcfs_config). | `bool` | `false` | no |
+| <a name="input_enable_queued_provisioning"></a> [enable\_queued\_provisioning](#input\_enable\_queued\_provisioning) | If true, enables Dynamic Workload Scheduler and adds the cloud.google.com/gke-queued taint to the node pool. | `bool` | `false` | no |
 | <a name="input_enable_secure_boot"></a> [enable\_secure\_boot](#input\_enable\_secure\_boot) | Enable secure boot for the nodes.  Keep enabled unless custom kernel modules need to be loaded. See [here](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot) for more info. | `bool` | `true` | no |
 | <a name="input_gke_cluster_exists"></a> [gke\_cluster\_exists](#input\_gke\_cluster\_exists) | A static flag that signals to modules that a cluster has been created. | `bool` | `false` | no |
 | <a name="input_gke_version"></a> [gke\_version](#input\_gke\_version) | GKE version | `string` | n/a | yes |

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -89,7 +89,7 @@ resource "google_container_node_pool" "node_pool" {
   max_pods_per_node = var.max_pods_per_node
 
   management {
-    auto_repair  = true
+    auto_repair  = var.auto_repair
     auto_upgrade = var.auto_upgrade
   }
 
@@ -104,6 +104,13 @@ resource "google_container_node_pool" "node_pool" {
     content {
       type        = var.placement_policy.type
       policy_name = var.placement_policy.name
+    }
+  }
+
+  dynamic "queued_provisioning" {
+    for_each = var.enable_queued_provisioning ? [1] : []
+    content {
+      enabled = true
     }
   }
 
@@ -328,6 +335,14 @@ resource "google_container_node_pool" "node_pool" {
     precondition {
       condition     = var.placement_policy.type != "COMPACT" || local.upgrade_settings.strategy != "BLUE_GREEN"
       error_message = "Compact placement is not supported with blue-green upgrades."
+    }
+    precondition {
+      condition     = !(var.enable_queued_provisioning == true && var.placement_policy.type == "COMPACT")
+      error_message = "placement_policy cannot be COMPACT when enable_queued_provisioning is true."
+    }
+    precondition {
+      condition     = !(var.enable_queued_provisioning == true && var.reservation_affinity.consume_reservation_type != "NO_RESERVATION")
+      error_message = "reservation_affinity should be NO_RESERVATION when enable_queued_provisioning is true."
     }
   }
 }

--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -160,6 +160,12 @@ variable "static_node_count" {
   default     = null
 }
 
+variable "auto_repair" {
+  description = "Whether the nodes will be automatically repaired."
+  type        = bool
+  default     = true
+}
+
 variable "auto_upgrade" {
   description = "Whether the nodes will be automatically upgraded."
   type        = bool
@@ -420,4 +426,10 @@ variable "run_workload_script" {
   description = "Whether execute the script to create a sample workload and inject rxdm sidecar into workload. Currently, implemented for A3-Highgpu and A3-Megagpu only."
   type        = bool
   default     = true
+}
+
+variable "enable_queued_provisioning" {
+  description = "If true, enables Dynamic Workload Scheduler and adds the cloud.google.com/gke-queued taint to the node pool."
+  type        = bool
+  default     = false
 }

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 5"
+      version = "> 6.16"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 5"
+      version = "> 6.16"
     }
     null = {
       source  = "hashicorp/null"
@@ -30,6 +30,9 @@ terraform {
     }
   }
   provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.45.0"
+  }
+  provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.45.0"
   }
 }


### PR DESCRIPTION
Enable queued provisioning on gke nodepool.
- Add the enable_queued_provisioning boolean variable.
- Update google-beta provider version to 5.21 (associated with queued_provisioning GA)
- Add precondition to ensure placement_policy is not set to COMPACT when enable_queued_provisioning is true.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
