### PR TITLE
Improve GKE service account posture by aligning with GKE best practices

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -42,16 +42,28 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
       - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: gpunets
@@ -65,10 +77,11 @@ deployment_groups:
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gpunets, gke_service_account]
+    use: [network1, gpunets, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine run kubectl command. It's required for the multi-network setup.
         display_name: "kubectl-access-network"
@@ -76,7 +89,7 @@ deployment_groups:
 
   - id: a3_highgpu_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gpunets, gke_service_account]
+    use: [gke_cluster, gpunets, node_pool_service_account]
     settings:
       machine_type: a3-highgpu-8g
       autoscaling_total_min_nodes: 2

--- a/examples/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu.yaml
@@ -42,16 +42,28 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
       - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: gpunets
@@ -65,10 +77,11 @@ deployment_groups:
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gpunets, gke_service_account]
+    use: [network1, gpunets, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine run kubectl command. It's required for the multi-network setup.
         display_name: "kubectl-access-network"
@@ -76,7 +89,7 @@ deployment_groups:
 
   - id: a3_megagpu_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gpunets, gke_service_account]
+    use: [gke_cluster, gpunets, node_pool_service_account]
     settings:
       machine_type: a3-megagpu-8g
       autoscaling_total_min_nodes: 2

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -93,9 +93,33 @@ deployment_groups:
         ip_range: 192.168.128.0/18
         region: $(vars.region)
 
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: a3-ultragpu-cluster
     source: modules/scheduler/gke-cluster
-    use: [gke-a3-ultra-net-0]
+    use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
       system_node_pool_machine_type: "e2-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
@@ -103,6 +127,7 @@ deployment_groups:
       enable_dcgm_monitoring: true
       enable_gcsfuse_csi: true
       enable_private_endpoint: false # Allows access from authorized public IPs
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
@@ -135,7 +160,7 @@ deployment_groups:
 
   - id: a3-ultragpu-pool
     source: modules/compute/gke-node-pool
-    use: [a3-ultragpu-cluster]
+    use: [a3-ultragpu-cluster, node_pool_service_account]
     settings:
       machine_type: a3-ultragpu-8g
       auto_upgrade: true

--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -37,9 +37,33 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network]
+    use: [network, workload_service_account]
     settings:
       release_channel: RAPID
       enable_persistent_disk_csi: true # enable Hyperdisk for the cluster
@@ -94,7 +118,7 @@ deployment_groups:
 
   - id: sample-pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: sample-pool
       zones: [$(vars.zone)]

--- a/examples/gke-managed-parallelstore.yaml
+++ b/examples/gke-managed-parallelstore.yaml
@@ -63,9 +63,33 @@ deployment_groups:
         allow:
         - protocol: tcp
 
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network]
+    use: [network, workload_service_account]
     settings:
       release_channel: RAPID
       enable_parallelstore_csi: true # enable Parallelstore for the cluster
@@ -97,7 +121,7 @@ deployment_groups:
 
   - id: sample-pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: sample-pool
       zones: [$(vars.zone)]

--- a/examples/hpc-gke.yaml
+++ b/examples/hpc-gke.yaml
@@ -37,10 +37,10 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
@@ -49,17 +49,30 @@ deployment_groups:
       - storage.objectViewer
       - artifactregistry.reader
 
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gke_service_account]
+    use: [network1, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      configure_workload_identity_sa: true
     outputs: [instructions]
 
   - id: compute_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
 
   - id: job-template
     source: modules/compute/gke-job-template

--- a/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
@@ -94,9 +94,33 @@ deployment_groups:
         ip_range: 192.168.128.0/18
         region: $(vars.region)
 
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: a3-ultragpu-cluster
     source: modules/scheduler/gke-cluster
-    use: [gke-a3-ultra-net-0]
+    use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
       release_channel: RAPID
       system_node_pool_machine_type: "e2-standard-16"
@@ -105,6 +129,7 @@ deployment_groups:
       enable_dcgm_monitoring: true
       enable_gcsfuse_csi: true
       enable_private_endpoint: false # Allows access from authorized public IPs
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
@@ -133,7 +158,7 @@ deployment_groups:
 
   - id: a3-ultragpu-pool
     source: modules/compute/gke-node-pool
-    use: [a3-ultragpu-cluster]
+    use: [a3-ultragpu-cluster, node_pool_service_account]
     settings:
       machine_type: a3-ultragpu-8g
       auto_upgrade: true

--- a/examples/ml-gke.yaml
+++ b/examples/ml-gke.yaml
@@ -41,10 +41,10 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
@@ -53,9 +53,21 @@ deployment_groups:
       - storage.objectViewer
       - artifactregistry.reader
 
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gke_service_account]
+    use: [network1, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
@@ -67,7 +79,7 @@ deployment_groups:
 
   - id: g2_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       disk_type: pd-balanced
       machine_type: g2-standard-4

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -39,10 +39,10 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
@@ -51,9 +51,21 @@ deployment_groups:
       - storage.objectViewer
       - artifactregistry.reader
 
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gke_service_account]
+    use: [network1, workload_service_account]
     settings:
       enable_filestore_csi: true
       enable_gcsfuse_csi: true
@@ -67,7 +79,7 @@ deployment_groups:
 
   - id: debug_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: debug
       zones: [$(vars.zone)]
@@ -132,7 +144,7 @@ deployment_groups:
 
   - id: local-ssd-pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: local-ssd
       machine_type: n2d-standard-2

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -365,16 +365,19 @@ module "workload_identity" {
   version = "~> 34.0"
 
   use_existing_gcp_sa = true
-  name                = "workload-identity-k8-sa"
+  name                = "workload-identity-k8s-sa"
   gcp_sa_name         = local.sa_email
   project_id          = var.project_id
-  roles               = var.enable_gcsfuse_csi ? ["roles/storage.admin"] : []
 
   # https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1059
   depends_on = [
     data.google_project.project,
     google_container_cluster.gke_cluster
   ]
+}
+
+locals {
+  k8s_service_account_name = one(module.workload_identity[*].k8s_service_account_name)
 }
 
 module "kubectl_apply" {

--- a/modules/scheduler/gke-cluster/outputs.tf
+++ b/modules/scheduler/gke-cluster/outputs.tf
@@ -66,13 +66,18 @@ output "instructions" {
         gcloud container clusters get-credentials ${google_container_cluster.gke_cluster.name} \
           --region ${google_container_cluster.gke_cluster.location} \
           --project ${var.project_id}
+
+      Use the following Kubernetes Service Account in the default namespace to run your workloads:
+        ${local.k8s_service_account_name}
+      The GCP Service Account mapped to this Kubernetes Service Account is:
+        ${local.sa_email}
     EOT
   )
 }
 
 output "k8s_service_account_name" {
   description = "Name of k8s service account."
-  value       = one(module.workload_identity[*].k8s_service_account_name)
+  value       = local.k8s_service_account_name
 }
 
 output "gke_version" {

--- a/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
@@ -42,16 +42,28 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
       - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: gpunets
@@ -65,10 +77,11 @@ deployment_groups:
 
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gpunets, gke_service_account]
+    use: [network1, gpunets, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       release_channel: 'RAPID'
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine run kubectl command. It's required for the multi-network setup.
         display_name: "kubectl-access-network"
@@ -76,7 +89,7 @@ deployment_groups:
 
   - id: a2_highgpu_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gpunets, gke_service_account]
+    use: [gke_cluster, gpunets, node_pool_service_account]
     settings:
       auto_upgrade: true
       machine_type: a2-highgpu-2g

--- a/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -41,10 +41,10 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
-  - id: gke_service_account
+  - id: node_pool_service_account
     source: community/modules/project/service-account
     settings:
-      name: gke-sa
+      name: gke-np-sa
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
@@ -53,12 +53,25 @@ deployment_groups:
       - storage.objectViewer
       - artifactregistry.reader
 
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, gke_service_account]
+    use: [network1, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - display_name: deployment-machine
         cidr_block: $(vars.authorized_cidr)
@@ -66,7 +79,7 @@ deployment_groups:
 
   - id: g2_latest_driver
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: g2-latest-driver
       machine_type: g2-standard-4
@@ -97,7 +110,7 @@ deployment_groups:
 
   - id: n1_pool_default
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: n1-pool-default
       disk_type: pd-balanced
@@ -125,7 +138,7 @@ deployment_groups:
 
   - id: n1_pool_full_spec
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: n1-pool-full-spec
       disk_type: pd-balanced
@@ -159,7 +172,7 @@ deployment_groups:
 
   - id: default_settings_pool
     source: modules/compute/gke-node-pool
-    use: [gke_cluster, gke_service_account]
+    use: [gke_cluster, node_pool_service_account]
     settings:
       name: default-settings-pool
 

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -18,6 +18,7 @@ tags:
 - gke
 - m.gke-cluster
 - m.gke-node-pool
+- m.service-account
 - m.gpu-rdma-vpc
 - m.kubectl-apply
 - m.vpc

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -18,6 +18,7 @@ tags:
 - m.gke-job-template
 - m.gke-node-pool
 - m.gke-storage
+- m.service-account
 - m.vpc
 - gke
 

--- a/tools/cloud-build/daily-tests/builds/gke-managed-parallelstore.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-parallelstore.yaml
@@ -19,6 +19,7 @@ tags:
 - m.gke-job-template
 - m.gke-node-pool
 - m.gke-storage
+- m.service-account
 - m.private-service-access
 - m.vpc
 - gke

--- a/tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 test_name: gke-managed-hyperdisk
-deployment_name: gke-managed-hyperdisk-{{ build }}
+deployment_name: gke-hyperdisk-{{ build }}
 zone: europe-west1-b  # for remote node
 region: europe-west1
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/gke-managed-parallelstore.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-parallelstore.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 test_name: gke-managed-parallelstore
-deployment_name: gke-managed-parallelstore-{{ build }}
+deployment_name: gke-ps-{{ build }}
 zone: us-central1-a  # for remote node
 region: us-central1
 workspace: /workspace


### PR DESCRIPTION
## Changes:
1. Create separate service accounts for workloads and node-pools in all GKE reference blueprints
2. Enable workload identity in all GKE reference blueprints

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
