### PR TITLE
Added support for clean target to remove gcluster binary and the ghpc…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ SHELL=/bin/bash -o pipefail
 ENG = ./cmd/... ./pkg/...
 TERRAFORM_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.tf" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
 PACKER_FOLDERS=$(shell find ./modules ./community/modules ./tools -type f -name "*.pkr.hcl" -not -path '*/\.*' -exec dirname "{}" \; | sort -u)
+BINARY_TARGETS := ghpc gcluster
+INSTALL_DIRS := . ~/bin /usr/local/bin
 
 ifneq (, $(shell which git))
 ## GIT IS PRESENT
@@ -71,6 +73,23 @@ install-dev-deps: warn-terraform-version warn-packer-version check-pre-commit ch
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	pip install -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
 	pip install -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/requirements.txt
+
+
+clean:
+	@for dir in $(INSTALL_DIRS); do \
+		for file in $(BINARY_TARGETS); do \
+			if [ -f "$$dir/$$file" ] || [ -L "$$dir/$$file" ]; then \
+				if [ -w "$$dir/$$file" ]; then \
+					echo "Removing $$dir/$$file"; \
+					rm "$$dir/$$file"; \
+				else \
+					echo "Do not have permissions to delete $$dir/$$file"; \
+				fi; \
+			else \
+				echo "$$dir/$$file does not exist"; \
+			fi; \
+		done; \
+	done
 
 # RULES SUPPORTING THE ABOVE
 


### PR DESCRIPTION
This CL updates the Makefile to add a "clean" make target. Running "make clean" will remove the regular file "gcluster" and the symlink "ghpc" (links to gcluster).

This PR to removes the build targets from the following directories after checking if the files exist and if it has permissions to delete them:
- current dir
- ~/bin
- /usr/local/bin


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
