### PR TITLE
Add integration test for a3ultra-vm.yaml

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -21,6 +21,8 @@ vars:
   deployment_name: a3ultra-vm-instance
   region: europe-west1
   zone: europe-west1-b
+  a3u_reservation_name: # supply reservation name
+  a3u_provisioning_model: RESERVATION_BOUND
   instance_image:
     project: ubuntu-os-accelerator-images
     family: ubuntu-accelerator-2204-amd64-with-nvidia-550
@@ -114,7 +116,8 @@ deployment_groups:
       disk_type: hyperdisk-balanced
       automatic_restart: true
       on_host_maintenance: TERMINATE
-      reservation_name: # supply reservation name
+      reservation_name: $(vars.a3u_reservation_name)
+      provisioning_model: $(vars.a3u_provisioning_model)
       network_interfaces:
         $(concat(
           [{

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-nvidia-smi.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-nvidia-smi.yml
@@ -1,0 +1,23 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Run nvidia-smi command
+  command: nvidia-smi
+  register: nvidia_smi_result
+  failed_when: nvidia_smi_result.rc != 0
+
+- name: Print nvidia-smi output
+  debug:
+    var: nvidia_smi_result.stdout_lines

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -1,0 +1,49 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- vm
+- m.filestore
+- m.gpu-rdma-vpc
+- m.startup-script
+- m.vpc
+- m.vm-instance
+- m.wait-for-startup
+
+timeout: 14400s  # 4hr
+steps:
+- id: ml-a3-ultragpu-jbvms
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    REGION=europe-west1
+    ZONE=europe-west1-b
+    BLUEPRINT="/workspace/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml"
+    sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
+    sed -i -e '/reason:/d' $${BLUEPRINT}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
@@ -1,0 +1,38 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined in build file with --extra-vars flag!
+test_name: a3u-jbvms
+deployment_name: a3u-jbvms-{{ build }}
+hostname_prefix: "{{ deployment_name }}-beowulf"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml"
+region: europe-west1
+zone: europe-west1-b
+network: "{{ deployment_name }}-net-0"
+remote_node: "{{ hostname_prefix }}-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-nvidia-smi.yml
+custom_vars:
+  mounts:
+  - /home
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  disk_size_gb: 200
+  a3u_reservation_name: hpc-exfr-2
+  a3u_provisioning_model: RESERVATION_BOUND


### PR DESCRIPTION
This PR adds an integration test for the [a3ultra-vm.yaml blueprint](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml). The integration test deploys the a3ultra-vm.yaml blueprint and runs `nvidia-smi` on `remote_node: "{{ hostname_prefix }}-0"`. 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
