### PR TITLE
Use `dataclass` for GCP instance

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -563,7 +563,7 @@ def add_nodeset_topology(
         except Exception:
             continue
     
-        phys_host = inst.resourceStatus.get("physicalHost", "")
+        phys_host = inst.resource_status.get("physicalHost", "")
         bldr.summary.physical_host[inst.name] = phys_host
         up_nodes.add(inst.name)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/suspend.py
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
+from typing import List, Any
 import argparse
 import logging
 
@@ -46,11 +46,14 @@ def truncate_iter(iterable, max_count):
         yield el
 
 
-def delete_instance_request(instance):
+def delete_instance_request(name: str) -> Any:
+    inst = lookup().instance(name)
+    assert inst
+
     request = lookup().compute.instances().delete(
         project=lookup().project,
-        zone=lookup().instance(instance).zone,
-        instance=instance,
+        zone=inst.zone,
+        instance=name,
     )
     log_api_request(request)
     return request

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -15,6 +15,7 @@
 from typing import Optional, Any
 import sys
 from dataclasses import dataclass, field
+from datetime import datetime
 
 SCRIPTS_DIR = "community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts"
 if SCRIPTS_DIR not in sys.path:
@@ -22,6 +23,8 @@ if SCRIPTS_DIR not in sys.path:
 
 import util
 
+
+SOME_TS = datetime.fromisoformat("2018-09-03T20:56:35.450686+00:00")
 # TODO: use "real" classes once they are defined (instead of NSDict)
 
 @dataclass
@@ -83,17 +86,19 @@ class TstMachineConf:
 class TstTemplateInfo:
     gpu: Optional[util.AcceleratorInfo]
 
-@dataclass
-class TstInstance:
-    name: str
-    region: str = "gondor"
-    zone: str = "anorien"
-    placementPolicyId: Optional[str] = None
-    physicalHost: Optional[str] = None
-
-    @property
-    def resourceStatus(self):
-        return {"physicalHost": self.physicalHost}
+def tstInstance(name: str, physical_host: Optional[str] = None):
+    return util.Instance(
+        name=name,
+        zone="anorien",
+        status="RUNNING",
+        creation_timestamp=SOME_TS,
+        resource_status=util.NSDict(
+            physicalHost = physical_host
+        ),
+        scheduling=util.NSDict(),
+        upcoming_maintenance=None,
+        role="compute",
+    )
 
 def make_to_hostnames_mock(tbl: Optional[dict[str, list[str]]]):
     tbl = tbl or {}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_topology.py
@@ -16,7 +16,7 @@ import pytest
 import json
 import mock
 from pytest_unordered import unordered
-from common import TstCfg, TstNodeset, TstTPU, TstInstance
+from common import TstCfg, TstNodeset, TstTPU, tstInstance
 import sort_nodes
 
 import util
@@ -62,13 +62,13 @@ def test_gen_topology_conf(tpu_mock):
     lkp = util.Lookup(cfg)
     lkp.instances = lambda: { n.name: n for n in [
         # nodeset blue
-        TstInstance("m22-blue-0"),  # no physicalHost
-        TstInstance("m22-blue-0", physicalHost="/a/a/a"),
-        TstInstance("m22-blue-1", physicalHost="/a/a/b"),
-        TstInstance("m22-blue-2", physicalHost="/a/b/a"),
-        TstInstance("m22-blue-3", physicalHost="/b/a/a"),
+        tstInstance("m22-blue-0"),  # no physicalHost
+        tstInstance("m22-blue-0", physical_host="/a/a/a"),
+        tstInstance("m22-blue-1", physical_host="/a/a/b"),
+        tstInstance("m22-blue-2", physical_host="/a/b/a"),
+        tstInstance("m22-blue-3", physical_host="/b/a/a"),
         # nodeset green
-        TstInstance("m22-green-3", physicalHost="/a/a/c"),
+        tstInstance("m22-green-3", physical_host="/a/a/c"),
     ]}
 
     uncompressed = conf.gen_topology(lkp)
@@ -173,19 +173,19 @@ def test_gen_topology_conf_update():
     # don't dump
 
     # set empty physicalHost - no reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == False
     # don't dump
 
     # set physicalHost - reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="/a/b/c")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="/a/b/c")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == True
     sum.dump(lkp)
 
     # change physicalHost - reconfigure
-    lkp.instances = lambda: { n.name: n for n in [TstInstance("m22-green-0", physicalHost="/a/b/z")]}
+    lkp.instances = lambda: { n.name: n for n in [tstInstance("m22-green-0", physical_host="/a/b/z")]}
     upd, sum = conf.gen_topology_conf(lkp)
     assert upd == True
     sum.dump(lkp)


### PR DESCRIPTION
* Add `Instance` dataclass for better type constraints;

```sh
$ mypy community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts --check-untyped-defs
# Before
Found 135 errors in 13 files (checked 16 source files)
# After
Found 119 errors in 12 files (checked 16 source files)
```

* Stop fetching unused fields in aggregatedList of VMs

  On tested cluster of 40 nodes:
  - the reduction in response size (measured as dumped JSON) is **46 times (1153 KB -> 25 KB)**;
  - some reduction in latency, but variance is too high to say definitely. 