### PR TITLE
Adding var.provisioning_model to vm-instance module

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -231,12 +231,13 @@ limitations under the License.
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except for when `placement_policy`, spot provisioning, or GPUs require it to be `TERMINATE` | `string` | `null` | no |
 | <a name="input_placement_policy"></a> [placement\_policy](#input\_placement\_policy) | Control where your VM instances are physically located relative to each other within a zone.<br/>See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#nested_group_placement_policy | `any` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
+| <a name="input_provisioning_model"></a> [provisioning\_model](#input\_provisioning\_model) | Provisioning model for cloud instance. | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy to | `string` | n/a | yes |
 | <a name="input_reservation_name"></a> [reservation\_name](#input\_reservation\_name) | Name of the reservation to use for VM resources, should be in one of the following formats:<br/>- projects/PROJECT\_ID/reservations/RESERVATION\_NAME<br/>- RESERVATION\_NAME<br/><br/>Must be a "SPECIFIC\_RESERVATION"<br/>Set to empty string if using no reservation or automatically-consumed reservations | `string` | `""` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | DEPRECATED - Use `service_account_email` and `service_account_scopes` instead. | <pre>object({<br/>    email  = string,<br/>    scopes = set(string)<br/>  })</pre> | `null` | no |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Service account e-mail address to use with the node pool | `string` | `null` | no |
 | <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Scopes to to use with the node pool. | `set(string)` | <pre>[<br/>  "https://www.googleapis.com/auth/cloud-platform"<br/>]</pre> | no |
-| <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing, allowing for preemption | `bool` | `false` | no |
+| <a name="input_spot"></a> [spot](#input\_spot) | DEPRECATED - Use `provisioning_model` instead. | `bool` | `null` | no |
 | <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Startup script used on the instance | `string` | `null` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to attach the VM. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Network tags, provided as a list | `list(string)` | `[]` | no |

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -327,10 +327,22 @@ variable "placement_policy" {
   }
 }
 
+# tflint-ignore: terraform_unused_declarations
 variable "spot" {
-  description = "Provision VMs using discounted Spot pricing, allowing for preemption"
+  description = "DEPRECATED - Use `provisioning_model` instead."
   type        = bool
-  default     = false
+  default     = null
+
+  validation {
+    condition     = var.spot == null
+    error_message = "The 'spot' setting is deprecated. If you intend to use Spot pricing, please set 'var.provisioning_model' to \"SPOT\" and do not set 'var.spot' at all."
+  }
+}
+
+variable "provisioning_model" {
+  description = "Provisioning model for cloud instance."
+  type        = string
+  default     = null
 }
 
 variable "min_cpu_platform" {


### PR DESCRIPTION
In this PR, I deprecate the `var.spot` variable and add in the `var.provisioning_model` variable in the vm-instance module. This enables the vm-instace module to support other provisioning models outside of "SPOT". 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
