### PR TITLE
Replace Spack w/ Enroot/pyxis for NCCL tests

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/run-nccl-tests-via-ramble.sh
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/run-nccl-tests-via-ramble.sh
@@ -19,54 +19,54 @@ trap "printf '\nCaught Ctrl+c. Exiting...\n'; exit" INT
 # Use current unix timestamp as a unique tag
 # for jobs submitted
 TAG=$(date +%s)
-TEST_DIR=nccl-tests-"${TAG}"
+TEST_DIR=${PWD}/nccl-tests-"${TAG}"
 SOFTWARE_INSTALL=/opt/apps
 
 cat <<EOF
 This script will install the following packages using on this VM:
-  build-essential
-  g++-12
-  gcc-12
-  gfortran-12
   jq
-  libgcc-12-dev
-  libgfortran-12-dev
-  libopenmpi-dev
-  openmpi-bin
   python3-venv
 
-And will clone spack (https://github.com/spack/spack.git)
-and ramble (https://github.com/GoogleCloudPlatform/ramble.git)
-to "${SOFTWARE_INSTALL}"/. Afterwards it will create a ramble workspace to run a
-number of NCCL tests in $(readlink -f "${TEST_DIR}"/). As part of the build
-process, spack will add some configuration files to your "${HOME}"/.spack
-directory.
+It will then set up enroot credentials to be able to use artifact registry 
+by adding the following to ${HOME}/.enroot/.credentials:
+
+  machine us-docker.pkg.dev login oauth2accesstoken password \$(gcloud auth print-access-token)
+
+And will clone ramble (https://github.com/GoogleCloudPlatform/ramble.git)
+to "${SOFTWARE_INSTALL}"/, and it will create an enroot "sqsh" file located
+in your ${HOME}/.enroot/ folder. Afterwards it will create a ramble workspace
+to run a number of NCCL tests in $(readlink -f "${TEST_DIR}"/).
 
 EOF
-read -rp "To continue, hit any key. To cancel, [Ctrl-c]"
+
+read -t 30 -rp "To continue, hit [enter]. To cancel, type [Ctrl-c]. Will auto-continue in 30s" || true
 
 mkdir -p "${TEST_DIR}"
 
 # Install prerequisites
-sudo apt-get install -y g++-12 gfortran-12 build-essential gcc-12 libgfortran-12-dev libgcc-12-dev python3-venv jq libopenmpi-dev openmpi-bin
+sudo apt-get install -y python3-venv jq
 
-# Install ramble and spack, and make world read/writeable.
+# Create enroot credentials set up for artifact registry
+mkdir -p "${HOME}"/.enroot/
+ENROOT_CONFIG_CREDENTIALS="${HOME}"/.enroot/.credentials
+
+if ! grep -q "us-docker.pkg.dev" "${ENROOT_CONFIG_CREDENTIALS}"; then
+	cat <<EOF >>"${ENROOT_CONFIG_CREDENTIALS}"
+machine us-docker.pkg.dev login oauth2accesstoken password \$(gcloud auth print-access-token)
+EOF
+fi
+
+# Install ramble and make world read/writeable.
 sudo git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
-sudo git clone --depth 1 -c feature.manyFiles=true -b develop https://github.com/spack/spack.git "${SOFTWARE_INSTALL}"/spack || true
-sudo chmod -R a+w "${SOFTWARE_INSTALL}"/{ramble,spack}
+sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 
 # Create python environment for ramble, and install requirements
 python3 -m venv "${SOFTWARE_INSTALL}"/ramble/env || true
 source "${SOFTWARE_INSTALL}"/ramble/env/bin/activate
 pip install -q -r "${SOFTWARE_INSTALL}"/ramble/requirements.txt
 
-# Activate ramble and spack
+# Activate ramble
 . ${SOFTWARE_INSTALL}/ramble/share/ramble/setup-env.sh
-. ${SOFTWARE_INSTALL}/spack/share/spack/setup-env.sh
-
-# Set up Spack external packages
-spack external find python diffutils xz ncurses flex curl openssl m4 openssh
-spack external find -p /usr/local/cuda cuda
 
 # Create a new workspace for this work
 ramble workspace create -a -d "${TEST_DIR}"
@@ -75,68 +75,50 @@ ramble workspace create -a -d "${TEST_DIR}"
 cat <<EOF >"${TEST_DIR}"/configs/ramble.yaml
 # Ramble Configuration for NCCL Tests
 ramble:
-  env_vars:
-    set:
-      OMPI_MCA_pml: "^ucx"
-      OMPI_MCA_btl: "^openib"
-      OMPI_MCA_btl_tcp_if_include: enp0s19
-
-      CUDA_VISIBLE_DEVICES: 0,1,2,3,4,5,6,7
-      NCCL_NET: gIB
-      NCCL_SOCKET_IFNAME: enp0s19,enp192s20
-      NCCL_CROSS_NIC: 0
-      NCCL_NET_GDR_LEVEL: PIX
-      NCCL_P2P_NET_CHUNKSIZE: 131072
-      NCCL_P2P_PCI_CHUNKSIZE: 131072
-      NCCL_P2P_NVL_CHUNKSIZE: 524288
-      NCCL_NVLS_CHUNKSIZE: 524288
-      NCCL_IB_GID_INDEX: 3
-      NCCL_IB_ADAPTIVE_ROUTING: 1
-      NCCL_IB_QPS_PER_CONNECTION: 4
-      NCCL_IB_TC: 52
-      NCCL_IB_FIFO_TC: 84
-      NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE: /usr/local/gib/configs/guest_config.txtpb
-      NCCL_TUNER_CONFIG_PATH: /usr/local/gib/configs/tuner_config.txtpb
-    prepend:
-    - paths:
-        LD_LIBRARY_PATH: /usr/local/gib/lib64
-
+  modifiers:
+  - name: pyxis-enroot
+  - name: nccl-gib
   variables:
-    mpi_command: srun --mpi=pmix
-    batch_submit: 'sbatch {execute_experiment}'
+    batch_submit: sbatch '{execute_experiment}'
+
+    srun_args: >-
+      --mpi=pmix
+      --container-workdir /third_party/nccl-tests/build/
+      --container-image {container_path}
+      --container-mounts "/usr/local/gib,/var/tmp"
+
+    mpi_command: srun {srun_args}
+
+    hostlist: \${SLURM_JOB_NODELIST}
+
+    container_name: nccl-plugin-gib-diagnostic
+    container_dir: "\${HOME}/.enroot"
+    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:latest
+    processes_per_node: 8
     processes_per_node: '{gpus_per_node}'
     gpus_per_node: '8'
+    nccl-tests_path: null
+
+  env_vars:
+    set:
+      OMPI_MCA_btl_tcp_if_include: enp0s19
+      PMIX_MCA_gds: ^ds12
+      NCCL_NET: gIB
+      NCCL_SOCKET_IFNAME: enp0s19,enp192s20
+      LD_LIBRARY_PATH: /usr/local/gib/lib64:/usr/lib/x86_64-linux-gnu
+
   applications:
     nccl-tests:
       workloads:
         '{workload}':
           experiments:
             '{workload}-{n_nodes}':
-              variants:
-                package_manager: spack
               variables:
                 workload: [all-gather, all-reduce, reduce-scatter]
                 n_nodes: [2, 4, 8, 16, 32]
               matrix:
               - n_nodes
               - workload
-
-  software:
-    packages:
-      pmix:
-        pkg_spec: pmix
-      mpi:
-        pkg_spec: openmpi +cuda cuda_arch=90
-      cuda:
-        pkg_spec: cuda@12.4.0
-      nccl:
-        pkg_spec: nccl@2.23.4-1 cuda_arch=90
-      nccl-tests:
-        pkg_spec: nccl-tests cuda_arch=90
-    environments:
-      nccl-tests:
-        packages: [cuda, mpi, nccl, nccl-tests, pmix]
-
 EOF
 
 # Populate slurm sbatch script
@@ -153,6 +135,8 @@ cd "{experiment_run_dir}"
 {command}
 EOF
 
+cd "${RAMBLE_WORKSPACE}"
+
 # Get number of nodes available
 N_NODES=$(sinfo -h -o %D)
 
@@ -163,14 +147,13 @@ ramble workspace info --where '{n_nodes} <= '"$N_NODES"
 printf "\n------- About to run the following: ------\n\n"
 printf "source %s/ramble/env/bin/activate\n" "${SOFTWARE_INSTALL}"
 printf ". %s/ramble/share/ramble/setup-env.sh\n" "${SOFTWARE_INSTALL}"
-printf ". %s/spack/share/spack/setup-env.sh\n" "${SOFTWARE_INSTALL}"
 printf "ramble workspace activate %s\n" "${TEST_DIR}"
 printf "ramble workspace setup --where '{n_nodes} <= %s'\n" "${N_NODES}"
 printf "ramble on --where '{n_nodes} <= %s' \n" "${N_NODES}"
 
 # Set up experiments
 printf "\n--------- Setting up Benchmarks -------\n"
-printf "         This may take 20-30 minutes     \n"
+printf "         This may take ~5-10 minutes     \n"
 ramble workspace setup --where '{n_nodes} <= '"${N_NODES}"
 
 # Submit Experiments to Slurm
@@ -215,10 +198,9 @@ jq -r '["workload","n_nodes","msg_size","busbw"], (.experiments[] as $exp | $exp
 | select(.Size | tonumber  > 8000000000)
 | [.workload, .n_nodes, .Size, ."Out of Place Bus Bandwidth"])
 | @tsv' results.latest.json
-printf "\nFor full results, see \"summary.tsv\"\n"
+printf "\nFor full results, see %s\n" "${TEST_DIR}"/summary.tsv
 
 printf "\n- To reactivate this ramble workspace, run -\n\n"
 printf "source %s/ramble/env/bin/activate\n" "${SOFTWARE_INSTALL}"
 printf ". %s/ramble/share/ramble/setup-env.sh\n" "${SOFTWARE_INSTALL}"
-printf ". %s/spack/share/spack/setup-env.sh\n" "${SOFTWARE_INSTALL}"
 printf "ramble workspace activate %s\n" "${TEST_DIR}"


### PR DESCRIPTION
This speeds up the test duration, as well as resolves issues encountered between compatibility of spack-installed mpi/slurm w/ existing slurm enviornment.

Has been manually tested on a fresh a3u-slurm-ubuntu-gcs cluster.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
