### PR TITLE
Fixed naming for deployment name in test to fit in size limit

### DIFF
--- a/tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue.yml
@@ -17,7 +17,7 @@
 # region, zone must be defined
 # in build file with --extra-vars flag!
 test_name: gke-a2high-kueue
-deployment_name: gke-a2high-kueue-{{ build }}
+deployment_name: gke-a2high-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml"
 network: "gke-a2high-net-{{ build }}"


### PR DESCRIPTION
Changed deployment name for gke-a2high-kueue test to fit in size limit

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
