### PR TITLE
Updates to use variable provisioning_model for vm-instances

### DIFF
--- a/community/modules/compute/pbspro-execution/main.tf
+++ b/community/modules/compute/pbspro-execution/main.tf
@@ -70,8 +70,8 @@ module "execution_startup_script" {
 module "pbs_execution" {
   source = "../../../../modules/compute/vm-instance"
 
-  instance_count = var.instance_count
-  spot           = var.spot
+  instance_count     = var.instance_count
+  provisioning_model = var.spot ? "SPOT" : null
 
   deployment_name = var.deployment_name
   name_prefix     = local.resource_prefix

--- a/community/modules/remote-desktop/chrome-remote-desktop/main.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/main.tf
@@ -76,7 +76,7 @@ module "instances" {
   instance_count                    = var.instance_count
   name_prefix                       = var.name_prefix
   add_deployment_name_before_prefix = var.add_deployment_name_before_prefix
-  spot                              = var.spot
+  provisioning_model                = var.spot ? "SPOT" : null
 
   deployment_name = var.deployment_name
   project_id      = var.project_id

--- a/community/modules/scheduler/pbspro-client/main.tf
+++ b/community/modules/scheduler/pbspro-client/main.tf
@@ -59,8 +59,8 @@ module "client_startup_script" {
 module "pbs_client" {
   source = "../../../../modules/compute/vm-instance"
 
-  instance_count = var.instance_count
-  spot           = var.spot
+  instance_count     = var.instance_count
+  provisioning_model = var.spot ? "SPOT" : null
 
   deployment_name = var.deployment_name
   name_prefix     = local.resource_prefix

--- a/community/modules/scheduler/pbspro-server/main.tf
+++ b/community/modules/scheduler/pbspro-server/main.tf
@@ -72,8 +72,8 @@ module "server_startup_script" {
 module "pbs_server" {
   source = "../../../../modules/compute/vm-instance"
 
-  instance_count = var.instance_count
-  spot           = var.spot
+  instance_count     = var.instance_count
+  provisioning_model = var.spot ? "SPOT" : null
 
   deployment_name = var.deployment_name
   name_prefix     = local.resource_prefix


### PR DESCRIPTION
PR updates instances of using the vm-instance module to use `provisioning_model` instead of `spot`.

