### PR TITLE
Fix k8s service account message issue

### DIFF
--- a/modules/scheduler/gke-cluster/outputs.tf
+++ b/modules/scheduler/gke-cluster/outputs.tf
@@ -52,6 +52,14 @@ locals {
     EOT
   )
   allowlist_your_ip_message = var.enable_private_endpoint ? local.private_endpoint_message : local.public_endpoint_message
+  kubernetes_service_account_message = local.k8s_service_account_name == null ? "" : trimspace(
+    <<-EOT
+      Use the following Kubernetes Service Account in the default namespace to run your workloads:
+        ${local.k8s_service_account_name}
+      The GCP Service Account mapped to this Kubernetes Service Account is:
+        ${local.sa_email}
+    EOT
+  )
 }
 
 output "instructions" {
@@ -67,10 +75,7 @@ output "instructions" {
           --region ${google_container_cluster.gke_cluster.location} \
           --project ${var.project_id}
 
-      Use the following Kubernetes Service Account in the default namespace to run your workloads:
-        ${local.k8s_service_account_name}
-      The GCP Service Account mapped to this Kubernetes Service Account is:
-        ${local.sa_email}
+      ${local.kubernetes_service_account_message}
     EOT
   )
 }


### PR DESCRIPTION
The current error message does not account for the case where local.k8s_service_account_name message is null (i.e. workload identify federation is not enabled). This PR handles that scenario

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
