### PR TITLE
Add missing indexes and a3U documentation in readme for gke blueprints

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,6 +42,9 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [hpc-gke.yaml](#hpc-gkeyaml--) ![core-badge] ![experimental-badge]
   * [ml-gke](#ml-gkeyaml--) ![core-badge] ![experimental-badge]
   * [storage-gke](#storage-gkeyaml--) ![core-badge] ![experimental-badge]
+  * [gke-managed-hyperdisk.yaml](#gke-managed-hyperdiskyaml--) ![core-badge] ![experimental-badge]
+  * [gke-managed-parallelstore.yaml](#gke-managed-parallelstoreyaml--) ![core-badge] ![experimental-badge]
+  * [gke-a3-ultragpu.yaml](#gke-a3-ultragpuyaml--) ![core-badge] ![experimental-badge]
   * [gke-a3-megagpu](#gke-a3-megagpuyaml--) ![core-badge] ![experimental-badge]
   * [gke-a3-highgpu](#gke-a3-highgpuyaml--) ![core-badge] ![experimental-badge]
   * [htc-slurm.yaml](#htc-slurmyaml-) ![community-badge]
@@ -1140,6 +1143,12 @@ The blueprint contains the following:
 > [whatismyip.com](https://whatismyip.com) to determine your IP address.
 
 [gke-managed-parallelstore.yaml]: ../examples/gke-managed-parallelstore.yaml
+
+### [gke-a3-ultragpu.yaml] ![core-badge] ![experimental-badge]
+
+Refer to [AI Hypercomputer Documentation](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#create-cluster) for instructions.
+
+[gke-a3-ultragpu.yaml]: ../examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
 
 ### [gke-a3-megagpu.yaml] ![core-badge] ![experimental-badge]
 


### PR DESCRIPTION
Updated Readme file with the following changes:

1. Added missing entry in index for gke-managed-hyperdisk.yaml & gke-managed-parallelstore.yaml blueprints
2. Added documentation for gke-a3-ultragpu.yaml 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
