### PR TITLE
Handle current API format for `upcomingMaintenance`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -563,7 +563,7 @@ def add_nodeset_topology(
         except Exception:
             continue
     
-        phys_host = inst.resource_status.get("physicalHost", "")
+        phys_host = inst.resource_status.physical_host or ""
         bldr.summary.physical_host[inst.name] = phys_host
         up_nodes.add(inst.name)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -468,9 +468,8 @@ def get_upcoming_maintenance(lkp: util.Lookup) -> Dict[str, Tuple[str, datetime]
     upc_maint_map = {}
 
     for node, inst in lkp.instances().items():
-        if inst.upcoming_maintenance:
-          start_time = parse_gcp_timestamp(inst.upcoming_maintenance['startTimeWindow']['earliest'])
-          upc_maint_map[node + "_maintenance"] = (node, start_time)
+        if inst.resource_status.upcoming_maintenance:
+          upc_maint_map[node + "_maintenance"] = (node, inst.resource_status.upcoming_maintenance.window_start_time)
 
     return upc_maint_map
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -92,11 +92,11 @@ def tstInstance(name: str, physical_host: Optional[str] = None):
         zone="anorien",
         status="RUNNING",
         creation_timestamp=SOME_TS,
-        resource_status=util.NSDict(
-            physicalHost = physical_host
+        resource_status=util.InstanceResourceStatus(
+            physical_host=physical_host,
+            upcoming_maintenance=None,
         ),
         scheduling=util.NSDict(),
-        upcoming_maintenance=None,
         role="compute",
     )
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -174,6 +174,51 @@ class MachineType:
             self.family, 1,  # assume 1 socket for all other families
         )
 
+
+@dataclass(frozen=True)
+class UpcomingMaintenance:
+    window_start_time: datetime
+
+    @classmethod
+    def from_json(cls, jo: Optional[dict]) -> Optional["UpcomingMaintenance"]:
+        if jo is None:
+            return None
+        try:
+            if "windowStartTime" in jo:
+                ts = parse_gcp_timestamp(jo["windowStartTime"])
+            elif "startTimeWindow" in jo:
+                ts = parse_gcp_timestamp(jo["startTimeWindow"]["earliest"])
+            else:
+                raise Exception("Neither windowStartTime nor startTimeWindow are found")
+        except BaseException as e:
+            raise ValueError(f"Unexpected format for upcomingMaintenance: {jo}") from e
+        return cls(window_start_time=ts)
+
+@dataclass(frozen=True)
+class InstanceResourceStatus:
+    physical_host: Optional[str]
+    upcoming_maintenance: Optional[UpcomingMaintenance]
+
+    @classmethod
+    def from_json(cls, jo: Optional[dict]) -> "InstanceResourceStatus":
+        if not jo:
+            return cls(
+                physical_host=None,
+                upcoming_maintenance=None,
+            )
+        
+        try:
+            maint = UpcomingMaintenance.from_json(jo.get("upcomingMaintenance"))
+        except ValueError as e:
+            log.exception("Failed to parse upcomingMaintenance, ignoring")
+            maint = None # intentionally swallow exception
+        
+        return cls(
+            physical_host=jo.get("physicalHost"),
+            upcoming_maintenance=maint,
+        )
+
+
 @dataclass(frozen=True)
 class Instance:
   name: str
@@ -181,13 +226,9 @@ class Instance:
   status: str
   creation_timestamp: datetime
   role: Optional[str]
-
-  # TODO: use proper InstanceResourceStatus class
-  resource_status: NSDict
+  resource_status: InstanceResourceStatus
   # TODO: use proper InstanceScheduling class
   scheduling: NSDict
-  # TODO: use proper UpcomingMaintenance class
-  upcoming_maintenance: Optional[NSDict] = None
 
   @classmethod
   def from_json(cls, jo: dict) -> "Instance":
@@ -198,9 +239,8 @@ class Instance:
       zone=trim_self_link(jo["zone"]),
       status=jo["status"],
       creation_timestamp=parse_gcp_timestamp(jo["creationTimestamp"]),
-      resource_status=NSDict(jo.get("resourceStatus")),
+      resource_status=InstanceResourceStatus.from_json(jo.get("resourceStatus")),
       scheduling=NSDict(jo.get("scheduling")),
-      upcoming_maintenance=NSDict(jo["upcomingMaintenance"]) if "upcomingMaintenance" in jo else None,
       role = labels.get("slurm_instance_role"),
     )
 
@@ -1545,11 +1585,6 @@ class Lookup:
             "zone",
         ]
         
-        # TODO: Merge this with all fields when upcoming maintenance is
-        # supported in beta.
-        if endpoint_version(ApiEndpoint.COMPUTE) == 'alpha':
-          instance_information_fields.append("upcomingMaintenance")
-
         instance_fields = ",".join(sorted(instance_information_fields))
         fields = f"items.zones.instances({instance_fields}),nextPageToken"
         flt = f"labels.slurm_cluster_name={self.cfg.slurm_cluster_name} AND name:{self.cfg.slurm_cluster_name}-*"


### PR DESCRIPTION
* Instead of fetching `instance.upcomingMaintenance` do `instance.resourceStatus.upcomingMaintenance`; 
* Handle both possible paths for maintenance start time `upcomingMaintenance.windowStartTime` & `upcomingMaintenance.startTimeWindow.earliest`.

See current API: https://cloud.google.com/compute/docs/reference/rest/v1/instances/get

**Testing done:**

```sh
$ gcloud compute instances simulate-maintenance-event gg  --with-extended-notifications=True
...
$ gcloud alpha compute instances describe gg  --format=json | jq ".resourceStatus"
{
  "lastInstanceTerminationDetails": {
    "terminationReason": "INTERNAL_ERROR"
  },
  "scheduling": {},
  "upcomingMaintenance": {
    "canReschedule": true,
    "latestWindowStartTime": "2025-01-30T00:04:44Z",
    "maintenanceStatus": "PENDING",
    "type": "SCHEDULED",
    "windowEndTime": "2025-01-30T04:04:43Z",
    "windowStartTime": "2025-01-30T00:04:43Z"
  }
}
```

```py
>>  lkp.instance("gg").resource_status.upcoming_maintenance

UpcomingMaintenance(window_start_time=datetime.datetime(2025, 1, 30, 0, 4, 43, tzinfo=datetime.timezone.utc))
```