### PR TITLE
Draft implementation to support JSON output

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -28,10 +28,11 @@ import (
 )
 
 func addDeployFlags(c *cobra.Command) *cobra.Command {
-	return addGroupSelectionFlags(
-		addAutoApproveFlag(
-			addArtifactsDirFlag(
-				addCreateFlags(c))))
+	return addJsonOutputFlag(
+		addGroupSelectionFlags(
+			addAutoApproveFlag(
+				addArtifactsDirFlag(
+					addCreateFlags(c)))))
 }
 
 func init() {
@@ -93,7 +94,7 @@ func doDeploy(deplRoot string) {
 			moduleDir := filepath.Join(groupDir, subPath)
 			checkErr(deployPackerGroup(moduleDir, getApplyBehavior()), ctx)
 		case config.TerraformKind:
-			checkErr(deployTerraformGroup(groupDir, artDir, getApplyBehavior()), ctx)
+			checkErr(deployTerraformGroup(groupDir, artDir, getApplyBehavior(), getJsonOutputBehavior()), ctx)
 		default:
 			checkErr(
 				config.BpError{
@@ -152,10 +153,10 @@ func deployPackerGroup(moduleDir string, applyBehavior shell.ApplyBehavior) erro
 	return nil
 }
 
-func deployTerraformGroup(groupDir string, artifactsDir string, applyBehavior shell.ApplyBehavior) error {
+func deployTerraformGroup(groupDir string, artifactsDir string, applyBehavior shell.ApplyBehavior, outputFormat shell.OutputFormat) error {
 	tf, err := shell.ConfigureTerraform(groupDir)
 	if err != nil {
 		return err
 	}
-	return shell.ExportOutputs(tf, artifactsDir, applyBehavior)
+	return shell.ExportOutputs(tf, artifactsDir, applyBehavior, outputFormat)
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -28,7 +28,7 @@ func (s *MySuite) TestDeployGroups(c *C) {
 	pathEnv := os.Getenv("PATH")
 	os.Setenv("PATH", "")
 
-	err = deployTerraformGroup(".", getArtifactsDir("."), shell.NeverApply)
+	err = deployTerraformGroup(".", getArtifactsDir("."), shell.NeverApply, shell.TextOutput)
 	c.Check(err, NotNil)
 
 	err = deployPackerGroup(".", shell.NeverApply)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -106,7 +106,9 @@ func destroyTerraformGroup(groupDir string) error {
 		return err
 	}
 
-	return shell.Destroy(tf, getApplyBehavior())
+	// Always output text when destroying the cluster
+	// The current implementation outputs JSON only for the "deploy" command
+	return shell.Destroy(tf, getApplyBehavior(), shell.TextOutput)
 }
 
 func destroyChoice(nextGroup config.GroupName) bool {

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -71,5 +71,6 @@ func runExportCmd(cmd *cobra.Command, args []string) {
 	tf, err := shell.ConfigureTerraform(groupDir)
 	checkErr(err, ctx)
 
-	checkErr(shell.ExportOutputs(tf, artifactsDir, shell.NeverApply), ctx)
+	// Always output text when exporting (never JSON)
+	checkErr(shell.ExportOutputs(tf, artifactsDir, shell.NeverApply, shell.TextOutput), ctx)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -82,6 +82,20 @@ func filterYaml(cmd *cobra.Command, args []string, toComplete string) ([]string,
 	return []string{"yaml", "yml"}, cobra.ShellCompDirectiveFilterFileExt
 }
 
+var flagJsonOutput bool
+
+func getJsonOutputBehavior() shell.OutputFormat {
+	if flagJsonOutput {
+		return shell.JsonOutput
+	}
+	return shell.TextOutput
+}
+
+func addJsonOutputFlag(c *cobra.Command) *cobra.Command {
+	c.Flags().BoolVar(&flagJsonOutput, "json-output", false, "Output errors in JSON format")
+	return c
+}
+
 var flagSkipGroups []string
 var flagOnlyGroups []string
 

--- a/pkg/shell/terraform.go
+++ b/pkg/shell/terraform.go
@@ -36,6 +36,20 @@ import (
 	"github.com/zclconf/go-cty/cty/gocty"
 )
 
+// OutputFormat determines the format in which the errors are reported.
+// Current supported format are text (default option) and JSON. Future
+// format could be protobuf
+type OutputFormat uint
+
+// 2 output formats are currently supported:
+//   - Text
+//   - JSON
+//   - Future option is ProtoBuf
+const (
+	TextOutput OutputFormat = iota
+	JsonOutput
+)
+
 // ApplyBehavior abstracts behaviors for making changes to cloud infrastructure
 // when gcluster believes that they may be necessary
 type ApplyBehavior uint
@@ -224,6 +238,29 @@ func promptForApply(tf *tfexec.Terraform, path string, b ApplyBehavior) bool {
 	}
 }
 
+// This function applies the terraform plan, but generates outputs in JSON format
+// (instead of text)
+func applyPlanJsonOutput(tf *tfexec.Terraform, path string) error {
+	planFileOpt := tfexec.DirOrPlan(path)
+	logging.Info("Running terraform apply on deployment group %s", tf.WorkingDir())
+	// To do: Make file name as a user input
+	jsonFilename := "cluster_toolkit_output.json"
+	jsonFile, err := os.Create(jsonFilename)
+	defer jsonFile.Close()
+	if err != nil {
+		logging.Info("Cannot create JSON output file %s", jsonFilename)
+		return err
+	}
+	tf.SetStdout(os.Stdout)
+	tf.SetStderr(os.Stderr)
+	if err := tf.ApplyJSON(context.Background(), jsonFile, planFileOpt); err != nil {
+		return err
+	}
+	tf.SetStdout(nil)
+	tf.SetStderr(nil)
+	return nil
+}
+
 func applyPlanConsoleOutput(tf *tfexec.Terraform, path string) error {
 	planFileOpt := tfexec.DirOrPlan(path)
 	logging.Info("Running terraform apply on deployment group %s", tf.WorkingDir())
@@ -240,7 +277,7 @@ func applyPlanConsoleOutput(tf *tfexec.Terraform, path string) error {
 // generate a Terraform plan to apply or destroy a module
 // recall "destroy" is just an alias for "apply -destroy"!
 // apply the plan automatically or after prompting the user
-func applyOrDestroy(tf *tfexec.Terraform, b ApplyBehavior, destroy bool) error {
+func applyOrDestroy(tf *tfexec.Terraform, b ApplyBehavior, of OutputFormat, destroy bool) error {
 	action := "adding or changing"
 	pastTense := "applied"
 	if destroy {
@@ -256,6 +293,7 @@ func applyOrDestroy(tf *tfexec.Terraform, b ApplyBehavior, destroy bool) error {
 	// capture Terraform plan in a file
 	f, err := os.CreateTemp("", "plan-)")
 	if err != nil {
+		logging.Info("deploy.go.0000: applyOrDestroy()")
 		return err
 	}
 	defer os.Remove(f.Name())
@@ -263,7 +301,6 @@ func applyOrDestroy(tf *tfexec.Terraform, b ApplyBehavior, destroy bool) error {
 	if err != nil {
 		return err
 	}
-
 	var apply bool
 	if wantsChange {
 		logging.Info("Deployment group %s requires %s cloud infrastructure", tf.WorkingDir(), action)
@@ -276,15 +313,25 @@ func applyOrDestroy(tf *tfexec.Terraform, b ApplyBehavior, destroy bool) error {
 		return nil
 	}
 
-	if err := applyPlanConsoleOutput(tf, f.Name()); err != nil {
-		return err
+	switch of {
+
+	case JsonOutput:
+		if err := applyPlanJsonOutput(tf, f.Name()); err != nil {
+			return err
+		}
+	case TextOutput: // Text output to the console is also the default choice
+		fallthrough
+	default:
+		if err := applyPlanConsoleOutput(tf, f.Name()); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func getOutputs(tf *tfexec.Terraform, b ApplyBehavior) (map[string]cty.Value, error) {
-	err := applyOrDestroy(tf, b, false)
+func getOutputs(tf *tfexec.Terraform, b ApplyBehavior, o OutputFormat) (map[string]cty.Value, error) {
+	err := applyOrDestroy(tf, b, o, false)
 	if err != nil {
 		return nil, err
 	}
@@ -302,11 +349,11 @@ func outputsFile(artifactsDir string, group config.GroupName) string {
 
 // ExportOutputs will run terraform output and capture data needed for
 // subsequent deployment groups
-func ExportOutputs(tf *tfexec.Terraform, artifactsDir string, applyBehavior ApplyBehavior) error {
+func ExportOutputs(tf *tfexec.Terraform, artifactsDir string, applyBehavior ApplyBehavior, outputFormat OutputFormat) error {
 	thisGroup := config.GroupName(filepath.Base(tf.WorkingDir()))
 	filepath := outputsFile(artifactsDir, thisGroup)
 
-	outputValues, err := getOutputs(tf, applyBehavior)
+	outputValues, err := getOutputs(tf, applyBehavior, outputFormat)
 	if err != nil {
 		return err
 	}
@@ -428,8 +475,8 @@ func ImportInputs(groupDir string, artifactsDir string, bp config.Blueprint) err
 }
 
 // Destroy destroys all infrastructure in the module working directory
-func Destroy(tf *tfexec.Terraform, b ApplyBehavior) error {
-	return applyOrDestroy(tf, b, true)
+func Destroy(tf *tfexec.Terraform, b ApplyBehavior, o OutputFormat) error {
+	return applyOrDestroy(tf, b, o, true)
 }
 
 func TfVersion() (string, error) {


### PR DESCRIPTION
**NOTE NOTE NOTE**
This a draft Pull Request to solicit early feedback. It has not been tested. This is also not the final implementation.
**NOTE NOTE NOTE**

This pull request adds support to output JSON instead of the usual "english text output" to "gcluster **deploy**". It adds a new flag to the deploy command called --json-output which writes a file called cluster_toolkit_output.json with the output messages written JSON format (instead of the usual "english text output" to STDOUT.

This pull request was submitted git commit --no-verify because of failing go staticchecks that prevent git commit from successfully running

What works as of now
 - Writes output to JSON file
 
 What does not work as of now:
 - Cluster Deployment does not seem to work (I am unsure if the failure is related to my changes)
