### PR TITLE
Add cuda-toolkit to a3ultra-jbvms blueprint

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -105,6 +105,14 @@ deployment_groups:
     settings:
       configure_ssh_host_patterns:
       - $(vars.hostname_prefix)-*
+      runners:
+      - type: shell
+        destination: install-cuda-toolkit.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          sudo add-nvidia-repositories -y
+          sudo apt install -y cuda-toolkit-12-8
 
   - id: a3ultra-vms
     source: modules/compute/vm-instance

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -111,8 +111,8 @@ deployment_groups:
         content: |
           #!/bin/bash
           set -e -o pipefail
-          sudo add-nvidia-repositories -y
-          sudo apt install -y cuda-toolkit-12-8
+          add-nvidia-repositories -y
+          apt install -y cuda-toolkit-12-8
 
   - id: a3ultra-vms
     source: modules/compute/vm-instance


### PR DESCRIPTION
This PR adds the installation of [cuda-toolkit-12-8](https://developer.nvidia.com/cuda-downloads?target_os=Linux&target_arch=x86_64&Distribution=Ubuntu&target_version=22.04&target_type=deb_network) to the [a3ultra-vm.yaml](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml) blueprint. 
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
