### PR TITLE
Fixes HPL benchmark test due to WARMUP_END_PROG environment variable.

### DIFF
--- a/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
@@ -122,7 +122,6 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
-      release_channel: RAPID
       system_node_pool_machine_type: "e2-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
@@ -133,11 +132,6 @@ deployment_groups:
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      maintenance_exclusions:
-      - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2024-12-01T00:00:00Z"
-        end_time: "2025-12-22T00:00:00Z"
-        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
       additional_networks:
         $(concat(
           [{
@@ -154,6 +148,15 @@ deployment_groups:
           }],
          gke-a3-ultra-rdma-net.subnetwork_interfaces_gke
         ))
+      # Cluster versions cannot be updated through the toolkit after creation
+      # Please manage cluster version from the Google Cloud Console directly
+      version_prefix: "1.31."
+      release_channel: RAPID
+      maintenance_exclusions:
+      - name: no-minor-or-node-upgrades-indefinite
+        start_time: "2024-12-01T00:00:00Z"
+        end_time: "2025-12-22T00:00:00Z"
+        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
     outputs: [instructions]
 
   - id: a3-ultragpu-pool

--- a/examples/hypercompute_clusters/a3u-gke-gcs/system_benchmarks/ramble-hpl.yaml
+++ b/examples/hypercompute_clusters/a3u-gke-gcs/system_benchmarks/ramble-hpl.yaml
@@ -125,6 +125,7 @@ data:
           ${!NCCL*}
           ${!OMPI*}
           LD_LIBRARY_PATH
+          WARMUP_END_PROG
           ${!HPL*}
           ${!UCX*}
           | sed 's/ / -x /g')
@@ -165,7 +166,7 @@ data:
               experiments:
                 hpl-{n_nodes}:
                   variables:
-                    n_nodes: [1,2,4,8,16,24,32]
+                    n_nodes: [1,2,4,8,16,32]
 
                     # 0 = ncclBcast, 1 = ncclSend/Recv
                     hpl_p2p_as_bcast: '0'


### PR DESCRIPTION
Previously if you don't  pass WARMUP_END_PROG, this will block after the warmup because OpenMPI doesn't pass environment variables by default. 

Also brings up to date with gke-a3-ultragpu best practices with GKE cluster versions. Has been tested manually.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
