### PR TITLE
Increase google and google-beta provider versions for GKE cluster

### DIFF
--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -107,16 +107,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | > 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.16 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.16 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | > 5.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | > 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.16 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.16 |
 
 ## Modules
 

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "> 5.0"
+      version = ">= 6.16"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "> 5.0"
+      version = ">= 6.16"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -30,6 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.45.0"
+  }
+
+  provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.45.0"
   }
 }


### PR DESCRIPTION
Current provider version has a known bug:

GKE Terraform Node Pool Update Failure
Issue: A customer experiences "Error: googleapi: Error 400:" when updating a GKE node pool using Terraform, due to an outdated Terraform provider (google-beta_v4.85.0). The provider incorrectly attempts to clear a kubelet_config field, which the GKE API rejects. The issue stems from an incompatibility between the old provider and a new computed field introduced in newer versions.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
