### PR TITLE
Prevent mixing tz-aware and tz-naive datetime.

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -154,7 +154,7 @@ def _find_dynamic_node_status() -> NodeAction:
     return NodeActionUnchanged()  # don't touch dynamic nodes
 
 def get_fr_action(fr: FutureReservation, state:Optional[NodeState]) -> Optional[NodeAction]:
-    now = datetime.now(timezone.utc)
+    now = util.now()
     if state is None:
         return None # handle like any other node
     if fr.start_time < now < fr.end_time:
@@ -283,7 +283,7 @@ def get_node_action(nodename: str) -> NodeAction:
     elif (state is None or "POWERED_DOWN" in state.flags) and inst.status == "RUNNING":
         log.info("%s is potential orphan node", nodename)
         threshold = timedelta(seconds=90)
-        age = datetime.now(timezone.utc) - inst.creation_timestamp
+        age = util.now() - inst.creation_timestamp
         log.info(f"{nodename} state: {state}, age: {age}")
         if age < threshold:
             log.info(f"{nodename} not marked as orphan, it started less than {threshold.seconds}s ago ({age.seconds}s)")

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/common.py
@@ -42,6 +42,7 @@ class TstNodeset:
     zone_policy_allow: Optional[list[str]] = field(default_factory=list)
     enable_placement: bool = True
     placement_max_distance: Optional[int] = None
+    future_reservation: Optional[str] = ""
 
 @dataclass
 class TstPartition:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -17,10 +17,11 @@ from typing import Optional, Type
 import pytest
 from mock import Mock
 from datetime import datetime, timezone, timedelta
+import unittest
 
 from common import TstNodeset, TstCfg # needed to import util
 import util
-from util import NodeState, MachineType, AcceleratorInfo, UpcomingMaintenance, InstanceResourceStatus
+from util import NodeState, MachineType, AcceleratorInfo, UpcomingMaintenance, InstanceResourceStatus, FutureReservation, ReservationDetails
 from google.api_core.client_options import ClientOptions  # noqa: E402
 
 # Note: need to install pytest-mock
@@ -414,6 +415,8 @@ UTC, PST = timezone.utc, timezone(timedelta(hours=-8))
         ("2024-11-05T15:23:33.702-08:00", datetime(2024, 11, 5, 15, 23, 33, 702000, tzinfo=PST)), 
         # from futureReservation.timeWindow.endTime
         ("2025-01-15T00:00:00Z", datetime(2025, 1, 15, 0, 0, tzinfo=UTC)),
+        # fallback to UTC if no tz is specified
+        ("2025-01-15T00:00:00", datetime(2025, 1, 15, 0, 0, tzinfo=UTC)),
     ])
 def test_parse_gcp_timestamp(got: str, want: datetime):
     assert util.parse_gcp_timestamp(got) == want
@@ -486,3 +489,90 @@ def tests_parse_UpcomingMaintenance_FAIL(got: dict):
     ])
 def test_parse_InstanceResourceStatus(got: dict, want: Optional[InstanceResourceStatus]):
     assert InstanceResourceStatus.from_json(got) == want
+
+
+def test_future_reservation_none():
+    lkp = util.Lookup(TstCfg())
+    assert lkp.future_reservation(TstNodeset()) == None
+
+
+def test_future_reservation_declined():
+    lkp = util.Lookup(TstCfg())
+    lkp._get_future_reservation = Mock(return_value=dict(
+        timeWindow = { "startTime": "2025-01-27T23:30:00Z", "endTime": "2025-02-03T23:30:00Z" },
+        status = {"procurementStatus": "DECLINED"},
+        specificReservationRequired = True,
+    ))
+
+    assert lkp.future_reservation(
+        TstNodeset(future_reservation="projects/manhattan/zones/danger/futureReservations/zebra")) == FutureReservation(
+            project='manhattan', 
+            zone='danger', 
+            name='zebra', 
+            specific=True, 
+            start_time=datetime(2025, 1, 27, 23, 30, tzinfo=timezone.utc), 
+            end_time=datetime(2025, 2, 3, 23, 30, tzinfo=timezone.utc), 
+            active_reservation=None)
+    lkp._get_future_reservation.assert_called_once_with("manhattan", "danger", "zebra")
+
+@unittest.mock.patch('util.now', return_value=datetime(2025, 2, 13, 0, 0, tzinfo=timezone.utc))
+def test_future_reservation_active(_):
+    lkp = util.Lookup(TstCfg())
+    lkp._get_future_reservation = Mock(return_value=dict(
+        timeWindow = { "startTime": "2025-01-27T23:30:00Z", "endTime": "2025-02-21T23:30:00Z" },
+        status = {
+            "procurementStatus": "FULFILLED",
+            "autoCreatedReservations": [
+                "https://www.googleapis.com/compute/alpha/projects/manhattan/zones/danger/reservations/melon"
+            ],
+        },
+        specificReservationRequired = True,
+    ))
+    lkp._get_reservation = Mock(return_value=dict())
+
+    assert lkp.future_reservation(
+        TstNodeset(future_reservation="projects/manhattan/zones/danger/futureReservations/zebra")) == FutureReservation(
+            project='manhattan', 
+            zone='danger', 
+            name='zebra', 
+            specific=True, 
+            start_time=datetime(2025, 1, 27, 23, 30, tzinfo=timezone.utc), 
+            end_time=datetime(2025, 2, 21, 23, 30, tzinfo=timezone.utc), 
+            active_reservation=ReservationDetails(
+                project='manhattan',
+                zone='danger',
+                name='melon',
+                policies=[],
+                bulk_insert_name="projects/manhattan/reservations/melon",
+                deployment_type=None))
+    
+    lkp._get_future_reservation.assert_called_once_with("manhattan", "danger", "zebra")
+    lkp._get_reservation.assert_called_once_with("manhattan", "danger", "melon")
+
+@unittest.mock.patch('util.now', return_value=datetime(2025, 2, 28, 0, 0, tzinfo=timezone.utc))
+def test_future_reservation_inactive(_):
+    lkp = util.Lookup(TstCfg())
+    lkp._get_future_reservation = Mock(return_value=dict(
+        timeWindow = { "startTime": "2025-01-27T23:30:00Z", "endTime": "2025-02-21T23:30:00Z" },
+        status = {
+            "procurementStatus": "FULFILLED",
+            "autoCreatedReservations": [
+                "https://www.googleapis.com/compute/alpha/projects/manhattan/zones/danger/reservations/melon"
+            ],
+        },
+        specificReservationRequired = True,
+    ))
+    lkp._get_reservation = Mock()
+
+    assert lkp.future_reservation(
+        TstNodeset(future_reservation="projects/manhattan/zones/danger/futureReservations/zebra")) == FutureReservation(
+            project='manhattan', 
+            zone='danger', 
+            name='zebra', 
+            specific=True, 
+            start_time=datetime(2025, 1, 27, 23, 30, tzinfo=timezone.utc), 
+            end_time=datetime(2025, 2, 21, 23, 30, tzinfo=timezone.utc), 
+            active_reservation=None)
+    
+    lkp._get_future_reservation.assert_called_once_with("manhattan", "danger", "zebra")
+    lkp._get_reservation.assert_not_called()

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -260,15 +260,32 @@ def authentication_project():
 DEFAULT_UNIVERSE_DOMAIN = "googleapis.com"
 
 
+def now() -> datetime:
+    """
+    Return current time as timezone-aware datetime.
+
+    IMPORTANT: DO NOT use `datetime.now()`, unless you explicitly need to have tz-naive datetime.
+    Otherwise there is a risk of getting: "cannot compare naive and aware datetimes" error, 
+    since all timetstamps we receive from GCP API are tz-aware.
+
+    Another motivation  for this function is to allow to mock time in tests.
+    """
+    return datetime.now(timezone.utc)
+
 def parse_gcp_timestamp(s: str) -> datetime:
   """
   Parse timestamp strings returned by GCP API into datetime.
   Works with both Zulu and non-Zulu timestamps.
+  NOTE: It always return tz-aware datetime (fallbacks to UTC and logs error).
   """
   # Requires Python >= 3.7
   # TODO: Remove this "hack" of trimming the Z from timestamps once we move to Python 3.11 
   # (context: https://discuss.python.org/t/parse-z-timezone-suffix-in-datetime/2220/30)
-  return datetime.fromisoformat(s.replace('Z', '+00:00'))
+  ts = datetime.fromisoformat(s.replace('Z', '+00:00'))
+  if ts.tzinfo is None: # fallback to UTC
+    log.error(f"Received timestamp without timezone info: {s}")
+    ts = ts.replace(tzinfo=timezone.utc)
+  return ts
 
 
 def universe_domain() -> str:
@@ -1667,7 +1684,7 @@ class Lookup:
         end_time = parse_gcp_timestamp(fr["timeWindow"]["endTime"])
 
         if "autoCreatedReservations" in fr["status"] and (res:=fr["status"]["autoCreatedReservations"][0]):
-            if (start_time<=datetime.now(timezone.utc)<=end_time):
+            if start_time <= now() <=end_time:
                 match = re.search(r'projects/(?P<project>[^/]+)/zones/(?P<zone>[^/]+)/reservations/(?P<name>[^/]+)(/.*)?$',res)
                 assert match, f"Unexpected reservation name '{res}'"
                 res_name = match.group("name")


### PR DESCRIPTION
* Add `util.now` to simplify obtaining tz-aware timestamps;
* Make `util.parse_gcp_timestamp` to fallback to UTC;
* Add tests for `Lookup.future_reservation`.
