### PR TITLE
Switch ofi startup script to not run automatically

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ HPC deployments on the Google Cloud Platform.`,
 				logging.Fatal("cmd.Help function failed: %s", err)
 			}
 		},
-		Version:     "v1.46.0",
+		Version:     "v1.46.1",
 		Annotations: annotation,
 	}
 )

--- a/community/examples/hpc-slurm-h4d.yaml
+++ b/community/examples/hpc-slurm-h4d.yaml
@@ -128,14 +128,8 @@ deployment_groups:
       machine_type: n2-standard-4
       enable_login_public_ips: true
 
-  - id: slurm_controller_startup
-    source: modules/scripts/startup-script
-    settings:
-      set_ofi_cloud_rdma_tunables: true
-
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     use: [h4d-slurm-net-0, h4d_partition, slurm_login, homefs, appsfs]
     settings:
       enable_controller_public_ips: true
-      controller_startup_script: $(slurm_controller_startup.startup_script)

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -25,6 +25,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.46.1"
   }
 }

--- a/community/modules/compute/mig/versions.tf
+++ b/community/modules/compute/mig/versions.tf
@@ -22,6 +22,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:mig/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:mig/v1.46.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.46.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.3"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.46.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.46.1"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.3"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.46.1"
   }
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.46.1"
   }
 
   required_version = ">= 0.13.0"

--- a/community/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/community/modules/file-system/cloud-storage-bucket/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.46.1"
   }
   required_version = ">= 0.14.0"
 }

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/files/fsi-montecarlo-on-batch/versions.tf
+++ b/community/modules/files/fsi-montecarlo-on-batch/versions.tf
@@ -35,9 +35,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.46.1"
   }
 }

--- a/community/modules/network/private-service-access/versions.tf
+++ b/community/modules/network/private-service-access/versions.tf
@@ -30,11 +30,11 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.46.1"
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.46.1"
   }
 
   required_version = ">= 1.2"

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/pubsub/bigquery-sub/versions.tf
+++ b/community/modules/pubsub/bigquery-sub/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.46.1"
   }
   required_version = ">= 1.0"
 }

--- a/community/modules/pubsub/topic/versions.tf
+++ b/community/modules/pubsub/topic/versions.tf
@@ -27,6 +27,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:topic/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:topic/v1.46.1"
   }
 }

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.46.1"
   }
 
   required_version = ">= 1.1"

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.46.1"
   }
 
   required_version = ">= 1.1.0"

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.46.1"
   }
 
   required_version = ">= 1.3.0"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.46.1"
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.46.1"
   }
 }

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -30,6 +30,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.46.1"
   }
 }

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -31,10 +31,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.46.1"
   }
 
   required_version = ">= 1.3.0"

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.46.1"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.46.1"
   }
 
   required_version = ">= 1.3.0"

--- a/modules/file-system/gke-persistent-volume/versions.tf
+++ b/modules/file-system/gke-persistent-volume/versions.tf
@@ -29,6 +29,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.46.1"
   }
 }

--- a/modules/file-system/gke-storage/versions.tf
+++ b/modules/file-system/gke-storage/versions.tf
@@ -16,6 +16,6 @@ terraform {
   required_version = ">= 1.5"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.46.1"
   }
 }

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/network/firewall-rules/versions.tf
+++ b/modules/network/firewall-rules/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.46.1"
   }
 
   required_version = ">= 1.5"

--- a/modules/network/pre-existing-subnetwork/versions.tf
+++ b/modules/network/pre-existing-subnetwork/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.46.1"
   }
 
   required_version = ">= 1.5"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.46.1"
   }
 
   required_version = ">= 1.5"

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.46.1"
   }
 
   required_version = ">= 0.14.0"

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -30,6 +30,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.46.1"
   }
 }

--- a/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -23,7 +23,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.46.1"
   }
 
   required_version = ">= 1.3"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -93,7 +93,7 @@ locals {
     }
   ]
 
-  ofi_runner = var.set_ofi_cloud_rdma_tunables == "" ? [] : [
+  ofi_runner = !var.set_ofi_cloud_rdma_tunables ? [] : [
     {
       type        = "data"
       destination = "/etc/profile.d/set_ofi_cloud_rdma_tunables.sh"
@@ -102,7 +102,8 @@ locals {
         export FI_PROVIDER="verbs;ofi_rxm"
         export FI_OFI_RXM_USE_RNDV_WRITE=1
         export FI_VERBS_INLINE_SIZE=39
-        export I_MPI_FABRICS="shm:rxm"
+        export I_MPI_FABRICS="shm:ofi"
+        export FI_UNIVERSE_SIZE=3072
         EOT
     },
   ]

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.46.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.46.1"
   }
 
   required_version = ">= 1.5"


### PR DESCRIPTION
Fixed the boolean logic behind whether the OFI tunable are set for Cloud RDMA (which was introduced in #3642 ). Thereby preventing it from running on all deployments.

Problem: Terraform around running/not running the script had a bug which made it run all the time. This is problematic for MPI workloads that rely on OFI tunables.

Solution: Fix the boolean logic so it accounts for whether `set_ofi_cloud_rdma_tunables` is set to true or false (and defaults to false).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
