### PR TITLE
Configure 2-Party Review on Github PRs from External Contributors

### DIFF
--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -1,0 +1,45 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'multi-approvers'
+
+on:
+  pull_request:
+    types:
+    - 'opened'
+    - 'edited'
+    - 'reopened'
+    - 'synchronize'
+    - 'ready_for_review'
+    - 'review_requested'
+    - 'review_request_removed'
+  pull_request_review:
+    types:
+    - 'submitted'
+    - 'dismissed'
+
+permissions:
+  actions: 'write'
+  contents: 'read'
+  pull-requests: 'read'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  multi-approvers:
+    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
+    with:
+      org-members-path: 'GoogleCloudPlatform/cluster-toolkit/develop/cluster-toolkit-writers.json'


### PR DESCRIPTION
This PR  adds a [workflow](https://github.com/abcxyz/pkg?tab=readme-ov-file#multi-approversyml) that configures 2-Party Review on PRs from External Contributors. We define an external contributor as someone who doesn't have write permissions to the Cluster toolkit Github repository. It will require a single approval for PRs created from users with write access, but require two approvals for PRs created by users without write permissions. This PR depends on [PR3662](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3662) being merged.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
