### PR TITLE
Include list of members with write permissions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,5 +134,5 @@ repos:
   rev: v2.2.6
   hooks:
   - id: codespell
-    exclude: requirements.txt$|/js/|go.sum$
+    exclude: requirements.txt$|/js/|go.sum$|cluster-toolkit-writers.json$
 exclude: tools/validate_configs/golden_copies/.*

--- a/cluster-toolkit-writers.json
+++ b/cluster-toolkit-writers.json
@@ -1,0 +1,347 @@
+[
+  {
+    "login": "ekuefler"
+  },
+  {
+    "login": "ankitkinra"
+  },
+  {
+    "login": "mr0re1"
+  },
+  {
+    "login": "tpdownes"
+  },
+  {
+    "login": "rohitramu"
+  },
+  {
+    "login": "cboneti"
+  },
+  {
+    "login": "sharabiani"
+  },
+  {
+    "login": "nick-stroud"
+  },
+  {
+    "login": "ighosh98"
+  },
+  {
+    "login": "harshthakkar01"
+  },
+  {
+    "login": "SwarnaBharathiMantena"
+  },
+  {
+    "login": "RachaelSTamakloe"
+  },
+  {
+    "login": "abbas1902"
+  },
+  {
+    "login": "xsxm"
+  },
+  {
+    "login": "cdunbar13"
+  },
+  {
+    "login": "alyssa-sm"
+  },
+  {
+    "login": "annuay-google"
+  },
+  {
+    "login": "pawloch00"
+  },
+  {
+    "login": "gokamesh"
+  },
+  {
+    "login": "nadig-google"
+  },
+  {
+    "login": "mohitchaurasia91"
+  },
+  {
+    "login": "jemish-google"
+  },
+  {
+    "login": "parulbajaj01"
+  },
+  {
+    "login": "chengcongdu"
+  },
+  {
+    "login": "kmbannerman"
+  },
+  {
+    "login": "AlexisYushio"
+  },
+  {
+    "login": "keenan-devrel"
+  },
+  {
+    "login": "dazuma"
+  },
+  {
+    "login": "jskeet"
+  },
+  {
+    "login": "glaforge"
+  },
+  {
+    "login": "cwest"
+  },
+  {
+    "login": "engelke"
+  },
+  {
+    "login": "fhinkel"
+  },
+  {
+    "login": "briandorsey"
+  },
+  {
+    "login": "palladius"
+  },
+  {
+    "login": "callingshotgun"
+  },
+  {
+    "login": "muncus"
+  },
+  {
+    "login": "darylducharme"
+  },
+  {
+    "login": "grayside"
+  },
+  {
+    "login": "koverholt"
+  },
+  {
+    "login": "wietsevenema"
+  },
+  {
+    "login": "ankurkotwal"
+  },
+  {
+    "login": "ksprashu"
+  },
+  {
+    "login": "arbrown"
+  },
+  {
+    "login": "momander"
+  },
+  {
+    "login": "donmccasland"
+  },
+  {
+    "login": "glasnt"
+  },
+  {
+    "login": "rsamborski"
+  },
+  {
+    "login": "alexismp"
+  },
+  {
+    "login": "meteatamel"
+  },
+  {
+    "login": "boredabdel"
+  },
+  {
+    "login": "iennae"
+  },
+  {
+    "login": "rominirani"
+  },
+  {
+    "login": "kazunori279"
+  },
+  {
+    "login": "davidcavazos"
+  },
+  {
+    "login": "bourgeoisor"
+  },
+  {
+    "login": "minherz"
+  },
+  {
+    "login": "vladkol"
+  },
+  {
+    "login": "kaslin"
+  },
+  {
+    "login": "parthea"
+  },
+  {
+    "login": "LukeSchlangen"
+  },
+  {
+    "login": "billyjacobson"
+  },
+  {
+    "login": "msampathkumar"
+  },
+  {
+    "login": "polong-lin"
+  },
+  {
+    "login": "villasenor"
+  },
+  {
+    "login": "alphinside"
+  },
+  {
+    "login": "vishwarajanand"
+  },
+  {
+    "login": "telpirion"
+  },
+  {
+    "login": "ZackAkil"
+  },
+  {
+    "login": "joeshirey"
+  },
+  {
+    "login": "m-strzelczyk"
+  },
+  {
+    "login": "NimJay"
+  },
+  {
+    "login": "molliemarie"
+  },
+  {
+    "login": "saraford"
+  },
+  {
+    "login": "maxsaltonstall"
+  },
+  {
+    "login": "kweinmeister"
+  },
+  {
+    "login": "Mukamik"
+  },
+  {
+    "login": "holtskinner"
+  },
+  {
+    "login": "Neenu1995"
+  },
+  {
+    "login": "Deleplace"
+  },
+  {
+    "login": "Sita04"
+  },
+  {
+    "login": "AbiramiSukumaran"
+  },
+  {
+    "login": "moficodes"
+  },
+  {
+    "login": "amanda-tarafa"
+  },
+  {
+    "login": "aliciawilliams"
+  },
+  {
+    "login": "nikitamaia"
+  },
+  {
+    "login": "ChloeCodesThings"
+  },
+  {
+    "login": "jeffonelson"
+  },
+  {
+    "login": "GabeWeiss"
+  },
+  {
+    "login": "h3xar0n"
+  },
+  {
+    "login": "katiemn"
+  },
+  {
+    "login": "iamthuya"
+  },
+  {
+    "login": "bradmiro"
+  },
+  {
+    "login": "shanecglass"
+  },
+  {
+    "login": "PicardParis"
+  },
+  {
+    "login": "gotochkin"
+  },
+  {
+    "login": "chubirka"
+  },
+  {
+    "login": "jesuispy"
+  },
+  {
+    "login": "hyunuk"
+  },
+  {
+    "login": "rachael-ds"
+  },
+  {
+    "login": "eaball35"
+  },
+  {
+    "login": "weifonghsia"
+  },
+  {
+    "login": "alokpattani"
+  },
+  {
+    "login": "dandhlee"
+  },
+  {
+    "login": "duncantech"
+  },
+  {
+    "login": "inardini"
+  },
+  {
+    "login": "lavinigam-gcp"
+  },
+  {
+    "login": "gericdong"
+  },
+  {
+    "login": "priyapandeyb"
+  },
+  {
+    "login": "erwinh85"
+  },
+  {
+    "login": "CadillacBurgess1"
+  },
+  {
+    "login": "debi-ch"
+  },
+  {
+    "login": "douglasjacobsen"
+  },
+  {
+    "login": "samskillman"
+  },
+  {
+    "login": "yuryu"
+  }
+]


### PR DESCRIPTION
This PR adds the list of cluster toolkit users with write access to the Cluster Toolkit github repository. This list will be used to configure 2-Party Review on Github PRs from External Contributors in the workflow defined in [PR3660](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3660). The workflow will require two members from this list to approve pull requests sent from an external contributor. We define an external contributor as someone who doesn't have write permissions to the Cluster toolkit Github repository.

Members of groups were generated by running the below command:
```
gh api   \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   --paginate /orgs/GoogleCloudPlatform/teams/<TEAM_NAME>/members \
| jq '[.[] | {login}]'
```
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
