### PR TITLE
Stable IP for HTCondor MIGs

### DIFF
--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -128,6 +128,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
+| [google_compute_address.ap](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_disk.spool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_region_disk.spool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_disk) | resource |
 | [google_storage_bucket_object.ap_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |

--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -97,7 +97,7 @@ locals {
     ])
   }
 
-  access_point_ips  = [data.google_compute_instance.ap.network_interface[0].network_ip]
+  access_point_ips  = google_compute_address.ap.address
   access_point_name = data.google_compute_instance.ap.name
 
   spool_disk_resource_name = "${var.deployment_name}-spool-disk"
@@ -225,6 +225,14 @@ resource "google_compute_disk" "spool" {
   size   = var.spool_disk_size_gb
 }
 
+resource "google_compute_address" "ap" {
+  project      = var.project_id
+  name         = local.name_prefix
+  subnetwork   = var.subnetwork_self_link
+  address_type = "INTERNAL"
+  purpose      = "GCE_ENDPOINT"
+}
+
 module "access_point_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "~> 12.1"
@@ -250,6 +258,8 @@ module "access_point_instance_template" {
   # secure boot
   enable_shielded_vm       = var.enable_shielded_vm
   shielded_instance_config = var.shielded_instance_config
+
+  network_ip = google_compute_address.ap.id
 
   # spool disk
   additional_disks = [
@@ -305,12 +315,11 @@ module "htcondor_ap" {
     device_name = local.spool_disk_device_name
     delete_rule = "ON_PERMANENT_INSTANCE_DELETION"
   }]
-
-  stateful_ips = [{
+  stateful_ips = var.enable_public_ips ? [{
     interface_name = "nic0"
     delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
-    is_external    = var.enable_public_ips
-  }]
+    is_external    = true
+  }] : null
 
   # the timeouts below are default for resource
   wait_for_instances = true

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -112,6 +112,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
+| [google_compute_address.cm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_storage_bucket_object.cm_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_compute_image.htcondor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_instance.cm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance) | data source |

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -69,7 +69,7 @@ locals {
     [local.schedd_runner]
   )
 
-  central_manager_ips  = [data.google_compute_instance.cm.network_interface[0].network_ip]
+  central_manager_ips  = google_compute_address.cm.address
   central_manager_name = data.google_compute_instance.cm.name
 
   list_instances_command = "gcloud compute instance-groups list-instances ${data.google_compute_region_instance_group.cm.name} --region ${var.region} --project ${var.project_id}"
@@ -132,6 +132,14 @@ module "startup_script" {
   runners = local.all_runners
 }
 
+resource "google_compute_address" "cm" {
+  project      = var.project_id
+  name         = local.name_prefix
+  subnetwork   = var.subnetwork_self_link
+  address_type = "INTERNAL"
+  purpose      = "GCE_ENDPOINT"
+}
+
 module "central_manager_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "~> 12.1"
@@ -156,6 +164,8 @@ module "central_manager_instance_template" {
   # secure boot
   enable_shielded_vm       = var.enable_shielded_vm
   shielded_instance_config = var.shielded_instance_config
+
+  network_ip = google_compute_address.cm.id
 }
 
 module "htcondor_cm" {
@@ -197,12 +207,6 @@ module "htcondor_cm" {
     min_ready_sec                = 300
     minimal_action               = "REPLACE"
     type                         = var.update_policy
-  }]
-
-  stateful_ips = [{
-    interface_name = "nic0"
-    delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
-    is_external    = false
   }]
 
   # the timeouts below are default for resource


### PR DESCRIPTION
Add stable IPs for HTCondor Access Point and Central Manager.

Related to https://github.com/GoogleCloudPlatform/cluster-toolkit/issues/3329