### PR TITLE
Add hyperdisk-ml support for gke-storage

### DIFF
--- a/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-ml-pvc.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-ml-pvc.yaml.tftpl
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc_name}
+  labels:
+  %{~ for key, val in labels ~}
+    ${key}: ${val}
+  %{~ endfor ~}
+spec:
+  accessModes:
+    - ${access_mode}
+  resources:
+    requests:
+      storage: ${capacity}
+  storageClassName: ${storage_class_name}
+

--- a/modules/file-system/gke-storage/storage-class/hyperdisk-ml-sc.yaml.tftpl
+++ b/modules/file-system/gke-storage/storage-class/hyperdisk-ml-sc.yaml.tftpl
@@ -1,0 +1,24 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ${name}
+  labels:
+  %{~ for key, val in labels ~}
+    ${key}: ${val}
+provisioner: pd.csi.storage.gke.io
+allowVolumeExpansion: true
+parameters:
+  %{~ endfor ~}
+  type: hyperdisk-ml
+volumeBindingMode: ${volume_binding_mode}
+reclaimPolicy: ${reclaim_policy}
+  %{~ if topology_zones != null ~}
+allowedTopologies:
+- matchLabelExpressions:
+  - key: topology.gke.io/zone
+    values:
+    %{~ for z in topology_zones ~}
+    - ${z}
+    %{~ endfor ~}
+  %{~ endif ~}
+

--- a/modules/file-system/gke-storage/variables.tf
+++ b/modules/file-system/gke-storage/variables.tf
@@ -41,7 +41,7 @@ variable "storage_type" {
   type        = string
   nullable    = false
   validation {
-    condition     = var.storage_type == null ? false : contains(["parallelstore", "hyperdisk-balanced", "hyperdisk-throughput", "hyperdisk-extreme"], lower(var.storage_type))
+    condition     = var.storage_type == null ? false : contains(["parallelstore", "hyperdisk-balanced", "hyperdisk-throughput", "hyperdisk-extreme", "hyperdisk-ml"], lower(var.storage_type))
     error_message = "Allowed string values for var.storage_type are \"Parallelstore\", \"Hyperdisk-balanced\", \"Hyperdisk-throughput\", \"Hyperdisk-extreme\"."
   }
 }


### PR DESCRIPTION
Hyperdisk-ml is the recommended storage for speeding up load times and inference of larger models eg. DeepSeek-R1, Llama3-405b, which often takes a long time ~20min+

Source: https://cloud.google.com/kubernetes-engine/docs/tutorials/serve-multihost-gpu#speed_up_model_load_times_with_hyperdisk_ml

This PR is to add hyperdisk-ml support by adding this disk type as a valid condition in `variables.tf`, and new templates for storage class and PVC