### PR TITLE
Enable NVIDIA DCGM in A3 Ultra Slurm blueprint

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
@@ -125,6 +125,51 @@ vars:
             state: started
             enabled: true
 
+  - type: ansible-local
+    destination: enable_dcgm.yml
+    content: |
+      ---
+      - name: Enable NVIDIA DCGM on GPU nodes
+        hosts: all
+        become: true
+        vars:
+          enable_ops_agent: true
+          enable_nvidia_dcgm: true
+        tasks:
+        - name: Update Ops Agent configuration
+          ansible.builtin.blockinfile:
+            path: /etc/google-cloud-ops-agent/config.yaml
+            insertafter: EOF
+            block: |
+              metrics:
+                receivers:
+                  dcgm:
+                    type: dcgm
+                service:
+                  pipelines:
+                    dcgm:
+                      receivers:
+                        - dcgm
+          notify:
+          - Restart Google Cloud Ops Agent
+        handlers:
+        - name: Restart Google Cloud Ops Agent
+          ansible.builtin.service:
+            name: google-cloud-ops-agent.service
+            state: "{{ 'restarted' if enable_ops_agent else 'stopped' }}"
+            enabled: "{{ enable_ops_agent }}"
+        post_tasks:
+        - name: Enable Google Cloud Ops Agent
+          ansible.builtin.service:
+            name: google-cloud-ops-agent.service
+            state: "{{ 'started' if enable_ops_agent else 'stopped' }}"
+            enabled: "{{ enable_ops_agent }}"
+        - name: Enable NVIDIA DCGM
+          ansible.builtin.service:
+            name: nvidia-dcgm.service
+            state: "{{ 'started' if enable_nvidia_dcgm else 'stopped' }}"
+            enabled: "{{ enable_nvidia_dcgm }}"
+
   # Configure Cloud Storage FUSE
   - type: ansible-local
     destination: gcsfuse.yml

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -316,6 +316,50 @@ deployment_groups:
                 name: nccl-plugin@$(vars.nccl_plugin_version).service
                 state: started
                 enabled: true
+      - type: ansible-local
+        destination: enable_dcgm.yml
+        content: |
+          ---
+          - name: Enable NVIDIA DCGM on GPU nodes
+            hosts: all
+            become: true
+            vars:
+              enable_ops_agent: true
+              enable_nvidia_dcgm: true
+            tasks:
+            - name: Update Ops Agent configuration
+              ansible.builtin.blockinfile:
+                path: /etc/google-cloud-ops-agent/config.yaml
+                insertafter: EOF
+                block: |
+                  metrics:
+                    receivers:
+                      dcgm:
+                        type: dcgm
+                    service:
+                      pipelines:
+                        dcgm:
+                          receivers:
+                            - dcgm
+              notify:
+              - Restart Google Cloud Ops Agent
+            handlers:
+            - name: Restart Google Cloud Ops Agent
+              ansible.builtin.service:
+                name: google-cloud-ops-agent.service
+                state: "{{ 'restarted' if enable_ops_agent else 'stopped' }}"
+                enabled: "{{ enable_ops_agent }}"
+            post_tasks:
+            - name: Enable Google Cloud Ops Agent
+              ansible.builtin.service:
+                name: google-cloud-ops-agent.service
+                state: "{{ 'started' if enable_ops_agent else 'stopped' }}"
+                enabled: "{{ enable_ops_agent }}"
+            - name: Enable NVIDIA DCGM
+              ansible.builtin.service:
+                name: nvidia-dcgm.service
+                state: "{{ 'started' if enable_nvidia_dcgm else 'stopped' }}"
+                enabled: "{{ enable_nvidia_dcgm }}"
 
   - id: a3_ultra_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -402,8 +402,8 @@ deployment_groups:
       is_default: true
       partition_conf:
         OverSubscribe: EXCLUSIVE
-        ResumeTimeout: 900
-        SuspendTimeout: 600
+        ResumeTimeout: 1200
+        SuspendTimeout: 1200
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login


### PR DESCRIPTION
The A3 Ultra Slurm blueprints inadvertently did not enable NVIDIA DCGM and the Cloud Ops Agent on the GPU compute nodes. This PR remedies that oversight.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
