### PR TITLE
OFE: update Python to version 3.12

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -48,7 +48,7 @@ printf "####################\n#### Installing required packages\n###############
 dnf install -y epel-release
 dnf update -y --security
 dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
-dnf install -y terraform-1.4.6
+dnf install -y terraform
 dnf install --best -y google-cloud-sdk nano make gcc python3.12-devel unzip git \
 	rsync wget nginx bind-utils policycoreutils-python-utils \
 	packer supervisor python3-certbot-nginx jq

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -49,7 +49,7 @@ dnf install -y epel-release
 dnf update -y --security
 dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
 dnf install -y terraform-1.4.6
-dnf install --best -y google-cloud-sdk nano make gcc python38-devel unzip git \
+dnf install --best -y google-cloud-sdk nano make gcc python3.12-devel unzip git \
 	rsync wget nginx bind-utils policycoreutils-python-utils \
 	packer supervisor python3-certbot-nginx jq
 curl --silent --show-error --location https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64 --output /usr/local/bin/yq
@@ -76,7 +76,7 @@ EOL
 
 dnf install -y grafana
 
-pip3.8 install google-api-python-client \
+pip3.12 install google-api-python-client \
 	google-cloud-secret-manager \
 	google.cloud.pubsub \
 	pyyaml addict httplib2
@@ -189,7 +189,7 @@ sudo su - gcluster -c /bin/bash <<EOF
   popd
 
   printf "\nEstablishing django environment..."
-  python3.8 -m venv /opt/gcluster/django-env
+  python3.12 -m venv /opt/gcluster/django-env
   source /opt/gcluster/django-env/bin/activate
   printf "\nUpgrading pip...\n"
   pip install --upgrade pip

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/partition_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/partition_config.yaml.j2
@@ -15,7 +15,10 @@
   settings:
     bandwidth_tier: {% if part.enable_tier1_networking %}tier_1_enabled{% else %}platform_default{% endif %}
     subnetwork_self_link: "projects/{{ cluster.project_id }}/regions/{{ cluster.cloud_region }}/subnetworks/{{ cluster.subnet.cloud_id }}"
-    enable_smt: {{ part.enable_hyperthreads }}
+    {% if not part.enable_hyperthreads %}
+    advanced_machine_features:
+      threads_per_core: 1
+    {% endif %}
     enable_placement: {{ part.enable_placement }}
     machine_type: {{ part.machine_type }}
     {% if part.reservation_name %}


### PR DESCRIPTION
Update for OFE to use Python 3.12 due to dependabot compatibility. See here:
https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3623

Minor fixes for OFE included.