### PR TITLE
Update a3-highgpu image blueprint to use install_nvidia_repo

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
@@ -86,7 +86,8 @@ deployment_groups:
             "install_ompi": true,
             "monitoring_agent": "cloud-ops",
             "nvidia_version": "latest",
-            "slurm_version": "23.11.8"
+            "slurm_version": "23.11.8",
+            "install_nvidia_repo": false
           }
       - type: shell
         destination: install_slurm.sh
@@ -95,7 +96,7 @@ deployment_groups:
           set -e -o pipefail
           ansible-galaxy role install googlecloudplatform.google_cloud_ops_agents
           ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.8.6 \
+              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.8.9 \
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml


### PR DESCRIPTION
This PR updates the a3-highgpu blueprint to use a new setting `install_nvidia_repo` which allows for optionally installing the nvidia repository in the image building process. It should be set to false when the image already has the nvidia repository installed.
