### PR TITLE
Update a3-highgpu image blueprint to remove slurm_version

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-1-image.yaml
@@ -86,7 +86,6 @@ deployment_groups:
             "install_ompi": true,
             "monitoring_agent": "cloud-ops",
             "nvidia_version": "latest",
-            "slurm_version": "23.11.8",
             "install_nvidia_repo": false
           }
       - type: shell


### PR DESCRIPTION
This PR removes the `slurm_version` setting from the a3-highgpu image blueprint.
