### PR TITLE
Remove autoscaling max nodes from A3H and A3M tests

### DIFF
--- a/tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml
@@ -33,7 +33,6 @@ cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
   reservation_affinity: "{{ reservation_affinity }}"
-  autoscaling_total_max_nodes: 2
   authorized_cidr: "{{ build_ip.stdout }}/32"
   network_name: "{{ network }}"
   local_ssd_count_nvme_block: 16

--- a/tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml
@@ -33,7 +33,6 @@ cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
   reservation_affinity: "{{ reservation_affinity }}"
-  autoscaling_total_max_nodes: 2
   authorized_cidr: "{{ build_ip.stdout }}/32"
   network_name: "{{ network }}"
   local_ssd_count_nvme_block: 16


### PR DESCRIPTION
Removed Autoscaling max nodes from tests in A3High and A3Mega, as static node count was added to them earlier.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
