### PR TITLE
SlurmGCP. Fix Debian-specific issues

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -179,7 +179,7 @@ def run_custom_scripts():
 def mount_save_state_disk():
     disk_name = f"/dev/disk/by-id/google-{lookup().cfg.controller_state_disk.device_name}"
     mount_point = util.slurmdirs.state
-    fs_type = "xfs"
+    fs_type = "ext4"
 
     rdevice = util.run(f"realpath {disk_name}").stdout.strip()
     file_output = util.run(f"file -s {rdevice}").stdout.strip()
@@ -234,7 +234,7 @@ def setup_munge_key():
     if munge_key.exists():
         log.info("Munge key already exists. Skipping key generation.")
     else:
-        run("create-munge-key -f", timeout=30)
+        run(f"dd if=/dev/random of={munge_key} bs=1024 count=1")
 
     shutil.chown(munge_key, user="munge", group="munge")
     os.chmod(munge_key, stat.S_IRUSR)


### PR DESCRIPTION
* Format controller state disk into `ext4` instead of `xfs`, because:
  * `ext4` is more fitting, no XL files are anticipated to be present;
  * Out debian image doesn't contain required packages to deal with `xfs`;
* Don't use `create-munge-key`, debian doesn't have it, instead generate it by `dd`.
