### PR TITLE
Allow the use of user-defined service accounts in vertex notebook instances

### DIFF
--- a/community/modules/compute/notebook/README.md
+++ b/community/modules/compute/notebook/README.md
@@ -76,11 +76,12 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the notebook. | `string` | n/a | yes |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | Bucket name, can be provided from the google-cloud-storage module | `string` | `null` | no |
-| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Instance Image | `map(string)` | <pre>{<br/>  "family": "tf-latest-cpu",<br/>  "name": null,<br/>  "project": "deeplearning-platform-release"<br/>}</pre> | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Instance Image | `map(string)` | <pre>{<br>  "family": "tf-latest-cpu",<br>  "name": null,<br>  "project": "deeplearning-platform-release"<br>}</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the resource Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to employ | `string` | n/a | yes |
 | <a name="input_mount_runner"></a> [mount\_runner](#input\_mount\_runner) | mount content from the google-cloud-storage module | `map(string)` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the notebook will be created. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | If defined, the instance will use the service account specified instead of the Default Compute Engine Service Account | `string` | `null` | no |
 | <a name="input_zone"></a> [zone](#input\_zone) | The zone to deploy to | `string` | n/a | yes |
 
 ## Outputs

--- a/community/modules/compute/notebook/main.tf
+++ b/community/modules/compute/notebook/main.tf
@@ -69,5 +69,12 @@ resource "google_workbench_instance" "instance" {
       project = var.instance_image.project
       family  = var.instance_image.family
     }
+
+    dynamic "service_accounts" {
+      for_each = var.service_account_email == null ? [] : [1]
+      content {
+        email = var.service_account_email
+      }
+    }
   }
 }

--- a/community/modules/compute/notebook/variables.tf
+++ b/community/modules/compute/notebook/variables.tf
@@ -79,3 +79,9 @@ variable "mount_runner" {
     error_message = "There must be 5 elements in the Mount Runner Arguments: ${var.mount_runner.args} \n "
   }
 }
+
+variable "service_account_email" {
+  description = "If defined, the instance will use the service account specified instead of the Default Compute Engine Service Account"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR adds the possibility of the user to define a service account and not use the default compute engine if he has security restrictions, for example.

`service_account_email` is an optional variable that will only be used if the user defines it, if left blank, the module behaviour will remain the same.