### PR TITLE
Fix issue 3748 (Error with stateful_ips iteration in MIG)

### DIFF
--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -325,7 +325,7 @@ module "htcondor_ap" {
     interface_name = "nic0"
     delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
     is_external    = true
-  }] : null
+  }] : []
 
   # the timeouts below are default for resource
   wait_for_instances = true


### PR DESCRIPTION
After upgrading to the latest release of Cluster Toolkit, an error occurs in the `google_compute_region_instance_group_manage`r resource when `enable_public_ips = false.`

**Issue:**

When `enable_public_ips = false`, the variable `stateful_ips `is `null`.
Terraform does not support iterating over null in `for_each`, leading to an error :

```
Error: Iteration over null value

on .terraform/modules/htcondor_access.htcondor_ap/modules/mig/main.tf line 83, in resource "google_compute_region_instance_group_manager" "mig":
 83:     for_each = [for static_ip in var.stateful_ips : static_ip if static_ip["is_external"] == true]

 var.stateful_ips is null
A null value cannot be used as the collection in a 'for' expression.
```

**Proposed solution:**
```
  stateful_ips = var.enable_public_ips ? [{
    interface_name = "nic0"
    delete_rule    = "ON_PERMANENT_INSTANCE_DELETION"
    is_external    = true
  }] : null # remplace null with []

```