### PR TITLE
Fix project references with custom terraform_providers block

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -59,16 +59,17 @@ locals {
 }
 
 data "google_project" "controller_project" {
-  project_id = var.controller_project_id
+  project_id = local.controller_project_id
 }
 
 resource "google_compute_disk" "controller_disk" {
   count = var.controller_state_disk != null ? 1 : 0
 
-  name = "${local.slurm_cluster_name}-controller-save"
-  type = var.controller_state_disk.type
-  size = var.controller_state_disk.size
-  zone = var.zone
+  project = local.controller_project_id
+  name    = "${local.slurm_cluster_name}-controller-save"
+  type    = var.controller_state_disk.type
+  size    = var.controller_state_disk.size
+  zone    = var.zone
 }
 
 # INSTANCE TEMPLATE


### PR DESCRIPTION
Without this fix, deployment fails with error:
```
Initializing deployment group cleantpu/primary
Testing if deployment group cleantpu/primary requires adding or changing cloud infrastructure
Error: exit status 1

Error: no project value set. `project_id` must be set at the resource level, or a default `project` value must be specified on the provider

  with module.slurm_controller.data.google_project.controller_project,
  on modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf line 61, in data "google_project" "controller_project":
  61: data "google_project" "controller_project" {


Error: Failed to retrieve project, pid: , err: project: required field is not set

  with module.slurm_controller.google_compute_disk.controller_disk[0],
  on modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf line 65, in resource "google_compute_disk" "controller_disk":
  65: resource "google_compute_disk" "controller_disk" {
```

My blueprint has following section at top, which causes this bug to surface:
```yaml
deployment_groups:
- group: primary
  terraform_providers:
    # override default requirements, that pin to specific version using ~>
    google:
      source: "hashicorp/google"
      version: ">= 6.0.0, != 6.13.0, < 7.0.0"
    google-beta:
      source: "hashicorp/google-beta"
      version: ">= 6.0.0, != 6.13.0, < 7.0.0"

```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
