### PR TITLE
remove the name prefix from the GCS buckets

### DIFF
--- a/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-gke-gcs/a3u-gke-gcs.yaml
@@ -119,7 +119,6 @@ deployment_groups:
     source: community/modules/file-system/cloud-storage-bucket
     settings:
       local_mount: /data
-      name_prefix: $(vars.deployment_name)-training
       random_suffix: true
       force_destroy: false
       enable_hierarchical_namespace: true
@@ -128,7 +127,6 @@ deployment_groups:
     source: community/modules/file-system/cloud-storage-bucket
     settings:
       local_mount: /data
-      name_prefix: $(vars.deployment_name)-checkpoint
       random_suffix: true
       force_destroy: false
       enable_hierarchical_namespace: true


### PR DESCRIPTION
Remove the name prefix from the GCS buckets as it is causing some inconsistency leading to FailedMount scenario.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
