### PR TITLE
Don't replace login nodes on controller replacement event

### DIFF
--- a/community/modules/internal/slurm-gcp/instance/README.md
+++ b/community/modules/internal/slurm-gcp/instance/README.md
@@ -48,14 +48,12 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.43 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 3.43 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
 
@@ -66,7 +64,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_compute_instance_from_template.slurm_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_from_template) | resource |
-| [null_resource.replace_trigger](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_instance_template.base](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_instance_template) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
 
@@ -82,7 +79,6 @@ No modules.
 | <a name="input_num_instances"></a> [num\_instances](#input\_num\_instances) | Number of instances to create. This value is ignored if static\_ips is provided. | `number` | `1` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | `null` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the instances should be created. | `string` | `null` | no |
-| <a name="input_replace_trigger"></a> [replace\_trigger](#input\_replace\_trigger) | Trigger value to replace the instances. | `string` | `""` | no |
 | <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances | `list(string)` | `[]` | no |
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | <a name="input_subnetwork_project"></a> [subnetwork\_project](#input\_subnetwork\_project) | The project that subnetwork belongs to | `string` | `null` | no |

--- a/community/modules/internal/slurm-gcp/instance/main.tf
+++ b/community/modules/internal/slurm-gcp/instance/main.tf
@@ -64,12 +64,6 @@ data "google_compute_instance_template" "base" {
 #############
 # INSTANCES #
 #############
-resource "null_resource" "replace_trigger" {
-  triggers = {
-    trigger = var.replace_trigger
-  }
-}
-
 resource "google_compute_instance_from_template" "slurm_instance" {
   count   = local.num_instances
   name    = format("%s-%s", var.hostname, format("%03d", count.index + 1))
@@ -113,8 +107,4 @@ resource "google_compute_instance_from_template" "slurm_instance" {
   }
 
   source_instance_template = data.google_compute_instance_template.base.self_link
-
-  lifecycle {
-    replace_triggered_by = [null_resource.replace_trigger.id]
-  }
 }

--- a/community/modules/internal/slurm-gcp/instance/variables.tf
+++ b/community/modules/internal/slurm-gcp/instance/variables.tf
@@ -107,13 +107,3 @@ variable "zone" {
   type        = string
   default     = null
 }
-
-#########
-# SLURM #
-#########
-
-variable "replace_trigger" {
-  description = "Trigger value to replace the instances."
-  type        = string
-  default     = ""
-}

--- a/community/modules/internal/slurm-gcp/instance/versions.tf
+++ b/community/modules/internal/slurm-gcp/instance/versions.tf
@@ -23,9 +23,5 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.43"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
-    }
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -72,7 +72,4 @@ module "slurm_login_instance" {
   static_ips          = each.value.static_ips
   subnetwork          = each.value.subnetwork
   zone                = each.value.zone
-
-  # trigger replacement of login nodes when the controller instance is replaced
-  replace_trigger = google_compute_instance_from_template.controller.self_link
 }


### PR DESCRIPTION
DO_NOT_MERGE: not ready while `/home` and `/opt/apps` are still mounted to controller