### PR TITLE
Bump py req version in `/community/front-end/ofe`

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -45,7 +45,7 @@ httplib2==0.22.0
 identify==2.6.1
 idna==3.10
 importlib-resources==6.4.5
-isort==5.13.2
+isort==6.0.1
 Jinja2==3.1.5
 jsonschema==4.23.0
 jsonschema-specifications==2023.12.1
@@ -67,7 +67,7 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
 pycparser==2.22
 PyJWT==2.9.0
-pylint==2.17.4
+pylint==3.3.4
 pylint-django==2.5.5
 pylint-plugin-utils==0.8.2
 pyparsing==3.1.4

--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -2,7 +2,7 @@ altgraph==0.17.4
 archspec==0.2.5
 argcomplete==3.5.3
 asgiref==3.8.1
-astroid==2.15.5
+astroid==3.3.8
 attrs==25.1.0
 # This should be supported by zoneinfo in Python 3.9+
 backports.zoneinfo==0.2.1;python_version<"3.9"


### PR DESCRIPTION
Dependabot PR (#3738, #3746) is failing on other py req version constraint, so fixing them out here.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
