### PR TITLE
Workaround python changes to support older images

### DIFF
--- a/community/modules/internal/slurm-gcp/instance_template/files/startup_sh_unlinted
+++ b/community/modules/internal/slurm-gcp/instance_template/files/startup_sh_unlinted
@@ -23,6 +23,17 @@ if [[ -z "$HOME" ]]; then
 	HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
 fi
 
+# Temporary workaround for transition period when some of older images
+# don't have "baked in" python yet.
+# TODO: Remove
+SLURM_PY="/slurm/python/venv/bin/python3.13"
+SYSTEM_PY="/usr/bin/python3"
+if [[ ! -e "$SLURM_PY" ]]; then
+  echo "Symlink $SLURM_PY does not exist. Creating symlink to $SYSTEM_PY"
+  mkdir -p /slurm/python/venv/bin
+  ln -s "$SYSTEM_PY" "$SLURM_PY"
+fi
+
 METADATA_SERVER="metadata.google.internal"
 URL="http://$METADATA_SERVER/computeMetadata/v1"
 CURL="curl -sS --fail --header Metadata-Flavor:Google"


### PR DESCRIPTION
Symlink missing Slurm-specific python env to "system" one.

**Tested:**

```yaml
  instance_image:
    project: schedmd-slurm-public
    family: slurm-gcp-6-8-hpc-rocky-linux-8 # < previous image family
```

```sh
$ ls /slurm/python/venv/bin/python3.13 -al
lrwxrwxrwx 1 root root 16 Mar 21 22:11 /slurm/python/venv/bin/python3.13 -> /usr/bin/python3
```

```sh
$ srun -N 2 hostname
pydopy-debugnodeset-1
pydopy-debugnodeset-0
```