### PR TITLE
Relax slurm_cluster_name validation slightly

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -37,8 +37,8 @@ variable "slurm_cluster_name" {
   default     = null
 
   validation {
-    condition     = var.slurm_cluster_name == null || can(regex("^[a-z](?:[a-z0-9]{0,9})$", var.slurm_cluster_name))
-    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z](?:[a-z0-9]{0,9})$'."
+    condition     = var.slurm_cluster_name == null || can(regex("^[a-z](?:[-a-z0-9]{0,14}[a-z0-9])?$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z](?:[-a-z0-9]{0,14}[a-z0-9])?$'."
   }
 }
 


### PR DESCRIPTION
Relaxes the name restrictions slightly, allowing hyphens in the interior and up to 16 characters instead of the previous 10, to improve usability. This makes it possible to at least have names like

cluster-<date> (e.g. cluster-20250326)
slurm-test-0000, slurm-test-0001, etc.