### PR TITLE
Force retry use of gce service account

### DIFF
--- a/community/modules/internal/slurm-gcp/instance_template/files/startup_sh_unlinted
+++ b/community/modules/internal/slurm-gcp/instance_template/files/startup_sh_unlinted
@@ -78,6 +78,9 @@ SCRIPTS_ZIP="$HOME/slurm-gcp-scripts.zip"
 export CLOUDSDK_CORE_UNIVERSE_DOMAIN="$UNIVERSE_DOMAIN"
 until gcloud storage cp "$BUCKET/slurm-gcp-devel.zip" "$SCRIPTS_ZIP"; do
 	echo "WARN: Could not download SlurmGCP scripts, retrying in 5 seconds."
+        # Remove marker used to determine if gcloud is being used in a GCE VM.
+        # This can get mistakenly set to False in some cases.
+	rm -f /root/.config/gcloud/gce
 	sleep 5
 done
 unzip -o "$SCRIPTS_ZIP" -d "$SCRIPTS_DIR"


### PR DESCRIPTION
Repeatedly remove /root/.config/gcloud/gce during the startup script prior to using gcloud to more reliably authenticate quickly

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
