### PR TITLE
Update filestore timeout config based on high capacity tier

### DIFF
--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -40,8 +40,7 @@ specified in the Toolkit using the following names:
 
 - Basic HDD: "BASIC\_HDD" ([preferred][tierapi]) or "STANDARD" (deprecated)
 - Basic SSD: "BASIC\_SSD" ([preferred][tierapi]) or "PREMIUM" (deprecated)
-- Zonal With Lower Capacity Band: "ZONAL"
-- Zonal With Higher Capacity Band or High Scale SSD: "HIGH\_SCALE\_SSD"
+- Zonal: "ZONAL"
 - Enterprise: "ENTERPRISE"
 - Regional: "REGIONAL"
 

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -40,9 +40,10 @@ specified in the Toolkit using the following names:
 
 - Basic HDD: "BASIC\_HDD" ([preferred][tierapi]) or "STANDARD" (deprecated)
 - Basic SSD: "BASIC\_SSD" ([preferred][tierapi]) or "PREMIUM" (deprecated)
+- Zonal With Lower Capacity Band: "ZONAL"
 - Zonal With Higher Capacity Band or High Scale SSD: "HIGH\_SCALE\_SSD"
 - Enterprise: "ENTERPRISE"
-- Zonal With Lower Capacity Band: "ZONAL"
+- Regional: "REGIONAL"
 
 [tierapi]: https://cloud.google.com/filestore/docs/reference/rest/v1beta1/Tier
 

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -24,10 +24,9 @@ resource "random_id" "resource_name_suffix" {
 }
 
 locals {
-  is_high_capacity_zonal_tier    = contains(["HIGH_SCALE_SSD", "ZONAL"], var.filestore_tier) && var.size_gb >= 10240 && var.size_gb <= 102400
-  is_high_capacity_regional_tier = var.filestore_tier == "REGIONAL" && var.size_gb >= 10240 && var.size_gb <= 102400
+  is_high_capacity_tier = contains(["HIGH_SCALE_SSD", "ZONAL", "REGIONAL"], var.filestore_tier) && var.size_gb >= 10240 && var.size_gb <= 102400
 
-  timeouts      = local.is_high_capacity_zonal_tier || local.is_high_capacity_regional_tier ? [1] : []
+  timeouts      = local.is_high_capacity_tier ? [1] : []
   server_ip     = google_filestore_instance.filestore_instance.networks[0].ip_addresses[0]
   remote_mount  = format("/%s", google_filestore_instance.filestore_instance.file_shares[0].name)
   fs_type       = "nfs"

--- a/modules/file-system/filestore/main.tf
+++ b/modules/file-system/filestore/main.tf
@@ -24,7 +24,10 @@ resource "random_id" "resource_name_suffix" {
 }
 
 locals {
-  timeouts      = var.filestore_tier == "HIGH_SCALE_SSD" ? [1] : []
+  is_high_capacity_zonal_tier    = contains(["HIGH_SCALE_SSD", "ZONAL"], var.filestore_tier) && var.size_gb >= 10240 && var.size_gb <= 102400
+  is_high_capacity_regional_tier = var.filestore_tier == "REGIONAL" && var.size_gb >= 10240 && var.size_gb <= 102400
+
+  timeouts      = local.is_high_capacity_zonal_tier || local.is_high_capacity_regional_tier ? [1] : []
   server_ip     = google_filestore_instance.filestore_instance.networks[0].ip_addresses[0]
   remote_mount  = format("/%s", google_filestore_instance.filestore_instance.file_shares[0].name)
   fs_type       = "nfs"

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -95,6 +95,8 @@ variable "filestore_tier" {
       "REGIONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
+    # Avoid adding the legacy tier name in error_message, for e.g. 'HIGH_SCALE_SSD', 'ENTERPRISE'.
+    # As we want to steer the customer to new one's, but also support the legacy ones for older customers.
     error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
   }
 }

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -95,7 +95,7 @@ variable "filestore_tier" {
       "REGIONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
-    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','HIGH_SCALE_SSD','ZONAL','REGIONAL','ENTERPRISE'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
+    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
   }
 }
 

--- a/modules/file-system/filestore/variables.tf
+++ b/modules/file-system/filestore/variables.tf
@@ -95,7 +95,7 @@ variable "filestore_tier" {
       "REGIONAL",
       "ENTERPRISE"
     ], var.filestore_tier)
-    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','ZONAL','REGIONAL'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
+    error_message = "Allowed values for filestore_tier are 'BASIC_HDD','BASIC_SSD','HIGH_SCALE_SSD','ZONAL','REGIONAL','ENTERPRISE'.\nhttps://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier\nhttps://cloud.google.com/filestore/docs/reference/rest/v1/Tier."
   }
 }
 


### PR DESCRIPTION
Timeout config for filestore provisioning, require an update based on newly supported [tiers](https://cloud.google.com/filestore/docs/service-tiers) definition.

Update README with supported filestore resource [tiers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance#tier-1).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
