### PR TITLE
Populate partition configs outside of `slurm_files` module

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -271,6 +271,7 @@ limitations under the License.
 | [google_secret_manager_secret_version.cloudsql_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_storage_bucket_iam_member.legacy_readers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
+| [google_storage_bucket_object.parition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_project.controller_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -49,7 +49,6 @@ No modules.
 | [google_storage_bucket_object.nodeset_dyn_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.nodeset_startup_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.nodeset_tpu_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
-| [google_storage_bucket_object.parition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_storage_bucket_object.prolog_scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [random_uuid.cluster_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
 | [archive_file.slurm_gcp_devel_zip](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
@@ -95,7 +94,6 @@ No modules.
 | <a name="input_nodeset_startup_scripts"></a> [nodeset\_startup\_scripts](#input\_nodeset\_startup\_scripts) | List of scripts to be ran on compute VM startup in the specific nodeset. | <pre>map(list(object({<br/>    filename = string<br/>    content  = string<br/>  })))</pre> | `{}` | no |
 | <a name="input_nodeset_tpu"></a> [nodeset\_tpu](#input\_nodeset\_tpu) | Cluster nodenets (TPU), as a list. | `list(any)` | `[]` | no |
 | <a name="input_output_dir"></a> [output\_dir](#input\_output\_dir) | Directory where this module will write its files to. These files include:<br/>cloud.conf; cloud\_gres.conf; config.yaml; resume.py; suspend.py; and util.py. | `string` | `null` | no |
-| <a name="input_partitions"></a> [partitions](#input\_partitions) | Cluster partitions as a list. | `list(any)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID. | `string` | n/a | yes |
 | <a name="input_prolog_scripts"></a> [prolog\_scripts](#input\_prolog\_scripts) | List of scripts to be used for Prolog. Programs for the slurmd to execute<br/>whenever it is asked to run a job step from a new job allocation.<br/>See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog. | <pre>list(object({<br/>    filename = string<br/>    content  = optional(string)<br/>    source   = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_slurm_bin_dir"></a> [slurm\_bin\_dir](#input\_slurm\_bin\_dir) | Path to directory of Slurm binary commands (e.g. scontrol, sinfo). If 'null',<br/>then it will be assumed that binaries are in $PATH. | `string` | `null` | no |
@@ -111,10 +109,8 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_bucket_dir"></a> [bucket\_dir](#output\_bucket\_dir) | Path directory within `bucket_name` for Slurm cluster file storage. |
+| <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | GCS Bucket name of Slurm cluster file storage. |
 | <a name="output_config"></a> [config](#output\_config) | Cluster configuration. |
-| <a name="output_nodeset"></a> [nodeset](#output\_nodeset) | Cluster nodesets. |
-| <a name="output_nodeset_dyn"></a> [nodeset\_dyn](#output\_nodeset\_dyn) | Cluster nodesets (dynamic). |
-| <a name="output_nodeset_tpu"></a> [nodeset\_tpu](#output\_nodeset\_tpu) | Cluster nodesets (TPU). |
-| <a name="output_partitions"></a> [partitions](#output\_partitions) | Cluster partitions. |
 | <a name="output_slurm_bucket_path"></a> [slurm\_bucket\_path](#output\_slurm\_bucket\_path) | GCS Bucket URI of Slurm cluster file storage. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -143,14 +143,6 @@ resource "google_storage_bucket_object" "config" {
   content = yamlencode(local.config)
 }
 
-resource "google_storage_bucket_object" "parition_config" {
-  for_each = { for p in var.partitions : p.partition_name => p }
-
-  bucket  = data.google_storage_bucket.this.name
-  name    = "${local.bucket_dir}/partition_configs/${each.key}.yaml"
-  content = yamlencode(each.value)
-}
-
 resource "google_storage_bucket_object" "nodeset_config" {
   for_each = { for ns in var.nodeset : ns.nodeset_name => merge(ns, {
     instance_properties = jsondecode(ns.instance_properties_json)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/outputs.tf
@@ -19,6 +19,16 @@ output "slurm_bucket_path" {
   value       = local.bucket_path
 }
 
+output "bucket_name" {
+  description = "GCS Bucket name of Slurm cluster file storage."
+  value       = data.google_storage_bucket.this.name
+}
+
+output "bucket_dir" {
+  description = "Path directory within `bucket_name` for Slurm cluster file storage."
+  value       = local.bucket_dir
+}
+
 output "config" {
   description = "Cluster configuration."
   value       = local.config
@@ -32,24 +42,4 @@ output "config" {
     condition     = length(local.x_nodeset_overlap) == 0
     error_message = "All nodeset names must be unique among all nodeset types."
   }
-}
-
-output "partitions" {
-  description = "Cluster partitions."
-  value       = lookup(local.config, "partitions", null)
-}
-
-output "nodeset" {
-  description = "Cluster nodesets."
-  value       = lookup(local.config, "nodeset", null)
-}
-
-output "nodeset_dyn" {
-  description = "Cluster nodesets (dynamic)."
-  value       = lookup(local.config, "nodeset_dyn", null)
-}
-
-output "nodeset_tpu" {
-  description = "Cluster nodesets (TPU)."
-  value       = lookup(local.config, "nodeset_tpu", null)
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
@@ -320,19 +320,6 @@ variable "nodeset_tpu" {
   default     = []
 }
 
-variable "partitions" {
-  description = "Cluster partitions as a list."
-  type        = list(any)
-  default     = []
-
-  validation {
-    condition = alltrue([
-      for n in var.partitions[*].partition_name : can(regex("^[a-z](?:[a-z0-9]*)$", n))
-    ])
-    error_message = "Items 'partition_name' must be a match of regex '^[a-z](?:[a-z0-9]*)$'."
-  }
-}
-
 variable "cloud_parameters" {
   description = "cloud.conf options. Default behavior defined in scripts/conf.py"
   type = object({

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -181,8 +181,6 @@ module "slurm_files" {
   ]
   login_network_storage = var.login_network_storage
 
-  partitions = var.partitions
-
   nodeset     = local.nodesets
   nodeset_dyn = values(local.nodeset_dyn_map)
   # Use legacy format for now


### PR DESCRIPTION
**Motivation:** 💦 disentangle separate components of terraform.

Non-breaking change:

```sh
Terraform will perform the following actions:

  # module.slurm_controller.module.slurm_files.google_storage_bucket_object.parition_config["az"] has moved to module.slurm_controller.google_storage_bucket_object.parition_config["az"]
    resource "google_storage_bucket_object" "parition_config" {
        id                  = "slurm-partconf0b06c-partconf-files/partition_configs/az.yaml"
        name                = "partconf-files/partition_configs/az.yaml"
        # (19 unchanged attributes hidden)
    }

  # module.slurm_controller.module.slurm_files.google_storage_bucket_object.parition_config["buki"] has moved to module.slurm_controller.google_storage_bucket_object.parition_config["buki"]
    resource "google_storage_bucket_object" "parition_config" {
        id                  = "slurm-partconf0b06c-partconf-files/partition_configs/buki.yaml"
        name                = "partconf-files/partition_configs/buki.yaml"
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 0 to change, 0 to destroy.
```