### PR TITLE
Bump golang versions `(1.22, 1.23) -> (1.23, 1.24)`

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -40,7 +40,7 @@ jobs:
         cache: 'pip'
     - uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: '1.23'
         check-latest: true
     - uses: hashicorp/setup-terraform@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # PREAMBLE
 MIN_PACKER_VERSION=1.7.9 # for building images
 MIN_TERRAFORM_VERSION=1.5.7 # for deploying modules
-MIN_GOLANG_VERSION=1.22 # for building gcluster
+MIN_GOLANG_VERSION=1.23 # for building gcluster
 
 .PHONY: install install-user tests format install-dev-deps \
         warn-go-missing warn-terraform-missing warn-packer-missing \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module hpc-toolkit
 
-go 1.22.0
+go 1.23.0
 
 require (
 	cloud.google.com/go/storage v1.49.0 // indirect

--- a/tools/cloud-build/provision/pr-go-build-test.tf
+++ b/tools/cloud-build/provision/pr-go-build-test.tf
@@ -15,7 +15,7 @@
 
 resource "google_cloudbuild_trigger" "pr_go_build_test" {
   # NOTE: make sure that go.mod:go and Makefile:MIN_GOLANG_VERSION match lowest version.
-  for_each = toset(["1.22", "1.23"])
+  for_each = toset(["1.23", "1.24"])
 
   name        = "PR-Go-${replace(each.key, ".", "-")}-build-test"
   description = "Test that the PR builds with Go ${each.key}"


### PR DESCRIPTION
1.24 build is tested by 

```yaml
---
steps:
- name: golang:1.24
  entrypoint: /bin/bash
  args:
  - -c
  - make ghpc test-engine
```