### PR TITLE
Start slurmd in tpu nodes with -N slurmName

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -476,6 +476,29 @@ def setup_compute():
         slurmd_options.append(f'--conf="Feature={slurmd_feature}"')
         slurmd_options.append("-Z")
 
+    if os.getenv("OS_ENV") == "slurm_container":
+        try:
+            def _extract_slurmd_nodename(slurm_names, tpu_env):
+                wid = None
+                for line in tpu_env.splitlines():
+                    if line.startswith('WORKER_ID:'):
+                        wid = line.split(":", 1)[1].strip().strip("'")
+                if wid is not None:
+                    for pair in slurm_names.split(";"):
+                        if pair.startswith(f"WORKER_{wid}"):
+                            return pair.split(":", 1)[1]
+                return None
+
+            slurm_names = util.instance_metadata("attributes/slurm_names")
+            tpu_env = util.instance_metadata("attributes/tpu-env")
+            slurmd_nodename = _extract_slurmd_nodename(slurm_names,tpu_env)
+
+        except Exception:
+            # TODO: differentiate between unset and error
+            slurmd_nodename = None
+        if slurmd_nodename is not None:
+            slurmd_options.append(f'-N {slurmd_nodename}')
+
     sysconf = f"""SLURMD_OPTIONS='{" ".join(slurmd_options)}'"""
     update_system_config("slurmd", sysconf)
     install_custom_scripts()


### PR DESCRIPTION
Is important that this commit is pushed after the related slurm-gcp commit called "Start docker container with real hostname" is present in the image.

This commit changes how the slurmd process starts in the docker container, now it starts with the real hostname of the TPU, so we need to start slurmd with -N nodename.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
