### PR TITLE
Make is_flex_node return a bool in all cases

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1942,7 +1942,7 @@ class Lookup:
             nodeset = self.node_nodeset(node)
             if nodeset.dws_flex.use_bulk_insert:
                 return False #For legacy flex support
-            return nodeset.dws_flex.enabled
+            return bool(nodeset.dws_flex.enabled)
         except:
             return False
 


### PR DESCRIPTION
Before in cases where the nodeset doesn't have a `dws_flex` field (such as tpu nodesets):

```
    def is_flex_node(self, node: str) -> bool:
        try:
            nodeset = self.node_nodeset(node)
            if nodeset.dws_flex.use_bulk_insert:
                return False #For legacy flex support
            return nodeset.dws_flex.enabled #(nodeset.dws_flex.enabled = {}) so this returns empty dict
        except:
            return False

... later when using it as a predicate...
  File "/slurm/scripts/util.py", line 873, in separate
    res[pred(el)].append(el)
    ~~~^^^^^^^^^^
TypeError: tuple indices must be integers or slices, not Dict
```

Now return false so `is_flex_node` can still be used as predicate.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
