### PR TITLE
Update vm-instance to support additional persistent disks

### DIFF
--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -195,6 +195,7 @@ limitations under the License.
 | [google-beta_google_compute_instance.compute_vm](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance) | resource |
 | [google-beta_google_compute_resource_policy.placement_policy](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_resource_policy) | resource |
 | [google_compute_address.compute_ip](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_disk.additional_disks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_disk.boot_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [null_resource.image](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.replace_vm_trigger_from_placement](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -205,6 +206,7 @@ limitations under the License.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_add_deployment_name_before_prefix"></a> [add\_deployment\_name\_before\_prefix](#input\_add\_deployment\_name\_before\_prefix) | If true, the names of VMs and disks will always be prefixed with `deployment_name` to enable uniqueness across deployments.<br/>See `name_prefix` for further details on resource naming behavior. | `bool` | `false` | no |
+| <a name="input_additional_persistent_disks"></a> [additional\_persistent\_disks](#input\_additional\_persistent\_disks) | Configurations of additional disks to be included on the partition nodes. | <pre>object({<br/>    count = optional(number, 0)<br/>    type  = optional(string, "pd-balanced")<br/>    size  = optional(number, 200)<br/>  })</pre> | `{}` | no |
 | <a name="input_allocate_ip"></a> [allocate\_ip](#input\_allocate\_ip) | If not null, allocate IPs with the given configuration. See details at<br/>https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address | <pre>object({<br/>    address_type = optional(string, "INTERNAL")<br/>    purpose      = optional(string),<br/>    network_tier = optional(string),<br/>    ip_version   = optional(string, "IPV4"),<br/>  })</pre> | `null` | no |
 | <a name="input_allow_automatic_updates"></a> [allow\_automatic\_updates](#input\_allow\_automatic\_updates) | If false, disables automatic system package updates on the created instances.  This feature is<br/>only available on supported images (or images derived from them).  For more details, see<br/>https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates | `bool` | `true` | no |
 | <a name="input_auto_delete_boot_disk"></a> [auto\_delete\_boot\_disk](#input\_auto\_delete\_boot\_disk) | Controls if boot disk should be auto-deleted when instance is deleted. | `bool` | `true` | no |

--- a/modules/compute/vm-instance/variables.tf
+++ b/modules/compute/vm-instance/variables.tf
@@ -74,6 +74,16 @@ variable "local_ssd_interface" {
   default     = "NVME"
 }
 
+variable "additional_persistent_disks" {
+  description = "Configurations of additional disks to be included on the partition nodes."
+  type = object({
+    count = optional(number, 0)
+    type  = optional(string, "pd-balanced")
+    size  = optional(number, 200)
+  })
+  default = {}
+}
+
 variable "name_prefix" {
   description = <<-EOT
     An optional name for all VM and disk resources.


### PR DESCRIPTION
Add a simple input variable that enables the specification of additional persistent disks, configuring their type and size. Future work to allow additional access modes for the disks themselves (multi-writer, etc) and additional modes for attaching them (read-only).

This is a squashed version of #3886 which was closed to protect the branch that may remain in use by other users until this PR lands in an official release of the Toolkit.

This PR can be evaluated using

```yaml
---
blueprint_name: feat-request

vars:
  deployment_name: poc-feat
  project_id: $$PROJECT$$
  region: us-central1
  zone: us-central1-f

deployment_groups:
- group: primary
  modules:
  - id: network
    source: modules/network/vpc
  - id: vm
    source: modules/compute/vm-instance
    use:
    - network
    settings:
      machine_type: n1-standard-32
      instance_count: 2
      additional_persistent_disks:
        count: 3
        type: pd-ssd
        size: 250
      startup_script: |
        #!/bin/bash
        parted --script /dev/disk/by-id/google-additional-disk-0 mklabel gpt
        parted --script /dev/disk/by-id/google-additional-disk-0 mkpart primary ext4 0% 100%
        parted --script /dev/disk/by-id/google-additional-disk-1 mklabel gpt
        parted --script /dev/disk/by-id/google-additional-disk-1 mkpart primary ext4 0% 100%
        parted --script /dev/disk/by-id/google-additional-disk-2 mklabel gpt
        parted --script /dev/disk/by-id/google-additional-disk-2 mkpart primary ext4 0% 100%
        mkfs.ext4 -m 0 /dev/disk/by-id/google-additional-disk-0-part1
        mkfs.ext4 -m 0 /dev/disk/by-id/google-additional-disk-1-part1
        mkfs.ext4 -m 0 /dev/disk/by-id/google-additional-disk-2-part1
        mkdir -p /mnt/p0
        mkdir -p /mnt/p1
        mkdir -p /mnt/p2
        mount /dev/disk/by-id/google-additional-disk-0-part1 /mnt/p0
        mount /dev/disk/by-id/google-additional-disk-1-part1 /mnt/p1
        mount /dev/disk/by-id/google-additional-disk-2-part1 /mnt/p2
```

SSH to the VM reveals the 3 disks ready for access.

```
ext_tpdownes_google_com@poc-feat-0 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs         59G     0   59G   0% /dev
tmpfs            59G     0   59G   0% /dev/shm
tmpfs            59G   17M   59G   1% /run
tmpfs            59G     0   59G   0% /sys/fs/cgroup
/dev/sda2       200G  6.9G  193G   4% /
/dev/sda1       200M  5.8M  194M   3% /boot/efi
tmpfs            12G     0   12G   0% /run/user/0
/dev/sdb1       246G   28K  246G   1% /mnt/p0
/dev/sdc1       246G   28K  246G   1% /mnt/p1
/dev/sdd1       246G   28K  246G   1% /mnt/p2
tmpfs            12G     0   12G   0% /run/user/2715883726
```

and on the 2nd VM:

```
[ext_tpdownes_google_com@poc-feat-1 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs         59G     0   59G   0% /dev
tmpfs            59G     0   59G   0% /dev/shm
tmpfs            59G   17M   59G   1% /run
tmpfs            59G     0   59G   0% /sys/fs/cgroup
/dev/sda2       200G  6.9G  193G   4% /
/dev/sda1       200M  5.8M  194M   3% /boot/efi
tmpfs            12G     0   12G   0% /run/user/0
/dev/sdb1       246G   28K  246G   1% /mnt/p0
/dev/sdc1       246G   28K  246G   1% /mnt/p1
/dev/sdd1       246G   28K  246G   1% /mnt/p2
tmpfs            12G     0   12G   0% /run/user/2715883726
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
