### PR TITLE
Adding Managed Lustre to Cluster Toolkit

### DIFF
--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -7,6 +7,7 @@ The Toolkit contains modules that will **provision**:
 
 - [Filestore (GCP managed NFS)][filestore]
 - [DDN EXAScaler lustre][ddn-exascaler]
+- [Managed Lustre][managed-lustre]
 - [Parallelstore][parallelstore]
 - [NFS server (non-GCP managed)][nfs-server]
 
@@ -16,6 +17,7 @@ with a network storage device that is already set up. The
 
 - nfs
 - lustre
+- managed-lustre
 - gcsfuse
 
 ## Connecting to Network Storage
@@ -104,12 +106,13 @@ filestore | via USE | via USE | via USE | via STARTUP | via USE | via USE
 nfs-server | via USE | via USE | via USE | via STARTUP | via USE | via USE
 cloud-storage-bucket (GCS)| via USE | via USE | via USE | via STARTUP | via USE | via USE
 DDN EXAScaler lustre | via USE | via USE | via USE | Needs Testing | via USE | via USE
+Managed Lustre | via USE | Needs Testing | via USE | Needs Testing | Needs Testing |  Needs Testing
 Parallelstore | via USE | Needs Testing | via USE | Needs Testing | Needs Testing | Needs Testing
   |  |   |   |   |   |  
 filestore (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | via USE
 nfs-server (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | via USE
 DDN EXAScaler lustre (pre-existing) | via USE | via USE | via USE | Needs Testing | via USE | via USE
-Managed Lustre (pre-existing) | Needs Testing | Needs Testing | via USE | Needs Testing | Needs Testing |  Needs Testing
+Managed Lustre (pre-existing) | via USE| Needs Testing | via USE | Needs Testing | Needs Testing |  Needs Testing
 Parallelstore (pre-existing) | via USE | Needs Testing | via USE | Needs Testing | Needs Testing | Needs Testing
 GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | Needs Testing
 
@@ -127,5 +130,6 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | 
 [filestore]: ../modules/file-system/filestore/README.md
 [pre-existing-network-storage]: ../modules/file-system/pre-existing-network-storage/README.md
 [ddn-exascaler]: ../community/modules/file-system/DDN-EXAScaler/README.md
+[managed-lustre]: ../modules/file-system/managed-lustre/README.md
 [parallelstore]: ../modules/file-system/parallelstore/README.md
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -2,7 +2,7 @@
 
 This module creates a [Managed Lustre](https://cloud.google.com/managed-lustre)
 instance. Managed Lustre is a high performance network file system that can be
-mounted to one or more compute VMs.
+mounted to one or more VMs.
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
@@ -14,8 +14,7 @@ VM running Ubuntu 20.04, 22.04 or Rocky Linux 8 (including the HPC flavor).
 
 ### Managed Lustre Access
 
-Currently Managed Lustre is only available on allowlisted projects.  To set
-this up, please work with your account representative.
+Managed Lustre is available by invitation only. If you'd like to request access to Managed Lustre in your Google Cloud project, contact your sales representative.
 
 ### Example - New VPC
 
@@ -196,7 +195,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | File share capacity in GiB. |
+| <a name="output_capacity_gib"></a> [capacity\_gib](#output\_capacity\_gib) | File share capacity in GiB. |
 | <a name="output_install_managed_lustre_client"></a> [install\_managed\_lustre\_client](#output\_install\_managed\_lustre\_client) | Script for installing Managed Lustre client |
 | <a name="output_lustre_id"></a> [lustre\_id](#output\_lustre\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/instances/{{name}}` |
 | <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a Managed Lustre instance. |

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -47,7 +47,7 @@ The Lustre client modules are pre-installed in the official images.  With the
 official images, Lustre can be used as follows:
 
 ```yaml
-- id: lustre-gcp
+- id: managed_lustre
   source: modules/file-system/managed-lustre
   use: [network, private_service_access]
   settings:
@@ -63,7 +63,7 @@ official images, Lustre can be used as follows:
   use:
   - network
   - lustre_partition
-  - lustre-gcp
+  - managed_lustre
   - slurm_login
   settings:
     machine_type: n2-standard-4
@@ -130,31 +130,6 @@ to set it up.
       private_vpc_connection_peering: <private_vpc_connection_peering> # will look like "servicenetworking.googleapis.com"
 ```
 
-### Import data from GCS bucket
-
-You can import data from your GCS bucket to Managed Lustre instance. Important
-to note that data may not be available to the instance immediately. This
-depends on latency and size of data. Below is the example of importing data
-from  bucket.
-
-```yaml
-  - id: lustre
-    source: modules/file-system/managed-lustre
-    use: [network, private-service-access]
-    settings:
-      import_gcs_bucket_uri: gs://gcs-bucket/folder-path
-      import_destination_path: /gcs/import/
-```
-
-Here you can replace `import_gcs_bucket_uri` with the uri of sub folder within
-GCS bucket and `import_destination_path` with local directory within the
-Managed Lustre instance.
-
-> [!NOTE]
-> Prior to deployment of the Managed Lustre instance, please follow
-> [these instructions](https://cloud.google.com/managed-lustre/docs/transfer-data#required_permissions)
-> to give bucket access to the project service account.
-
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -178,7 +153,6 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.27.0 |
-| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -186,7 +160,6 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.27.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -198,7 +171,6 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_lustre_instance.lustre_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/lustre_instance) | resource |
-| [null_resource.hydration](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_compute_network_peering.private_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network_peering) | data source |
 
@@ -208,8 +180,6 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used as name of the Lustre instance if no name is specified. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | Description of the created Lustre instance. | `string` | `"Lustre Instance"` | no |
-| <a name="input_import_destination_path"></a> [import\_destination\_path](#input\_import\_destination\_path) | The name of local path to import data on Lustre instance from GCS bucket. | `string` | `null` | no |
-| <a name="input_import_gcs_bucket_uri"></a> [import\_gcs\_bucket\_uri](#input\_import\_gcs\_bucket\_uri) | The name of the GCS bucket to import data from to the Lustre instance. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the Managed Lustre instance. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Local mount point for the Managed Lustre instance. | `string` | `"/shared"` | no |
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Mounting options for the file system. | `string` | `"defaults,_netdev"` | no |
@@ -227,7 +197,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | File share capacity in GiB. |
-| <a name="output_install_managed_lustre_client"></a> [install\_managed\_lustre\_client](#output\_install\_managed\_lustre\_client) | Script for installing NFS client |
+| <a name="output_install_managed_lustre_client"></a> [install\_managed\_lustre\_client](#output\_install\_managed\_lustre\_client) | Script for installing Managed Lustre client |
 | <a name="output_lustre_id"></a> [lustre\_id](#output\_lustre\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/instances/{{name}}` |
 | <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a Managed Lustre instance. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -1,0 +1,166 @@
+## Description
+
+This module creates a [Managed Lustre](https://cloud.google.com/managed-lustre)
+instance. Managed Lustre is a high performance network file system that can be
+mounted to one or more compute VMs.
+
+For more information on this and other network storage options in the Cluster
+Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
+
+### Supported Operating Systems
+
+A Managed Lustre instance can be used with Slurm cluster or compute
+VM running Ubuntu 20.04, 22.04 or Rocky Linux 8 (including the HPC flavor).
+
+> [!WARNING] The Ubuntu OS client kernel modules are only available for a
+> limited number of kernels. To check compatibility please see
+> [Artifact Registry](https://pantheon.corp.google.com/artifacts/browse/lustre-client-binaries/us?e=-13802955&hl=en&invt=Abuvpg&mods=logs_tg_prod&project=lustre-client-binaries)
+> to check which kernels the packages currently support.
+
+### Managed Lustre Access
+
+Currently Managed Lustre is only available on allowlisted projects.  To set
+this up, please work with your account representative.
+
+### Example - New VPC
+
+For Managed Lustre instance, Below snippet creates new VPC and configures
+private-service-access for this newly created network.  Both items are required
+to be passed to the Lustre module to ensure that they're built in order and
+that the correct subnetwork has private service access.
+
+```yaml
+ - id: network
+    source: modules/network/vpc
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24
+
+  - id: lustre
+    source: modules/file-system/managed-lustre
+    use: [network, private_service_access]
+```
+
+### Example - Existing VPC
+
+If you want to use existing network with private-service-access configured, you need
+to manually provide `private_vpc_connection_peering` to the parallelstore module.
+You can get this details from the Google Cloud Console UI in `VPC network peering`
+section. Below is the example of using existing network and creating parallelstore.
+If existing network is not configured with private-service-access, you can follow
+[Configure private service access](https://cloud.google.com/vpc/docs/configure-private-services-access)
+to set it up.
+
+```yaml
+  - id: network
+    source: modules/network/pre-existing-vpc
+    settings:
+      network_name: <network_name> // Add network name
+      subnetwork_name: <subnetwork_name> // Add subnetwork name
+
+  - id: lustre
+    source: modules/file-system/managed-lustre
+    use: [network]
+    settings:
+      private_vpc_connection_peering: <private_vpc_connection_peering> # will look like "servicenetworking.googleapis.com"
+```
+
+### Import data from GCS bucket
+
+You can import data from your GCS bucket to Managed Lustre instance. Important
+to note that data may not be available to the instance immediately. This
+depends on latency and size of data. Below is the example of importing data
+from  bucket.
+
+```yaml
+  - id: lustre
+    source: modules/file-system/managed-lustre
+    use: [network, private-service-access]
+    settings:
+      import_gcs_bucket_uri: gs://gcs-bucket/folder-path
+      import_destination_path: /gcs/import/
+```
+
+Here you can replace `import_gcs_bucket_uri` with the uri of sub folder within
+GCS bucket and `import_destination_path` with local directory within the
+Managed Lustre instance.
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.27.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.27.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_lustre_instance.lustre_instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/lustre_instance) | resource |
+| [null_resource.hydration](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_compute_subnetwork.private_subnetwork](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used as name of the Lustre instance if no name is specified. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Description of the created Lustre instance. | `string` | `"Lustre Instance"` | no |
+| <a name="input_import_destination_path"></a> [import\_destination\_path](#input\_import\_destination\_path) | The name of local path to import data on Lustre instance from GCS bucket. | `string` | `null` | no |
+| <a name="input_import_gcs_bucket_uri"></a> [import\_gcs\_bucket\_uri](#input\_import\_gcs\_bucket\_uri) | The name of the GCS bucket to import data from to the Lustre instance. | `string` | `null` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the Managed Lustre instance. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Local mount point for the Managed Lustre instance. | `string` | `"/shared"` | no |
+| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Mounting options for the file system. | `string` | `"defaults,_netdev"` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name of the Lustre instance | `string` | n/a | yes |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection.<br/>If using new VPC, please use community/modules/network/private-service-access to create private-service-access and<br/>If using existing VPC with private-service-access enabled, set this manually." | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Lustre instance will be created. | `string` | n/a | yes |
+| <a name="input_remote_mount"></a> [remote\_mount](#input\_remote\_mount) | Remote mount point of the Managed Lustre instance | `string` | n/a | yes |
+| <a name="input_size_gib"></a> [size\_gib](#input\_size\_gib) | Storage size of the Managed Lustre instance in GB. See https://cloud.google.com/managed-lustre/docs/create-instance for limitations | `number` | `18000` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnetwork self-link this instance will be on, required for checking private service access | `string` | n/a | yes |
+| <a name="input_zone"></a> [zone](#input\_zone) | Location for the Lustre instance. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | File share capacity in GiB. |
+| <a name="output_install_managed_lustre_client"></a> [install\_managed\_lustre\_client](#output\_install\_managed\_lustre\_client) | Script for installing NFS client |
+| <a name="output_lustre_id"></a> [lustre\_id](#output\_lustre\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/instances/{{name}}` |
+| <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a filestore instance. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "managed-lustre", ghpc_role = "file-system" })
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
+
+data "google_compute_subnetwork" "private_subnetwork" {
+  self_link = var.subnetwork_self_link
+}
+
+locals {
+  server_ip     = split(":", google_lustre_instance.lustre_instance.mount_point)[0]
+  remote_mount  = split(":", google_lustre_instance.lustre_instance.mount_point)[1]
+  fs_type       = "lustre"
+  mount_options = var.mount_options
+  instance_id   = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
+
+  install_managed_lustre_client_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/install-managed-lustre-client.sh"
+    "destination" = "install-managed-lustre-client${replace(var.local_mount, "/", "_")}.sh"
+  }
+  mount_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/mount.sh"
+    "args"        = "\"${local.server_ip}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
+    "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
+  }
+}
+
+resource "google_lustre_instance" "lustre_instance" {
+  project = var.project_id
+
+  description = var.description
+  instance_id = local.instance_id
+  location    = var.zone
+
+  filesystem   = var.remote_mount
+  capacity_gib = var.size_gib
+
+  labels  = local.labels
+  network = var.network_id
+
+  timeouts {
+    create = "1h"
+    update = "1h"
+    delete = "1h"
+  }
+
+  depends_on = [var.private_vpc_connection_peering]
+
+  lifecycle {
+    precondition {
+      condition     = data.google_compute_subnetwork.private_subnetwork.private_ip_google_access
+      error_message = "The subnetwork that the lustre instance is hosted on must have private service access."
+    }
+  }
+}
+
+resource "null_resource" "hydration" {
+  count = var.import_gcs_bucket_uri != null ? 1 : 0
+
+  depends_on = [resource.google_lustre_instance.lustre_instance]
+  provisioner "local-exec" {
+    command = "curl -X POST   -H \"Content-Type: application/json\"   -H \"Authorization: Bearer $(gcloud auth print-access-token)\"   -d '{\"gcsPath\": {\"uri\":\"${var.import_gcs_bucket_uri}\"}, \"lustrePath\": {\"path\":\"${var.import_destination_path}\"}}'   https://lustre.googleapis.com/v1/projects/${var.project_id}/locations/${var.zone}/instances/${local.instance_id}:importData"
+  }
+}

--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -23,8 +23,9 @@ resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
 
-data "google_compute_subnetwork" "private_subnetwork" {
-  self_link = var.subnetwork_self_link
+data "google_compute_network_peering" "private_peering" {
+  name    = var.private_vpc_connection_peering
+  network = var.network_self_link
 }
 
 locals {
@@ -70,7 +71,7 @@ resource "google_lustre_instance" "lustre_instance" {
 
   lifecycle {
     precondition {
-      condition     = data.google_compute_subnetwork.private_subnetwork.private_ip_google_access
+      condition     = data.google_compute_network_peering.private_peering.state == "ACTIVE"
       error_message = "The subnetwork that the lustre instance is hosted on must have private service access."
     }
   }

--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -76,12 +76,3 @@ resource "google_lustre_instance" "lustre_instance" {
     }
   }
 }
-
-resource "null_resource" "hydration" {
-  count = var.import_gcs_bucket_uri != null ? 1 : 0
-
-  depends_on = [resource.google_lustre_instance.lustre_instance]
-  provisioner "local-exec" {
-    command = "curl -X POST   -H \"Content-Type: application/json\"   -H \"Authorization: Bearer $(gcloud auth print-access-token)\"   -d '{\"gcsPath\": {\"uri\":\"${var.import_gcs_bucket_uri}\"}, \"lustrePath\": {\"path\":\"${var.import_destination_path}\"}}'   https://lustre.googleapis.com/v1/projects/${var.project_id}/locations/${var.zone}/instances/${local.instance_id}:importData"
-  }
-}

--- a/modules/file-system/managed-lustre/metadata.yaml
+++ b/modules/file-system/managed-lustre/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - lustre.googleapis.com

--- a/modules/file-system/managed-lustre/outputs.tf
+++ b/modules/file-system/managed-lustre/outputs.tf
@@ -37,7 +37,7 @@ output "lustre_id" {
   value       = google_lustre_instance.lustre_instance.instance_id
 }
 
-output "capacity_gb" {
+output "capacity_gib" {
   description = "File share capacity in GiB."
   value       = google_lustre_instance.lustre_instance.capacity_gib
 }

--- a/modules/file-system/managed-lustre/outputs.tf
+++ b/modules/file-system/managed-lustre/outputs.tf
@@ -28,7 +28,7 @@ output "network_storage" {
 }
 
 output "install_managed_lustre_client" {
-  description = "Script for installing NFS client"
+  description = "Script for installing Managed Lustre client"
   value       = file("${path.module}/scripts/install-managed-lustre-client.sh")
 }
 

--- a/modules/file-system/managed-lustre/outputs.tf
+++ b/modules/file-system/managed-lustre/outputs.tf
@@ -15,7 +15,7 @@
  */
 
 output "network_storage" {
-  description = "Describes a filestore instance."
+  description = "Describes a Managed Lustre instance."
   value = {
     server_ip             = local.server_ip
     remote_mount          = local.remote_mount

--- a/modules/file-system/managed-lustre/outputs.tf
+++ b/modules/file-system/managed-lustre/outputs.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "network_storage" {
+  description = "Describes a filestore instance."
+  value = {
+    server_ip             = local.server_ip
+    remote_mount          = local.remote_mount
+    local_mount           = var.local_mount
+    fs_type               = local.fs_type
+    mount_options         = local.mount_options
+    client_install_runner = local.install_managed_lustre_client_runner
+    mount_runner          = local.mount_runner
+  }
+}
+
+output "install_managed_lustre_client" {
+  description = "Script for installing NFS client"
+  value       = file("${path.module}/scripts/install-managed-lustre-client.sh")
+}
+
+output "lustre_id" {
+  description = "An identifier for the resource with format `projects/{{project}}/locations/{{location}}/instances/{{name}}`"
+  value       = google_lustre_instance.lustre_instance.instance_id
+}
+
+output "capacity_gb" {
+  description = "File share capacity in GiB."
+  value       = google_lustre_instance.lustre_instance.capacity_gib
+}

--- a/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
@@ -47,17 +47,9 @@ if [[ ${DIST} == "Ubuntu" ]]; then
 	# Set up apt repo
 	echo "deb [ signed-by=${KEY_LOC}/${KEY_NAME} ] https://us-apt.pkg.dev/projects/lustre-client-binaries lustre-client-ubuntu-${UBUNTU_CODENAME} main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
 
-	# Install modules and insert them into the kernel
+	# Install modules
 	apt update
 	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
-	# Stop auto-upgrades to prevent kernel changes
-	mkdir /etc/apt/conf.d
-	touch /etc/apt/conf.d/20auto-upgrades
-	cat >/etc/apt/conf.d/20auto-upgrades <<-EOF
-		APT::Periodic::Update-Package-Lists "0";
-		APT::Periodic::Unattended-Upgrade "0";
-	EOF
-	apt-mark hold linux-image*
 elif [[ ${DIST} == "Rocky" ]]; then
 	# Set up yum repo
 	touch /etc/yum.repos.d/artifact-registry.repo

--- a/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Install Managed Lustre client modules
+# Based on these instructions: https://cloud.google.com/managed-lustre/docs/connect-from-compute-engine
+
+# The client modules currently only support Rocky 8, and Ubuntu 20.04/22.04
+
+set -e
+if grep -q lustre /proc/filesystems; then
+	echo "Skipping managed lustre client install as it is already supported"
+	exit 0
+fi
+
+# Get distro information
+. /etc/os-release
+DIST="NA"
+if [[ $NAME == *"Ubuntu"* ]]; then
+	if [[ $VERSION_ID == "20.04" || $VERSION_ID == "22.04" ]]; then
+		DIST="Ubuntu"
+	fi
+elif [[ $NAME == *"Rocky"* ]]; then
+	if [[ $VERSION_ID == "8"* ]]; then
+		DIST="Rocky"
+	fi
+fi
+
+if [[ ${DIST} == "Ubuntu" ]]; then
+	KEY_LOC=/etc/apt/keyrings
+	KEY_NAME=gcp-ar-repo.gpg
+	# Download new repo key
+	mkdir -p "${KEY_LOC}"
+	wget -O - https://us-apt.pkg.dev/doc/repo-signing-key.gpg 2>/dev/null | gpg --dearmor - | tee "${KEY_LOC}/${KEY_NAME}" >/dev/null
+
+	# Set up apt repo
+	echo "deb [ signed-by=${KEY_LOC}/${KEY_NAME} ] https://us-apt.pkg.dev/projects/lustre-client-binaries lustre-client-ubuntu-${UBUNTU_CODENAME} main" | tee -a /etc/apt/sources.list.d/artifact-registry.list
+
+	# Install modules and insert them into the kernel
+	apt update
+	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
+	# Stop auto-upgrades to prevent kernel changes
+	mkdir /etc/apt/conf.d
+	touch /etc/apt/conf.d/20auto-upgrades
+	cat >/etc/apt/conf.d/20auto-upgrades <<-EOF
+		APT::Periodic::Update-Package-Lists "0";
+		APT::Periodic::Unattended-Upgrade "0";
+	EOF
+	apt-mark hold linux-image*
+elif [[ ${DIST} == "Rocky" ]]; then
+	# Set up yum repo
+	touch /etc/yum.repos.d/artifact-registry.repo
+	tee -a /etc/yum.repos.d/artifact-registry.repo <<-EOF
+		[lustre-client-rocky-8]
+		name=lustre-client-rocky-8
+		baseurl=https://us-yum.pkg.dev/projects/lustre-client-binaries/lustre-client-rocky-8
+		enabled=1
+		repo_gpgcheck=0
+		gpgcheck=0
+	EOF
+	# Install modules
+	yum makecache
+	yum --enablerepo=lustre-client-rocky-8 install -y kmod-lustre-client lustre-client
+fi
+
+if [[ $DIST != "NA" ]]; then
+	# Load the new lustre client module
+	modprobe lustre
+fi

--- a/modules/file-system/managed-lustre/scripts/mount.sh
+++ b/modules/file-system/managed-lustre/scripts/mount.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+SERVER_IP=$1
+REMOTE_MOUNT=$2
+LOCAL_MOUNT=$3
+FS_TYPE=$4
+MOUNT_OPTIONS=$5
+
+[[ -z "${MOUNT_OPTIONS}" ]] && POPULATED_MOUNT_OPTIONS="defaults" || POPULATED_MOUNT_OPTIONS="${MOUNT_OPTIONS}"
+
+if [ "${FS_TYPE}" = "gcsfuse" ]; then
+	FS_SPEC="${REMOTE_MOUNT}"
+else
+	FS_SPEC="${SERVER_IP}:${REMOTE_MOUNT}"
+fi
+
+SAME_LOCAL_IDENTIFIER="^[^#].*[[:space:]]${LOCAL_MOUNT}"
+EXACT_MATCH_IDENTIFIER="${FS_SPEC}[[:space:]]${LOCAL_MOUNT}[[:space:]]${FS_TYPE}[[:space:]]${POPULATED_MOUNT_OPTIONS}[[:space:]]0[[:space:]]0"
+
+grep -q "${SAME_LOCAL_IDENTIFIER}" /etc/fstab && SAME_LOCAL_IN_FSTAB=true || SAME_LOCAL_IN_FSTAB=false
+grep -q "${EXACT_MATCH_IDENTIFIER}" /etc/fstab && EXACT_IN_FSTAB=true || EXACT_IN_FSTAB=false
+findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT}" --target "${LOCAL_MOUNT}" &>/dev/null && EXACT_MOUNTED=true || EXACT_MOUNTED=false
+
+# Do nothing and success if exact entry is already in fstab and mounted
+if [ "$EXACT_IN_FSTAB" = true ] && [ "${EXACT_MOUNTED}" = true ]; then
+	echo "Skipping mounting source: ${FS_SPEC}, already mounted to target:${LOCAL_MOUNT}"
+	exit 0
+fi
+
+# Fail if previous fstab entry is using same local mount
+if [ "$SAME_LOCAL_IN_FSTAB" = true ] && [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Mounting failed as local mount: ${LOCAL_MOUNT} was already in use in fstab"
+	exit 1
+fi
+
+# Add to fstab if entry is not already there
+if [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Adding ${FS_SPEC} -> ${LOCAL_MOUNT} to /etc/fstab"
+	echo "${FS_SPEC} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
+fi
+
+# Mount from fstab
+echo "Mounting --target ${LOCAL_MOUNT} from fstab"
+mkdir -p "${LOCAL_MOUNT}"
+mount --target "${LOCAL_MOUNT}"

--- a/modules/file-system/managed-lustre/variables.tf
+++ b/modules/file-system/managed-lustre/variables.tf
@@ -88,23 +88,6 @@ variable "mount_options" {
   default     = "defaults,_netdev"
 }
 
-variable "import_gcs_bucket_uri" {
-  description = "The name of the GCS bucket to import data from to the Lustre instance."
-  type        = string
-  default     = null
-
-  validation {
-    condition     = try(startswith(var.import_gcs_bucket_uri, "gs://"), var.import_gcs_bucket_uri == null)
-    error_message = "The import_gcs_bucket_uri must start with \"gs://\"."
-  }
-}
-
-variable "import_destination_path" {
-  description = "The name of local path to import data on Lustre instance from GCS bucket."
-  type        = string
-  default     = null
-}
-
 variable "private_vpc_connection_peering" {
   description = <<-EOT
     The name of the VPC Network peering connection.

--- a/modules/file-system/managed-lustre/variables.tf
+++ b/modules/file-system/managed-lustre/variables.tf
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "ID of project in which Lustre instance will be created."
+  type        = string
+}
+
+variable "description" {
+  description = "Description of the created Lustre instance."
+  type        = string
+  default     = "Lustre Instance"
+}
+
+variable "deployment_name" {
+  description = "Name of the HPC deployment, used as name of the Lustre instance if no name is specified."
+  type        = string
+}
+
+variable "zone" {
+  description = "Location for the Lustre instance."
+  type        = string
+}
+
+variable "name" {
+  description = "Name of the Lustre instance"
+  type        = string
+}
+
+variable "network_id" {
+  description = <<-EOT
+    The ID of the GCE VPC network to which the instance is connected given in the format:
+    `projects/<project_id>/global/networks/<network_name>`"
+    EOT
+  type        = string
+  nullable    = false
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
+}
+
+variable "subnetwork_self_link" {
+  description = "Subnetwork self-link this instance will be on, required for checking private service access"
+  type        = string
+  nullable    = false
+}
+
+variable "remote_mount" {
+  description = "Remote mount point of the Managed Lustre instance"
+  type        = string
+  nullable    = false
+}
+
+variable "local_mount" {
+  description = "Local mount point for the Managed Lustre instance."
+  type        = string
+  default     = "/shared"
+}
+
+variable "size_gib" {
+  description = "Storage size of the Managed Lustre instance in GB. See https://cloud.google.com/managed-lustre/docs/create-instance for limitations"
+  type        = number
+  default     = 18000
+}
+
+variable "labels" {
+  description = "Labels to add to the Managed Lustre instance. Key-value pairs."
+  type        = map(string)
+}
+
+variable "mount_options" {
+  description = "Mounting options for the file system."
+  type        = string
+  default     = "defaults,_netdev"
+}
+
+variable "import_gcs_bucket_uri" {
+  description = "The name of the GCS bucket to import data from to the Lustre instance."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = startswith(var.import_gcs_bucket_uri, "gs://")
+    error_message = "The import_gcs_bucket_uri must start with \"gs://\"."
+  }
+}
+
+variable "import_destination_path" {
+  description = "The name of local path to import data on Lustre instance from GCS bucket."
+  type        = string
+  default     = null
+}
+
+variable "private_vpc_connection_peering" {
+  description = <<-EOT
+    The name of the VPC Network peering connection.
+    If using new VPC, please use community/modules/network/private-service-access to create private-service-access and
+    If using existing VPC with private-service-access enabled, set this manually."
+    EOT
+  type        = string
+  nullable    = false
+}

--- a/modules/file-system/managed-lustre/variables.tf
+++ b/modules/file-system/managed-lustre/variables.tf
@@ -53,8 +53,8 @@ variable "network_id" {
   }
 }
 
-variable "subnetwork_self_link" {
-  description = "Subnetwork self-link this instance will be on, required for checking private service access"
+variable "network_self_link" {
+  description = "Network self-link this instance will be on, required for checking private service access"
   type        = string
   nullable    = false
 }
@@ -94,7 +94,7 @@ variable "import_gcs_bucket_uri" {
   default     = null
 
   validation {
-    condition     = startswith(var.import_gcs_bucket_uri, "gs://")
+    condition     = try(startswith(var.import_gcs_bucket_uri, "gs://"), var.import_gcs_bucket_uri == null)
     error_message = "The import_gcs_bucket_uri must start with \"gs://\"."
   }
 }

--- a/modules/file-system/managed-lustre/versions.tf
+++ b/modules/file-system/managed-lustre/versions.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.27.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.48.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.48.0"
+  }
+
+  required_version = ">= 1.3.0"
+}

--- a/modules/file-system/managed-lustre/versions.tf
+++ b/modules/file-system/managed-lustre/versions.tf
@@ -24,10 +24,6 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 3.0"
-    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.48.0"

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -75,24 +75,8 @@ The following is an example of using `pre-existing-network-storage` with the
 ```
 
 This is similar to the `lustre` filesystem, with the exception that it connects
-with a managed Lustre instance hosted by GCP.  Currently only Rocky 8 and a
-subset of Ubuntu 22.04 and 20.04 kernels are compatible.  The following Ubuntu
-images are supported:
-
-Ubuntu 22.04
-
-1. ubuntu-2204-jammy-v20250128
-1. ubuntu-2204-jammy-v20250409
-
-Ubuntu 20.04
-
-1. ubuntu-2004-focal-v20250130
-
-This list will be updated as more kernels are supported.
-
-> [!WARNING] When used on Ubuntu for lustre, this module stops apt from
-> auto-upgrading packages. This is meant to prevent any instability caused by
-> upgrading the kernel.
+with a managed Lustre instance hosted by GCP.  Currently only Rocky 8 and
+Ubuntu 20.04 and Ubuntu 22.04 are supported.
 
 The following is an example of using `pre-existing-network-storage` with the `daos`
 filesystem. In order to use existing `parallelstore` instance, `fs_type` needs to be

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -79,6 +79,10 @@ duplicates = [
         "modules/scheduler/gke-cluster/templates/network-object.yaml.tftpl",
         "modules/scheduler/pre-existing-gke-cluster/templates/network-object.yaml.tftpl",
     ],
+    [
+        "modules/file-system/pre-existing-network-storage/scripts/install-managed-lustre-client.sh",
+        "modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh"
+    ]
 ]
 
 for group in duplicates:

--- a/tools/duplicate-diff.py
+++ b/tools/duplicate-diff.py
@@ -19,6 +19,7 @@ duplicates = [
     [
         "modules/file-system/pre-existing-network-storage/scripts/mount.sh",
         "modules/file-system/filestore/scripts/mount.sh",
+        "modules/file-system/managed-lustre/scripts/mount.sh",
         "community/modules/file-system/cloud-storage-bucket/scripts/mount.sh",
         "community/modules/file-system/nfs-server/scripts/mount.sh",
     ],


### PR DESCRIPTION
This creates a Managed Lustre module to the Cluster Toolkit.  It follows a lot of the Parallelstore structure.

This builds on top of this [PR](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3937)

Tested on several vm-instance deployments
- Ubuntu 20.04
- Ubuntu 22.04
- Rocky8/HPC Rocky8

Tested on Slurm
- HPC Rocky 8
- Ubuntu with A4H machines