### PR TITLE
Fix Packer documentation for minimum necessary IAM roles

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -55,7 +55,7 @@ A simple way to enable inbound SSH access is to use the VPC module with
 ### User or service account executing Packer at command line
 
 The user or service account running Packer must have the permission to create
-VMs in the selected VPC network and, if [use_iap](#input_use_iap) is set, must
+VMs in the selected VPC network and, if [use\_iap](#input_use_iap) is set, must
 have the "IAP-Secured Tunnel User" role. Recommended roles are:
 
 - `roles/compute.instanceAdmin.v1`

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -52,7 +52,7 @@ the metadata-based startup-script solution.
 A simple way to enable inbound SSH access is to use the VPC module with
 `allowed_ssh_ip_ranges` set to `0.0.0.0/0`.
 
-### User or service account running Packer
+### User or service account executing Packer at command line
 
 The user or service account running Packer must have the permission to create
 VMs in the selected VPC network and, if [use_iap](#input_use_iap) is set, must
@@ -71,6 +71,7 @@ have the permission to modify its own metadata and to read from Cloud Storage
 buckets. Recommended roles are:
 
 - `roles/compute.instanceAdmin.v1`
+- `roles/iam.serviceAccountUser`
 - `roles/logging.logWriter`
 - `roles/monitoring.metricWriter`
 - `roles/storage.objectViewer`


### PR DESCRIPTION
- Fix a bug in Packer module documentation; the role `iam.serviceAccountUser` is necessary for temporary build VMs to modify their own instance metadata
- Minor change to properly escape an underscore within a Markdown link

Reference: https://cloud.google.com/iam/docs/understanding-roles#compute.instanceAdmin.v1

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
