### PR TITLE
Revert network profile URI

### DIFF
--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -217,7 +217,7 @@ deployment_groups:
     source: modules/network/gpu-rdma-vpc
     settings:
       network_name: $(vars.deployment_name)-rdma-net
-      network_profile: https://www.googleapis.com/compute/v1/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
+      network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
       network_routing_mode: REGIONAL
       subnetworks_template:
         name_prefix: $(vars.deployment_name)-mrdma-sub


### PR DESCRIPTION
The A4H blueprint is causing issues because it uses terraform-google-network module uses the `google-beta` provider and the `network_profile` is set to `v1`.  This reverts that back to beta to help reduce the chance that when they redeploy the blueprint that it doesn't destroy a good chunk of the infrastructure.

A larger solution allowing either `v1` or `beta` APIs in the `network_profile` setting will follow this up.
