### PR TITLE
Fix workload_policy varible definition and usage.

### DIFF
--- a/modules/compute/resource-policy/README.md
+++ b/modules/compute/resource-policy/README.md
@@ -69,7 +69,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The resource policy's name. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID for the resource policy. | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | The region for the the resource policy. | `string` | n/a | yes |
-| <a name="input_workload_policy"></a> [workload\_policy](#input\_workload\_policy) | Describes the workload policy | <pre>object({<br/>    type                  = optional(string, null)<br/>    max_topology_distance = optional(string, null)<br/>    accelerator_topology  = optional(string, null)<br/>  })</pre> | `null` | no |
+| <a name="input_workload_policy"></a> [workload\_policy](#input\_workload\_policy) | Describes the workload policy | <pre>object({<br/>    type                  = optional(string, null)<br/>    max_topology_distance = optional(string, null)<br/>    accelerator_topology  = optional(string, null)<br/>  })</pre> | <pre>{<br/>  "accelerator_topology": null,<br/>  "max_topology_distance": null,<br/>  "type": null<br/>}</pre> | no |
 
 ## Outputs
 

--- a/modules/compute/resource-policy/main.tf
+++ b/modules/compute/resource-policy/main.tf
@@ -21,12 +21,12 @@ resource "google_compute_resource_policy" "policy" {
   provider = google-beta
 
   dynamic "workload_policy" {
-    for_each = var.workload_policy != null ? [1] : []
+    for_each = var.workload_policy.type != null ? [1] : []
 
     content {
-      type                  = workload_policy.value.type
-      max_topology_distance = workload_policy.value.max_topology_distance
-      accelerator_topology  = workload_policy.value.accelerator_topology
+      type                  = var.workload_policy.type
+      max_topology_distance = var.workload_policy.max_topology_distance
+      accelerator_topology  = var.workload_policy.accelerator_topology
     }
   }
 

--- a/modules/compute/resource-policy/variables.tf
+++ b/modules/compute/resource-policy/variables.tf
@@ -46,5 +46,10 @@ variable "workload_policy" {
     max_topology_distance = optional(string, null)
     accelerator_topology  = optional(string, null)
   })
-  default = null
+  default = {
+    type                  = null
+    max_topology_distance = null
+    accelerator_topology  = null
+  }
+  nullable = false
 }


### PR DESCRIPTION
Added a check on `var.workload_policy.type` as its a [required field](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#type-1)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
