### PR TITLE
Update A3U and A4H Slurm examples with Lustre modules

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -232,11 +232,6 @@ deployment_groups:
         - protocol: udp
         - protocol: icmp
 
-  # If you are using the Managed Lustre instance below, uncomment this block
-  # - id: private_service_access
-  #   source: community/modules/network/private-service-access
-  #   use: [a3ultra-slurm-net-0]
-
   - id: a3ultra-slurm-net-1
     source: modules/network/vpc
     settings:
@@ -282,10 +277,14 @@ deployment_groups:
     outputs:
     - network_storage
 
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [a3ultra-slurm-net-0]
+
   # To use Managed Lustre as for the shared /home directory:
   # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
   # 2. Uncomment the managed-lustre and private-service-access blocks
-  # 3. Change the "install_managed_lustre" value to true
+  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
   # - id: homefs
   #   source: modules/file-system/managed-lustre
   #   use:

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -13,11 +13,6 @@
 # limitations under the License.
 
 ---
-# This blueprint uses private preview functionality in limited availability,
-# see README.md for further information
-
-# This blueprint requires a Cluster Toolkit binary built from a
-# release >= 1.44.0
 
 blueprint_name: a3ultra-slurm
 
@@ -33,7 +28,7 @@ vars:
     project: ubuntu-os-accelerator-images
     family: ubuntu-accelerator-2204-amd64-with-nvidia-570
   image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.9.1
+  build_slurm_from_git_ref: 6.10.0
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -72,6 +67,7 @@ deployment_groups:
             "install_cuda": false,
             "install_gcsfuse": true,
             "install_lustre": false,
+            "install_managed_lustre": false,
             "install_nvidia_repo": true,
             "install_ompi": true,
             "allow_kernel_upgrades": false,
@@ -236,6 +232,11 @@ deployment_groups:
         - protocol: udp
         - protocol: icmp
 
+  # If you are using the Managed Lustre instance below, uncomment this block
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [a3ultra-slurm-net-0]
+
   - id: a3ultra-slurm-net-1
     source: modules/network/vpc
     settings:
@@ -280,6 +281,23 @@ deployment_groups:
         reason: Avoid data loss
     outputs:
     - network_storage
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # 3. Change the "install_managed_lustre" value to true
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - a3ultra-slurm-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: 18000
+  #     name: lustre-instance
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #   outputs:
+  #   - network_storage
 
 - group: cluster
   modules:

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -27,7 +27,7 @@ vars:
     project: ubuntu-os-cloud
     family: ubuntu-2204-lts
   image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.9.1
+  build_slurm_from_git_ref: 6.10.0
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -74,6 +74,7 @@ deployment_groups:
             "install_cuda": false,
             "install_gcsfuse": true,
             "install_lustre": false,
+            "install_managed_lustre": false,
             "install_ompi": true,
             "install_nvidia_repo": true,
             "allow_kernel_upgrades": false,
@@ -198,6 +199,11 @@ deployment_groups:
         - protocol: udp
         - protocol: icmp
 
+  # If you are using the Managed Lustre instance below, uncomment this block
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [a4high-slurm-net-0]
+
   - id: a4high-slurm-net-1
     source: modules/network/vpc
     settings:
@@ -242,6 +248,23 @@ deployment_groups:
         reason: Avoid data loss
     outputs:
     - network_storage
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # 3. Change the "install_managed_lustre" value to true
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - a4high-slurm-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: 18000
+  #     name: lustre-instance1
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #   outputs:
+  #   - network_storage
 
 - group: cluster
   modules:

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -199,11 +199,6 @@ deployment_groups:
         - protocol: udp
         - protocol: icmp
 
-  # If you are using the Managed Lustre instance below, uncomment this block
-  # - id: private_service_access
-  #   source: community/modules/network/private-service-access
-  #   use: [a4high-slurm-net-0]
-
   - id: a4high-slurm-net-1
     source: modules/network/vpc
     settings:
@@ -249,10 +244,14 @@ deployment_groups:
     outputs:
     - network_storage
 
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [a4high-slurm-net-0]
+
   # To use Managed Lustre as for the shared /home directory:
   # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
   # 2. Uncomment the managed-lustre and private-service-access blocks
-  # 3. Change the "install_managed_lustre" value to true
+  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
   # - id: homefs
   #   source: modules/file-system/managed-lustre
   #   use:


### PR DESCRIPTION
With the new Managed Lustre module added to the Toolkit, this updates the A3U and A4 blueprints to include commented out examples of Managed Lustre, along with instructions for replacing filestore with lustre for the home directory.

It also removes some outdated comments and increases the Slurm-GCP version to be compliant with managed lustre.