### PR TITLE
Fix name of step in A3 Mega Slurm integration test

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm.yaml
@@ -21,7 +21,7 @@ tags:
 
 timeout: 14400s  # 4hr
 steps:
-- id: ml-a3-highgpu-slurm-image
+- id: ml-a3-megagpu-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:


### PR DESCRIPTION
The name of the image building step appears to have been copied from the A3 High integration test. This PR renames it properly.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
