### PR TITLE
Add a simple XPK blueprint example

### DIFF
--- a/community/examples/xpk-n2-filestore/config-map.yaml.tftpl
+++ b/community/examples/xpk-n2-filestore/config-map.yaml.tftpl
@@ -1,0 +1,14 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ${deployment_name}-resources-configmap
+data:
+  ${machine_type}-${vms_per_slice}: "${vms_per_slice}"
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ${deployment_name}-metadata-configmap
+data:
+  capacity_type: ON_DEMAND
+  xpk_version: ${xpk_version}

--- a/community/examples/xpk-n2-filestore/kueue-xpk-configuration.yaml.tftpl
+++ b/community/examples/xpk-n2-filestore/kueue-xpk-configuration.yaml.tftpl
@@ -1,0 +1,66 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "1x${machine_type}-${vms_per_slice}"
+spec: {}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: cluster-queue
+spec:
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu"]
+    flavors:
+    - name: "1x${machine_type}-${vms_per_slice}"
+      resources:
+      - name: "cpu"
+        nominalQuota: ${cpu_count}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  name: multislice-queue
+spec:
+  clusterQueue: cluster-queue
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: very-low
+value: 100
+globalDefault: false
+description: "Very Low"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: low
+value: 250
+globalDefault: false
+description: "Low"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: medium
+value: 500
+globalDefault: false
+description: "Medium"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high
+value: 750
+globalDefault: false
+description: "High"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: very-high
+value: 1000
+globalDefault: false
+description: "Very High"

--- a/community/examples/xpk-n2-filestore/storage-crd.yaml
+++ b/community/examples/xpk-n2-filestore/storage-crd.yaml
@@ -1,0 +1,66 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: storages.xpk.x-k8s.io
+spec:
+  group: xpk.x-k8s.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              type:
+                type: string
+              cluster:
+                type: string
+              auto_mount:
+                type: boolean
+              mount_point:
+                type: string
+              readonly:
+                type: boolean
+              manifest:
+                type: string
+              pv:
+                type: string
+              pvc:
+                type: string
+            required:
+            - type
+            - cluster
+            - auto_mount
+            - mount_point
+            - readonly
+            - manifest
+            - pvc
+            - pv
+        x-kubernetes-validations:
+        - message: Value is immutable
+          rule: self == oldSelf
+  scope: Cluster
+  names:
+    plural: storages
+    singular: storage
+    kind: Storage
+    shortNames:
+    - stg

--- a/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
+++ b/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
@@ -1,0 +1,120 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+blueprint_name: xpk-n2
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: xpk-01
+  region: us-central1
+  zones:
+  - us-central1-a
+  filestore_zone: us-central1-a
+  authorized_cidr: <your-ip-address>/32
+  gcp_public_cidrs_access_enabled: false
+  kueue_config_path: $(ghpc_stage("./kueue-xpk-configuration.yaml.tftpl"))
+  config_map_path: $(ghpc_stage("./config-map.yaml.tftpl"))
+  storage_crd_path: $(ghpc_stage("./storage-crd.yaml"))
+  machine_type: n2-standard-32
+  slice_vm_count: 2
+  slice_cpu_count: 64
+  xpk_version: v0.8.0
+  kueue_version: v0.11.1
+  jobset_version: v0.7.2
+  kjob_version: f775609365df47bdc3e7c10290d8efae7f512464
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+    settings:
+      subnetwork_name: $(vars.deployment_name)-subnet
+      secondary_ranges_list:
+      - subnetwork_name: $(vars.deployment_name)-subnet
+        ranges:
+        - range_name: pods
+          ip_cidr_range: 10.4.0.0/14
+        - range_name: services
+          ip_cidr_range: 10.0.32.0/20
+
+  - id: gke_cluster
+    source: modules/scheduler/gke-cluster
+    use: [network]
+    settings:
+      system_node_pool_machine_type: "e2-standard-4"
+      system_node_pool_node_count:
+        total_min_nodes: 1
+        total_max_nodes: 1000
+      enable_private_endpoint: false
+      gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      master_authorized_networks:
+      - display_name: deployment-machine
+        cidr_block: $(vars.authorized_cidr)
+      version_prefix: "1.31."
+      release_channel: RAPID
+      maintenance_exclusions:
+      - name: no-minor-or-node-upgrades-indefinite
+        start_time: "2024-12-01T00:00:00Z"
+        end_time: "2025-12-22T00:00:00Z"
+        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
+      enable_filestore_csi: true
+    outputs: [instructions]
+
+  - id: cpu_pool
+    source: modules/compute/gke-node-pool
+    use: [gke_cluster]
+    settings:
+      static_node_count: $(vars.slice_vm_count)
+      machine_type: $(vars.machine_type)
+      threads_per_core: 2  # enable simultaneous multi-threading to meet XPK system characteristics
+      auto_upgrade: true
+      zones: $(vars.zones)
+
+  - id: workload-manager-install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+        version: $(vars.kueue_version)
+        config_path: $(vars.kueue_config_path)
+        config_template_vars: {machine_type: $(vars.machine_type), vms_per_slice: $(vars.slice_vm_count), cpu_count: $(vars.slice_cpu_count)}
+      jobset:
+        install: true
+        version: $(vars.jobset_version)
+      apply_manifests:
+      - source: $(vars.config_map_path)
+        template_vars: {deployment_name: $(vars.deployment_name), machine_type: $(vars.machine_type), vms_per_slice: $(vars.slice_vm_count), xpk_version: $(vars.xpk_version)}
+      - source: $(vars.storage_crd_path)
+        # Server-side applies avoid last-applied-configuration and associated annotation length issues
+      - source: https://raw.githubusercontent.com/kubernetes-sigs/kjob/$(vars.kjob_version)/config/crd/bases/kjobctl.x-k8s.io_applicationprofiles.yaml
+        server_side_apply: true
+      - source: https://raw.githubusercontent.com/kubernetes-sigs/kjob/$(vars.kjob_version)/config/crd/bases/kjobctl.x-k8s.io_jobtemplates.yaml
+        server_side_apply: true
+      - source: https://raw.githubusercontent.com/kubernetes-sigs/kjob/$(vars.kjob_version)/config/crd/bases/kjobctl.x-k8s.io_rayclustertemplates.yaml
+        server_side_apply: true
+      - source: https://raw.githubusercontent.com/kubernetes-sigs/kjob/$(vars.kjob_version)/config/crd/bases/kjobctl.x-k8s.io_rayjobtemplates.yaml
+        server_side_apply: true
+      - source: https://raw.githubusercontent.com/kubernetes-sigs/kjob/$(vars.kjob_version)/config/crd/bases/kjobctl.x-k8s.io_volumebundles.yaml
+        server_side_apply: true
+
+  - id: homefs
+    source: modules/file-system/filestore
+    use: [network]
+    settings:
+      name: $(vars.deployment_name)-homefs
+      zone: $(vars.filestore_zone)
+      local_mount: /home

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [tutorial-fluent.yaml](#tutorial-fluentyaml--) ![community-badge] ![experimental-badge]
   * [omnia-cluster.yaml](#omnia-clusteryaml---) ![community-badge] ![experimental-badge] ![deprecated-badge]
   * [gke-tpu-v4](#gke-tpu-v4--) ![community-badge] ![experimental-badge]
+  * [xpk-n2-filestore](#xpk-n2-filestore--) ![community-badge] ![experimental-badge]
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Blueprint Boilerplate](#blueprint-boilerplate)
@@ -1308,6 +1309,52 @@ deployment_groups:
 This example shows how TPU v4 cluster can be created and be used to run a job that requires TPU capacity on GKE. Additional information on TPU blueprint and associated changes are in this [README](/community/examples/gke-tpu-v4/README.md).
 
 [gke-tpu-v4]: ../community/examples/gke-tpu-v4
+
+### [xpk-n2-filestore] ![community-badge] ![experimental-badge]
+
+This example shows how to set up an [XPK](https://github.com/AI-Hypercomputer/xpk)-compatible GKE cluster - giving researchers a Slurm-like CLI experience but with lightweight Kueue and Kjob resources on the cluster side. The blueprint creates a low-cost, CPU-based XPK cluster, using a single n2-standard-32-2 slice.
+
+Client-side installation of the XPK CLI is also required (see the [prerequisites](https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#prerequisites) and [installation](https://github.com/AI-Hypercomputer/xpk?tab=readme-ov-file#installation) in the XPK repository). Set `gcloud config set compute/zone <zone>` and `gcloud config set project <project-id>` to avoid their repeated inclusion in XPK commands.
+
+Attach the Filestore instance for use in workloads and jobs with the `xpk storage` command:
+
+```bash
+python3 xpk.py storage attach xpk-01-homefs \
+  --cluster=xpk-01 \
+  --type=gcpfilestore \
+  --auto-mount=true \
+  --mount-point=/home \
+  --mount-options="" \
+  --readonly=false \
+  --size=1024 \
+  --vol=nfsshare
+```
+
+After blueprint provisioning, XPK CLI installation, and storage setup, users can run interactive shells, workloads, and jobs:
+
+```bash
+# Start an interactive shell (somewhat analogous to a Slurm login node)
+python3 xpk.py shell --cluster xpk-01
+```
+
+```bash
+# Submit a workload (Kueue-based)
+python3 xpk.py workload create \
+  --cluster xpk-01 \
+  --num-slices=1 \
+  --device-type=n2-standard-32-2 \
+  --workload xpk-test-workload \
+  --command="ls /home"
+```
+
+```bash
+# Run and manage jobs (kjob-focused)
+python3 xpk.py run --cluster xpk-01 your-script.sh
+python3 xpk.py batch --cluster xpk-01 your-script.sh
+python3 xpk.py info --cluster xpk-01
+```
+
+[xpk-n2-filestore]: ../community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
 
 ## Blueprint Schema
 

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -120,7 +120,7 @@ check_background() {
 	fi
 }
 
-CONFIGS=$(find examples/ community/examples/ tools/validate_configs/test_configs/ docs/tutorials/ docs/videos/build-your-own-blueprint/ -name "*.yaml" -type f -not -path 'examples/machine-learning/a3-megagpu-8g/*' -not -path 'examples/machine-learning/a3-ultragpu-8g/*' -not -path 'examples/gke-a3-ultragpu/*' -not -path 'examples/hypercompute_clusters/*' -not -path 'examples/gke-dws-flex-start/*' -not -path 'examples/gke-a4/*' -not -path 'examples/gke-a3-megagpu/*' -not -path 'examples/machine-learning/a4-highgpu-8g/*' -not -path 'community/examples/gke-tpu-v4-2x2x2/*')
+CONFIGS=$(find examples/ community/examples/ tools/validate_configs/test_configs/ docs/tutorials/ docs/videos/build-your-own-blueprint/ -name "*.yaml" -type f -not -path 'examples/machine-learning/a3-megagpu-8g/*' -not -path 'examples/machine-learning/a3-ultragpu-8g/*' -not -path 'examples/gke-a3-ultragpu/*' -not -path 'examples/hypercompute_clusters/*' -not -path 'examples/gke-dws-flex-start/*' -not -path 'examples/gke-a4/*' -not -path 'examples/gke-a3-megagpu/*' -not -path 'examples/machine-learning/a4-highgpu-8g/*' -not -path 'community/examples/gke-tpu-v4-2x2x2/*' -not -path 'community/examples/xpk-n2-filestore/*')
 # Exclude blueprints that use v5 modules.
 declare -A EXCLUDE_EXAMPLE
 EXCLUDE_EXAMPLE["tools/validate_configs/test_configs/two-clusters-sql.yaml"]=


### PR DESCRIPTION
This PR provides a single n2 slice (n2-standard-32-2) [XPK](https://github.com/AI-Hypercomputer/xpk) example setup to:
1. Enable existing Cluster Toolkit users to quickly try a "getting started"-type XPK setup
2. Highlight the server-side components of XPK (which otherwise requires significant XPK reverse engineering, given the imperative and Python-based core of XPK)
3. Provide reference code for introducing XPK components into other blueprints/setups

Design decisions:
* Heavy version pinning, given the developing v0 nature of XPK, Kjob, and Kueue
* Use of f775609365df47bdc3e7c10290d8efae7f512464 for Kjob, based on the need for >v0.1.0 given XPK's use of `--pod-template-annotation`, but no >v0.1.0 release (the two tags v0.2.0-devel and v0.1.0 are on the same commit). This will be switched to a proper tagged release, upon the next XPK release. f775609365df47bdc3e7c10290d8efae7f512464 is specifically chosen, as it is just prior to the dependabot version bump of Kueue to v0.11.2 (Cluster Toolkit currently covers up to v0.11.1). The kjob CRD manifest links are deliberately structured to accept either a version tag or a commit hash.

Manually tested various happy-path and non-happy-path scenarios. Testing confirmed functionality of all relevant xpk commands: `workload`, `storage`, `cluster`, `inspector`, `info`, `batch`, `job`, `shell`, `version`, `config`, and `run`.

### Submission Checklist

* ✅ Fork your PR branch from the Toolkit "develop" branch (not main)
* ✅ Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* ✅ Confirm that "make tests" passes all tests
* ✅ Add or modify unit tests to cover code changes
* ✅ Ensure that unit test coverage remains above 80%
* ✅ Update all applicable documentation
* ✅ Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
