### PR TITLE
fix(htcondor): explicitly set region for cm and ap addresses to match subnetwork region

### DIFF
--- a/community/modules/scheduler/htcondor-access-point/main.tf
+++ b/community/modules/scheduler/htcondor-access-point/main.tf
@@ -234,6 +234,7 @@ resource "google_compute_disk" "spool" {
 resource "google_compute_address" "ap" {
   project      = var.project_id
   name         = local.name_prefix
+  region       = var.region
   subnetwork   = var.subnetwork_self_link
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"

--- a/community/modules/scheduler/htcondor-central-manager/main.tf
+++ b/community/modules/scheduler/htcondor-central-manager/main.tf
@@ -141,6 +141,7 @@ module "startup_script" {
 resource "google_compute_address" "cm" {
   project      = var.project_id
   name         = local.name_prefix
+  region       = var.region
   subnetwork   = var.subnetwork_self_link
   address_type = "INTERNAL"
   purpose      = "GCE_ENDPOINT"


### PR DESCRIPTION
This PR fixes an issue in the scheduler htcondor module where google_compute_address resources for both the Access Point (ap) and Central Manager (cm) were created without an explicitly defined region.

Problem :
When deploying in a multi-region setup, the google_compute_address resources default to the region specified in the provider block. However, the associated subnetwork may belong to a different region. This led to the following deployment error : 


```
│ Error: Error creating Address: googleapi: Error 400: Invalid value for field 'resource.subnetwork': 'projects//regions/europe-west4/subnetworks/htcondor-subnet'. Subnetwork must be in the same region., invalid
│ 
│   with module.htcondor_access.google_compute_address.ap,
│   on modules/embedded/community/modules/scheduler/htcondor-access-point/main.tf line 234, in resource "google_compute_address" "ap":
│  234: resource "google_compute_address" "ap" {
│ 
╵
╷
│ Error: Error creating Address: googleapi: Error 400: Invalid value for field 'resource.subnetwork': 'projects//regions/europe-west4/subnetworks/htcondor-subnet'. Subnetwork must be in the same region., invalid
│ 
│   with module.htcondor_cm.google_compute_address.cm,
│   on modules/embedded/community/modules/scheduler/htcondor-central-manager/main.tf line 141, in resource "google_compute_address" "cm":
│  141: resource "google_compute_address" "cm" {
```

Fix
The fix explicitly sets the region attribute for both ap and cm address resources to use var.region, ensuring that they are provisioned in the same region as the subnetwork (var.subnetwork_self_link).

Changes
Added `region = var.region` to the google_compute_address "ap" resource in the Access Point module

Added `region = var.region` to the google_compute_address "cm" resource in the Central Manager module

This ensures compatibility and correctness in multi-region deployments.