### PR TITLE
Add guidance on setting ResumeRate for Slurm

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -204,6 +204,34 @@ The default has been set to 128. Values above this have not been fully tested
 and may cause congestion on the controller. A more scalable solution is under
 way.
 
+## ResumeRate and Node Resumption
+
+The `ResumeRate` parameter in `slurm.conf` controls the maximum number of nodes
+that Slurm attempts to resume (power up) per minute. This is particularly
+important in cloud environments where auto-scaling can lead to a large number of
+nodes starting concurrently.
+
+When many nodes start simultaneously, they can place a heavy load on shared
+resources, especially shared filesystems, as they all try to mount filesystems
+and access configuration files at the same time. By limiting the `ResumeRate`,
+you can stagger the node startup process, reducing the peak load on these shared
+resources and improving overall cluster stability during scaling events.
+
+For example, to limit the node resumption rate to 100 nodes per minute,
+configure the blueprint as follows:
+
+```yaml
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    ...
+    settings:
+      cloud_parameters:
+        resume_rate: 100
+```
+
+Adjust this value based on the capabilities of your shared filesystem and the
+expected scaling behavior of your cluster.
+
 ## Support
 The Cluster Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
 modules. For support with the underlying modules, see the instructions in the


### PR DESCRIPTION
Adds documentation to the schedmd-slurm-gcp-v6-controller module README explaining the purpose of the ResumeRate parameter and how to configure it via cloud_parameters to help manage load on shared filesystems during node auto-scaling.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
