### PR TITLE
Fix cloud rdma driver script for rocky 8

### DIFF
--- a/modules/scripts/startup-script/files/install_cloud_rdma_drivers.sh
+++ b/modules/scripts/startup-script/files/install_cloud_rdma_drivers.sh
@@ -19,21 +19,30 @@ OS_VERSION="$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"
 OS_VERSION_MAJOR="$(awk -F '=' '/VERSION_ID/ {print $2}' /etc/os-release | sed -e 's/"//g' -e 's/\..*$//')"
 
 if { [ "${OS_ID}" = "rocky" ] || [ "${OS_ID}" = "rhel" ]; } && { [ "${OS_VERSION_MAJOR}" = "8" ]; }; then
-	KMOD_VERSION="$(dnf list installed | grep "kmod-idpf-irdma" | awk '{print $2}')"
+	KMOD_VERSION="$(dnf list installed | awk '$1 ~ /^kmod-idpf-irdma(\.|$)/ {print $2}')"
 
-	# Downloading the RDMA packages and installing them
-	sudo dnf install https://depot.ciq.com/public/files/gce-accelerator/irdma-kernel-modules-el8-x86_64/irdma-repos.rpm -y
-	sudo dnf upgrade kmod-idpf-irdma rdma-core libibverbs-utils librdmacm-utils infiniband-diags perftest -y
-	NEW_KMOD_VERSION="$(dnf list installed | grep "kmod-idpf-irdma" | awk '{print $2}')"
-
-	# Restarting drivers so they can use RDMA without needing a reboot (for new installs or for kmod package updates)
-	if { [ -z "${KMOD_VERSION}" ] || [ "${KMOD_VERSION}" != "${NEW_KMOD_VERSION}" ]; }; then
+	# For images that do not already have Cloud RDMA drivers installed
+	if [ -z "${KMOD_VERSION}" ]; then
+		sudo dnf install https://depot.ciq.com/public/files/gce-accelerator/irdma-kernel-modules-el8-x86_64/irdma-repos.rpm -y
+		sudo dnf install kmod-idpf-irdma rdma-core libibverbs-utils librdmacm-utils infiniband-diags perftest -y
 		sudo rmmod idpf
 		sudo rmmod irdma
 		sudo modprobe idpf
-	fi
+		exit 0
+	else
+		# Downloading the RDMA packages and upgrading existing drivers
+		sudo dnf install https://depot.ciq.com/public/files/gce-accelerator/irdma-kernel-modules-el8-x86_64/irdma-repos.rpm -y
+		sudo dnf upgrade kmod-idpf-irdma rdma-core libibverbs-utils librdmacm-utils infiniband-diags perftest -y
+		NEW_KMOD_VERSION="$(dnf list installed | awk '$1 ~ /^kmod-idpf-irdma(\.|$)/ {print $2}')"
 
-	exit 0
+		# Restarting drivers so they can use RDMA without needing a reboot (specifically checking for kmod package updates)
+		if [ "${KMOD_VERSION}" != "${NEW_KMOD_VERSION}" ]; then
+			sudo rmmod idpf
+			sudo rmmod irdma
+			sudo modprobe idpf
+		fi
+		exit 0
+	fi
 else
 	echo "Unsupported operating system ${OS_ID} ${OS_VERSION}. Cloud RDMA Drivers are only supported on Rocky Linux 8."
 	exit 1


### PR DESCRIPTION
Flow for images without cloud rdma drivers was not working correctly due to the use of `dnf upgrade` which requires some version of the package to already exist.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
