### PR TITLE
Fixing the kernel upgrade flag for slurm image creation

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
@@ -372,7 +372,7 @@ deployment_groups:
             "install_lustre": false,
             "install_nvidia_repo": true,
             "install_ompi": true,
-            "update_kernel": false,
+            "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
           }
       - type: shell

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -74,7 +74,7 @@ deployment_groups:
             "install_lustre": false,
             "install_nvidia_repo": true,
             "install_ompi": true,
-            "update_kernel": false,
+            "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
           }
       - type: shell

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -73,7 +73,7 @@ deployment_groups:
             "install_lustre": false,
             "install_ompi": true,
             "install_nvidia_repo": true,
-            "update_kernel": false,
+            "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
           }
       - type: shell


### PR DESCRIPTION
The option of `update_kernel` has never been correct but has not caused issues previously.  This PR makes that fix.