### PR TITLE
disable unattended upgrades in a3u and a4h slurm solutions

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/slurm-a3mega-image.yaml
@@ -61,6 +61,18 @@ deployment_groups:
         destination: prevent_unintentional_upgrades.sh
         content: |
           #!/bin/bash
+          # Unattended upgrades are disabled in this blueprint so that software does not
+          # get updated daily and lead to potential instability in the cluster environment.
+          #
+          # Unattended Upgrades installs available security updates from the Ubuntu
+          # security pocket for installed packages daily by default. Administrators who
+          # disable this feature assume all responsibility for manually reviewing and
+          # patching their systems against vulnerabilities.
+          #
+          # To enable unattended upgrades, please remove the following lines:
+          #   systemctl stop unattended-upgrades.service
+          #   systemctl disable unattended-upgrades.service
+          #   systemctl mask unattended-upgrades.service
           set -e -o pipefail
           systemctl stop unattended-upgrades.service
           systemctl disable unattended-upgrades.service

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -61,6 +61,23 @@ deployment_groups:
       docker:
         enabled: true
       runners:
+      - type: shell
+        destination: disable_unattended_upgrades.sh
+        content: |
+          #!/bin/bash
+          # Unattended upgrades are disabled in this blueprint so that software does not
+          # get updated daily and lead to potential instability in the cluster environment.
+          #
+          # Unattended Upgrades installs available security updates from the Ubuntu
+          # security pocket for installed packages daily by default. Administrators who
+          # disable this feature assume all responsibility for manually reviewing and
+          # patching their systems against vulnerabilities.
+          #
+          # To enable unattended upgrades, please remove this section.
+          set -e -o pipefail
+          systemctl stop unattended-upgrades.service
+          systemctl disable unattended-upgrades.service
+          systemctl mask unattended-upgrades.service
       - type: data
         destination: /var/tmp/slurm_vars.json
         content: |

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -58,6 +58,23 @@ deployment_groups:
         world_writable: true
       runners:
       - type: shell
+        destination: disable_unattended_upgrades.sh
+        content: |
+          #!/bin/bash
+          # Unattended upgrades are disabled in this blueprint so that software does not
+          # get updated daily and lead to potential instability in the cluster environment.
+          #
+          # Unattended Upgrades installs available security updates from the Ubuntu
+          # security pocket for installed packages daily by default. Administrators who
+          # disable this feature assume all responsibility for manually reviewing and
+          # patching their systems against vulnerabilities.
+          #
+          # To enable unattended upgrades, please remove this section.
+          set -e -o pipefail
+          systemctl stop unattended-upgrades.service
+          systemctl disable unattended-upgrades.service
+          systemctl mask unattended-upgrades.service
+      - type: shell
         destination: prep-for-slurm-build.sh
         content: |
           #!/bin/bash


### PR DESCRIPTION
This PR disables unattended-upgrades in A3U and A4 Slurm solutions

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
