### PR TITLE
update kueue configurations and reservations in a3 mega, ultra and A4

### DIFF
--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -47,6 +47,8 @@ vars:
   # <project>/<reservation-name>/reservationBlocks/<reservation-block-name>
   extended_reservation:
 
+  accelerator_type: nvidia-h100-mega-80gb
+
 deployment_groups:
 - group: primary
   modules:
@@ -120,6 +122,9 @@ deployment_groups:
       machine_type: a3-megagpu-8g
       static_node_count: $(vars.static_node_count)
       zones: [$(vars.zone)]
+      guest_accelerator:
+      - type: $(vars.accelerator_type)
+        count: 8
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:
@@ -135,6 +140,6 @@ deployment_groups:
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a3_megagpu_pool.static_gpu_count)
-          node_pool_name: $(a3_megagpu_pool.node_pool_names[0])
+          accelerator_type: $(vars.accelerator_type)
       jobset:
         install: true

--- a/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
@@ -29,7 +29,7 @@ metadata:
   name: "a3-mega"
 spec:
   nodeLabels:
-    cloud.google.com/gke-nodepool: ${node_pool_name}
+    cloud.google.com/gke-accelerator: ${accelerator_type}
   topologyName: "gke-default"
   tolerations:
   - key: "nvidia.com/gpu"

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -34,6 +34,7 @@ vars:
   static_node_count: # add this
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
+  accelerator_type: nvidia-h200-141gb
 
 deployment_groups:
 - group: primary
@@ -186,7 +187,7 @@ deployment_groups:
       disk_size_gb: $(vars.a3ultra_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
       guest_accelerator:
-      - type: nvidia-h200-141gb
+      - type: $(vars.accelerator_type)
         count: 8
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
@@ -219,7 +220,7 @@ deployment_groups:
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a3-ultragpu-pool.static_gpu_count)
-          node_pool_name: $(a3-ultragpu-pool.node_pool_names[0])
+          accelerator_type: $(vars.accelerator_type)
       jobset:
         install: true
       apply_manifests:

--- a/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
@@ -29,7 +29,7 @@ metadata:
   name: "a3-ultra"
 spec:
   nodeLabels:
-    cloud.google.com/gke-nodepool: ${node_pool_name}
+    cloud.google.com/gke-accelerator: ${accelerator_type}
   topologyName: "gke-default"
   tolerations:
   - key: "nvidia.com/gpu"

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -51,6 +51,7 @@ vars:
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   system_node_pool_disk_size_gb: 200
   a4_node_pool_disk_size_gb: 100
+  accelerator_type: nvidia-b200
 
 
 deployment_groups:
@@ -204,7 +205,7 @@ deployment_groups:
       disk_size_gb: $(vars.a4_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
       guest_accelerator:
-      - type: nvidia-b200
+      - type: $(vars.accelerator_type)
         count: 8
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
@@ -238,7 +239,7 @@ deployment_groups:
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a4-pool.static_gpu_count)
-          node_pool_name: $(a4-pool.node_pool_names[0])
+          accelerator_type: $(vars.accelerator_type)
       jobset:
         install: true
       apply_manifests:

--- a/examples/gke-a4/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a4/kueue-configuration.yaml.tftpl
@@ -29,7 +29,7 @@ metadata:
   name: "a4"
 spec:
   nodeLabels:
-    cloud.google.com/gke-nodepool: ${node_pool_name}
+    cloud.google.com/gke-accelerator: ${accelerator_type}
   topologyName: "gke-default"
   tolerations:
   - key: "nvidia.com/gpu"

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
@@ -29,7 +29,7 @@ metadata:
   name: "tas-flavor"
 spec:
   nodeLabels:
-    cloud.google.com/gke-nodepool: "a2-highgpu-2g-a2highgpupool"
+    cloud.google.com/gke-accelerator: nvidia-tesla-a100
   topologyName: "gke-default"
   tolerations:
   - key: "nvidia.com/gpu"


### PR DESCRIPTION
### Submission Checklist
Use `accelerator_type` instead of `cloud.google.com/gke-nodepool`
Updated and tested gke-a3-megagpu blueprint. Will update cloud docs to reflect the new blueprint once these changes are released 


NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
