### PR TITLE
Add pfs-managed-lustre examples to replace pfs-lustre

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -27,7 +27,8 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [image-builder.yaml](#image-builderyaml-) ![core-badge]
   * [serverless-batch.yaml](#serverless-batchyaml-) ![core-badge]
   * [serverless-batch-mpi.yaml](#serverless-batch-mpiyaml-) ![core-badge]
-  * [pfs-lustre.yaml](#pfs-lustreyaml-) ![core-badge]
+  * [pfs-lustre.yaml](#pfs-lustreyaml-) ![core-badge] ![deprecated-badge]
+  * [pfs-managed-lustre-vms.yaml](#pfs-managed-lustre-vmsyaml-) ![core-badge]
   * [ps-slurm.yaml](#ps-slurmyaml--) ![core-badge] ![experimental-badge]
   * [pfs-parallelstore.yaml](#pfs-parallelstoreyaml--) ![core-badge] ![experimental-badge]
   * [cae-slurm.yaml](#cae-slurmyaml-) ![core-badge]
@@ -599,7 +600,9 @@ The blueprint contains the following:
 
 [serverless-batch-mpi.yaml]: ../examples/serverless-batch-mpi.yaml
 
-### [pfs-lustre.yaml] ![core-badge]
+### [pfs-lustre.yaml] ![core-badge] ![deprecated-badge]
+
+_This blueprint has been deprecated and will be removed on August 1, 2025._
 
 Creates a DDN EXAScaler lustre file-system that is mounted in two client instances.
 
@@ -625,6 +628,31 @@ For this example the following is needed in the selected region:
 * Compute Engine API: N2 CPUs: **~116: 32 MDS, 32 MGS, 3x16 OSS, 2x2 client-vms**
 
 [pfs-lustre.yaml]: ./pfs-lustre.yaml
+
+### [pfs-managed-lustre-vms.yaml] ![core-badge]
+
+Creates a Managed Lustre file-system that is mounted in one client instance.
+
+The [GCP Managed Lustre](../modules/file-system/managed-lustre/README.md)
+file system is designed for high IO performance. It has a minimum capacity of ~18TiB and is mounted at `/lustre`.
+
+After the creation of the file-system and the client instances, the lustre drivers will be automatically installed and the mount-point configured on the VMs. This may take a few minutes after the VMs are created and can be verified by running:
+
+```sh
+watch mount -t lustre
+```
+
+#### Quota Requirements for pfs-managed-lustre.yaml
+
+For this example, the following is needed in the selected region:
+
+* Compute Engine API: Persistent Disk SSD (GB): **~800GB: 800GB MDT**
+* Compute Engine API: Persistent Disk Standard (GB): **~328GB: 128 MGT, 200GB client-vm**
+* Compute Engine API: Hyperdisk Balanced (GB): **~27432GB: 18432 GB OST Pool, 8*1125GB OST**
+* Compute Engine API: N2 CPUs: **~34: 32 MGS, 2 client-vm**
+* Compute Engine API: C3 CPUs: **~396: 44 MDS, 2*176 OSS**
+
+[pfs-managed-lustre-vms.yaml]: ./pfs-managed-lustre-vms.yaml
 
 ### [ps-slurm.yaml] ![core-badge] ![experimental-badge]
 

--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -1,0 +1,82 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: managed-lustre-slurm
+
+vars:
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: managed-lustre-slurm
+  region: us-central1
+  zone: us-central1-a
+  compute_node_machine_type: c2-standard-4
+
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
+
+deployment_groups:
+- group: lustre
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  # Required for Managed Lustre instance
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
+  - id: lustre-gcp
+    source: modules/file-system/managed-lustre
+    use: [network, private_service_access]
+    settings:
+      name: lustre-instance
+      local_mount: /lustre
+      remote_mount: lustrefs
+      size_gib: 18000
+
+- group: slurm-cluster
+  modules:
+  - id: lustre-nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      node_count_dynamic_max: 2
+      machine_type: $(vars.compute_node_machine_type)
+      allow_automatic_updates: false
+
+  - id: lustre_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - lustre-nodeset
+    settings:
+      partition_name: lustre
+      is_default: true
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      machine_type: n2-standard-4
+      enable_login_public_ips: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - lustre_partition
+    - lustre-gcp
+    - slurm_login
+    settings:
+      machine_type: n2-standard-4
+      enable_controller_public_ips: true

--- a/examples/pfs-managed-lustre-vm.yaml
+++ b/examples/pfs-managed-lustre-vm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# WARNING: this example has been deprecated as of v1.51.0 of the Cluster Toolkit
-
 ---
-blueprint_name: pfs-lustre
+blueprint_name: pfs-managed-lustre-vms
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: small-lustre
+  deployment_name: pfs-managed-lustre-vms
   region: us-central1
-  zone: us-central1-c
+  zone: us-central1-a
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -29,23 +27,30 @@ vars:
 deployment_groups:
 - group: primary
   modules:
-  - id: network1
-    source: modules/network/pre-existing-vpc
+  - id: network
+    source: modules/network/vpc
 
-  # This file system has an associated license cost.
-  # https://console.developers.google.com/marketplace/product/ddnstorage/exascaler-cloud
-  - id: lustre
-    source: community/modules/file-system/DDN-EXAScaler
-    use: [network1]
+  # Required for Managed Lustre instance
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+
+  - id: lustre-gcp
+    source: modules/file-system/managed-lustre
+    use: [network, private_service_access]
     settings:
+      name: lustre-instance
       local_mount: /lustre
+      remote_mount: lustrefs
+      size_gib: 18000
 
   - source: modules/compute/vm-instance
-    id: compute_instances
-    use: [network1, lustre]
+    id: lustre_ubuntu22_instances
+    use: [network, lustre-gcp]
     settings:
-      name_prefix: client-vm
-      add_deployment_name_before_prefix: true
-      instance_count: 2
+      name_prefix: lustre-ubuntu22
+      instance_count: 1
       machine_type: n2-standard-2
-      allow_automatic_updates: false
+      instance_image:
+        project: ubuntu-os-cloud
+        name: ubuntu-2204-jammy-v20250128

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -1,0 +1,43 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.managed-lustre
+- m.vpc
+- m.private-service-access
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+- id: managed-lustre-slurm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml"

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -1,0 +1,40 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.managed-lustre
+- m.vpc
+- m.private-service-access
+- m.vm-instance
+- vm
+
+timeout: 14400s  # 4hr
+steps:
+- id: managed-lustre-vm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml"

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
@@ -1,0 +1,39 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+test_name: managed-lustre-slurm
+deployment_name: "managed-lustre-slurm-{{ build }}"
+region: us-central1
+zone: us-central1-a
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/pfs-managed-lustre-slurm.yaml"
+network: "{{ deployment_name }}-net"
+slurm_cluster_name: "mgdltr{{ build[0:3] }}"
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  compute_node_machine_type: c2-standard-4
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+# Note: Pattern matching in gcloud only supports 1 wildcard.
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+post_deploy_tests:
+- test-validation/test-partitions.yml
+- test-validation/test-mounts.yml
+custom_vars:
+  mounts:
+  - /lustre
+  partitions:
+  - lustre

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml
@@ -1,0 +1,28 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+test_name: managed-lustre-vm
+deployment_name: "managed-lustre-vm-{{ build }}"
+region: us-central1
+zone: us-central1-a
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/pfs-managed-lustre-vm.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-lustre-ubuntu22-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+custom_vars:
+  mounts:
+  - /lustre


### PR DESCRIPTION
These examples replaces the pfs-lustre example as a 1P solution for Lustre.  The PR also begins the deprecation process for the pfs-lustre example.

Two integration tests are also added to test managed lustre creation and module installation for both regular VMs and Slurm.
