### PR TITLE
Bring parity of functionality to both A3U and A4

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -42,9 +42,9 @@ vars:
   nccl_plugin_version: v1.0.5
   base_network_name: $(vars.deployment_name)
   #Consumption options (set to true or fill in reservation name, pick only one)
-  a4h_dws_flex_enabled: false
-  a4h_enable_spot_vm: false
-  a4h_reservation_name: ""
+  a3u_dws_flex_enabled: false
+  a3u_enable_spot_vm: false
+  a3u_reservation_name: ""
 
 deployment_groups:
 - group: image-env
@@ -470,10 +470,10 @@ deployment_groups:
       on_host_maintenance: TERMINATE
 
       #Consumption options
-      reservation_name: $(vars.a4h_reservation_name)
-      enable_spot_vm: $(vars.a4h_enable_spot_vm)
+      reservation_name: $(vars.a3u_reservation_name)
+      enable_spot_vm: $(vars.a3u_enable_spot_vm)
       dws_flex:
-        enabled: $(vars.a4h_dws_flex_enabled)
+        enabled: $(vars.a3u_dws_flex_enabled)
 
       advanced_machine_features:
         threads_per_core: null # Use platform default value

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 ---
 
 blueprint_name: a3ultra-slurm
@@ -22,7 +21,6 @@ vars:
   region: # supply region
   zone: # supply zone
   a3u_cluster_size: # supply cluster size
-  a3u_reservation_name: # supply reservation name
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
@@ -40,9 +38,13 @@ vars:
   instance_image:
     project: $(vars.project_id)
     family: $(vars.deployment_name)-u22
-  disk_size_gb: 200
+  disk_size_gb: 100
   nccl_plugin_version: v1.0.5
   base_network_name: $(vars.deployment_name)
+  #Consumption options (set to true or fill in reservation name, pick only one)
+  a4h_dws_flex_enabled: false
+  a4h_enable_spot_vm: false
+  a4h_reservation_name: ""
 
 deployment_groups:
 - group: image-env
@@ -58,6 +60,7 @@ deployment_groups:
       install_ansible: true
       docker:
         enabled: true
+        world_writable: true
       runners:
       - type: shell
         destination: disable_unattended_upgrades.sh
@@ -228,6 +231,11 @@ deployment_groups:
                 name:
                 - ibverbs-utils
                 state: present
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+
 
 - group: image
   modules:
@@ -350,6 +358,7 @@ deployment_groups:
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
           ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
@@ -379,6 +388,7 @@ deployment_groups:
                   ExecStartPre=/snap/bin/gcloud auth configure-docker --quiet us-docker.pkg.dev
                   ExecStart=/usr/bin/docker run --rm --name nccl-gib-installer --volume /usr/local/gib:/var/lib/gib \
                       us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:%i install --install-nccl
+                  ExecStartPost=/usr/bin/chmod -R a+r /usr/local/gib
 
                   [Install]
                   WantedBy=slurmd.service
@@ -458,11 +468,18 @@ deployment_groups:
       enable_placement: false
       disk_type: hyperdisk-balanced
       on_host_maintenance: TERMINATE
-      reservation_name: $(vars.a3u_reservation_name)
+
+      #Consumption options
+      reservation_name: $(vars.a4h_reservation_name)
+      enable_spot_vm: $(vars.a4h_enable_spot_vm)
+      dws_flex:
+        enabled: $(vars.a4h_dws_flex_enabled)
+
       advanced_machine_features:
         threads_per_core: null # Use platform default value
       node_conf:
         CoresPerSocket: 56
+        SocketsPerBoard: 2
         ThreadsPerCore: 2
       additional_networks:
         $(concat(

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -23,8 +23,8 @@ vars:
   a4h_cluster_size: # supply cluster size
   # Image settings
   base_image:
-    project: ubuntu-os-cloud
-    family: ubuntu-2204-lts
+    project: ubuntu-os-accelerator-images
+    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20250425
   image_build_machine_type: n2-standard-16
   build_slurm_from_git_ref: 6.10.0
   # Cluster env settings
@@ -38,11 +38,10 @@ vars:
   instance_image:
     project: $(vars.project_id)
     family: $(vars.deployment_name)-u22
-  disk_size_gb: 200
+  disk_size_gb: 100
   nccl_plugin_version: v1.0.5
   benchmark_dir: $(ghpc_stage("system_benchmarks"))
   base_network_name: $(vars.deployment_name)
-
   #Consumption options (set to true or fill in reservation name, pick only one)
   a4h_dws_flex_enabled: false
   a4h_enable_spot_vm: false
@@ -81,12 +80,6 @@ deployment_groups:
           systemctl stop unattended-upgrades.service
           systemctl disable unattended-upgrades.service
           systemctl mask unattended-upgrades.service
-      - type: shell
-        destination: prep-for-slurm-build.sh
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          ansible-galaxy role install googlecloudplatform.google_cloud_ops_agents
       - type: data
         destination: /var/tmp/slurm_vars.json
         content: |
@@ -96,8 +89,8 @@ deployment_groups:
             "install_gcsfuse": true,
             "install_lustre": false,
             "install_managed_lustre": false,
-            "install_ompi": true,
             "install_nvidia_repo": true,
+            "install_ompi": true,
             "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
           }
@@ -111,6 +104,7 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
+            # this duplicates the ulimits configuration of the HPC VM Image
       - type: data
         destination: /etc/security/limits.d/99-unlimited.conf
         content: |
@@ -121,10 +115,10 @@ deployment_groups:
           * - cpu unlimited
           * - rtprio unlimited
       - type: ansible-local
-        destination: install_a4h_drivers.yml
+        destination: configure_gpu.yml
         content: |
           ---
-          - name: Install A4 Drivers and Utils
+          - name: Install NVIDIA packages
             hosts: all
             become: true
             vars:
@@ -133,12 +127,11 @@ deployment_groups:
               cuda_repo_filename: /tmp/{{ cuda_repo_url | basename }}
               enable_nvidia_dcgm: false
               nvidia_packages:
-              - nvidia-open-570
-              - nvidia-utils-570
-              - nvidia-container-toolkit
               - cuda-toolkit-12-8
               - datacenter-gpu-manager
+              - libnvidia-cfg1-570-server
               - libnvidia-nscq-570
+              - nvidia-compute-utils-570-server
             tasks:
             - name: Download NVIDIA repository package
               ansible.builtin.get_url:
@@ -148,6 +141,40 @@ deployment_groups:
               ansible.builtin.apt:
                 deb: "{{ cuda_repo_filename }}"
                 state: present
+            # The following 3 tasks work around a temporary issue with Ubuntu
+            # packaging of NVIDIA 570 driver series for kernel 6.8.0-1028
+            - name: Unfreeze 570 driver metapackage
+              ansible.builtin.command:
+                argv:
+                - apt-mark
+                - unhold
+                - linux-modules-nvidia-570-server-open-gcp
+            - name: Remove 570 driver metapackage
+              ansible.builtin.apt:
+                name: linux-modules-nvidia-570-server-open-gcp
+                state: absent
+            - name: Install latest 570 driver for kernel
+              ansible.builtin.apt:
+                name: linux-modules-nvidia-570-server-open-6.8.0-1028-gcp
+                state: latest
+            - name: Reduce NVIDIA repository priority
+              ansible.builtin.copy:
+                dest: /etc/apt/preferences.d/cuda-repository-pin-600
+                mode: 0o0644
+                owner: root
+                group: root
+                content: |
+                  Package: nsight-compute
+                  Pin: origin *ubuntu.com*
+                  Pin-Priority: -1
+
+                  Package: nsight-systems
+                  Pin: origin *ubuntu.com*
+                  Pin-Priority: -1
+
+                  Package: *
+                  Pin: release l=NVIDIA CUDA
+                  Pin-Priority: 400
             - name: Install NVIDIA fabric and CUDA
               ansible.builtin.apt:
                 name: "{{ item }}"
@@ -158,10 +185,37 @@ deployment_groups:
                 name: "{{ item }}"
                 selection: hold
               loop: "{{ nvidia_packages }}"
+            - name: Create nvidia-persistenced override directory
+              ansible.builtin.file:
+                path: /etc/systemd/system/nvidia-persistenced.service.d
+                state: directory
+                owner: root
+                group: root
+                mode: 0o755
+            - name: Configure nvidia-persistenced override
+              ansible.builtin.copy:
+                dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
+                owner: root
+                group: root
+                mode: 0o644
+                content: |
+                  [Service]
+                  ExecStart=
+                  ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
+              notify: Reload SystemD
+            handlers:
+            - name: Reload SystemD
+              ansible.builtin.systemd:
+                daemon_reload: true
             post_tasks:
             - name: Disable NVIDIA DCGM by default (enable during boot on GPU nodes)
               ansible.builtin.service:
                 name: nvidia-dcgm.service
+                state: stopped
+                enabled: false
+            - name: Disable nvidia-persistenced SystemD unit (enable during boot on GPU nodes)
+              ansible.builtin.service:
+                name: nvidia-persistenced.service
                 state: stopped
                 enabled: false
 
@@ -192,7 +246,7 @@ deployment_groups:
     settings:
       disk_size: $(vars.disk_size_gb)
       machine_type: $(vars.image_build_machine_type)
-      source_image_family: $(vars.base_image.family)
+      source_image: $(vars.base_image.image)
       source_image_project_id: [$(vars.base_image.project)]
       image_family: $(vars.instance_image.family)
       omit_external_ip: false
@@ -361,6 +415,7 @@ deployment_groups:
             vars:
               enable_ops_agent: true
               enable_nvidia_dcgm: true
+              enable_nvidia_persistenced: true
             tasks:
             - name: Update Ops Agent configuration
               ansible.builtin.blockinfile:
@@ -395,6 +450,11 @@ deployment_groups:
                 name: nvidia-dcgm.service
                 state: "{{ 'started' if enable_nvidia_dcgm else 'stopped' }}"
                 enabled: "{{ enable_nvidia_dcgm }}"
+            - name: Enable NVIDIA Persistence Daemon
+              ansible.builtin.service:
+                name: nvidia-persistenced.service
+                state: "{{ 'started' if enable_nvidia_persistenced else 'stopped' }}"
+                enabled: "{{ enable_nvidia_persistenced }}"
 
   - id: a4high_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
@@ -450,7 +510,7 @@ deployment_groups:
       partition_conf:
         OverSubscribe: EXCLUSIVE
         ResumeTimeout: 1200
-        SuspendTimeout: 600
+        SuspendTimeout: 1200
 
   - id: slurm_login
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -104,7 +104,7 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
-            # this duplicates the ulimits configuration of the HPC VM Image
+      # this duplicates the ulimits configuration of the HPC VM Image
       - type: data
         destination: /etc/security/limits.d/99-unlimited.conf
         content: |


### PR DESCRIPTION
* Accelerator images for A4
* persistenced enabled for A4
* NVIDIA repo pinning
* SocketsPerBoard 2 for A3U
* Enroot Config for A3U
* A4 ResumeTimeout Match 1200 from A3U
* Disk sizes 100GB for compute nodes
* Add DWS Flex for A3U
* Incorpriate accelerator image patch for A4

Marking as a breaking change as we are switching the base image being used in A4.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
