### PR TITLE
Remove k8s service account var from gke-a3U blueprint

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
@@ -34,4 +34,3 @@ vars:
   # disk for each node of the system node pool.
   a3ultra_node_pool_disk_size_gb: <A3ULTRA_NODE_POOL_DISK_SIZE_GB> # the size of
   # disk for each node.
-  k8s_service_account_name: <K8S_SERVICE_ACCOUNT_NAME>

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
@@ -26,7 +26,6 @@ zone: europe-west1-b
 remote_node: "{{ deployment_name }}-remote-node-0"
 extended_reservation: hpc-exr-2
 static_node_count: 2
-k8s_service_account_name: workload-identity-k8s-sa
 cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
@@ -34,7 +33,6 @@ cli_deployment_vars:
   extended_reservation: "{{ extended_reservation }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
-  k8s_service_account_name: "{{ k8s_service_account_name}}"
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:


### PR DESCRIPTION
We are not using this var anywhere in the blueprint and are hardcoding the value. Moreover, it's not very clear to the users what's the purpose of this and what value should be inputted. So removing this will be better.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
