### PR TITLE
move h4d tests to us-central1

### DIFF
--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -41,8 +41,8 @@ steps:
     cd /workspace && make
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    REGION=europe-west4
-    ZONE=europe-west4-b
+    REGION=us-central1
+    ZONE=us-central1-a
     BLUEPRINT="/workspace/examples/h4d-vm.yaml"
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}

--- a/tools/cloud-build/daily-tests/tests/h4d-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/h4d-vm.yml
@@ -19,8 +19,8 @@ test_name: h4d-jbvms
 deployment_name: h4d-jbvms-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/h4d-vm.yaml"
-region: europe-west4
-zone: europe-west4-b
+region: us-central1
+zone: us-central1-a
 network: "{{ test_name }}-net"
 remote_node: "{{ deployment_name }}-0"
 post_deploy_tests:


### PR DESCRIPTION
There is quota but the h4d team has actually just restricted us from using Europe west. So change the region to us-central1.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
