### PR TITLE
Make delete instances status tracking "asynchronous"

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/local_pubsub.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/local_pubsub.py
@@ -1,0 +1,196 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Implementation of message queue that mimics interface of GCP (PubSub)[https://cloud.google.com/pubsub]
+
+Messages are stored on controller state disk (to survive controller re-creation) with following layout:
+
+/<controller_state_disk_mount>/<pubsub_folder>
+├- <TOPIC>
+|  └- <MESSAGE_ID>
+└- .staging
+   └- <TOPIC>
+      └- <MESSAGE_ID>
+
+One message is one immutable file, that will be deleted after acknowledgement.
+NOTE: Implementation assumes that both `<TOPIC>` and `.staging/<TOPIC>` are on the same disk device,
+so it can rely on atomic "move / rename" operation.
+"""
+from typing import Any
+import util
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import os
+import uuid
+
+import logging
+log = logging.getLogger()
+
+
+@dataclass(frozen=True)
+class Message:
+    id: str
+    created: datetime
+    data: Any
+
+    def to_json(self) -> dict[str, str]:
+        return dict(
+            id=self.id,
+            created=self.created.isoformat(),
+            data=self.data)
+    
+    @classmethod
+    def from_json(cls, data: dict[str, str]) -> 'Message':
+        return cls(
+            id=data['id'],
+            created=datetime.fromisoformat(data['created']),
+            data=data['data'])
+
+class Topic:
+    """
+    Acts as PubSub topic (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics).
+    We can have multiple instances of 
+    """
+    def __init__(self, path: Path, staging: Path) -> None:
+        self._path = path
+        self._staging = staging
+    
+    def _gen_id(self, created: datetime) -> str:
+        ts = created.strftime("%Y_%m_%d-%H_%M_%S")
+        suf = str(uuid.uuid4())[:8]
+        return f"{ts}-{suf}"
+    
+    def publish(self, data: Any) -> None:
+        created = util.now()
+        id = self._gen_id(created)
+        msg = Message(id=id, created=created, data=data)
+        
+        staged = self._staging / msg.id
+        dst = self._path / msg.id
+
+        # Write to stagin area first then perform atomic move
+        # to prevent "reads of partial writes"
+        staged.write_text(json.dumps(msg.to_json()))
+        util.chown_slurm(staged)
+        staged.rename(dst)
+
+
+class Subscription:
+    """
+    Acts as PubSub subscription (https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.subscriptions)
+    with following settings:
+
+    ```
+    ackDeadlineSeconds = +Inf     # don't resend message that was already being delivered but not acked yet
+    retainAckedMessages = False   # don't persist messages that were already acked 
+    enableMessageOrdering = True  # delivers messages in chronoligical order
+    messageRetentionDuration = +Inf # don't expire messages  
+    deadLetterPolicy = None         # "deadlettering" is disabled, subscriber should take care of any poisonous messages
+    retryPolicy = {                 # NACKed message will be re-delievered after some time
+        minimumBackoff = 30s        # NOTE: Practically there is no timer, but Subscription instance will not try to re-deliver NACKed messages.
+        maximumBackoff = 30s        # Assumes that slurmsync runs every 30+ sec.
+    }
+    ```
+
+    IMPORTANT: Should only be run as part of slurmsync, 
+    this is our way to ensure that at most one instance exists at a time.
+    There is no concurancy safeguards in place, avoid multithreaded `pull`,
+    while multithreaded `ack` & `modify_ack_deadline` are OK.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self._path: Path = path
+        # contains ALL messages pulled by this subscription instance
+        # both acked, nacked, and still being processed
+        # used to prevent double delivery within lifetime of subscription (slurmsync)
+        self._pulled: set[str] = set()
+
+    def _delete(self, id: str) -> None:
+        log.debug(f"removing {id}")
+        try:
+            os.unlink(self._path / id)
+        except:
+            log.exception(f"Failed to remove message {id}")
+    
+    def _read_msg(self, id: str) -> Message | None:
+        try:
+            with open(self._path / id, 'r') as f:
+                content = json.loads(f.read())
+                return Message.from_json(content)
+        except Exception:
+            log.exception(f"Failed to read message {id}")
+            self._delete(id) # delete message to reduce "deadlettering"
+            return None
+
+    def pull(self, max_messages: int) -> list[Message]:
+        if not self._path.exists():
+            log.warning(f"Topic {self._path} does not exist")
+            return []
+        res = []
+        ls = sorted(os.listdir(self._path))
+        for name in ls:
+            msg = self._read_msg(name)
+            if msg is not None and msg.id not in self._pulled:
+                self._pulled.add(msg.id)
+                res.append(msg)
+
+            if len(res) >= max_messages:
+                break
+        return res
+
+
+    def ack(self, ids: list[str]) -> None:
+        for id in ids:
+            self._delete(id)
+
+
+    def modify_ack_deadline(self, ids: list[str], deadline: int) -> None:
+        """
+        Modifies the ack deadline for a specific message. 
+        IMPORTANT: Only accepts deadline=0, which is a way to NACK
+        Any other values are also meaningless due to ackDeadlineSeconds==+Inf
+        """
+        assert deadline == 0 # no op, next subscriber (slurmsync) will pick this up
+
+
+# Topics and Subscriptions are singletons
+# TODO: consider making thread-safe
+_topics = {}
+_subscriptions = {}
+
+def _make_path(name: str) -> Path:
+    p = util.slurmdirs.state / "pubsub" / name
+    p.mkdir(parents=True, exist_ok=True)
+    util.chown_slurm(p)
+    return p
+
+def _make_staging_path(name: str) -> Path:
+    p = util.slurmdirs.state / "pubsub" / ".staging" / name
+    p.mkdir(parents=True, exist_ok=True)
+    util.chown_slurm(p)
+    return p
+
+def topic(name: str) -> Topic:
+    if name not in _topics:
+        _topics[name] = Topic(_make_path(name), _make_staging_path(name))
+    return _topics[name]
+
+def subscription(name: str) -> Subscription:
+    if name not in _subscriptions:
+        _subscriptions[name] = Subscription(_make_path(name))
+    return _subscriptions[name]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1242,6 +1242,13 @@ def batch_execute(requests, retry_cb=None, log_err=log.error):
     return done, failed
 
 
+def get_operation_req(lkp: "Lookup", name: str, region: Optional[str]=None, zone: Optional[str]=None) -> Any:
+  if zone:
+    return lkp.compute.zoneOperations().get(project=lkp.project, zone=zone, operation=name)
+  elif region:
+    return lkp.compute.regionOperations().get(project=lkp.project, region=region, operation=name)
+  return lkp.compute.globalOperations().get(project=lkp.project, operation=name)
+
 def wait_request(operation, project: str):
     """makes the appropriate wait request for a given operation"""
     if "zone" in operation:
@@ -1277,11 +1284,6 @@ def wait_for_operation(operation) -> Dict[str, Any]:
             )
             return result
 
-
-def wait_for_operations(operations):
-    return [
-        wait_for_operation(op) for op in operations
-    ]
 
 
 def get_filtered_operations(op_filter):

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/watch_delete_vm_op.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/watch_delete_vm_op.py
@@ -1,0 +1,124 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+
+from dataclasses import dataclass, asdict
+import util
+import local_pubsub 
+
+import logging
+log = logging.getLogger()
+
+# Name of the topic
+TOPIC = "watch_delete_vm_op"
+
+@dataclass(frozen=True)
+class WatchDeleteVmOp_Message:
+    op_name: str
+    zone: str
+    node: str
+
+class WatchDeleteVmOp_Topic:
+    def __init__(self, topic: local_pubsub.Topic) -> None:
+        self._t = topic
+
+    def publish(self, op: dict[str, Any], node: str) -> None:
+        assert op.get("operationType") == "delete"
+        assert op.get("zone")
+        assert node
+
+        msg = WatchDeleteVmOp_Message(op_name=op["name"], zone=op["zone"], node=node)
+        self._t.publish(data=asdict(msg))
+
+
+def watch_delete_vm_op_topic() -> WatchDeleteVmOp_Topic:
+    return WatchDeleteVmOp_Topic(local_pubsub.topic(TOPIC))
+
+
+def _watch_op(lkp: util.Lookup, m: WatchDeleteVmOp_Message) -> bool:
+    """
+    Processes VM delete-operation.
+    If operation is still running - do nothing
+    If operation failed - log error & remove op from watch list
+    If operation is done - remove op from watch list do nothing
+    
+    To avoid querying status for each op individually, use list of VM instances as 
+    a source of data. Don't query op for instance X if instance X is not present 
+    (presumably deleted).
+    NOTE: This optimization can lead to false-positives -
+    absence of error-logs in case op failed, but VM got deleted by other means.
+
+    Returns True if message should be marked as processed (ack).
+    """
+
+    inst = lkp.instance(m.node)
+    
+    if not inst:
+        log.debug(f"Stop watching op {m.op_name}, VM {m.node} appears to be deleted")
+        return True # ack, potentially false-positive
+
+    if inst.status == "TERMINATED":
+        log.debug(f"Stop watching op {m.op_name}, VM {m.node} is TERMINATED")
+        return True # ack, potentially false-positive
+
+    if inst.status == "STOPPING":
+        log.debug(f"Skipping op {m.op_name}, VM {m.node} is STOPPING")
+        return False # try later
+
+    try:
+        op = util.get_operation_req(lkp, m.op_name, zone=m.zone).execute()
+    except:
+        # TODO: consider less conservative handling, but be careful not to cause deadlettering.
+        log.exception(f"Failed to get operation {m.op_name}, will not retry")
+        return True # ack (remove)
+
+    if op["status"] != "DONE":
+        log.debug(f"Watching op {m.op_name} is still not done ({op['status']})")
+        return False # try later
+
+    if "error" in op:
+        log.error(f"Operation {m.op_name} to delete {m.node} finished with error: {op['error']}")
+    else:
+        log.debug(f"Operation {m.op_name} to delete {m.node} successfully finished")
+    return True # ack
+
+
+def watch_vm_delete_ops(lkp: util.Lookup) -> None:
+    sub = local_pubsub.subscription(TOPIC)
+
+    # Pull once instead of "pulling until empty", motivation:
+    # Bulk of cases processed by `_watch_op` relies on freshness of `lkp.instances`,
+    # `lkp.instances` are fetched once during run of `slurmsync`.
+    # Therefore we shouldn't try to re-process messages that has been already NACKed in this run,
+    # since they will be handled with the same `lkp.instance` as a previous attempt.
+    msgs = sub.pull(max_messages=1000) # 1000 is arbitrary number to be adjusted if needed.
+    log.debug(f"Processing {len(msgs)} delete VM operations")
+    # TODO: handle messages in butches to improve latency
+    for m in msgs:
+        try:
+            dm = WatchDeleteVmOp_Message(**m.data)
+            ack = _watch_op(lkp, dm)
+        except Exception:
+            log.exception(f"Failed to process the message {m.id}, removing")
+            ack = True
+        if ack:
+            sub.ack([m.id])
+        else:
+            sub.modify_ack_deadline([m.id], deadline=0) # NACK
+        
+
+        
+        


### PR DESCRIPTION
* Add message queue that mimics "local PubSub";
* Use messages to track VM deletion operations.

```sh
$ time ./suspend.py qq-debugnodeset-[0-99]
real    1m21.206s  # current
...
real    0m3.223s # new
```

All watched operations has been processed with 0 requests to GCP API.
```
$ cat log/slurmsync.log
...
2025-04-30 23:56:38,065 DEBUG: Stop watching op operation-1746057356262-63407a87a3dd7-94bdae50-3eb440e2, VM qq-debugnodeset-41 appears to be deleted
2025-04-30 23:56:38,065 DEBUG: removing 2025_04_30-23_55_56-9f547251                            
2025-04-30 23:56:38,065 DEBUG: Skipping op operation-1746057356249-63407a87a087b-a699921d-bac63eeb, VM qq-debugnodeset-7 is STOPPING                
2025-04-30 23:56:38,065 DEBUG: Stop watching op operation-1746057356281-63407a87a87aa-8089101f-dce1988d, VM qq-debugnodeset-79 appears to be deleted
2025-04-30 23:56:38,066 DEBUG: removing 2025_04_30-23_55_56-a252198c                                                                                
2025-04-30 23:56:38,066 DEBUG: Stop watching op operation-1746057356257-63407a87a2937-80450bb7-c91bb64e, VM qq-debugnodeset-29 appears to be deleted
2025-04-30 23:56:38,066 DEBUG: removing 2025_04_30-23_55_56-a26aa30b 
...
2025-04-30 23:56:38,071 DEBUG: Stop watching op operation-1746057356267-63407a87a4faa-6419e92a-7bf5c0fd, VM qq-debugnodeset-51 appears to be deleted
2025-04-30 23:56:38,071 DEBUG: removing 2025_04_30-23_55_56-ffceeb16
2025-04-30 23:56:38,072 DEBUG: No delete VM operations to process
...
```

**Follow up:**
* Create a wrapper for message-type-specific PubSub (see `watch_delete_vm_op.py`) to reduce code duplication across multiple message-types.
* Implement asynchronous handling of other ops:
  * resume watch bulkInsert;
  * resume watch MIG;
  * suspend watch MIG;
  * resume init;
  * suspend init;