### PR TITLE
Get rid of template_cache

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/file_cache.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/file_cache.py
@@ -1,0 +1,80 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+from pathlib import Path
+import shutil
+import pickle
+
+import logging
+log = logging.getLogger()
+
+# Can't reuse tool from util.py to avoid circular dependencies
+# TODO: break down util.py for better modularity.
+def _chown_slurm(path: Path) -> None:
+    shutil.chown(path, user="slurm", group="slurm")
+
+class FileCache:
+    def __init__(self, path: Path):
+        self.path = path
+    
+    def get(self, key: str) -> Any | None:
+        p = self.path / key
+        if not p.exists():
+            return None
+        
+        try:
+            with p.open("rb") as f:
+                return pickle.load(f)
+            
+        except Exception as e:
+            log.warning(f"Failed to read cached value at {p}: {e}")
+            return None
+        
+    def set(self, key: str, data: Any) -> None:
+        p = self.path / key
+        
+        try:
+            # Create & chown before writing to minimize chances
+            # of ending up with root-owned corrupted file that can't be cleaned up
+            # TODO: restrict usage of cache by root to avoid all this complexity
+            # or have a cache per user.
+            p.touch(exist_ok=True)
+            _chown_slurm(p)
+            with p.open("wb") as f:
+                pickle.dump(data, f)
+            
+        except Exception as e:
+            log.warning(f"Failed to write cached value at {p}: {e}")
+    
+
+class NoCache:
+    def get(self, key: str) -> Any:
+        log.warning("No cache used")
+        return None
+    
+    def set(self, key: str, data: Any) -> None:
+        log.warning("No cache used")
+
+
+def cache(name: str) -> FileCache | NoCache:
+    try:
+        path = Path("/tmp/slurm_gcp_cache/") / name
+        if not path.exists():
+            path.mkdir(exist_ok=True, parents=True)
+            _chown_slurm(path)
+        return FileCache(path)
+    except:
+        log.exception(f"Failed to create cache, fallback to NoCache")
+        return NoCache()

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -91,8 +91,8 @@ def instance_properties(nodeset: NSDict, model:str, placement_group:Optional[str
     props = NSDict()
 
     if labels: # merge in extra labels on instance and disks
-        template = lookup().node_template(model)
-        template_info = lookup().template_info(template)
+        template_link = lookup().node_template(model)
+        template_info = lookup().template_info(template_link)
 
         props.labels = {**template_info.labels, **labels}
         

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -29,7 +29,6 @@ import logging.handlers
 import math
 import os
 import re
-import shelve
 import shlex
 import shutil
 import socket
@@ -44,7 +43,6 @@ from functools import lru_cache, reduce, wraps
 from itertools import chain, islice
 from pathlib import Path
 from time import sleep, time
-
 
 # TODO: remove "type: ignore" once moved to newer version of libraries
 from google.cloud import secretmanager
@@ -65,7 +63,7 @@ from requests.exceptions import RequestException
 
 import yaml
 from addict import Dict as NSDict # type: ignore
-
+import file_cache
 
 USER_AGENT = "Slurm_GCP_Scripts/1.5 (GPN:SchedMD)"
 ENV_CONFIG_YAML = os.getenv("SLURM_CONFIG_YAML")
@@ -1365,8 +1363,6 @@ class Lookup:
 
     def __init__(self, cfg):
         self._cfg = cfg
-        self.template_cache_path = Path(__file__).parent / "template_info.cache"
-        self.template_cache_path_exists = Path(__file__).parent / "template_info.cache.exists"
 
     @property
     def cfg(self):
@@ -1520,7 +1516,8 @@ class Lookup:
         nodeset = self.node_nodeset_name(node_name)
         return self.cfg.nodeset_dyn.get(nodeset) is not None
 
-    def node_template(self, node_name=None):
+    def node_template(self, node_name=None) -> str:
+        """ Self link of nodeset template """
         return self.node_nodeset(node_name).instance_template
 
     def node_template_info(self, node_name=None):
@@ -1823,38 +1820,13 @@ class Lookup:
         machine_conf.memory = machine.memory_mb - (400 + (30 * gb))
         return machine_conf
 
-    @contextmanager
-    def template_cache(self, writeback=False):
-        flag: Literal["c", "r"] = "c" if writeback else "r"
-        err = None
-        for wait in backoff_delay(0.125, timeout=60, count=20):
-            try:
-                cache = shelve.open(
-                    str(self.template_cache_path), flag=flag, writeback=writeback
-                )
-                break
-            except OSError as e:
-                err = e
-                log.debug(f"Failed to access template info cache: {e}")
-                sleep(wait)
-                continue
-        else:
-            # reached max_count of waits
-            raise Exception(f"Failed to access cache file. latest error: {err}")
-        try:
-            yield cache
-        finally:
-            cache.close()
-
     @lru_cache(maxsize=None)
     def template_info(self, template_link):
         template_name = trim_self_link(template_link)
-        # split read and write access to minimize write-lock. This might be a
-        # bit slower? TODO measure
-        if self.template_cache_path_exists.exists():
-            with self.template_cache() as cache:
-                if template_name in cache:
-                    return NSDict(cache[template_name])
+        cache = file_cache.cache("template_cache")
+
+        if cached := cache.get(template_name):
+            return NSDict(cached)
 
         template = ensure_execute(
             self.compute.instanceTemplates().get(
@@ -1880,26 +1852,7 @@ class Lookup:
         else:
             template.gpu = None
 
-        # keep write access open for minimum time
-        with self.template_cache(writeback=True) as cache:
-            cache[template_name] = template.to_dict()
-        
-        # Note that shelve database may add custom suffix on top of the path
-        # > The filename specified is the base filename for the underlying database. 
-        # We find all files which could be the database and open the first one.
-        cache_files = [filename for filename in os.listdir(self.template_cache_path.parent) if filename.startswith(self.template_cache_path.name)]
-        if not cache_files:
-            # No cache files found, skip
-            return template
-        # Change ownership of the cache files to the slurm user
-        # This is needed to avoid permission issues when running slurmsync
-        # as a different user (e.g. when using sudo)
-        for filename in cache_files:
-            chown_slurm(Path(self.template_cache_path.parent) / filename)
-        
-        # Create a marker file to indicate that the cache file exists
-        self.template_cache_path_exists.touch()
-        chown_slurm(self.template_cache_path_exists)
+        cache.set(template_name, template.to_dict())
         return template
 
 


### PR DESCRIPTION
Context: #3946 

* Stop using blocking shelve-based `template_cache`;
* Use non-blocking homegrown implementation.


**Testing done:**
* Slurm intengration tests + manual tests with verification of content of cached folder;

* Run `80` workers concurrently (`3` at a time), each worker is either `root` (even) or `orlov` (odd). Worker does `10` attempts to lookup a key (random value in range `[0, 3]`) from the same cache, if key is missing, it takes worker `2 seconds` to compute it before saving into cache. The cached value is repeated string of digits (`key`) of size `(k+1) / 2 megabytes` 

Code available here: https://github.com/mr0re1/hpc-toolkit/tree/tmpl_cache_tst



```sh
$ rm -rf /tmp/test_f_c/ && sudo /usr/local/google/home/orlov/p310/bin/python file_cache_test.py   > /tmp/out

...
# Was able to trigger "concurrency issues"
# ts         wid msg key
1746556945422 1 MISS 2
1746556945422 0 MISS 2
1746556947427 0 SAVED 2
1746556947428 1 SAVED 2
Failed to read cached value at /tmp/test_f_c/2: Ran out of input
1746556947429 0 MISS 2
1746556947429 1 HIT 2

# Another example:
Failed to write cached value at /tmp/test_f_c/2: [Errno 13] Permission denied: '/tmp/test_f_c/2'
Failed to read cached value at /tmp/test_f_c/3: pickle data was truncated
```

<img width="674" alt="Screenshot 2025-05-06 at 12 37 51 PM" src="https://github.com/user-attachments/assets/a15f0e0c-c38b-43e4-bedb-5d081e44d205" />

* Tested agains old `template_cache` implementation, with same setup, looks comparable (hit/miss and total elapsed time).

```sh
$ rm -rf /tmp/test_f_c/ && mkdir /tmp/test_f_c && sudo /usr/local/google/home/orlov/p310/bin/python file_cache_test.py > /tmp/out

Traceback (most recent call last):
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 170, in <module>
    compute(random.randint(0, DOMAIN))
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 159, in compute
    file_cache._chown_slurm(Path(template_cache_path.parent) / filename)
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/file_cache.py", line 27, in _chown_slurm
    shutil.chown(path, user="orlov", group="primarygroup")
  File "/usr/local/lib/python3.10/shutil.py", line 1383, in chown
    os.chown(path, _user, _group)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/test_f_c/template_info.cache.bak'
Traceback (most recent call last):
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 170, in <module>
    compute(random.randint(0, DOMAIN))
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 159, in compute
    file_cache._chown_slurm(Path(template_cache_path.parent) / filename)
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/file_cache.py", line 27, in _chown_slurm
    shutil.chown(path, user="orlov", group="primarygroup")
  File "/usr/local/lib/python3.10/shutil.py", line 1383, in chown
    os.chown(path, _user, _group)
PermissionError: [Errno 1] Operation not permitted: '/tmp/test_f_c/template_info.cache.dir'

...
```

<img width="685" alt="Screenshot 2025-05-06 at 3 36 44 PM" src="https://github.com/user-attachments/assets/3e28c20c-199e-4f92-83ed-8a04fa58b519" />


But in case of corrupted cache files, current implementation can not recover.

```sh
$ echo "spanish inquisition" > /tmp/test_f_c/template_info.cache.dat
$ sudo /usr/local/google/home/orlov/p310/bin/python file_cache_test.py

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 170, in <module>
    compute(random.randint(0, DOMAIN))
  File "/usr/local/google/home/orlov/wp/hpc-toolkit/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/./file_cache_test_worker_old.py", line 137, in compute
    res = cache[key]
  File "/usr/local/lib/python3.10/shelve.py", line 114, in __getitem__
    value = Unpickler(f).load()
_pickle.UnpicklingError: unpickling stack underflow
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/shelve.py", line 111, in __getitem__
    value = self.cache[key]
KeyError: '0'

# ... 79 more times
# no work has been done
```