### PR TITLE
Add randomness to managed lustre integration tests

### DIFF
--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -21,6 +21,7 @@ vars:
   region: us-central1
   zone: us-central1-a
   compute_node_machine_type: c2-standard-4
+  lustre_instance_id: lustre-instance
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -40,7 +41,7 @@ deployment_groups:
     source: modules/file-system/managed-lustre
     use: [network, private_service_access]
     settings:
-      name: lustre-instance
+      name: $(vars.lustre_instance_id)
       local_mount: /lustre
       remote_mount: lustrefs
       size_gib: 18000

--- a/examples/pfs-managed-lustre-vm.yaml
+++ b/examples/pfs-managed-lustre-vm.yaml
@@ -20,6 +20,7 @@ vars:
   deployment_name: pfs-managed-lustre-vms
   region: us-central1
   zone: us-central1-a
+  lustre_instance_id: lustre-instance
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -39,7 +40,7 @@ deployment_groups:
     source: modules/file-system/managed-lustre
     use: [network, private_service_access]
     settings:
-      name: lustre-instance
+      name: $(vars.lustre_instance_id)
       local_mount: /lustre
       remote_mount: lustrefs
       size_gib: 18000

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
@@ -26,6 +26,7 @@ cli_deployment_vars:
   zone: "{{ zone }}"
   compute_node_machine_type: c2-standard-4
   slurm_cluster_name: "{{ slurm_cluster_name }}"
+  lustre_instance_id: "lustre-instance-{{build}}"
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml
@@ -21,6 +21,8 @@ workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/pfs-managed-lustre-vm.yaml"
 network: "{{ deployment_name }}-net"
 remote_node: "{{ deployment_name }}-lustre-ubuntu22-0"
+cli_deployment_vars:
+  lustre_instance_id: "lustre-instance-{{build}}"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 custom_vars:


### PR DESCRIPTION
See title.

Test using the two pfs-managed-lustre integration tests.

Note due to capacity constraints these tests should never be run simultaneously.