### PR TITLE
Managed Lustre Data Import (Hydration)

### DIFF
--- a/modules/file-system/managed-lustre/variables.tf
+++ b/modules/file-system/managed-lustre/variables.tf
@@ -108,3 +108,18 @@ variable "gke_support_enabled" {
   nullable    = false
   default     = false
 }
+
+variable "import_gcs_bucket_uri" {
+  description = <<-EOT
+    The name of the GCS bucket to import data from to managed lustre. Data will
+    be imported to the local_mount directory. Changing this value will not
+    trigger a redeployment, to prevent data deletion.
+    EOT
+  type        = string
+  default     = null
+
+  validation {
+    condition     = startswith(coalesce(var.import_gcs_bucket_uri, "gs://"), "gs://")
+    error_message = "The GCS bucket uri must start with 'gs://'"
+  }
+}


### PR DESCRIPTION
This PR adds the capability to import data from GCS bucket upon creation of the Managed Lustre instance.

The bucket is checked for existence prior to running the import command.  

The import command has an option for a destination folder which was ignored.  This was due to the fact that we're creating a fresh Lustre instance that will not have any data, and the destination folder option requires the specified folder to exist before importing.

Note: This will fail quietly if permissions are not set up correctly.  Without the ability to check specific permissions in Terraform this is difficult to do in an automated way, so users are warned in the documentation.

This was tested (using a modified pfs-managed-lustre-vm.yaml blueprint):
1. Importing data from bucket within the same project
2. Importing data from another project
3. No data import
4. Non-existing bucket