### PR TITLE
Test nvidia-smi on A* blueprints

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
@@ -1,0 +1,34 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - custom_vars.gpu_partition is defined
+    - custom_vars.gpu_count is defined
+
+- name: Run nvidia-smi command
+  ansible.builtin.command: srun -N 1 -p "{{ custom_vars.gpu_partition }}" --gpus-per-node={{ custom_vars.gpu_count }} nvidia-smi -L
+  register: nvidia_smi_result
+  failed_when: nvidia_smi_result.rc != 0
+
+- name: Fail on GPU count mismatch
+  ansible.builtin.fail:
+    msg: "GPU count did not match {{ custom_vars.gpu_count }}"
+  when: nvidia_smi_result.stdout_lines | length != custom_vars.gpu_count
+
+- name: Print nvidia-smi output
+  ansible.builtin.debug:
+    msg: "{{ nvidia_smi_result.stdout }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
@@ -28,7 +28,10 @@ post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
 - test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
 custom_vars:
+  gpu_partition: a3
+  gpu_count: 8
   partitions:
   - a3
   - debug

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-cluster.yml
@@ -28,7 +28,10 @@ post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
 - test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
 custom_vars:
+  gpu_partition: a3mega
+  gpu_count: 8
   partitions:
   - a3mega
   - debug

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
@@ -29,9 +29,12 @@ post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
 - test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
 post_destroy_tasks:
 - post-destroy-tasks/delete-image.yml
 custom_vars:
+  gpu_count: 8
+  gpu_partition: a3ultra
   partitions:
   - a3ultra
   mounts:

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
@@ -29,9 +29,12 @@ post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
 - test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
 post_destroy_tasks:
 - post-destroy-tasks/delete-image.yml
 custom_vars:
+  gpu_count: 8
+  gpu_partition: a4high
   partitions:
   - a4high
   mounts:


### PR DESCRIPTION
This PR creates a new deployment test that runs nvidia-smi on an accelerator node in a Slurm cluster.  It compares the nvidia-smi gpu count to the expected number of GPUs.

Updates the A3H, A3M, A3U and A4H blueprints.
