### PR TITLE
Fix logic for verifying gpu count for machine types

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -48,7 +48,7 @@ output "nodeset" {
   }
 
   precondition {
-    condition     = local.nodeset.gpu.count > 0 || !var.dws_flex.enabled || var.dws_flex.use_bulk_insert
+    condition     = local.nodeset.gpu != null || !var.dws_flex.enabled || var.dws_flex.use_bulk_insert
     error_message = "DWS Flex-Start is only supported for GPU instances"
   }
 


### PR DESCRIPTION
The default value for a non-gpu instance will be none, so we should not be using count to verify whether we have a gpu-based instance or not.

Before
```
Error: Attempt to get attribute from null value

  on modules/embedded/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf line 51, in output "nodeset":
  51:     condition     = local.nodeset.gpu.count > 0 || !var.dws_flex.enabled || var.dws_flex.use_bulk_insert
    ├────────────────
    │ local.nodeset.gpu is null

This value is null, so it does not have any attributes.
```

As a result we should instead verify whether the gpu value is non-null instead of just the count.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
