### PR TITLE
Explicitly define labels at `google_compute_instance_from_template`

### DIFF
--- a/community/modules/internal/slurm-gcp/instance/main.tf
+++ b/community/modules/internal/slurm-gcp/instance/main.tf
@@ -70,6 +70,8 @@ resource "null_resource" "replace_trigger" {
   }
 }
 
+# TODO: `internal/slurm-gcp/login` is ONLY user of `internal/slurm-gcp/instance`
+# Remove this module, add functionality (+ prune generality) to the login module directly.
 resource "google_compute_instance_from_template" "slurm_instance" {
   count   = local.num_instances
   name    = format("%s-%s", var.hostname, format("%03d", count.index + 1))
@@ -113,6 +115,10 @@ resource "google_compute_instance_from_template" "slurm_instance" {
   }
 
   source_instance_template = data.google_compute_instance_template.base.self_link
+  # Due to https://github.com/hashicorp/terraform-provider-google/issues/21693
+  # we have to explicitly override instance labels instead of inheriting them from template.
+  labels = data.google_compute_instance_template.base.labels
+
 
   lifecycle {
     replace_triggered_by = [null_resource.replace_trigger.id]

--- a/community/modules/internal/slurm-gcp/instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/instance_template/README.md
@@ -77,6 +77,7 @@
 | Name | Description |
 |------|-------------|
 | <a name="output_instance_template"></a> [instance\_template](#output\_instance\_template) | Instance template details |
+| <a name="output_labels"></a> [labels](#output\_labels) | Labels attached to the instance template |
 | <a name="output_name"></a> [name](#output\_name) | Name of instance template |
 | <a name="output_self_link"></a> [self\_link](#output\_self\_link) | Self\_link of instance template |
 | <a name="output_service_account"></a> [service\_account](#output\_service\_account) | Service account object, includes email and scopes. |

--- a/community/modules/internal/slurm-gcp/instance_template/main.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/main.tf
@@ -71,6 +71,13 @@ locals {
     tier_1_enabled   = "GVNIC"
   }
   nic_type = lookup(local.nic_type_map, var.bandwidth_tier, null)
+
+  labels = merge(var.labels,
+    {
+      slurm_cluster_name  = var.slurm_cluster_name
+      slurm_instance_role = var.slurm_instance_role
+    },
+  )
 }
 
 ########
@@ -104,25 +111,19 @@ module "instance_template" {
   access_config               = var.access_config
 
   # Instance
-  machine_type              = var.machine_type
-  min_cpu_platform          = var.min_cpu_platform
-  name_prefix               = local.name_prefix
-  gpu                       = var.gpu
-  service_account           = local.service_account
-  shielded_instance_config  = var.shielded_instance_config
-  advanced_machine_features = var.advanced_machine_features
-  enable_confidential_vm    = var.enable_confidential_vm
-  enable_shielded_vm        = var.enable_shielded_vm
-  preemptible               = var.preemptible
-  spot                      = var.spot
-  on_host_maintenance       = var.on_host_maintenance
-  labels = merge(
-    var.labels,
-    {
-      slurm_cluster_name  = var.slurm_cluster_name
-      slurm_instance_role = var.slurm_instance_role
-    },
-  )
+  machine_type                = var.machine_type
+  min_cpu_platform            = var.min_cpu_platform
+  name_prefix                 = local.name_prefix
+  gpu                         = var.gpu
+  service_account             = local.service_account
+  shielded_instance_config    = var.shielded_instance_config
+  advanced_machine_features   = var.advanced_machine_features
+  enable_confidential_vm      = var.enable_confidential_vm
+  enable_shielded_vm          = var.enable_shielded_vm
+  preemptible                 = var.preemptible
+  spot                        = var.spot
+  on_host_maintenance         = var.on_host_maintenance
+  labels                      = local.labels
   instance_termination_action = var.termination_action
   resource_manager_tags       = var.resource_manager_tags
 

--- a/community/modules/internal/slurm-gcp/instance_template/outputs.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/outputs.tf
@@ -36,3 +36,8 @@ output "service_account" {
   description = "Service account object, includes email and scopes."
   value       = module.instance_template.service_account
 }
+
+output "labels" {
+  description = "Labels attached to the instance template"
+  value       = local.labels
+}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -129,6 +129,9 @@ resource "google_compute_instance_from_template" "controller" {
   project                  = local.controller_project_id
   zone                     = var.zone
   source_instance_template = module.slurm_controller_template.self_link
+  # Due to https://github.com/hashicorp/terraform-provider-google/issues/21693
+  # we have to explicitly override instance labels instead of inheriting them from template.
+  labels = module.slurm_controller_template.labels
 
   allow_stopping_for_update = true
 


### PR DESCRIPTION
Explicitly define labels at `google_compute_instance_from_template`
to workaround https://github.com/hashicorp/terraform-provider-google/issues/21693

**Effect:** Restores labels (both customer defined and gcluster ones) on login and controller VM instances.

**NON-BREAKING** change:

```sh
$ g co blue_label
Switched to branch 'blue_label'
$ make && ./ghpc deploy qq.yaml --force
...
Terraform will perform the following actions:

  # module.slurm_controller.google_compute_instance_from_template.controller will be updated in-place
  ~ resource "google_compute_instance_from_template" "controller" {
      ~ effective_labels           = {
          + "ghpc_blueprint"             = "qq"
          ...
          + "slurm_instance_role"        = "controller"
            # (1 unchanged element hidden)
        }
        id                         = "projects/X/zones/us-central1-a/instances/qq-controller"
      ~ labels                     = {
          + "ghpc_blueprint"      = "qq"
          ...
          + "slurm_instance_role" = "controller"
        }
        ...
      ~ terraform_labels           = {
          + "ghpc_blueprint"             = "qq"
          ...
          + "slurm_instance_role"        = "controller"
            # (1 unchanged element hidden)
        }
        # (22 unchanged attributes hidden)

        # (9 unchanged blocks hidden)
    }

# module.slurm_controller.module.login["slurm-login"].module.instance.google_compute_instance_from_template.slurm_instance[0] will be updated in-place
  ~ resource "google_compute_instance_from_template" "slurm_instance" {
      ~ effective_labels           = {
          + "ghpc_blueprint"             = "qq"
          ...
          + "slurm_instance_role"        = "login"
            # (1 unchanged element hidden)
        }
        id                         = "projects/X/zones/us-central1-a/instances/qq-slurm-login-001"
      ~ labels                     = {
          + "ghpc_blueprint"             = "qq"
         ...
          + "slurm_instance_role"        = "login"
        }
        ...
      ~ terraform_labels           = {
          + "ghpc_blueprint"             = "qq"
          ...
          + "slurm_instance_role"        = "login"
            # (1 unchanged element hidden)
        }
        # (22 unchanged attributes hidden)

        # (7 unchanged blocks hidden)
    }

Plan: 0 to add, 2 to change, 0 to destroy.
```