### PR TITLE
A3 Ultra Slurm: workaround temporary driver packaging issue

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -26,7 +26,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    family: ubuntu-accelerator-2204-amd64-with-nvidia-570
+    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20250425
   image_build_machine_type: n2-standard-16
   build_slurm_from_git_ref: 6.10.0
   # Cluster env settings
@@ -137,6 +137,22 @@ deployment_groups:
               ansible.builtin.apt:
                 deb: "{{ cuda_repo_filename }}"
                 state: present
+            # The following 3 tasks work around a temporary issue with Ubuntu
+            # packaging of NVIDIA 570 driver series for kernel 6.8.0-1028
+            - name: Unfreeze 570 driver metapackage
+              ansible.builtin.command:
+                argv:
+                - apt-mark
+                - unhold
+                - linux-modules-nvidia-570-server-open-gcp
+            - name: Remove 570 driver metapackage
+              ansible.builtin.apt:
+                name: linux-modules-nvidia-570-server-open-gcp
+                state: absent
+            - name: Install latest 570 driver for kernel
+              ansible.builtin.apt:
+                name: linux-modules-nvidia-570-server-open-6.8.0-1028-gcp
+                state: latest
             - name: Reduce NVIDIA repository priority
               ansible.builtin.copy:
                 dest: /etc/apt/preferences.d/cuda-repository-pin-600
@@ -221,7 +237,7 @@ deployment_groups:
     settings:
       disk_size: $(vars.disk_size_gb)
       machine_type: $(vars.image_build_machine_type)
-      source_image_family: $(vars.base_image.family)
+      source_image: $(vars.base_image.image)
       source_image_project_id: [$(vars.base_image.project)]
       image_family: $(vars.instance_image.family)
       omit_external_ip: false


### PR DESCRIPTION
Without this change, we cannot install the latest NVIDIA drivers and libraries in version-alignment. This change installs the latest 570 series drivers at the time of the commit.

Underlying issue is that the linux-modules-nvidia-570-server-open-gcp metapackage does not have a released version that points to a prebuilt 570.133.20 driver package.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
