### PR TITLE
Relax `retry_exception` test

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1110,13 +1110,15 @@ def to_hostnames(nodelist: str) -> List[str]:
     return hostnames
 
 
-def retry_exception(exc):
+def retry_exception(exc) -> bool:
     """return true for exceptions that should always be retried"""
+    msg = str(exc)
     retry_errors = (
         "Rate Limit Exceeded",
         "Quota Exceeded",
+        "Quota exceeded",
     )
-    return any(e in str(exc) for e in retry_errors)
+    return any(err in msg for err in retry_errors)
 
 
 def ensure_execute(request):


### PR DESCRIPTION
Relax test to correctly classify:

```py
{
  'message': "Quota exceeded for quota metric 'Filtered list cost overhead' and limit 'Filtered list cost overhead per minute per region' of service 'compute.googleapis.com' for consumer 'project_number:X'.", 
  'domain': 'usageLimits', 
  'reason': 'rateLimitExceeded'
}
```