### PR TITLE
Remove instance image override at the top of cae.yaml example

### DIFF
--- a/examples/cae/cae-slurm.yaml
+++ b/examples/cae/cae-slurm.yaml
@@ -39,9 +39,6 @@ vars:
   # Visit https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/docs/images.md#published-image-family
   # for a list of valid family options with Slurm; note: the image types for the compute nodes
   # and the Chrome Remote Desktop (CRD) need to have the same Slurm base.
-  instance_image:
-    family: slurm-gcp-6-9-hpc-rocky-linux-8
-    project: schedmd-slurm-public
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md


### PR DESCRIPTION
The Computer Aided Engineering (CAE) example makes use of chrome-remote-desktop as a means to visualize computational output. Currently the module intends to run a Debian as that is among the supported operating systems for chrome-remote-desktop. The value gets overwritten by the top level declaration which uses the Slurm Rocky 8 image. This PR removes that image overriding so that the chrome-remote-desktop in the example deploys with the intended image and the startup scripts can run and complete.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
