### PR TITLE
Initial commit to add Lustre opt-in sections to the H4D blueprints

### DIFF
--- a/community/examples/hpc-slurm-h4d.yaml
+++ b/community/examples/hpc-slurm-h4d.yaml
@@ -63,6 +63,26 @@ deployment_groups:
       filestore_share_name: homeshare
       local_mount: /home
 
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [h4d-slurm-net-0]
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - h4d-slurm-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: 18000
+  #     name: lustre-instance
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #   outputs:
+  #   - network_storage
+
   - id: appsfs
     source: modules/file-system/filestore
     use: [h4d-slurm-net-0]

--- a/examples/h4d-vm.yaml
+++ b/examples/h4d-vm.yaml
@@ -70,6 +70,26 @@ deployment_groups:
     outputs:
     - network_storage
 
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [cluster-net-0]
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - cluster-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: 18000
+  #     name: lustre-instance
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #   outputs:
+  #   - network_storage
+
   - id: h4d_startup
     source: modules/scripts/startup-script
     settings:


### PR DESCRIPTION
Adding lustre opt-in section for the home filesystem.  Instructions are present for switching from filestore to lustre for H4D.

Tested the h4d-vm blueprint to ensure connection and driver installation on H4D machines. 
