### PR TITLE
refactor http.h dependency

### DIFF
--- a/modules/management/kubectl-apply/versions.tf
+++ b/modules/management/kubectl-apply/versions.tf
@@ -25,8 +25,9 @@ terraform {
       version = ">= 1.7.0"
     }
     http = {
-      source  = "hashicorp/http"
-      version = "~> 3.0"
+      source                = "hashicorp/http"
+      version               = "~> 3.0"
+      configuration_aliases = [http.h, ]
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### Submission Checklist

Fixes the Warning log: 
```
Earlier versions of Terraform used empty provider blocks ("proxy provider configurations") for child modules to declare their need to be passed a provider configuration by their callers. That approach was ambiguous and is now deprecated.

If you control this module, you can migrate to the new declaration syntax by removing all of the empty provider "http" blocks and then adding or updating an entry like the following to the required_providers block of module.workload-manager-install: http = { source = "hashicorp/http" configuration_aliases = [ http.h, ] }
```


Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
