### PR TITLE
Adding DCGM test to gpu tests for slurm

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
@@ -32,3 +32,12 @@
 - name: Print nvidia-smi output
   ansible.builtin.debug:
     msg: "{{ nvidia_smi_result.stdout }}"
+
+- name: Run DCGM diagnostics
+  ansible.builtin.command: srun -N 2 -p "{{ custom_vars.gpu_partition }}" dcgmi diag -r 1
+  register: nvidia_dcgmi_result
+  failed_when: nvidia_dcgmi_result.rc != 0
+
+- name: Print DCGM output
+  ansible.builtin.debug:
+    msg: "{{ nvidia_dcgmi_result.stdout }}"


### PR DESCRIPTION
Add test to ensure that the Datacenter Gpu Manager is operational on the Accelerator nodes

Tested on Cloud build with local folder, will run related A* tests.

Tested failures by running the gpu tests on a non accelerator test (slurm-v6-ubuntu) to make sure the return code causes a failure.