### PR TITLE
Improve API consumption of `_handle_bulk_insert_op`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1293,42 +1293,6 @@ def wait_for_operation(operation) -> Dict[str, Any]:
 
 
 
-def get_filtered_operations(op_filter):
-    """get list of operations associated with group id"""
-    project = lookup().project
-    operations: List[Any] = []
-
-    def get_aggregated_operations(items):
-        # items is a dict of location key to value: dict(operations=<list of operations>) or an empty dict
-        operations.extend(
-            chain.from_iterable(
-                ops["operations"] for ops in items.values() if "operations" in ops
-            )
-        )
-
-    act = lookup().compute.globalOperations()
-    op = act.aggregatedList(
-        project=project, filter=op_filter, fields="items.*.operations,nextPageToken"
-    )
-
-    while op is not None:
-        result = ensure_execute(op)
-        get_aggregated_operations(result["items"])
-        op = act.aggregatedList_next(op, result)
-    return operations
-
-
-def get_insert_operations(group_ids):
-    """get all insert operations from a list of operationGroupId"""
-    if isinstance(group_ids, str):
-        group_ids = group_ids.split(",")
-    filters = [
-        "operationType=insert",
-        " OR ".join(f"(operationGroupId={id})" for id in group_ids),
-    ]
-    return get_filtered_operations(" AND ".join(f"({f})" for f in filters if f))
-
-
 def getThreadsPerCore(template) -> int:
     if not template.machine_type.supports_smt:
         return 1


### PR DESCRIPTION
* Instead of doing `globalOperations.aggregateList` perform series (usually just 1) of zonal list requests - to stop hitting `HeavyWeightReadRequestsPerMinutePerProject` limits;
* Do not perform server-side filtering on non-indexed fields, instead do it client-side to avoid `ListRequestsFilterCostOverheadPerMinutePerProjectPerRegion` limits;
* Incorporate `createTime` range and `user` (both are indexed) into server-side filtering.

New approach consumes 0 - `filtered_list_cost_overhead`, while old one was effectively churring (on server side) through all operations.

Latency is smaller but not significantly (~2 times improvement) - **no thorough sampling has been done**.

See: https://cloud.google.com/compute/api-quota#api-rate-limits


