### PR TITLE
Improve logging details of `subprocess.run`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -623,35 +623,6 @@ if __name__ == "__main__":
 
     try:
         main()
-    except subprocess.TimeoutExpired as e:
-        stdout = (e.stdout or b"").decode().strip()
-        stderr = (e.stderr or b"").decode().strip()
-
-        log.error(
-            f"""TimeoutExpired:
-    command={e.cmd}
-    timeout={e.timeout}
-    stdout:
-{stdout}
-    stderr:
-{stderr}
-"""
-        )
-        log.error("Aborting setup...")
-        failed_motd()
-    except subprocess.CalledProcessError as e:
-        log.error(
-            f"""CalledProcessError:
-    command={e.cmd}
-    returncode={e.returncode}
-    stdout:
-{e.stdout.strip()}
-    stderr:
-{e.stderr.strip()}
-"""
-        )
-        log.error("Aborting setup...")
-        failed_motd()
     except Exception:
         log.exception("Aborting setup...")
         failed_motd()

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -793,17 +793,54 @@ def run(
     if not shell and isinstance(args, str):
         args = shlex.split(args)
     log.debug(f"run: {args}")
-    result = subprocess.run(
-        args,
-        stdout=stdout,
-        stderr=stderr,
-        shell=shell,
-        timeout=timeout,
-        check=check,
-        universal_newlines=universal_newlines,
-        **kwargs,
-    )
+    try:
+        result = subprocess.run(
+            args,
+            stdout=stdout,
+            stderr=stderr,
+            shell=shell,
+            timeout=timeout,
+            check=check,
+            universal_newlines=universal_newlines,
+            **kwargs,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
+        log_subprocess(e)
+        raise
+    log_subprocess(result)
     return result
+
+def log_subprocess(subj: subprocess.CalledProcessError | subprocess.TimeoutExpired | subprocess.CompletedProcess) -> None:
+    match subj:
+        case subprocess.CompletedProcess(returncode=0):
+            # Do not log successful runs, to not overwhelm logs (e.g. scontrol show jobs --json)
+            # TODO: consider still doing it in DEBUG or trim output to few KBs. 
+            return
+        case subprocess.CompletedProcess(): # non-zero returncode
+            log.error(f"Command '{subj.args}' returned exit status {subj.returncode}.")
+        case subprocess.CalledProcessError() | subprocess.TimeoutExpired():
+            log.error(str(subj))
+        
+
+    def normalize(out: None | str | bytes) -> None | str:
+        """
+        Turns stderr and stdout into string:
+        > A bytes sequence, or a string if run() was called with an encoding, errors, or text=True. None if was not captured.
+        """
+        match out:
+            case None:
+                return None
+            case str():
+                return out.strip()
+            case bytes():
+                return out.decode().strip()
+            case _:
+                return repr(out)
+
+    if stdout := normalize(subj.stdout):
+        log.error(f"stdout: {stdout}")
+    if stderr := normalize(subj.stderr):
+        log.error(f"stderr: {stderr}")
 
 
 def chown_slurm(path: Path, mode=None) -> None:


### PR DESCRIPTION
Currently failures of `subprocess.run` aren't properly logged (stdour and stderr are missing), e.g:

```log
2025-05-09 05:14:40,485 DEBUG: run: ['/usr/local/bin/scontrol', 'update', 'jobid=9', 'admincomment=GCP', 'Error:', 'Quota', '"\'C2_CPUS\'"', 'exceeded.', 'Limit:', '300.0', 'in', 'region', 'us-central1.']
2025-05-09 05:14:40,497 ERROR: Fatal exception
Traceback (most recent call last):
  File "/slurm/scripts/resume.py", line 672, in <module>
    main(args.nodelist)
    ~~~~^^^^^^^^^^^^^^^
  File "/slurm/scripts/resume.py", line 666, in main
    resume_nodes(nodes, resume_data)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/slurm/scripts/resume.py", line 357, in resume_nodes
    down_nodes_notify_jobs(grouped_nodes[ident].nodes, f"GCP Error: {exc._get_reason()}", resume_data) # type: ignore                                  
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                 
  File "/slurm/scripts/resume.py", line 475, in down_nodes_notify_jobs
    run(f"{lookup().scontrol} update jobid={job.job_id} admincomment='{reason_quoted}'")                                                               
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                               
  File "/slurm/scripts/util.py", line 796, in run
    result = subprocess.run(
        args,
    ...<6 lines>...
        **kwargs,
    )
  File "/slurm/python/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/local/bin/scontrol', 'update', 'jobid=9', 'admincomment=GCP', 'Error:', 'Quota', '"\'C2_CPUS\'"', 'exceeded.', 'Limit:', '300.0', 'in', 'region', 'us-central1.']' returned non-zero exit status 1.
```

Always log failed invocations , regardless of `check=` value.

<img width="1332" alt="Screenshot 2025-05-09 at 2 43 23 PM" src="https://github.com/user-attachments/assets/6413f245-0f95-4624-9401-4edbdda95cfb" />


```log
2025-05-09 21:49:05,875 DEBUG: run: ['/usr/local/bin/scontrol', 'update', 'jobid=16', 'admincomment=GCP', 'Error:', 'Quota', '"\'C2_CPUS\'"', 'exceeded.', 'Limit:', '300.0', 'in', 'region', 'us-central1.']

=== VVV new lines VVV ===
2025-05-09 21:49:05,888 ERROR: Command '['/usr/local/bin/scontrol', 'update', 'jobid=16', 'admincomment=GCP', 'Error:', 'Quota', '"\'C2_CPUS\'"', 'exceeded.', 'Limit:', '300.0', 'in', 'region', 'us-central1.']' returned non-zero exit status 1.
2025-05-09 21:49:05,888 ERROR: stderr: Update of this parameter is not supported: Quota
Request aborted
=== ^^^ new lines ^^^ ===

2025-05-09 21:49:05,888 ERROR: Fatal exception
Traceback (most recent call last):
  File "/slurm/scripts/resume.py", line 649, in <module>
    main(args.nodelist)
    ~~~~^^^^^^^^^^^^^^^
  File "/slurm/scripts/resume.py", line 643, in main
    resume_nodes(nodes, resume_data)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/slurm/scripts/resume.py", line 358, in resume_nodes
    down_nodes_notify_jobs(grouped_nodes[ident].nodes, f"GCP Error: {exc._get_reason()}", resume_data) # type: ignore
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/slurm/scripts/resume.py", line 452, in down_nodes_notify_jobs
    run(f"{lookup().scontrol} update jobid={job.job_id} admincomment='{reason_quoted}'")
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/slurm/scripts/util.py", line 797, in run
    result = subprocess.run(
        args,
    ...<6 lines>...
        **kwargs,
    )
  File "/slurm/python/lib/python3.13/subprocess.py", line 577, in run
    raise CalledProcessError(retcode, process.args,
                             output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['/usr/local/bin/scontrol', 'update', 'jobid=16', 'admincomment=GCP', 'Error:', 'Quota', '"\'C2_CPUS\'"', 'exceeded.', 'Limit:', '300.0', 'in', 'region', 'us-central1.']' returned non-zero exit status 1.
```
