### PR TITLE
Fix multiple bugs in notifying jobs during failed resume

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -435,28 +435,21 @@ def _handle_bulk_insert_op(op: Dict, nodes: List[str], resume_data: Optional[Res
 
 def down_nodes_notify_jobs(nodes: List[str], reason: str, resume_data: Optional[ResumeData]) -> None:
     """set nodes down with reason"""
-    nodelist = util.to_hostlist(nodes)
-    reason_quoted = shlex.quote(reason)
-    
-    log.error(f"Marking nodes {nodelist} as DOWN, reason: {reason}")
-    run(f"{lookup().scontrol} update nodename={nodelist} state=down reason={reason_quoted}")
-
-    if resume_data is None:
-        log.warning("Cannot update and notify jobs with API failures as no valid resume file is present.")
-        return
-    
     nodes_set = set(nodes) # turn into set to speed up intersection
-    for job in resume_data.jobs:
+    jobs = resume_data.jobs if resume_data else []
+    reason_quoted = shlex.quote(reason)
+
+    for job in jobs:
         if not (set(job.nodes_alloc) & nodes_set):
             continue
-        run(f"{lookup().scontrol} update jobid={job.job_id} admincomment='{reason_quoted}'")
-        run(f"{lookup().scontrol} notify {job.job_id} '{reason_quoted}'")
+        run(f"{lookup().scontrol} update jobid={job.job_id} admincomment={reason_quoted}", check=False)
+        run(f"{lookup().scontrol} notify {job.job_id} {reason_quoted}", check=False)
 
-
-def hold_job(job_id, reason):
-    """hold job, set comment to reason"""
-    run(f"{lookup().scontrol} hold jobid={job_id}")
-    run(f"{lookup().scontrol} update jobid={job_id} comment='{reason}'")
+    nodelist = util.to_hostlist(nodes)
+    log.error(f"Marking nodes {nodelist} as DOWN, reason: {reason}")
+    run(f"{lookup().scontrol} update nodename={nodelist} state=down reason={reason_quoted}", check=False)
+    
+    
 
 
 def create_placement_request(pg_name: str, region: str, max_distance: Optional[int]):


### PR DESCRIPTION
* Fix invalid args formatting that leads to `Update of this parameter is not supported: Quota` errors;
* Fix order of node shutting down and job notifications, previously majority of job notifications failed due to job has been killed already;
* Remove unneeded logging.

```log
2025-05-09 22:11:59,303 DEBUG: run: ['/usr/local/bin/scontrol', 'update', 'jobid=17', "admincomment=GCP Error: Quota 'C2_CPUS' exceeded. Limit: 300.0 in re
gion us-central1."]
2025-05-09 22:11:59,307 DEBUG: run: ['/usr/local/bin/scontrol', 'notify', '17', "GCP Error: Quota 'C2_CPUS' exceeded. Limit: 300.0 in region us-central1."]
2025-05-09 22:11:59,312 ERROR: Marking nodes qq-debugnodeset-[5003-5999] as DOWN, reason: GCP Error: Quota 'C2_CPUS' exceeded. Limit: 300.0 in region us-ce
ntral1.
2025-05-09 22:11:59,312 DEBUG: run: ['/usr/local/bin/scontrol', 'update', 'nodename=qq-debugnodeset-[5003-5999]', 'state=down', "reason=GCP Error: Quota 'C
2_CPUS' exceeded. Limit: 300.0 in region us-central1."]
```


```sh
$ sacct --format="JobID,AdminComment%80"
JobID                                                                            AdminComment 
------------ -------------------------------------------------------------------------------- 
17                   GCP Error: Quota 'C2_CPUS' exceeded. Limit: 300.0 in region us-central1.
```