### PR TITLE
Set resumeTimeout to max for all flex partitions

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -70,6 +70,11 @@ output "nodeset" {
   }
 
   precondition {
+    condition     = !var.enable_spot_vm || !var.dws_flex.enabled
+    error_message = "Cannot use both Flex-Start and Spot VMs for provisioning."
+  }
+
+  precondition {
     condition     = var.reservation_name == "" || var.future_reservation == ""
     error_message = "Cannot use reservations and future reservations in the same nodeset"
   }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/main.tf
@@ -25,10 +25,9 @@ locals {
 locals {
   partition_conf = merge({
     "Default"        = var.is_default ? "YES" : null
-    "ResumeTimeout"  = var.resume_timeout != null ? var.resume_timeout : (local.has_tpu ? 600 : (local.has_flex ? 65535 : 300))
     "SuspendTime"    = var.suspend_time < 0 ? "INFINITE" : var.suspend_time
     "SuspendTimeout" = var.suspend_timeout != null ? var.suspend_timeout : (local.has_tpu ? 240 : 120)
-  }, var.partition_conf)
+  }, var.partition_conf, { "ResumeTimeout" = local.has_flex ? 65535 : try(var.partition_conf["ResumeTimeout"], coalesce(var.resume_timeout, (local.has_tpu ? 600 : 300))) })
 
   partition = {
     partition_name = var.partition_name

--- a/docs/slurm-dws-flex.md
+++ b/docs/slurm-dws-flex.md
@@ -20,6 +20,11 @@ In order to make use of DWS Flex Start mode with SlurmGCP, you must use the `dws
       # the rest of the settings, e.g. node_count_static, machine_type, additional_disks, etc.
 ```
 
+**Node behavior:**
+
+* Static nodes will be re-provisioned when `max_run_duration` ends.
+* Dynamic nodes in exclusive partitions will delete instances after the job completes (even if `max_run_duration` has yet to pass).
+
 > [!WARNING]
 > DWS Flex Start cannot be used in tandem with a reservation or placement policy.
 <p>


### PR DESCRIPTION
Flex Start should override any ResumeTimeout set either by default or explicitly in the blueprint:

1. Non-Flex partition with custom `partition_conf` (unaffected):
```
# in blueprint #
  - id: partition
    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
    use: [nodeset]
    settings:
      partition_conf:
        ResumeTimeout: 1200
        SuspendTimeout: 1200

# within cluster #
PartitionName=compute Nodes=nodeset State=UP DefMemPerCPU=7752 SuspendTime=300 Default=YES OverSubscribe=EXCLUSIVE ResumeTimeout=1200 SuspendTimeout=1200
```

2. Non-flex partition with no custom settings for ResumeTimeout (unaffected):
```
PartitionName=compute Nodes=nodeset State=UP DefMemPerCPU=7752 SuspendTime=300 Default=YES OverSubscribe=EXCLUSIVE ResumeTimeout=300 SuspendTimeout=120
```

3. Flex partition with no custom settings: Override `ResumeTimeout` to `2^16`

4. Flex partition with custom `partition_conf`/`var.resume_timeout`: Only `ResumeTimeout` is overwritten to `2^16`
```
  - id: partition
    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
    use: [nodeset]
    settings:
      partition_conf:
        ResumeTimeout: 1200
        SuspendTimeout: 1200

PartitionName=compute Nodes=nodeset State=UP DefMemPerCPU=7752 SuspendTime=300 Default=YES OverSubscribe=EXCLUSIVE ResumeTimeout=65535 SuspendTimeout=1200
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
