### PR TITLE
Fix missing region

### DIFF
--- a/community/modules/internal/slurm-gcp/instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/instance_template/README.md
@@ -55,7 +55,7 @@
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Allow the instance to be preempted. | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID to create resources in. | `string` | n/a | yes |
 | <a name="input_provisioning_model"></a> [provisioning\_model](#input\_provisioning\_model) | The provisioning model of the instance | `string` | `null` | no |
-| <a name="input_region"></a> [region](#input\_region) | Region where the instance template should be created. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the instance template should be created. | `string` | n/a | yes |
 | <a name="input_reservation_affinity"></a> [reservation\_affinity](#input\_reservation\_affinity) | Specifies the reservations that this instance can consume from. | `object({ type = string })` | `null` | no |
 | <a name="input_resource_manager_tags"></a> [resource\_manager\_tags](#input\_resource\_manager\_tags) | (Optional) A set of key/value resource manager tag pairs to bind to the instances. Keys must be in the format tagKeys/{tag\_key\_id}, and values are in the format tagValues/456. | `map(string)` | `{}` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instances. See<br/>'main.tf:local.service\_account' for the default. | <pre>object({<br/>    email  = string<br/>    scopes = set(string)<br/>  })</pre> | `null` | no |

--- a/community/modules/internal/slurm-gcp/instance_template/variables.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/variables.tf
@@ -75,7 +75,7 @@ EOD
 variable "region" {
   type        = string
   description = "Region where the instance template should be created."
-  default     = null
+  nullable    = false
 }
 
 variable "tags" {

--- a/community/modules/internal/slurm-gcp/internal_instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/README.md
@@ -60,7 +60,7 @@ No modules.
 | <a name="input_preemptible"></a> [preemptible](#input\_preemptible) | Allow the instance to be preempted | `bool` | `false` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID | `string` | `null` | no |
 | <a name="input_provisioning_model"></a> [provisioning\_model](#input\_provisioning\_model) | The provisioning model of the instance | `string` | `null` | no |
-| <a name="input_region"></a> [region](#input\_region) | Region where the instance template should be created. | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the instance template should be created. | `string` | n/a | yes |
 | <a name="input_reservation_affinity"></a> [reservation\_affinity](#input\_reservation\_affinity) | Specifies the reservations that this instance can consume from. | `object({ type = string })` | `null` | no |
 | <a name="input_resource_manager_tags"></a> [resource\_manager\_tags](#input\_resource\_manager\_tags) | (Optional) A set of key/value resource manager tag pairs to bind to the instances. Keys must be in the format tagKeys/{tag\_key\_id}, and values are in the format tagValues/456. | `map(string)` | `{}` | no |
 | <a name="input_service_account"></a> [service\_account](#input\_service\_account) | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template#service_account. | <pre>object({<br/>    email  = optional(string)<br/>    scopes = set(string)<br/>  })</pre> | n/a | yes |

--- a/community/modules/internal/slurm-gcp/internal_instance_template/variables.tf
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/variables.tf
@@ -92,7 +92,7 @@ variable "on_host_maintenance" {
 variable "region" {
   type        = string
   description = "Region where the instance template should be created."
-  default     = null
+  nullable    = false
 }
 
 variable "advanced_machine_features" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -56,6 +56,7 @@ module "slurm_nodeset_template" {
   name_prefix                = each.value.nodeset_name
   on_host_maintenance        = each.value.on_host_maintenance
   preemptible                = each.value.preemptible
+  region                     = each.value.region
   resource_manager_tags      = each.value.resource_manager_tags
   spot                       = each.value.spot
   termination_action         = each.value.termination_action


### PR DESCRIPTION
Fixes error (when using multivpc networks and provider overrides): Error: cannot determine self_link for subnetwork "***": 
```
Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'.

  with module.slurm_controller.module.slurm_nodeset_template["debugnodeset"].module.instance_template.google_compute_instance_template.tpl,
  on modules/embedded/community/modules/internal/slurm-gcp/internal_instance_template/main.tf line 70, in resource "google_compute_instance_template" "tpl":
  70: resource "google_compute_instance_template" "tpl" {
```

This is a better way to fix this than #3046

Added a validation to variables to prevent this types of errors in other places / future.

This error is present, if provider_overrides are present in the blueprint, such as:
```yaml
deployment_groups:
- group: primary
  terraform_providers:
    google:
      source: "hashicorp/google"
      version: ">= 6.0.0, != 6.13.0, < 7.0.0"
    google-beta:
      source: "hashicorp/google-beta"
      version: ">= 6.0.0, != 6.13.0, < 7.0.0"

```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
