### PR TITLE
CloudSQL improvements: database flags, query insights, bump default version

### DIFF
--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -10,9 +10,9 @@ accounting data storage.
 ### Example
 
 ```yaml
-- id: project
-  source: community/modules/database/cloudsql-federation
-  use: [network1]
+- id: cloudsql
+  source: community/modules/database/slurm-cloudsql-federation
+  use: [network]
   settings:
     sql_instance_name: slurm-sql6-demo
     tier: "db-f1-micro"
@@ -77,7 +77,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_authorized_networks"></a> [authorized\_networks](#input\_authorized\_networks) | IP address ranges as authorized networks of the Cloud SQL for MySQL instances | `list(string)` | `[]` | no |
 | <a name="input_data_cache_enabled"></a> [data\_cache\_enabled](#input\_data\_cache\_enabled) | Whether data cache is enabled for the instance. Can be used with ENTERPRISE\_PLUS edition. | `bool` | `false` | no |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_5_7"` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | Database flags to set on instance. | `map(string)` | `{}` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The version of the database to be created. | `string` | `"MYSQL_8_0"` | no |
 | <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether or not to allow Terraform to destroy the instance. | `string` | `false` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment | `string` | n/a | yes |
 | <a name="input_disk_autoresize"></a> [disk\_autoresize](#input\_disk\_autoresize) | Set to false to disable automatic disk grow. | `bool` | `true` | no |
@@ -88,6 +89,7 @@ No modules.
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is going to be created in.:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection, used only as dependency for Cloud SQL creation. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created | `string` | n/a | yes |
+| <a name="input_query_insights"></a> [query\_insights](#input\_query\_insights) | Query insights configuration. | <pre>object({<br/>    enabled                 = optional(bool, false)<br/>    query_plans_per_minute  = optional(number)<br/>    query_string_length     = optional(number)<br/>    record_application_tags = optional(bool)<br/>    record_client_address   = optional(bool)<br/>  })</pre> | `{}` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region where SQL instance will be configured | `string` | n/a | yes |
 | <a name="input_sql_instance_name"></a> [sql\_instance\_name](#input\_sql\_instance\_name) | name given to the sql instance for ease of identificaion | `string` | n/a | yes |
 | <a name="input_sql_password"></a> [sql\_password](#input\_sql\_password) | Password for the SQL database. | `any` | `null` | no |

--- a/community/modules/database/slurm-cloudsql-federation/main.tf
+++ b/community/modules/database/slurm-cloudsql-federation/main.tf
@@ -59,6 +59,23 @@ resource "google_sql_database_instance" "instance" {
         data_cache_enabled = var.data_cache_enabled
       }
     }
+
+    dynamic "database_flags" {
+      for_each = var.database_flags
+      content {
+        name  = database_flags.key
+        value = database_flags.value
+      }
+    }
+
+    insights_config {
+      query_insights_enabled  = var.query_insights.enabled
+      query_plans_per_minute  = var.query_insights.query_plans_per_minute
+      query_string_length     = var.query_insights.query_string_length
+      record_application_tags = var.query_insights.record_application_tags
+      record_client_address   = var.query_insights.record_client_address
+    }
+
     ip_configuration {
       ipv4_enabled                                  = false
       private_network                               = var.use_psc_connection ? null : var.network_id

--- a/community/modules/database/slurm-cloudsql-federation/variables.tf
+++ b/community/modules/database/slurm-cloudsql-federation/variables.tf
@@ -24,7 +24,7 @@ variable "authorized_networks" {
 variable "database_version" {
   description = "The version of the database to be created."
   type        = string
-  default     = "MYSQL_5_7"
+  default     = "MYSQL_8_0"
   validation {
     condition     = contains(["MYSQL_5_7", "MYSQL_8_0", "MYSQL_8_4"], var.database_version)
     error_message = "The database version must be either MYSQL_5_7, MYSQL_8_0 or MYSQL_8_4."
@@ -35,6 +35,13 @@ variable "data_cache_enabled" {
   description = "Whether data cache is enabled for the instance. Can be used with ENTERPRISE_PLUS edition."
   type        = bool
   default     = false
+}
+
+variable "database_flags" {
+  description = "Database flags to set on instance."
+  type        = map(string)
+  default     = {}
+  nullable    = false
 }
 
 variable "deployment_name" {
@@ -73,6 +80,19 @@ variable "enable_backups" {
 variable "project_id" {
   description = "Project in which the HPC deployment will be created"
   type        = string
+}
+
+variable "query_insights" {
+  description = "Query insights configuration."
+  nullable    = false
+  default     = {}
+  type = object({
+    enabled                 = optional(bool, false)
+    query_plans_per_minute  = optional(number)
+    query_string_length     = optional(number)
+    record_application_tags = optional(bool)
+    record_client_address   = optional(bool)
+  })
 }
 
 variable "region" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -166,6 +166,7 @@ resource "google_secret_manager_secret" "cloudsql" {
   count = var.cloudsql != null ? 1 : 0
 
   secret_id = "${local.slurm_cluster_name}-slurm-secret-cloudsql"
+  project   = var.project_id
 
   replication {
     dynamic "auto" {


### PR DESCRIPTION
* add possibility to set database flags
* allow query insights management
* set default version to 8_0 to avoid extended support costs ([see details here](https://cloud.google.com/sql/docs/mysql/db-versions#database-version-support))

If deployment relies on default version being deployed, this change will automatically upgrade their database version (hence, I'm adding `release-breaking-changes` flag - though update should work in place)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
