### PR TITLE
Remove pre-set deployment names from GKE example blueprints

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -18,7 +18,7 @@ blueprint_name: gke-a3-highgpu
 
 vars:
   project_id:  ## Set GCP Project ID Here ##
-  deployment_name: gke-a3-highgpu
+  deployment_name: ## Set Deployment Name Here ##
   region: us-central1
   zone: us-central1-c
   # Cidr block containing the IP of the machine calling terraform.

--- a/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
@@ -22,7 +22,7 @@ terraform_backend_defaults:
 vars:
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: gke-a3-mega
+  deployment_name: DEPLOYMENT_NAME
 
   # Your GCP Project ID
   project_id: PROJECT_ID

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
@@ -19,7 +19,7 @@ terraform_backend_defaults:
     bucket: BUCKET_NAME
 
 vars:
-  deployment_name: gke-a3-ultra
+  deployment_name: DEPLOYMENT_NAME
   project_id: PROJECT_ID
   region: COMPUTE_REGION
   zone: COMPUTE_ZONE

--- a/examples/gke-a4/gke-a4-deployment.yaml
+++ b/examples/gke-a4/gke-a4-deployment.yaml
@@ -24,7 +24,7 @@ vars:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: gke-a4
+  deployment_name:
 
   # The GCP Region used for this deployment.
   region:

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu-deployment.yaml
@@ -24,7 +24,7 @@ vars:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: gke-a3u-dws-fs-qp
+  deployment_name:
 
   # The GCP Region used for this deployment.
   region:

--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu-deployment.yaml
@@ -24,7 +24,7 @@ vars:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: gke-a3u-dws-fs
+  deployment_name:
 
   # The GCP Region used for this deployment.
   region:


### PR DESCRIPTION
Remove the pre-set deployment names from the GKE blueprint examples to avoid naming conflicts in deployment.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
