### PR TITLE
Updating Slurm dev key logic to use static file instead of env var

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -325,8 +325,13 @@ def get_credentials() -> Optional[service_account.Credentials]:
 
 @lru_cache(maxsize=1)
 def get_dev_key() -> Optional[str]:
-    """Get dev key for project"""
-    return os.environ.get("GOOGLE_DEVELOPER_KEY")
+    """Get dev key for project (uses json or yaml format)"""
+    try:
+        with open("/etc/slurm/slurm_vars.yaml", 'r') as file:
+            data = yaml.safe_load(file)
+            return data['google_developer_key']
+    except:
+        return None
 
 
 def create_client_options(api: ApiEndpoint) -> ClientOptions:


### PR DESCRIPTION
Using a static file with the key is more reliable.  This has been tested on a clean build of Slurm with a custom image that adds the dev key.
