### PR TITLE
New way to timeout on dpkg during `install_ansible`

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 REQ_ANSIBLE_VERSION=2.11
 REQ_ANSIBLE_PIP_VERSION=4.10.0
 REQ_PIP_WHEEL_VERSION=0.37.1
@@ -22,28 +22,19 @@ REQ_PIP_MAJOR_VERSION=21
 REQ_PYTHON3_VERSION=6
 
 apt_wait() {
-	while fuser /var/lib/dpkg/lock >/dev/null 2>&1; do
-		echo "Sleeping for dpkg lock"
-		sleep 3
-	done
 	while fuser /var/lib/apt/lists/lock >/dev/null 2>&1; do
 		echo "Sleeping for apt lists lock"
 		sleep 3
 	done
-	if [ -f /var/log/unattended-upgrades/unattended-upgrades.log ]; then
-		echo "Sleeping until unattended-upgrades finishes"
-		while fuser /var/log/unattended-upgrades/unattended-upgrades.log >/dev/null 2>&1; do
-			sleep 3
-		done
-	fi
 }
 
 # Installs any dependencies needed for python based on the OS
 install_python_deps() {
-	if [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
-		grep -qi ubuntu /etc/os-release 2>/dev/null; then
+	# this file is present on both Debian and Ubuntu OSes
+	if [ -f /etc/debian_version ]; then
+		apt_wait
 		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
-		apt-get install -y python3-distutils python3-venv
+		apt-get install -o DPkg::Lock::Timeout=600 -y python3-distutils python3-venv
 	fi
 }
 
@@ -106,7 +97,7 @@ install_python3_yum() {
 install_python3_apt() {
 	apt_wait
 	apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
-	apt-get install -y python3 python3-distutils python3-pip python3-venv
+	apt-get install -o DPkg::Lock::Timeout=600 -y python3 python3-distutils python3-pip python3-venv
 	python_path=$(command -v python3)
 }
 
@@ -154,8 +145,9 @@ install_pip3_yum() {
 # Install python3 with the apt package manager. Updates python_path to the
 # newly installed packaged.
 install_pip3_apt() {
+	apt_wait
 	apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
-	apt-get install -y python3-pip
+	apt-get install -o DPkg::Lock::Timeout=600 -y python3-pip
 }
 
 install_pip3() {


### PR DESCRIPTION
* Make use of `-o DPkg::Lock::Timeout=600` (available in `apt > 1.9.11`) to avoid dpkg lock collisions with `unattended-upgrades`;
* Remove `fuser /var/lib/dpkg/lock`;
* Remove `"Sleeping until unattended-upgrades finishes"`.

`DPkg::Lock::Timeout` is avaiable on all OSes of our interest:
* Debian bullseye (11) [has](https://qa.debian.org/madison.php?package=apt) `apt 2.2.4`;
* Ubuntu 20.04 has `apt 2.0.10`.

See: https://unix.stackexchange.com/a/277255