### PR TITLE
Drop CentOS 7 support for Ansible installation

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -65,31 +65,15 @@ get_python_minor_version() {
 
 # Install python3 with the yum package manager. Updates python_path to the
 # newly installed packaged.
-install_python3_yum() {
-	major_version=$(rpm -E "%{rhel}")
+install_python3_dnf() {
 	set -- "--disablerepo=*" "--enablerepo=baseos,appstream"
-
-	if grep -qi 'ID="rhel"' /etc/os-release && {
-		[ "${major_version}" -eq "7" ] || [ "${major_version}" -eq "8" ] ||
-			[ "${major_version}" -eq "9" ]
-	}; then
+	if grep -qi 'ID="rhel"' /etc/os-release; then
 		# Do not set --disablerepo / --enablerepo on RedHat, due to complex repo names
 		# clear array
 		set --
-	elif [ "${major_version}" -eq "7" ]; then
-		set -- "--disablerepo=*" "--enablerepo=base,epel"
-	elif [ "${major_version}" -eq "8" ]; then
-		# use defaults
-		true
-	elif [ "${major_version}" -eq "9" ]; then
-		# use defaults
-		true
-	else
-		echo "Unsupported version of centos/RHEL/Rocky"
-		return 1
 	fi
-	yum install "$@" -y python3 python3-pip
-	python_path=$(rpm -ql python3 | grep 'bin/python3$')
+	dnf install "$@" -y python3 python3-pip
+	python_path=$(command -v python3)
 }
 
 # Install python3 with the apt package manager. Updates python_path to the
@@ -102,11 +86,10 @@ install_python3_apt() {
 }
 
 install_python3() {
-	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
-		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-		install_python3_yum
-	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
-		grep -qi ubuntu /etc/os-release 2>/dev/null; then
+	if [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] ||
+		[ -f /etc/system-release ]; then
+		install_python3_dnf
+	elif [ -f /etc/debian_version ]; then
 		install_python3_apt
 	else
 		echo "Error: Unsupported Distribution"
@@ -114,35 +97,19 @@ install_python3() {
 	fi
 }
 
-# Install python3 with the yum package manager. Updates python_path to the
+# Install pip3 with the dnf package manager. Updates python_path to the
 # newly installed packaged.
-install_pip3_yum() {
-	major_version=$(rpm -E "%{rhel}")
+install_pip3_dnf() {
 	set -- "--disablerepo=*" "--enablerepo=baseos,appstream"
-
-	if grep -qi 'ID="rhel"' /etc/os-release && {
-		[ "${major_version}" -eq "7" ] || [ "${major_version}" -eq "8" ] ||
-			[ "${major_version}" -eq "9" ]
-	}; then
+	if grep -qi 'ID="rhel"' /etc/os-release; then
 		# Do not set --disablerepo / --enablerepo on RedHat, due to complex repo names
 		# clear array
 		set --
-	elif [ "${major_version}" -eq "7" ]; then
-		set -- "--disablerepo=*" "--enablerepo=base,epel"
-	elif [ "${major_version}" -eq "8" ]; then
-		# use defaults
-		true
-	elif [ "${major_version}" -eq "9" ]; then
-		# use defaults
-		true
-	else
-		echo "Unsupported version of centos/RHEL/Rocky"
-		return 1
 	fi
-	yum install "$@" -y python3-pip
+	dnf install "$@" -y python3-pip
 }
 
-# Install python3 with the apt package manager. Updates python_path to the
+# Install pip3 with the apt package manager. Updates python_path to the
 # newly installed packaged.
 install_pip3_apt() {
 	apt_wait
@@ -151,11 +118,10 @@ install_pip3_apt() {
 }
 
 install_pip3() {
-	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
-		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
-		install_pip3_yum
-	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release 2>/dev/null ||
-		grep -qi ubuntu /etc/os-release 2>/dev/null; then
+	if [ -f /etc/redhat-release ] || [ -f /etc/oracle-release ] ||
+		[ -f /etc/system-release ]; then
+		install_pip3_dnf
+	elif [ -f /etc/debian_version ]; then
 		install_pip3_apt
 	else
 		echo "Error: Unsupported Distribution"

--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -44,18 +44,6 @@ deployment_groups:
           set -ex
           echo \$(ansible --version)
 
-  - id: workstation-centos
-    source: modules/compute/vm-instance
-    use:
-    - network1
-    - startup-script
-    settings:
-      name_prefix: centos
-      add_deployment_name_before_prefix: true
-      instance_image:
-        name: centos-7-v20240611
-        project: centos-cloud
-
   - id: workstation-ubuntu-2004
     source: modules/compute/vm-instance
     use:
@@ -156,7 +144,6 @@ deployment_groups:
     source: community/modules/scripts/wait-for-startup
     settings:
       instance_names:
-      - $(workstation-centos.name[0])
       - $(workstation-ubuntu-2004.name[0])
       - $(workstation-ubuntu-2204.name[0])
       - $(workstation-debian-11.name[0])

--- a/tools/cloud-build/daily-tests/tests/ansible-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/ansible-vm.yml
@@ -20,6 +20,6 @@ zone: us-central1-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml"
 network: "default"
-remote_node: "{{ deployment_name }}-centos-0"
+remote_node: "{{ deployment_name }}-rocky8-0"
 post_deploy_tests:
 - test-validation/test-ansible-vm.yml


### PR DESCRIPTION
This PR removes all support and test coverage for installing Ansible into VMs running CentOS 7. CentOS 7 has been EOL since 30 June 2024. The version of Ansible we are using is blocked by the old dependencies available within CentOS 7 so this is a first step in updating Ansible to a more recent version.

Additionally takes the first steps toward a more "fail open" model where new releases of RedHat derivatives may continue to work without modification.

Blocks on #4137.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
