### PR TITLE
Add Ubuntu 24.04 Ansible installation and test coverage

### DIFF
--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -34,7 +34,7 @@ install_python_deps() {
 	if [ -f /etc/debian_version ]; then
 		apt_wait
 		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
-		apt-get install -o DPkg::Lock::Timeout=600 -y python3-distutils python3-venv
+		apt-get install -o DPkg::Lock::Timeout=600 -y python3-setuptools python3-venv
 	fi
 }
 
@@ -93,7 +93,7 @@ install_python3_dnf() {
 install_python3_apt() {
 	apt_wait
 	apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
-	apt-get install -o DPkg::Lock::Timeout=600 -y python3 python3-distutils python3-pip python3-venv
+	apt-get install -o DPkg::Lock::Timeout=600 -y python3 python3-setuptools python3-pip python3-venv
 	python_path=$(command -v python3)
 }
 

--- a/modules/scripts/startup-script/files/install_ansible.sh
+++ b/modules/scripts/startup-script/files/install_ansible.sh
@@ -171,20 +171,10 @@ main() {
 		install_python_deps
 	fi
 
-	# Install and/or upgrade pip
+	# Install OS-packaged pip
 	if ! ${python_path} -m pip --version 2>/dev/null; then
 		if ! install_pip3; then
 			return 1
-		fi
-	fi
-
-	# Upgrade system-wide pip
-	# Do not run on Debian 12 - system pip package modification is forbidden
-	if [ ! -f /etc/debian_version ] || [ "$(lsb_release -a 2>/dev/null | sed -n 's/Release:\s\+\([0-9]\+\).\?.*/\1/p')" -ne "12" ]; then
-		pip_version=$(${python_path} -m pip --version | sed -nr 's/^pip ([0-9]+\.[0-9]+).*$/\1/p')
-		pip_major_version=$(echo "${pip_version}" | cut -d '.' -f 1)
-		if [ "${pip_major_version}" -lt "${REQ_PIP_MAJOR_VERSION}" ]; then
-			${python_path} -m pip install --upgrade pip
 		fi
 	fi
 

--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -68,6 +68,18 @@ deployment_groups:
         family: ubuntu-2204-lts
         project: ubuntu-os-cloud
 
+  - id: workstation-ubuntu-2404
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - startup-script
+    settings:
+      name_prefix: ubuntu2404
+      add_deployment_name_before_prefix: true
+      instance_image:
+        family: ubuntu-2404-lts-amd64
+        project: ubuntu-os-cloud
+
   - id: workstation-debian-11
     source: modules/compute/vm-instance
     use:
@@ -146,6 +158,7 @@ deployment_groups:
       instance_names:
       - $(workstation-ubuntu-2004.name[0])
       - $(workstation-ubuntu-2204.name[0])
+      - $(workstation-ubuntu-2404.name[0])
       - $(workstation-debian-11.name[0])
       - $(workstation-debian-12.name[0])
       - $(workstation-rocky-8.name[0])


### PR DESCRIPTION
This PR adds Ansible support for Ubuntu 24.04 by:

- removing "pip upgrades pip system-wide" step for all Linux distributions
- switches from python3-distutils to python3-setuptools for all Debian-derived Linux distributions

### Switching to python3-setuptools

On Ubuntu 24.04, python3-distutils is no longer separately packaged and python3-setuptools is the recommended alternative. On all recent Debian-derived platforms python3-setuptools is packaged and, if it exists, depends upon python3-distutils. So this PR makes the choice to uniformly install python3-setuptools.

Background: `distutils` is built into Python while `setuptools` is a 3rd party solution, but has wider adoption and functionality.

### Removing pip self-upgrade

The motivation to upgrade pip system-wide is not very well-founded as it only beneficial to:

- user-managed system-wide pip installations
- enabling a high-versioned pip by default in new virtual environments

Because pip can be upgraded within virtual environments, this is not critical. Additionally, PEP 668 is the Python community's official position against using Python package management tools (pip, etc) to manage packages alongside "externally" managed packages (apt, dnf, etc). Recent Debian and Ubuntu releases have adopted PEP 668 by default, thus breaking the ability to use packaged-pip to upgrade pip system-wide.

- https://peps.python.org/pep-0668/
- https://packaging.python.org/en/latest/specifications/externally-managed-environments/#externally-managed-environments

Blocked by #4139.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
