### PR TITLE
Improve Slurm GPU testing

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gpus-slurm.yml
@@ -33,7 +33,7 @@
   ansible.builtin.debug:
     msg: "{{ nvidia_smi_result.stdout }}"
 
-- name: Run DCGM diagnostics
+- name: Run DCGM diagnostics (works without requesting GPUs)
   ansible.builtin.command: srun -N 2 -p {{ custom_vars.gpu_partition }} dcgmi diag -r 1
   register: nvidia_dcgmi_result
   failed_when: nvidia_dcgmi_result.rc != 0
@@ -47,3 +47,13 @@
   register: nvidia_persistenced_result
   failed_when: nvidia_persistenced_result.rc != 0
   when: custom_vars.test_persistenced is defined and custom_vars.test_persistenced
+
+- name: Verify enroot/pyxis can run GPU jobs
+  ansible.builtin.command: srun -N 2 -p {{ custom_vars.gpu_partition }} --gpus-per-node={{ custom_vars.gpu_count }} --container-image=nvidia/cuda:12.4.1-cudnn-runtime-rockylinux8 nvidia-smi
+  register: enroot_gpu_result
+  failed_when: enroot_gpu_result.rc != 0
+  changed_when: false
+
+- name: Print nvidia-smi output from enroot container
+  ansible.builtin.debug:
+    msg: "{{ enroot_gpu_result.stdout }}"


### PR DESCRIPTION
This PR adds a test for Slurm on GPU compute nodes that uses enroot to confirm end-to-end GPU functionality. The 4 checks have failed with error message expected due to #4144. In this case, failure indicates success - the tests fail when there is a broken element in the software stack.

These changes were manually tested with the changes in #4145 and the tests passed, indicating that both the test and the changes were successful.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
