### PR TITLE
Auto execute basic Slurm integration test

### DIFF
--- a/tools/cloud-build/provision/pr-tests.tf
+++ b/tools/cloud-build/provision/pr-tests.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  auto_approved_pr_tests = [
+    "slurm-gcp-v6-simple-job-completion"
+  ]
+}
+
+
 resource "google_cloudbuild_trigger" "pr_test" {
   for_each    = data.external.list_tests_midnight.result
   name        = "PR-test-${each.key}"
@@ -19,7 +26,7 @@ resource "google_cloudbuild_trigger" "pr_test" {
 
   filename = "tools/cloud-build/daily-tests/builds/${each.key}.yaml"
   approval_config {
-    approval_required = true
+    approval_required = !contains(local.auto_approved_pr_tests, each.key)
   }
 
   github {


### PR DESCRIPTION
Do not require approval for `PR-test-slurm-gcp-v6-simple-job-completion`,
intention is to make it required for PR merging.
This test: doesn't require Filestore, takes ~10 minutes.

