### PR TITLE
Drop CentOS 7 from integration test for DDN/WhamCloud Lustre implementation

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml
@@ -88,24 +88,6 @@ deployment_groups:
   # Simple VM #
   #############
 
-  - id: workstation-centos
-    source: modules/compute/vm-instance
-    use:
-    - network1
-    - lustre
-    - startup-script
-    settings:
-      name_prefix: centos
-      add_deployment_name_before_prefix: true
-      instance_image:
-        name: centos-7-v20240611
-        project: centos-cloud
-  - id: wait-centos
-    source: community/modules/scripts/wait-for-startup
-    settings:
-      instance_name: $(workstation-centos.name[0])
-      timeout: 7200
-
   - id: workstation-rocky
     source: modules/compute/vm-instance
     use:
@@ -123,20 +105,3 @@ deployment_groups:
     settings:
       instance_name: $(workstation-rocky.name[0])
       timeout: 7200
-
-  # - id: workstation-ubuntu
-  #   source: modules/compute/vm-instance
-  #   use:
-  #   - network1
-  #   - lustre
-  #   - startup-script
-  #   settings:
-  #     name_prefix: ubuntu
-  #     instance_image:
-  #       family: ubuntu-2004-lts
-  #       project: ubuntu-os-cloud
-  # - id: wait-ubuntu
-  #   source: community/modules/scripts/wait-for-startup
-  #   settings:
-  #     instance_name: $(workstation-ubuntu.name[0])
-  #     timeout: 7200

--- a/tools/cloud-build/daily-tests/tests/lustre-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/lustre-vm.yml
@@ -20,7 +20,7 @@ zone: us-central1-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/lustre-vm.yaml"
 network: "default"
-remote_node: "{{ deployment_name }}-centos-0"
+remote_node: "{{ deployment_name }}-rocky-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-lustre-vm.yml
@@ -30,6 +30,4 @@ custom_vars:
   mounts:
   - /lustre
   vm_os_types:
-  - centos
   - rocky
-  # - ubuntu


### PR DESCRIPTION
CentOS 7 has long been EOL and support for installing Ansible in CentOS 7 was recently removed in #4138. We no longer support DDN Lustre on CentOS 7 and we guide users to the Google Cloud Managed Lustre service on all platforms. So this test is no longer testing a supported use case.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
