### PR TITLE
Improvements to `python-integration-tests`

### DIFF
--- a/tools/python-integration-tests/deployment.py
+++ b/tools/python-integration-tests/deployment.py
@@ -54,10 +54,8 @@ class Deployment:
 
     def generate_uniq_deployment_name(self):
         BUILD_ID = os.environ.get('BUILD_ID')
-        if BUILD_ID:
-            return "-".join([self.blueprint_name, str(BUILD_ID[:6])])
-        else:
-            return "-".join([self.blueprint_name, str(uuid.uuid4())[:6]])
+        prefix = (BUILD_ID if BUILD_ID else str(uuid.uuid4()))[:6]
+        return f"{prefix}-{self.blueprint_name}"
 
     def set_deployment_variables(self):
         self.workspace = os.path.abspath(os.getcwd().strip())

--- a/tools/python-integration-tests/test.py
+++ b/tools/python-integration-tests/test.py
@@ -48,15 +48,13 @@ class SlurmTest(Test):
         self.ssh_client.connect("localhost", self.ssh_manager.local_port, username=self.deployment.username, pkey=self.ssh_manager.key)
 
     def close_ssh(self):
-        self.ssh_manager.close()
+        if self.ssh_manager:
+            self.ssh_manager.close()
 
     def setUp(self):
-        try:
-            super().setUp()
-            hostname = self.get_login_node()
-            self.ssh(hostname)
-        except Exception as err:
-            self.fail(f"Unexpected error encountered. stderr: {err.stderr}")
+        super().setUp()
+        hostname = self.get_login_node()
+        self.ssh(hostname)
 
     def clean_up(self):
         super().clean_up()


### PR DESCRIPTION
* Change name of deployment from `<name>-<uid>` to `<uid>-<name>` to prevent collisions caused by shortening.
* Fix following exceptions and mishandling:
```
Traceback (most recent call last):
  File "/workspace/tools/python-integration-tests/test.py", line 63, in clean_up
    self.close_ssh()
  File "/workspace/tools/python-integration-tests/test.py", line 51, in close_ssh
    self.ssh_manager.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

```
Traceback (most recent call last):
  File "/workspace/tools/python-integration-tests/test.py", line 60, in setUp
    self.fail(f"Unexpected error encountered. stderr: {err.stderr}")
AttributeError: 'OSError' object has no attribute 'stderr'
```

Testing done: 
Run 2 instances of the test concurrently - both passed.