### PR TITLE
HCLS solution: Fix mistaken variable name in README

### DIFF
--- a/docs/videos/healthcare-and-life-sciences/README.md
+++ b/docs/videos/healthcare-and-life-sciences/README.md
@@ -110,16 +110,16 @@ storage intact and b) you can build software before you deploy your cluster.
    the cloud buckets being destroyed, it is recommended you run:
 
    ```bash
-   ./gcluster create examples/hcls-blueprint.yaml -w --vars project_id=<project> --vars bucket_force_delete=true
+   ./gcluster create examples/hcls-blueprint.yaml -w --vars project_id=<project> --vars bucket_force_destroy=true
    ```
 
-   The `bucket_force_delete` variable makes it easier to tear down the
+   The `bucket_force_destroy` variable makes it easier to tear down the
    deployment. If it is set to the default value of `false`, buckets with
    objects (files) will not be deleted and the `./gcluster destroy` command will
    fail partway through.
 
    If the data stored in the buckets should be preseverved, remove the
-   `--vars bucket_force_delete=true` portion of the command or set it to `false`
+   `--vars bucket_force_destroy=true` portion of the command or set it to `false`
 
 1. Deploy the `enable_apis` group
 


### PR DESCRIPTION
Without this change, the unused variable validation rule is triggered:

```
$ gcluster deploy --vars project_id=test-project,bucket_force_delete=true examples/hcls-blueprint.yaml
validator "test_deployment_variable_not_used" failed:
Error: the variable "bucket_force_delete" was not used in this blueprint
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
