### PR TITLE
Add recurse to condor spool directory

### DIFF
--- a/community/modules/scheduler/htcondor-access-point/files/htcondor_configure.yml
+++ b/community/modules/scheduler/htcondor-access-point/files/htcondor_configure.yml
@@ -82,6 +82,7 @@
         owner: condor
         group: condor
         mode: 0755
+        recurse: true
     - name: Create SystemD override directory for HTCondor
       ansible.builtin.file:
         path: /etc/systemd/system/condor.service.d


### PR DESCRIPTION
This fix ensure that the condor spool directory files are accessible even if for some reason the new image's condor UID changed when using stateful disk

Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

[x] Fork your PR branch from the Toolkit "develop" branch (not main)
[x] Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
[x] Confirm that "make tests" passes all tests
[x] Add or modify unit tests to cover code changes
[x] Ensure that unit test coverage remains above 80%
[x] Update all applicable documentation
[x] Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)