### PR TITLE
Add ubuntu 24.04 ARM64 check for ansible-vm test

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -80,6 +80,20 @@ deployment_groups:
         family: ubuntu-2404-lts-amd64
         project: ubuntu-os-cloud
 
+  - id: workstation-ubuntu-2404-arm
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - startup-script
+    settings:
+      name_prefix: ubuntu2404arm
+      machine_type: c4a-standard-4
+      disk_type: hyperdisk-balanced
+      add_deployment_name_before_prefix: true
+      instance_image:
+        family: ubuntu-2404-lts-arm64
+        project: ubuntu-os-cloud
+
   - id: workstation-debian-11
     source: modules/compute/vm-instance
     use:
@@ -159,6 +173,7 @@ deployment_groups:
       - $(workstation-ubuntu-2004.name[0])
       - $(workstation-ubuntu-2204.name[0])
       - $(workstation-ubuntu-2404.name[0])
+      - $(workstation-ubuntu-2404-arm.name[0])
       - $(workstation-debian-11.name[0])
       - $(workstation-debian-12.name[0])
       - $(workstation-rocky-8.name[0])


### PR DESCRIPTION
Adds ansible test coverage for Ubuntu 24.04 (ARM64) using the c4a machine type

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
