### PR TITLE
Slurm: disable public ips

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -54,6 +54,8 @@ deployment_groups:
   modules:
   # Source is an embedded module, denoted by "modules/*" without ./, ../, /
   # as a prefix. To refer to a local or community module, prefix with ./, ../ or /
+
+  # modules/network/vpc provides Cloud NAT and Private Google Access by default
   - id: network
     source: modules/network/vpc
 
@@ -87,6 +89,7 @@ deployment_groups:
       - logging.logWriter
       - monitoring.metricWriter
       - storage.objectViewer
+      # - storage.objectUser # add if using Cloud Storage Bucket as storage
 
   - id: compute_sa
     source: modules/project/service-account
@@ -284,10 +287,7 @@ deployment_groups:
     settings:
       instance_image: $(vars.slurm_image)
       machine_type: n2-standard-4
-      # we recommend disabling public IPs if possible
-      # but that requires your network to have a NAT or
-      # private access configured
-      enable_login_public_ips: true
+      enable_login_public_ips: false
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
@@ -303,10 +303,7 @@ deployment_groups:
         resume_timeout: 600
         suspend_rate: 0
         suspend_timeout: 600
-      # we recommend disabling public IPs if possible
-      # but that requires your network to have a NAT or
-      # private access configured
-      enable_controller_public_ips: true
+      enable_controller_public_ips: false
 
   - id: hpc_dashboard
     source: modules/monitoring/dashboard


### PR DESCRIPTION
* disable public IPs for login and controller, as network module provides NAT and private google access, and this is better starting point from security perspective
* provide hints about permissions for other service accounts

