### PR TITLE
Added Verbose flag in the Integration tests in test-gke-a3-mega.yml file

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
@@ -21,7 +21,7 @@
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
   ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Download NCCL test file
   delegate_to: localhost
@@ -38,12 +38,12 @@
 - name: Deploy pods with NCCL test workload
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml
+    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml -v=2
 
 - name: Wait until 2 pods are running
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pod --field-selector status.phase=Running --no-headers
+    kubectl get pod --field-selector status.phase=Running --no-headers -v=2
   register: pod_running
   until: pod_running.stdout_lines | length == 2
   retries: 20
@@ -52,7 +52,7 @@
 - name: Trigger all-gather NCCL test
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /scripts/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
+    kubectl -v=2 exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /scripts/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
     cat pod_logs.txt
   register: nccl_test_logs
 
@@ -70,5 +70,5 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete pod --all
-    kubectl delete service --all
+    kubectl delete pod --all -v=2
+    kubectl delete service --all -v=2


### PR DESCRIPTION
--verbosity in gcould container clusters
-v in kubectl commands

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
