### PR TITLE
Added Verbose Flags in Integration Tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-high.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-high.yml
@@ -21,7 +21,7 @@
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
   ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Download NCCL test file
   delegate_to: localhost
@@ -38,12 +38,12 @@
 - name: Create NCCL config map and deploy NCCL test pods
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml
+    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml -v=9
 
 - name: Wait until 2 pods are running
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pod --field-selector status.phase=Running --no-headers
+    kubectl get pod --field-selector status.phase=Running --no-headers -v=9
   register: pod_running
   until: pod_running.stdout_lines | length == 2
   retries: 20
@@ -52,7 +52,7 @@
 - name: Trigger all-gather NCCL test
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /configs/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
+    kubectl -v=9 exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /configs/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
     cat pod_logs.txt
   register: nccl_test_logs
 
@@ -70,5 +70,5 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete pod --all
-    kubectl delete service --all
+    kubectl delete pod --all -v=9
+    kubectl delete service --all -v=9

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
@@ -21,7 +21,7 @@
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
   ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Download NCCL test file
   delegate_to: localhost
@@ -38,12 +38,12 @@
 - name: Deploy pods with NCCL test workload
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml
+    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml -v=9
 
 - name: Wait until 2 pods are running
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pod --field-selector status.phase=Running --no-headers
+    kubectl get pod --field-selector status.phase=Running --no-headers -v=9
   register: pod_running
   until: pod_running.stdout_lines | length == 2
   retries: 20
@@ -52,7 +52,7 @@
 - name: Trigger all-gather NCCL test
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /scripts/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
+    kubectl -v=9 exec --stdin --tty --container=nccl-test nccl-test-host-1 -- /scripts/allgather.sh nccl-host-1 nccl-host-2 > pod_logs.txt
     cat pod_logs.txt
   register: nccl_test_logs
 
@@ -70,5 +70,5 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete pod --all
-    kubectl delete service --all
+    kubectl delete pod --all -v=9
+    kubectl delete service --all -v=9

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-ultra.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-ultra.yml
@@ -21,7 +21,7 @@
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
   ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Modify NCCL test parameters
   delegate_to: localhost
@@ -46,14 +46,14 @@
 - name: Run the NCCL test
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl create -f {{ workspace }}/examples/gke-a3-ultragpu/nccl-jobset-example.yaml
+    kubectl create -f {{ workspace }}/examples/gke-a3-ultragpu/nccl-jobset-example.yaml -v=9
   args:
     executable: /bin/bash
 
 - name: Wait for Job to hit 2/2 completions
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get job --field-selector status.successful=2
+    kubectl get job --field-selector status.successful=2 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 1
   retries: 20
@@ -81,4 +81,4 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete jobset --all
+    kubectl delete jobset --all -v=9

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a4.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a4.yml
@@ -21,19 +21,19 @@
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
   ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Run the NCCL test
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl create -f {{ workspace }}/examples/gke-a4/nccl-jobset-example.yaml
+    kubectl create -f {{ workspace }}/examples/gke-a4/nccl-jobset-example.yaml -v=9
   args:
     executable: /bin/bash
 
 - name: Wait for Job to hit 2/2 completions
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get job --field-selector status.successful=2
+    kubectl get job --field-selector status.successful=2 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 1
   retries: 20
@@ -61,4 +61,4 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete jobset --all
+    kubectl delete jobset --all -v=9

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-cluster-provisioning.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-cluster-provisioning.yml
@@ -20,4 +20,4 @@
 
 - name: Connect to the GKE cluster using gcloud command
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
@@ -20,13 +20,13 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Execute the job
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/{{ deployment_name }}/primary/my-job*)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -34,7 +34,7 @@
 - name: Wait for job to complete
   delegate_to: localhost
   ansible.builtin.command: |
-    kubectl get job --field-selector  status.successful=1
+    kubectl get job --field-selector  status.successful=1 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 1
   retries: 40
@@ -47,4 +47,4 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete job --all
+    kubectl delete job --all -v=9

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue.yml
@@ -20,13 +20,13 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Create the topology kueue
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
     echo ${array[0]}
   args:
     executable: /bin/bash
@@ -36,7 +36,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/tools/cloud-build/daily-tests/blueprints/kueue-config-files/host-topology-tas-small-job.yaml)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
     echo ${array[0]}
   args:
     executable: /bin/bash
@@ -45,7 +45,7 @@
 - name: Ensure all pods are on the same host
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pods \
+    kubectl get pods -v=9\
     -o custom-columns="Name:.metadata.name,Host:.spec.nodeSelector.cloud\.google\.com/gce-topology-host" | \
     sort -k2 | uniq -f 1 | wc -l
   register: unique_host_count
@@ -56,7 +56,7 @@
 - name: Delete the host topology kueue job
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete --all jobs
+    kubectl delete --all jobs -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -65,7 +65,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/tools/cloud-build/daily-tests/blueprints/kueue-config-files/rack-topology-tas-small-job.yaml)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
     echo ${array[0]}
   args:
     executable: /bin/bash
@@ -74,7 +74,7 @@
 - name: Ensure all pods are on the same rack
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pods \
+    kubectl get pods -v=9\
     -o custom-columns="Name:.metadata.name,Host:.spec.nodeSelector.cloud\.google\.com/gce-topology-subblock" | \
     sort -k2 | uniq -f 1 | wc -l
   register: unique_host_count
@@ -85,7 +85,7 @@
 - name: Delete the rack topology kueue job
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete --all jobs
+    kubectl delete --all jobs -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -94,7 +94,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/tools/cloud-build/daily-tests/blueprints/kueue-config-files/block-topology-tas-small-job.yaml)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
     echo ${array[0]}
   args:
     executable: /bin/bash
@@ -103,7 +103,7 @@
 - name: Ensure all pods are on the same block
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get pods \
+    kubectl get pods -v=9\
     -o custom-columns="Name:.metadata.name,Host:.spec.nodeSelector.cloud\.google\.com/gce-topology-block" | \
     sort -k2 | uniq -f 1 | wc -l
   register: unique_host_count

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-hyperdisk.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-hyperdisk.yml
@@ -14,14 +14,14 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Execute the job
   delegate_to: localhost
   ansible.builtin.shell: |
     jobs=({{ workspace }}/{{ deployment_name }}/primary/tensorflow*)
     for job in "${jobs[@]}"; do
-      kubectl create -f "$job"
+      kubectl create -f "$job" -v=9
     done
   args:
     executable: /bin/bash
@@ -30,7 +30,7 @@
 - name: Wait for job to complete
   delegate_to: localhost
   ansible.builtin.command: |
-    kubectl get job --field-selector  status.successful=1
+    kubectl get job --field-selector  status.successful=1 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 3 # 3 jobs total
   retries: 80

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-parallelstore.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-parallelstore.yml
@@ -14,14 +14,14 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Execute the job
   delegate_to: localhost
   ansible.builtin.shell: |
     jobs=({{ workspace }}/{{ deployment_name }}/primary/tensorflow*)
     for job in "${jobs[@]}"; do
-      kubectl create -f "$job"
+      kubectl create -f "$job" -v=9
     done
   args:
     executable: /bin/bash
@@ -30,7 +30,7 @@
 - name: Get job detail
   delegate_to: localhost
   ansible.builtin.command: |
-    kubectl get job
+    kubectl get job -v=9
   register: job_detail
 
 - name: Print job_detail debug output
@@ -40,7 +40,7 @@
 - name: Wait for job to complete
   delegate_to: localhost
   ansible.builtin.command: |
-    kubectl get job --field-selector  status.successful=1
+    kubectl get job --field-selector  status.successful=1 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 1
   retries: 80

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-ray.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-ray.yml
@@ -21,12 +21,12 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
 - name: Check ray CRDs exists in the cluster
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl get rayjobs.ray.io
+    kubectl get rayjobs.ray.io -v=9
   args:
     executable: /bin/bash
   changed_when: False

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-ml-gke-e2e-validation.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-ml-gke-e2e-validation.yml
@@ -20,14 +20,14 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ cli_deployment_vars.region }} --project {{ custom_vars.project }} --verbosity=debug
 
 # JOB 1
 - name: Execute job on g2 latest driver pool
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/{{ deployment_name }}/primary/job-g2-latest-driver*)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -37,7 +37,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/{{ deployment_name }}/primary/job-n1-pool-default*)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -47,7 +47,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/{{ deployment_name }}/primary/job-n1-pool-full-spec*)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -57,7 +57,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     array=({{ workspace }}/{{ deployment_name }}/primary/job-default-settings-pool*)
-    kubectl create -f ${array[0]}
+    kubectl create -f ${array[0]} -v=9
   args:
     executable: /bin/bash
   changed_when: False
@@ -65,7 +65,7 @@
 - name: Wait for jobs to complete
   delegate_to: localhost
   ansible.builtin.command: |
-    kubectl get job --field-selector  status.successful=1
+    kubectl get job --field-selector  status.successful=1 -v=9
   register: job_completion
   until: job_completion.stdout_lines | length > 4  # 4 jobs total
   retries: 40


### PR DESCRIPTION
Added -v=9 with kubectl and --verbosity=debug with gcloud container clusters because these flags provide the highest level of detail for each command. , especially raw API requests and responses. This is crucial for deep debugging to understand exactly what the tools are doing, diagnose obscure errors, and troubleshoot connectivity or permission issues at the lowest level.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
