### PR TITLE
Replace extended_reservation variable with reservation for TPU

### DIFF
--- a/community/examples/gke-tpu-v6/README.md
+++ b/community/examples/gke-tpu-v6/README.md
@@ -70,9 +70,13 @@ This section guides you through the cluster creation process, ensuring that your
    * `tpu_topology`: the TPU placement topology for pod slice node pool.
    * `static_node_count`: the number of TPU nodes in your cluster.
    * `authorized_cidr`: The IP address range that you want to allow to connect with the cluster. This CIDR block must include the IP address of the machine to call Terraform.
-   * `extended_reservation`: the name of your reservation. To target a specific block within your reservation, use the reservation and block names in the format `RESERVATION_NAME/reservationBlocks/BLOCK_NAME`.
+   * `reservation`: the name of the compute engine reservation of TPU v6 nodes.
 
     To modify advanced settings, edit `community/examples/gke-tpu-v6/gke-tpu-v6.yaml`.
+
+1. To use on-demand capacity, you can remove the reservation usage by making the following changes.
+   1. Remove the `reservation` variable from the [`gke-tpu-v6-deployment.yaml`](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml) file.
+   1. Remove the `reservation_affinity` block from the nodepool module.
 
 1. Generate [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp) to provide access to Terraform.
 

--- a/community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml
@@ -53,8 +53,5 @@ vars:
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
-  # The name of the compute engine reservation of TPU v4 nodes in the form of
-  # <project>/<reservation-name>
-  # In order to target a BLOCK_NAME, extended_reservation can be inputted as
-  # <project>/<reservation-name>/reservationBlocks/<reservation-block-name>
-  extended_reservation:
+  # The name of the compute engine reservation of TPU v6 nodes
+  reservation:

--- a/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
@@ -46,11 +46,8 @@ vars:
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
-  # The name of the compute engine reservation of TPU v4 nodes in the form of
-  # <project>/<reservation-name>
-  # In order to target a BLOCK_NAME, extended_reservation can be inputted as
-  # <project>/<reservation-name>/reservationBlocks/<reservation-block-name>
-  extended_reservation:
+  # The name of the compute engine reservation of TPU v6 nodes
+  reservation:
 
 
 deployment_groups:
@@ -115,7 +112,7 @@ deployment_groups:
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:
-        - name: $(vars.extended_reservation)
+        - name: $(vars.reservation)
       placement_policy:
         type: COMPACT
         tpu_topology: $(vars.tpu_topology)


### PR DESCRIPTION
Replace extended_reservation variable with reservation, for TPU example as this can confuse users into thinking TPUs have extended reservation support.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
