### PR TITLE
Improve Slurm tests

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -93,12 +93,9 @@ def start_motd():
     util.run(f"wall -n '{wall_msg}'", timeout=30)
 
 
-def end_motd(broadcast=True):
+def end_motd():
     """modify motd to signal that setup is complete"""
     Path("/etc/motd").write_text(MOTD_HEADER)
-
-    if not broadcast:
-        return
 
     run(
         "wall -n '*** Slurm {} setup complete ***'".format(lookup().instance_role),

--- a/tools/python-integration-tests/slurm_reconfig_size.py
+++ b/tools/python-integration-tests/slurm_reconfig_size.py
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ssh import SSHManager
 from deployment import Deployment
 from test import SlurmTest
 import unittest
 import time
+import logging
 
 class SlurmReconfigureSize(SlurmTest):
     # Class to test simple reconfiguration
@@ -26,7 +26,7 @@ class SlurmReconfigureSize(SlurmTest):
     
     def runTest(self):
         # Check 5 nodes are available
-        self.assert_equal(len(self.get_nodes()), 5)
+        self.assertEqual(len(self.get_nodes()), 5)
         
         self.deployment = Deployment(self.reconfig_blueprint)
         self.deployment.deploy()
@@ -35,7 +35,8 @@ class SlurmReconfigureSize(SlurmTest):
         time.sleep(90)
 
         # Check 3 nodes are available
-        self.assert_equal(len(self.get_nodes()), 3)
+        self.assertEqual(len(self.get_nodes()), 3)
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -17,73 +17,179 @@ import subprocess
 import socket
 import time
 import paramiko
+import logging
+import re
+import select
+import pty
+import contextlib
+import functools
+import shlex
+
+log = logging.getLogger()
+logging.getLogger("paramiko").setLevel("INFO")
+
+@functools.lru_cache()
+def init_key() -> str:
+    key_path = os.path.expanduser("~/.ssh/slurm_tests")
+    os.makedirs(os.path.dirname(key_path), exist_ok=True)
+
+    if os.path.exists(key_path):
+        log.info(f"{key_path=} already exists, reusing")
+    else:
+        subprocess.run(["ssh-keygen", "-t", "rsa", "-f", key_path, "-N", ""], check=True)
+
+    # Add the public key to OS Login
+    public_key_path = key_path + ".pub"
+    subprocess.run(["gcloud", "compute", "os-login", "ssh-keys", "add", "--key-file", public_key_path, "--ttl", "60m"], check=True, stdout=subprocess.DEVNULL)
+    return key_path
+
+
+def find_open_port():
+    while True:
+        with contextlib.closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            s.bind(("localhost", 0))
+            s.listen(1)
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            port = s.getsockname()[1]
+        yield port
+
+class Tunnel:
+    def __init__(self, host:str, project:str, zone:str, target_port:int=22):
+        self.host = host
+        self.target_port = target_port
+        self.port, self.proc = -1, None # pre-init to account for failed `_start_tunnel`
+        self.port, self.proc = self._start_tunnel(host, project, zone, target_port)
+
+    def __del__(self) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        if self.proc:
+            return f"Tunnel({self.port}:{self.host}:{self.target_port}<{self.proc.pid}>)"
+        return f"Tunnel({self.port}:{self.host}:{self.target_port}<closed>)"
+
+    def close(self) -> None:
+        if not self.proc:
+            return
+        if log:
+            log.info(f"closing {self}")
+        self.proc.terminate()
+        if time:
+            time.sleep(1) # give a second to terminate
+        if self.proc.poll() is None: 
+            self.proc.kill() # kill leftover process if still running
+        # TODO: shall we recursively kill children?
+
+
+    def _start_tunnel(self, instance:str, project:str, zone:str,  target_port:int):
+        listen = re.compile(r"^Listening on port \[\d+\].\n$")
+        log.info(f"start tunnel {instance}:{target_port}")
+
+        def tunnel(port: int):
+            """Attempt to create an iap tunnel on the local port"""
+            # the pty makes gcloud output a message on success, allowing us to
+            # proceed faster
+            stdoutfd, peer = pty.openpty()
+            stdout = os.fdopen(stdoutfd)
+            cmd = f"gcloud compute start-iap-tunnel {instance} {target_port} --{project=} --{zone=} --local-host-port=localhost:{port}"
+            log.info(f"Running {cmd}")
+            proc = subprocess.Popen(
+                shlex.split(cmd),
+                shell=False,
+                text=True,
+                stderr=subprocess.PIPE,
+                stdout=peer,
+                stdin=subprocess.DEVNULL,
+            )
+            stdout_sel = select.poll()
+            stdout_sel.register(stdout, select.POLLIN)
+            for w in [0.5, 1, 2, 4, 8, 16]:  # exponential backoff
+                if proc.poll() is None:
+                    if stdout_sel.poll(1):
+                        out = stdout.readline()
+                        log.info(f"gcloud iap-tunnel: {out}")
+                        if listen.match(out):
+                            log.info(f"gcloud iap-tunnel created on port {port}")
+                            return proc
+                else:
+                    stderr = proc.stderr.read() if proc.stderr else ""
+                    if "Could not fetch resource" in stderr:
+                        raise RuntimeError(f"Tunnel failed with unrecoverable error: {stderr}")
+                    log.info(f"gcloud iap-tunnel failed on {port=}, rc={proc.returncode}, {stderr=}")
+                    return None # to be retried
+                time.sleep(w)
+            log.error(f"gcloud iap-tunnel timed out on port {port}")
+            proc.kill()
+            return None
+
+        for port in find_open_port():
+            try:
+                t = tunnel(port)
+            except Exception:
+                log.exception("tunnel creation failed")
+                raise
+            if t is not None:
+                return port, t
+        raise RuntimeError("No available port found")
 
 class SSHManager:
-    # Manages tunnel and SSH connection.
-    _instance = None
+    def __init__(self, user: str, project: str, zone: str) -> None:
+        self.user = user
+        self.project = project
+        self.zone = zone
+        self.ssh_conns = {}
+        self.tunnels = {}
 
-    def __new__(cls, *args, **kwargs):
-       if not cls._instance:
-           cls._instance = super(SSHManager, cls).__new__(cls)
-       return cls._instance
+    def close(self) -> None:
+        for hostname in list(self.ssh_conns.keys()):
+            ssh = self.ssh_conns.get(hostname)
+            if ssh:
+                ssh.close()
+                del self.ssh_conns[hostname]
 
-    def __init__(self):
-        if not hasattr(self, 'ssh_client'):
-            self.tunnel = None
-            self.key = None
-            self.ssh_client = None
-            self.local_port = None
+        for hostname in list(self.tunnels.keys()):
+            tunnel = self.tunnels.get(hostname)
+            if tunnel:
+                tunnel.close()
+                del self.tunnels[hostname]
 
-    def run_command(self, cmd: str) -> subprocess.CompletedProcess:
-        res = subprocess.run(cmd, text=True, check=True, capture_output=True)
+    def tunnel(self, hostname: str) -> Tunnel:
+        if hostname not in self.tunnels:
+            self.tunnels[hostname] = Tunnel(hostname, self.project, self.zone)
+        return self.tunnels[hostname]
 
-    def get_available_port(self):
-        sock = socket.socket()
-        sock.bind(('', 0))
-        port = sock.getsockname()[1]
-        sock.close()
-        return port
 
-    def create_tunnel(self, instance_name, project_id, zone):
-        iap_tunnel_cmd = [
-            "gcloud", "compute", "start-iap-tunnel", instance_name,
-            "22", "--project", project_id, "--zone", zone,
-            f"--local-host-port=localhost:{self.local_port}"
-        ]
+    def ssh(self, hostname: str) -> paramiko.SSHClient:
+        if hostname in self.ssh_conns:
+            return self.ssh_conns[hostname]
 
-        self.tunnel = subprocess.Popen(iap_tunnel_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        
-        # Sleep to give the tunnel a few seconds to set up
-        time.sleep(3)
+        ssh = paramiko.SSHClient()
+        key = paramiko.RSAKey.from_private_key_file(init_key())
+        ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+        for wait in [0.5, 1, 2, 4, 8, 16, 32, 64, 128]:  # exponential backoff
+            tun = self.tunnel(hostname)
+            log.info(f"start ssh connection to {self.user}@{hostname} port {tun.port}")
+            try:
+                ssh.connect("127.0.0.1", username=self.user, pkey=key, port=tun.port)
+                break
+            except paramiko.ssh_exception.NoValidConnectionsError:
+                log.error("ssh connection failed, retrying tunnel")
+                time.sleep(wait)
+                tun = self.tunnels.pop(hostname)
+                tun.close()
+                continue
+            except Exception as e:
+                log.error(f"error on start ssh connection: {e}")
+        else:
+            log.error(f"Cannot connect through tunnel: {hostname}")
+            raise Exception(f"Cannot connect through tunnel: {hostname}")
+        self.ssh_conns[hostname] = ssh
+        return ssh
 
-    def get_keypath(self):
-        key_path = os.path.expanduser("~/.ssh/google_compute_engine")
-        os.makedirs(os.path.dirname(key_path), exist_ok=True)
 
-        self.run_command(["ssh-keygen", "-t", "rsa", "-f", key_path, "-N", ""])
-
-        # Add the public key to OS Login
-        public_key_path = key_path + ".pub"
-        self.run_command(["gcloud", "compute", "os-login", "ssh-keys", "add", "--key-file", public_key_path, "--ttl", "60m"])
-
-        return key_path
-
-    def setup_connection(self, instance_name, project_id, zone):
-        self.ssh_client = paramiko.SSHClient()
-        self.ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
-        self.key = paramiko.RSAKey.from_private_key_file(self.get_keypath())
-        self.local_port = self.get_available_port()
-        self.create_tunnel(instance_name, project_id, zone)
-
-    def close(self):
-        # Closes existing SSH connection and tunnel
-        if self.ssh_client:
-            self.ssh_client.close()
-        if self.tunnel:
-            self.tunnel.terminate()
-            time.sleep(1) # give a second to terminate
-            if self.tunnel.poll() is None: 
-                self.tunnel.kill() # kill leftover process if still running
-            self.tunnel.stdout.close()
-            self.tunnel.stderr.close()
-            self.tunnel = None
+def exec_and_check(ssh: paramiko.SSHClient, cmd: str) -> str:
+    _, stdout, stderr = ssh.exec_command(cmd)
+    rc = stdout.channel.recv_exit_status()
+    if rc != 0:
+        raise RuntimeError(f"'{cmd}' exited with code {rc}: {stderr.read().decode()}")
+    return stdout.read().decode()


### PR DESCRIPTION
* Don't override pre-existing SSH-key;
* Don't override "normal" key file `google_compute_engine`, instead use dedicated `slurm_tests`;
* Add more logging;
* Use shared tunnels and ssh connections;
* Log out output of commands;
* Don't use `time.sleep`, instead inspect outputs of commands to decide readiness (tunnel setup);
* Inspect `/slurm/scripts/setup.log` to decide on readiness.