### PR TITLE
Avoid "drop user" noise in setup.log

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -341,23 +341,13 @@ innodb_lock_wait_timeout=900
     run("systemctl enable mariadb", timeout=30)
     run("systemctl restart mariadb", timeout=30)
 
-    mysql = "mysql -u root -e"
-    run(f"""{mysql} "drop user 'slurm'@'localhost'";""", timeout=30, check=False)
+    mysql, host = "mysql -u root -e", lookup().control_host
+    run(f"""{mysql} "drop user if exists 'slurm'@'localhost'";""", timeout=30)
     run(f"""{mysql} "create user 'slurm'@'localhost'";""", timeout=30)
-    run(
-        f"""{mysql} "grant all on slurm_acct_db.* TO 'slurm'@'localhost'";""",
-        timeout=30,
-    )
-    run(
-        f"""{mysql} "drop user 'slurm'@'{lookup().control_host}'";""",
-        timeout=30,
-        check=False,
-    )
-    run(f"""{mysql} "create user 'slurm'@'{lookup().control_host}'";""", timeout=30)
-    run(
-        f"""{mysql} "grant all on slurm_acct_db.* TO 'slurm'@'{lookup().control_host}'";""",
-        timeout=30,
-    )
+    run(f"""{mysql} "grant all on slurm_acct_db.* TO 'slurm'@'localhost'";""", timeout=30)
+    run(f"""{mysql} "drop user if exists 'slurm'@'{host}'";""", timeout=30)
+    run(f"""{mysql} "create user 'slurm'@'{host}'";""", timeout=30)
+    run(f"""{mysql} "grant all on slurm_acct_db.* TO 'slurm'@'{host}'";""", timeout=30)
 
 
 def configure_dirs():


### PR DESCRIPTION
Avoid confusing errors in `setup.log` by adding `if exists` to `drop user` statements.

```
2025-05-29 22:50:55,840 ERROR: Command '['mysql', '-u', 'root', '-e', "drop user 'slurm'@'localhost';"]' returned exit status 1.
2025-05-29 22:50:55,841 ERROR: stderr: --------------
drop user 'slurm'@'localhost'
--------------

ERROR 1396 (HY000) at line 1: Operation DROP USER failed for 'slurm'@'localhost'
2025-05-29 22:50:55,859 ERROR: Command '['mysql', '-u', 'root', '-e', "drop user 'slurm'@'qq-controller';"]' returned exit status 1.
2025-05-29 22:50:55,859 ERROR: stderr: --------------
drop user 'slurm'@'qq-controller'
--------------

ERROR 1396 (HY000) at line 1: Operation DROP USER failed for 'slurm'@'qq-controller'
```