### PR TITLE
speed up deployment of GKE clusters

### DIFF
--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -89,6 +89,7 @@ resource "google_container_cluster" "gke_cluster" {
   # decouple node pool lifecycle from cluster life cycle
   remove_default_node_pool = true
   initial_node_count       = 1 # must be set when remove_default_node_pool is set
+  node_locations           = var.system_node_pool_zones
 
   deletion_protection = var.deletion_protection
 


### PR DESCRIPTION
### Submission Checklist

Simplify the Cluster Deployment operation for regional cluster deployment to reduce the time required to provision a GKE cluster by ~2 minutes.

With optimisation:

```
module.gke_cluster.google_container_cluster.gke_cluster: Creation complete after 8m49s [id=projects/hpc-toolkit-dev/locations/us-west4/clusters/gke-a3-mega-temp]
```

Without optimisation:

```
module.gke_cluster.google_container_cluster.gke_cluster: Creation complete after 10m30s [id=projects/hpc-toolkit-dev/locations/us-west4/clusters/gke-a3-mega-pb0]
```


NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
