### PR TITLE
Remove Docker configuration warning

### DIFF
--- a/modules/scripts/startup-script/files/install_docker.yml
+++ b/modules/scripts/startup-script/files/install_docker.yml
@@ -43,10 +43,7 @@
       dest: /etc/docker/daemon.json
       mode: '0644'
       content: '{{ docker_daemon_config }}'
-      # validate flag requires Docker server version 23.0 and above
-      # can add this back after private A3 DLVM image is deprecated
-      # this image comes with Docker version 20.10.17
-      # validate: /usr/bin/dockerd --validate --config-file %s
+      validate: /usr/bin/dockerd --validate --config-file %s
     when: docker_daemon_config
     notify:
     - Restart Docker

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -226,19 +226,6 @@ locals {
   }
 }
 
-check "health_check" {
-  assert {
-    condition     = local.docker_config == {}
-    error_message = <<-EOT
-      This message is only a warning. The Toolkit performs no validation of the
-      Docker daemon configuration. VM startup scripts will fail if the file is not
-      a valid Docker JSON configuration. Please review the Docker documentation:
-
-      https://docs.docker.com/engine/daemon/
-    EOT
-  }
-}
-
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }


### PR DESCRIPTION
With the EOL of Ubuntu 20.04 and #4167, we can now use built-in Ansible features to validate Docker configurations and fail explicitly. This removes a generic warning which the UI presents very similarly to an error.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
