### PR TITLE
Allow to run slum tests on already deployed cluster

### DIFF
--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -33,4 +33,4 @@ steps:
     cd /workspace && make
     export BUILD_ID="${BUILD_ID}"
 
-    python3 tools/python-integration-tests/slurm_simple_job_completion.py tools/python-integration-tests/blueprints/slurm-flex.yaml
+    python3 tools/python-integration-tests/slurm_simple_job_completion.py --blueprint=tools/python-integration-tests/blueprints/slurm-flex.yaml

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -33,4 +33,4 @@ steps:
     cd /workspace && make
     export BUILD_ID="${BUILD_ID}"
 
-    python3 tools/python-integration-tests/slurm_simple_job_completion.py tools/python-integration-tests/blueprints/slurm-simple.yaml
+    python3 tools/python-integration-tests/slurm_simple_job_completion.py  --blueprint=tools/python-integration-tests/blueprints/slurm-simple.yaml

--- a/tools/python-integration-tests/deployment.py
+++ b/tools/python-integration-tests/deployment.py
@@ -25,7 +25,6 @@ class Deployment:
         self.state_bucket = "daily-tests-tf-state"
         self.project_id = None
         self.workspace = None
-        self.instance_name = None
         self.username = None
         self.deployment_name = None
         self.blueprint_name = None
@@ -44,13 +43,14 @@ class Deployment:
 
     def get_posixAccount_info(self):
         # Extract the username from posixAccounts
-        result = self.run_command(f"gcloud compute os-login describe-profile --format=json").stdout
+        cmd = "gcloud compute os-login describe-profile --format=json"
+        result = self.run_command(cmd).stdout
         posixAccounts = json.loads(result)
 
         for account in posixAccounts.get('posixAccounts', []):
             if 'accountId' in account:
-                self.project_id = account['accountId']
-                self.username = account['username']
+                return account['accountId'], account['username']
+        raise RuntimeError(f"Can not find a project in `{cmd}`")
 
     def generate_uniq_deployment_name(self):
         BUILD_ID = os.environ.get('BUILD_ID')
@@ -61,8 +61,7 @@ class Deployment:
         self.workspace = os.path.abspath(os.getcwd().strip())
         self.parse_blueprint(self.blueprint_file)
         self.deployment_name = self.generate_uniq_deployment_name()
-        self.get_posixAccount_info()
-        self.instance_name = self.deployment_name.replace("-", "")[:10] + "-slurm-login-001"
+        self.project_id, self.username = self.get_posixAccount_info()
 
     def create_blueprint(self):
         cmd = [

--- a/tools/python-integration-tests/external_deployment.py
+++ b/tools/python-integration-tests/external_deployment.py
@@ -1,0 +1,27 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class ExternalDeployment:
+    def __init__(self, *, project_id: str, zone: str, username: str, deployment_name: str) -> None:
+        self.project_id = project_id
+        self.zone = zone
+        self.username = username
+        self.deployment_name = deployment_name
+
+    def deploy(self) -> None:
+        pass
+
+    def destroy(self) -> None:
+        pass
+    

--- a/tools/python-integration-tests/slurm_reconfig_size.py
+++ b/tools/python-integration-tests/slurm_reconfig_size.py
@@ -12,23 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ssh import SSHManager
 from deployment import Deployment
-from test import SlurmTest
-import unittest
+import test
 import time
 
-class SlurmReconfigureSize(SlurmTest):
-    # Class to test simple reconfiguration
-    def __init__(self, deployment):
-        super().__init__(Deployment("tools/python-integration-tests/blueprints/slurm-reconfig-before.yaml"))
-        self.reconfig_blueprint = "tools/python-integration-tests/blueprints/slurm-reconfig-after.yaml"
+class SlurmReconfigureSize(test.SlurmTest):
+    INIT_BP = "tools/python-integration-tests/blueprints/slurm-reconfig-before.yaml"
+    RECONFIG_BP = "tools/python-integration-tests/blueprints/slurm-reconfig-after.yaml"
+    
+    def get_deployment(self) -> Deployment:
+        return Deployment(SlurmReconfigureSize.INIT_BP)
+    
     
     def runTest(self):
         # Check 5 nodes are available
         self.assert_equal(len(self.get_nodes()), 5)
         
-        self.deployment = Deployment(self.reconfig_blueprint)
+        self.deployment = Deployment(SlurmReconfigureSize.RECONFIG_BP)
         self.deployment.deploy()
         
         # Wait 90 seconds for reconfig
@@ -38,4 +38,4 @@ class SlurmReconfigureSize(SlurmTest):
         self.assert_equal(len(self.get_nodes()), 3)
 
 if __name__ == "__main__":
-    unittest.main()
+    test.slurmtests_main()

--- a/tools/python-integration-tests/slurm_simple_job_completion.py
+++ b/tools/python-integration-tests/slurm_simple_job_completion.py
@@ -12,71 +12,47 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ssh import SSHManager
 from deployment import Deployment
-from test import SlurmTest
-import argparse
-import sys
-import unittest
+import test
 import time
 import json
 
-class SlurmSimpleJobCompletionTest(SlurmTest):
-    # Class to test simple slurm job completion
-    def __init__(self, deployment):
-        super().__init__(Deployment(self.Blueprint))
-        self.job_list = {}
+class SlurmSimpleJobCompletionTest(test.SlurmTest):
+    def get_deployment(self) -> Deployment:
+        bp = test.SLURMTESTS_ARGS.blueprint
+        assert bp
+        return Deployment(bp)
 
+    # Class to test simple slurm job completion
     def runTest(self):
         # Submits 5 jobs and checks if they are successful.
-        for i in range(5):
-            self.submit_job('sbatch -N 1 --wrap "sleep 20"')
-        self.monitor_squeue()
+        job_ids = []
+        for _ in range(5):
+            job_ids.append(self.submit_job('sbatch -N 1 --wrap "sleep 20"'))
+        self.wait_until_squeue_is_empty()
 
-        for job_id in self.job_list.keys():
-            result = self.is_job_complete(job_id)
-            self.assert_equal(True, result, f"Something went wrong with JobID:{job_id}.")
+        for job_id in job_ids:
+            self.assertIn("COMPLETED", self.job_state(job_id), f"Something went wrong with JobID:{job_id}.")
             print(f"JobID {job_id} finished successfully.")
 
-    def monitor_squeue(self):
-        # Monitors squeue and updates self.job_list until all running jobs are complete.
-        lines = []
-
+    def wait_until_squeue_is_empty(self):
         while True:
             stdin, stdout, stderr = self.ssh_client.exec_command('squeue')
-
             lines = stdout.read().decode().splitlines()[1:] # Skip header
 
             if not lines:
                 break
-            for line in lines:
-                parts = line.split()
-                job_id, partition, _, _, state, times, nodes, nodelist = line.split()
-
-                if job_id not in self.job_list:
-                    print(f"Job id {job_id} is not recognized.")
-                else:
-                    self.job_list[job_id].update({
-                        "partition": partition,
-                        "state": state,
-                        "time": times,
-                        "nodes": nodes,
-                        "nodelist": nodelist,
-                    })
             time.sleep(5)
 
-    def is_job_complete(self, job_id: str):
+    def job_state(self, job_id: str) -> list[str]:
         # Checks if a job successfully completed.
         stdin, stdout, stderr = self.ssh_client.exec_command(f'scontrol show job {job_id} --json')
         content = json.load(stdout)
-        return content["jobs"][0]["job_state"][0] == "COMPLETED"
+        return content["jobs"][0]["job_state"]
 
-    def submit_job(self, cmd: str):
+    def submit_job(self, cmd: str) -> str:
         stdin, stdout, stderr = self.ssh_client.exec_command(cmd)
-        jobID = stdout.read().decode().split()[-1]
-        self.job_list[jobID] = {}
+        return stdout.read().decode().split()[-1]
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        SlurmSimpleJobCompletionTest.Blueprint = sys.argv.pop()
-    unittest.main()
+    test.slurmtests_main()

--- a/tools/python-integration-tests/slurm_topology.py
+++ b/tools/python-integration-tests/slurm_topology.py
@@ -14,18 +14,17 @@
 
 from ssh import SSHManager
 from deployment import Deployment
-from test import SlurmTest
 from collections import defaultdict
-import unittest
 import logging
+import test
 
 logging.basicConfig(level=logging.INFO) 
 log = logging.getLogger()
 
-class SlurmTopologyTest(SlurmTest):
+class SlurmTopologyTest(test.SlurmTest):
     # Class to test Slurm topology
-    def __init__(self, deployment):
-        super().__init__(Deployment("tools/python-integration-tests/blueprints/topology-test.yaml"))
+    def get_deployment(self) -> Deployment:
+        return Deployment("tools/python-integration-tests/blueprints/topology-test.yaml")
 
     def runTest(self):
         # Checks isomorphism of last layer of nodes to determine topology.
@@ -68,4 +67,4 @@ class SlurmTopologyTest(SlurmTest):
         return switch_name
 
 if __name__ == "__main__":
-    unittest.main()
+    test.slurmtests_main()

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -57,10 +57,13 @@ class SSHManager:
         time.sleep(3)
 
     def get_keypath(self):
-        key_path = os.path.expanduser("~/.ssh/google_compute_engine")
+        key_path = os.path.expanduser("~/.ssh/slurm_tests")
         os.makedirs(os.path.dirname(key_path), exist_ok=True)
 
-        self.run_command(["ssh-keygen", "-t", "rsa", "-f", key_path, "-N", ""])
+        if os.path.exists(key_path):
+            pass
+        else:
+            self.run_command(["ssh-keygen", "-t", "rsa", "-f", key_path, "-N", ""])
 
         # Add the public key to OS Login
         public_key_path = key_path + ".pub"

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -90,3 +90,11 @@ class SSHManager:
             self.tunnel.stdout.close()
             self.tunnel.stderr.close()
             self.tunnel = None
+
+
+def exec_and_check(ssh: paramiko.SSHClient, cmd: str) -> str:
+    _, stdout, stderr = ssh.exec_command(cmd)
+    rc = stdout.channel.recv_exit_status()
+    if rc != 0:
+        raise RuntimeError(f"'{cmd}' exited with code {rc}: {stderr.read().decode()}")
+    return stdout.read().decode()


### PR DESCRIPTION
```sh
$ python3 tools/python-integration-tests/slurm_simple_job_completion.py --deployment-name=qq --project=io-playground --zone=us-central1-a --username=ext_orlov_google_com

...

JobID 39 finished successfully.
JobID 40 finished successfully.
JobID 41 finished successfully.
JobID 42 finished successfully.
JobID 43 finished successfully.
.
----------------------------------------------------------------------
Ran 1 test in 155.968s

OK
```

```sh
$ bbs 4236 --names "PR-test-slurm-gcp-v6-reconfig-size" "PR-test-slurm-gcp-v6-simple-job-completion" "PR-test-slurm-flex" "PR-test-slurm-gcp-v6-topology" -c 5
Using PR#4236: Allow to run slum tests on already deployed cluster
SUCCESS    PR-test-slurm-flex   go/ghpc-cb/d86808dd-50b7-4bef-a4e1-5079ac18ec99
SUCCESS    PR-test-slurm-gcp-v6-reconfig-size   go/ghpc-cb/19b76630-3547-42ad-8745-ac940887063f
SUCCESS    PR-test-slurm-gcp-v6-simple-job-completion   go/ghpc-cb/b32c911d-ad53-4b47-9f18-bf2179f057a4
SUCCESS    PR-test-slurm-gcp-v6-topology        go/ghpc-cb/020b9444-bcb3-4b62-80a1-98a7c15e93da
------- TOTAL:4 | SUCCESS: 4
done
```