### PR TITLE
Support disabling Single Node Health Checks using --task-prolog switc…

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tools/gpu-test
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tools/gpu-test
@@ -40,8 +40,6 @@ fi
 ###################################################
 # Disable running health checks
 ###################################################
-# The following change was implemented for https://b.corp.google.com/issues/421985463 and
-# https://b.corp.google.com/issues/421983794
 # Check if the environment variable '$SLURM_JOB_EXTRA' is set and contains the
 # substring 'healthchecks_prolog=off'
 if [[ -n "$SLURM_JOB_EXTRA" ]]; then


### PR DESCRIPTION
This CL checks if the environment variable '$SLURM_JOB_EXTRA' is set and contains if its value matches the substring 'healthchecks_prolog=off' . If it there is a substring match, then it exits the script without running Health Checks. 

The value of the environment variable $SLURM_JOB_EXTRA is set by the --task-prolog switch 

https://slurm.schedmd.com/prolog_epilog.html

