### PR TITLE
Fix job row insertion on load_bq.py

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/load_bq.py
@@ -93,7 +93,7 @@ schema_fields = [
     schema_field("cluster_id", "STRING", "UUID for the cluster", required=True),
     schema_field("entry_uuid", "STRING", "entry UUID for the job row", required=True),
     schema_field(
-        "job_db_uuid", "INT64", "job db index from the slurm database", required=True
+        "job_db_uuid", "STRING", "job db index from the slurm database", required=True
     ),
     schema_field("job_id_raw", "INT64", "raw job id", required=True),
     schema_field("job_id", "STRING", "job id", required=True),


### PR DESCRIPTION
See https://github.com/GoogleCloudPlatform/cluster-toolkit/issues/3944 for additional context.

Before when type casting `job_db_uuid` as `INT_64`:
```
Apr 14 21:07:09 smallslurm-controller load_bq.py[10026]: {'errors': [{'debugInfo': '',
Apr 14 21:07:09 smallslurm-controller load_bq.py[10026]: 'location': 'job_db_uuid',
Apr 14 21:07:09 smallslurm-controller load_bq.py[10026]: 'message': 'Cannot convert value to integer (bad value): '
Apr 14 21:07:09 smallslurm-controller load_bq.py[10026]: '9797115724809186304',
Apr 14 21:07:09 smallslurm-controller load_bq.py[10026]: 'reason': 'invalid'}],

9,797,115,724,809,186,304 > 9,223,372,036,854,775,807 A.K.A INT64 limit
```
Solution:
Represent `job_db_uuid` as a STRING like other uuid's.

```
Jun 10 02:06:31 abslurm-controller load_bq.py[5342]: loading 1 batches of BigQuery data in batches of size : 5000
Jun 10 02:06:31 abslurm-controller load_bq.py[5342]: loading BigQuery data batch 0 of 1
Jun 10 02:06:31 abslurm-controller load_bq.py[5342]: successfully loaded 3 jobs
```

Follow up action:
`job_db_uuid` being over INT64 is likely a bug in of itself, and this PR is more to unblock usage of big query.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
