### PR TITLE
Align GCSFuse configurations with best practices

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
@@ -205,18 +205,29 @@ vars:
             group: root
             mode: 0o644
             content: |
+              # GCSFuse configuration optimized for performance.
+              # Aligned with GCSFuse best practices for checkpointing workloads.
               file-cache:
-                max-size-mb: -1
+                max-size-mb: -1 # unlimited cache size
+                cache-file-for-range-read: true
                 enable-parallel-downloads: true
                 download-chunk-size-mb: 50
                 parallel-downloads-per-file: 16
-              cache-dir: /mnt/localssd
+              cache-dir: /mnt/localssd # utilizes local SSD for cache
+              metadata-cache:
+                ttl-secs: -1 # Cache metadata indefinitely
+                stat-cache-max-size-mb: -1 # Cache all stat entries
+                type-cache-max-size-mb: -1 # Cache all type entries
+                negative-ttl-secs: 0 # Do not cache negative lookups
+              implicit-dirs: true
               file-system:
                 dir-mode: "777"
                 file-mode: "777"
+                fuse-options: "allow_other,read_ahead_kb=1024"
                 rename-dir-limit: 20000  # Set to 20000 for hierarchical buckets
-                temp-dir: /mnt/localssd
-                fuse-options: allow_other
+                temp-dir: /mnt/localssd # utilizes local SSD for temp files
+              write:
+                enable-streaming-writes: true
               foreground: true
 
         - name: Create gcsfuse read-only configuration for input data
@@ -226,17 +237,26 @@ vars:
             group: root
             mode: 0o644
             content: |
-              file-cache:
-                max-size-mb: -1
-              metadata-cache:
-                ttl-secs: 3600  # Decrease if your data changes quickly.
+              # GCSFuse configuration optimized for read-only performance.
+              # Aligned with GCSFuse best practices for training workloads.
+              # File cache can be optionally enabled
+              # file-cache:
+              #   max-size-mb: -1
+              #   cache-file-for-range-read: true
+              #   enable-parallel-downloads: true
               cache-dir: /mnt/localssd
+              metadata-cache:
+                negative-ttl-secs: 0 # Do not cache negative lookups
+                ttl-secs: -1  # Cache metadata indefinitely.
+                stat-cache-max-size-mb: -1 # Cache all stat entries
+                type-cache-max-size-mb: -1 # Cache all type entries
+              implicit-dirs: true
               file-system:
                 dir-mode: "755" # need 5 on dir to enable ls
                 file-mode: "644"
-                temp-dir: /mnt/localssd
-                fuse-options: allow_other
-                kernel-list-cache-ttl-secs: 60
+                fuse-options: "allow_other,read_ahead_kb=1024"
+              write:
+                enable-streaming-writes: true
               foreground: true
 
         - name: Create gcsfuse systemd service
@@ -311,11 +331,14 @@ vars:
             group: root
             mode: 0o644
             content: |
+              # GCSFuse configuration for login/controller nodes.
+              implicit-dirs: true
               file-system:
                 dir-mode: "777"
                 file-mode: "777"
-                rename-dir-limit: 20000
-                fuse-options: allow_other
+                fuse-options: "allow_other,read_ahead_kb=1024"
+              write:
+                enable-streaming-writes: true
               foreground: true
 
         - name: Create gcsfuse systemd service


### PR DESCRIPTION
This commit updates the GCSFuse configurations in the a3u-slurm-ubuntu-gcs.yaml example to align with best practices for performance and consistency.

The following configurations were updated:
- /etc/gcsfuse-lssd.yml (A3-Ultra nodes, RW LSSD optimized)
- /etc/gcsfuse-ro.yml (A3-Ultra nodes, RO LSSD optimized)
- /etc/gcsfuse.yml (Login/controller nodes, standard RWX)

Key changes include:
- Enabled `cache-file-for-range-read` and `enable-parallel-downloads` for file caching.
- Set metadata cache TTLs to -1 (infinite) and negative TTL to 0.
- Added `stat-cache-max-size-mb: -1` and `type-cache-max-size-mb: -1` for metadata caching.
- Enabled `implicit-dirs` for file system handling.
- Appended `read_ahead_kb=1024` to fuse options.
- Enabled `enable-streaming-writes` for writable mounts (instead of using temp-dir)
- Added comments indicating the settings are aligned with GCSFuse best practices.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
