### PR TITLE
Allow setup using config/startup scripts from mounted NFS

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -595,12 +595,13 @@ def process_messages(lkp: util.Lookup) -> None:
 
 
 def main():
+    lkp = lookup()
+    if util.should_mount_slurm_bucket() and not lkp.is_controller:
+        return
     try:
         reconfigure_slurm()
     except Exception:
         log.exception("failed to reconfigure slurm")
-
-    lkp = lookup()
     if lkp.is_controller:
         try:
             process_messages(lkp)


### PR DESCRIPTION
To be proceeded by https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/4264

Essentially mirrors the use of `storage.Blob` and instead use `os. DirEntry`. Interface change where `blob.name` is equivalent to `file.path`.

Creates symlink between files in bucket and `/slurm/scripts/`. Shortcutting config hashing is intentional as we don't anticipate needing to update the config at the moment (goes hand in hand with the no-op for slurmsync).

Successful run:
```
2025-06-11 21:25:27,473 INFO: Starting setup, fetching config
2025-06-11 21:25:27,800 INFO: Config fetched
2025-06-11 21:25:27,807 ERROR: Command '['systemctl', 'is-active', '--quiet', 'google-cloud-ops-agent.service']' returned exit status 3.
2025-06-11 21:25:27,812 INFO: Setting up login
2025-06-11 21:25:27,846 INFO: Set up network storage
2025-06-11 21:25:27,847 INFO: Setting up mount (nfs) mount-controller:/home to /home
2025-06-11 21:25:27,847 INFO: Setting up mount (nfs) mount-controller:/opt/apps to /opt/apps
2025-06-11 21:25:27,849 INFO: Waiting for '/home' to be mounted...
2025-06-11 21:25:27,850 INFO: Waiting for '/opt/apps' to be mounted...
2025-06-11 21:25:27,875 INFO: Mount point '/opt/apps' was mounted.
2025-06-11 21:25:27,894 INFO: Mount point '/home' was mounted.
2025-06-11 21:25:27,896 INFO: Mounting munge share to: /mnt/munge
2025-06-11 21:25:27,923 INFO: Copy munge.key from: /mnt/munge
2025-06-11 21:25:27,924 INFO: Restrict permissions of munge.key
2025-06-11 21:25:27,924 INFO: Unmount /mnt/munge
2025-06-11 21:25:28,259 INFO: Check status of cluster services
2025-06-11 21:25:28,297 INFO: Done setting up login
```

Custom startup scripts also propagated on compute nodes:
```
[root@mount-nodeset-0 custom_scripts]# ls
nodeset.d  prolog.d  task_epilog.d  task_prolog.d
[root@mount-nodeset-0 custom_scripts]# cd prolog.d/
[root@mount-nodeset-0 prolog.d]# ls
test_prolog.sh
[root@mount-nodeset-0 custom_scripts]# cd nodeset.d/debugnodeset
[root@mount-nodeset-0 debugnodeset]# ls
ghpc_nodeset_startup.sh
```
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
