### PR TITLE
DO_NOT_MERGE. Example of startup script to fetch `devel.zip`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/files/login_startup.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/files/login_startup.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+
+set -ex
+
+SLURM_DIR=/slurm
+FLAGFILE=$SLURM_DIR/slurm_configured_do_not_remove
+SCRIPTS_DIR=$SLURM_DIR/scripts
+if [[ -z "$HOME" ]]; then
+    # google-startup-scripts.service lacks environment variables
+    HOME="$(getent passwd "$(whoami)" | cut -d: -f6)"
+fi
+
+for i in $(seq 10); do
+    [[ $i -gt 1 ]] && sleep 5;
+    ping -q -w1 -c1 metadata.google.internal > /dev/null && s=0 && break || s=$?;
+    echo "ERROR: Failed to contact metadata server, will retry"
+done
+if [[ $s -ne 0 ]]; then
+    echo "ERROR: Unable to contact metadata server, aborting"
+    wall -n '*** Slurm setup failed in the startup script! see `journalctl -u google-startup-scripts` ***'
+    exit 1
+else
+    echo "INFO: Successfully contacted metadata server"
+fi
+
+for i in $(seq 5); do
+    [[ $i -gt 1 ]] && sleep 2;
+    ping -q -w1 -c1 8.8.8.8 > /dev/null && s=0 && break || s=$?;
+    echo "failed to ping Google DNS, will retry"
+done
+if [[ $s -ne 0 ]]; then
+    echo "WARNING: No internet access detected"
+else
+    echo "INFO: Internet access detected"
+fi
+
+mkdir -p $SCRIPTS_DIR
+URL="http://metadata.google.internal/computeMetadata/v1"
+CLUSTER_NAME=$(curl -sS --fail --header Metadata-Flavor:Google $URL/instance/attributes/slurm_cluster_name)
+MOUNT_BUCKET=$(curl -sS --fail --header Metadata-Flavor:Google $URL/instance/attributes/slurm_bucket_mount)
+
+if [[ $MOUNT_BUCKET != "true" ]]; then
+    echo "ERROR: slurm_bucket_mount should be set to `true`"
+    exit 1
+fi
+
+echo "$CLUSTER_NAME-controller:/slurm/bucket /slurm/bucket     nfs     defaults,hard,intr,_netdev     0 0" >> /etc/fstab
+systemctl daemon-reload
+mkdir -p /slurm/bucket
+
+until mount /slurm/bucket; do
+  echo "WARN: Could not mount config bucket, retrying in 5 seconds."
+  sleep 5
+done
+
+if [[ ! -f /slurm/bucket/slurm-gcp-devel.zip ]]; then
+    echo "ERROR: Could not download SlurmGCP scripts"
+    exit 1
+fi
+
+unzip -o /slurm/bucket/slurm-gcp-devel.zip -d "$SCRIPTS_DIR"
+
+#temporary hack to not make the script fail on TPU vm
+chown slurm:slurm -R "$SCRIPTS_DIR" || true
+chmod 700 -R "$SCRIPTS_DIR"
+
+if [[ -f $FLAGFILE ]]; then
+    echo "WARNING: Slurm was previously configured, quitting"
+    exit 0
+fi
+touch $FLAGFILE
+
+echo "INFO: Running python cluster setup script"
+SETUP_SCRIPT_FILE=$SCRIPTS_DIR/setup.py
+chmod +x $SETUP_SCRIPT_FILE
+exec $SETUP_SCRIPT_FILE

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+data "local_file" "login_startup" {
+  filename = "${path.module}/files/login_startup.sh"
+}
 
 locals {
   # TODO: deprecate `var.login_[ startup_script, startup_scripts_timeout, network_storage]`
@@ -47,4 +50,6 @@ module "login" {
   # trigger replacement of login nodes when the controller instance is replaced
   # Needed for re-mounting volumes hosted on controller
   replace_trigger = google_compute_instance_from_template.controller.self_link
+
+  internal_startup_script = data.local_file.login_startup.content
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -22,6 +22,7 @@ import sys
 import stat
 import time
 import logging
+import uuid
 
 import shutil
 from pathlib import Path
@@ -35,21 +36,21 @@ from more_executors import Executors, ExceptionRetryPolicy
 
 log = logging.getLogger()
 
-def mounts_by_local(mounts):
+def mounts_by_local(mounts: list[NSMount]) -> dict[str, NSMount]:
     """convert list of mounts to dict of mounts, local_mount as key"""
-    return {str(Path(m.local_mount).resolve()): m for m in mounts}
+    return {str(m.local_mount.resolve()): m for m in mounts}
 
 
-def _get_default_mounts(lkp: util.Lookup) -> List[NSDict]:
+def _get_default_mounts(lkp: util.Lookup) -> list[NSMount]:
     if lkp.cfg.disable_default_mounts:
         return []
     return [
-        NSDict(
-                server_ip= "$controller",
-                remote_mount= path,
-                local_mount= path,
-                fs_type= "nfs",
-                mount_options= "defaults,hard,intr",
+        NSMount(
+                server_ip=lkp.controller_mount_server_ip(),
+                remote_mount=path,
+                local_mount=path,
+                fs_type="nfs",
+                mount_options="defaults,hard,intr",
         )
         for path in (
             dirs.home,
@@ -57,19 +58,34 @@ def _get_default_mounts(lkp: util.Lookup) -> List[NSDict]:
         )
     ]
 
-def resolve_network_storage(nodeset=None) -> List[NSMount]:
+def get_slurm_bucket_mount() -> NSMount:
+    bucket, path = util._get_bucket_and_common_prefix()
+    return  NSMount(
+        fs_type="gcsfuse",
+        server_ip="",
+        remote_mount=Path(bucket),
+        local_mount=dirs.slurm_bucket_mount,
+        mount_options=f"defaults,_netdev,implicit_dirs,only_dir={path}",
+    )
+
+def resolve_network_storage() -> List[NSMount]:
     """Combine appropriate network_storage fields to a single list"""
     lkp = lookup()
 
     # create dict of mounts, local_mount: mount_info
     mounts = mounts_by_local(_get_default_mounts(lkp))
 
+    if lkp.is_controller and util.should_mount_slurm_bucket():
+        mounts.update(mounts_by_local([get_slurm_bucket_mount()]))
+
     # On non-controller instances, entries in network_storage could overwrite
     # default exports from the controller. Be careful, of course
-    mounts.update(mounts_by_local(lkp.cfg.network_storage))
+    common = [lkp.normalize_ns_mount(m) for m in lkp.cfg.network_storage]
+    mounts.update(mounts_by_local(common))
 
     if lkp.is_login_node:
-        login_ns = lkp.cfg.login_groups[util.instance_login_group()].network_storage
+        login_group = lkp.cfg.login_groups[util.instance_login_group()] 
+        login_ns = [lkp.normalize_ns_mount(m) for m in login_group.network_storage]
         mounts.update(mounts_by_local(login_ns))
 
     if lkp.instance_role == "compute":
@@ -78,74 +94,46 @@ def resolve_network_storage(nodeset=None) -> List[NSMount]:
         except Exception:
             pass # external nodename, skip lookup
         else:
-            mounts.update(mounts_by_local(nodeset.network_storage))
+            nodeset_ns = [lkp.normalize_ns_mount(m) for m in nodeset.network_storage]
+            mounts.update(mounts_by_local(nodeset_ns))
 
-    return [lkp.normalize_ns_mount(mnt) for mnt in mounts.values()]
+    return list(mounts.values())
 
 
-def separate_external_internal_mounts(mounts):
-    """separate into cluster-external and internal mounts"""
-
-    def internal_mount(mount):
-        # NOTE: Valid Lustre server_ip can take the form of '<IP>@tcp'
-        server_ip = mount.server_ip.split("@")[0]
-        mount_addr = util.host_lookup(server_ip)
-        return mount_addr == lookup().control_host_addr
-
-    return separate(internal_mount, mounts)
-
+def is_controller_mount(mount) -> bool:
+    # NOTE: Valid Lustre server_ip can take the form of '<IP>@tcp'
+    server_ip = mount.server_ip.split("@")[0]
+    mount_addr = util.host_lookup(server_ip)
+    return mount_addr == lookup().control_host_addr
 
 def setup_network_storage():
     """prepare network fs mounts and add them to fstab"""
     log.info("Set up network storage")
-    # filter mounts into two dicts, cluster-internal and external mounts
-
+    
     all_mounts = resolve_network_storage()
-    ext_mounts, int_mounts = separate_external_internal_mounts(all_mounts)
-
     if lookup().is_controller:
-        mounts = ext_mounts
+        mounts, _ = separate(is_controller_mount, all_mounts)
     else:
-        mounts = ext_mounts + int_mounts
+        mounts = all_mounts
 
     # Determine fstab entries and write them out
     fstab_entries = []
     for mount in mounts:
-        local_mount = Path(mount.local_mount)
-        remote_mount = mount.remote_mount
+        local_mount = mount.local_mount
         fs_type = mount.fs_type
         server_ip = mount.server_ip or ""
+        src = mount.remote_mount if fs_type == "gcsfuse" else f"{server_ip}:{mount.remote_mount}"
+        
+        log.info(f"Setting up mount ({fs_type}) {src} to {local_mount}")
         util.mkdirp(local_mount)
 
-        log.info(
-            "Setting up mount ({}) {}{} to {}".format(
-                fs_type,
-                server_ip + ":" if fs_type != "gcsfuse" else "",
-                remote_mount,
-                local_mount,
-            )
-        )
-
         mount_options = mount.mount_options.split(",") if mount.mount_options else []
-        if not mount_options or "_netdev" not in mount_options:
+        if "_netdev" not in mount_options:
             mount_options += ["_netdev"]
-
-        if fs_type == "gcsfuse":
-            fstab_entries.append(
-                "{0}   {1}     {2}     {3}     0 0".format(
-                    remote_mount, local_mount, fs_type, ",".join(mount_options)
-                )
-            )
-        else:
-            fstab_entries.append(
-                "{0}:{1}    {2}     {3}      {4}  0 0".format(
-                    server_ip,
-                    remote_mount,
-                    local_mount,
-                    fs_type,
-                    ",".join(mount_options),
-                )
-            )
+        options_line = ",".join(mount_options)
+        
+        
+        fstab_entries.append(f"{src}   {local_mount}     {fs_type}     {options_line}     0 0")
 
     fstab = Path("/etc/fstab")
     if not Path(fstab.with_suffix(".bak")).is_file():
@@ -157,16 +145,16 @@ def setup_network_storage():
             f.write(entry)
             f.write("\n")
 
-    mount_fstab(mounts_by_local(mounts), log)
+    mount_fstab(mounts, log)
     if lookup().cfg.enable_slurm_auth:
       slurm_key_mount_handler()
     else:
       munge_mount_handler()
 
 
-def mount_fstab(mounts, log):
+def mount_fstab(mounts: list[NSMount], log):
     """Wait on each mount, then make sure all fstab is mounted"""
-    def mount_path(path):
+    def mount_path(path: Path):
         log.info(f"Waiting for '{path}' to be mounted...")
         try:
             run(f"mount {path}", timeout=120)
@@ -184,8 +172,8 @@ def mount_fstab(mounts, log):
     with Executors.thread_pool().with_timeout(MAX_MOUNT_TIMEOUT).with_retry(
         retry_policy=retry_policy
     ) as exe:
-        for path in mounts:
-            future = exe.submit(mount_path, path)
+        for m in mounts:
+            future = exe.submit(mount_path, m.local_mount)
             future_list.append(future)
 
         # Iterate over futures, checking for exceptions
@@ -306,36 +294,34 @@ def setup_nfs_exports():
     lkp = util.lookup()
     assert lkp.is_controller
 
-
     # The controller only needs to set up exports for cluster-internal mounts
-    # switch the key to remote mount path since that is what needs exporting
-    mounts = resolve_network_storage()
+    exported_mounts = [m for m in resolve_network_storage() if is_controller_mount(m)]
 
-    if lkp.cfg.enable_slurm_auth:
-      mounts.append(lkp.slurm_key_mount)
-    else:
-      mounts.append(lkp.munge_mount)
+    # key by remote mount path since that is what needs exporting
+    to_export = {m.remote_mount: "*(rw,no_subtree_check,no_root_squash)" for m in exported_mounts}
 
-    # controller mounts
-    _, con_mounts = separate_external_internal_mounts(mounts)
-    con_mounts = {m.remote_mount: m for m in con_mounts}
-    for nodeset in lkp.cfg.nodeset.values():
-        # get internal mounts for each nodeset by calling
-        # resolve_network_storage as from a node in each nodeset
-        ns_mounts = resolve_network_storage(nodeset=nodeset)
-        _, int_mounts = separate_external_internal_mounts(ns_mounts)
-        con_mounts.update({m.remote_mount: m for m in int_mounts})
+    key_mount = lkp.slurm_key_mount if lkp.cfg.enable_slurm_auth else lkp.munge_mount
+    if is_controller_mount(key_mount):
+        # Export key mount as read-only
+        to_export[key_mount.remote_mount] = "*(ro,no_subtree_check,no_root_squash)"
+    
+    if util.should_mount_slurm_bucket():
+        mnt = get_slurm_bucket_mount()
+        # FSID is required for virtual filesystem that is not based on a device
+        # Also export it as read-only
+        fsid=str(uuid.uuid4())
+        to_export[mnt.local_mount] = f"*(ro,no_subtree_check,no_root_squash,fsid={fsid})"
 
     # export path if corresponding selector boolean is True
-    exports = []
-    for path in con_mounts:
+    lines = []
+    for path,options in to_export.items():
         util.mkdirp(Path(path))
         run(rf"sed -i '\#{path}#d' /etc/exports", timeout=30)
-        exports.append(f"{path}  *(rw,no_subtree_check,no_root_squash)")
+        lines.append(f"{path}  {options}")
 
     exportsd = Path("/etc/exports.d")
     util.mkdirp(exportsd)
     with (exportsd / "slurm.exports").open("w") as f:
         f.write("\n")
-        f.write("\n".join(exports))
+        f.write("\n".join(lines))
     run("exportfs -a", timeout=30)


### PR DESCRIPTION
See:  `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/files/login_startup.sh` compute nodeset changes to be identical.

Significant part to replace `BUCKET` related logic:
```sh
CLUSTER_NAME=$(curl -sS --fail --header Metadata-Flavor:Google $URL/instance/attributes/slurm_cluster_name)
MOUNT_BUCKET=$(curl -sS --fail --header Metadata-Flavor:Google $URL/instance/attributes/slurm_bucket_mount)

if [[ $MOUNT_BUCKET != "true" ]]; then
    echo "ERROR: slurm_bucket_mount should be set to `true`"
    exit 1
fi

echo "$CLUSTER_NAME-controller:/slurm/bucket /slurm/bucket     nfs     defaults,hard,intr,_netdev     0 0" >> /etc/fstab
systemctl daemon-reload
mkdir -p /slurm/bucket

until mount /slurm/bucket; do
  echo "WARN: Could not mount config bucket, retrying in 5 seconds."
  sleep 5
done

if [[ ! -f /slurm/bucket/slurm-gcp-devel.zip ]]; then
    echo "ERROR: Could not download SlurmGCP scripts"
    exit 1
fi
```

In blueprint, following has been added to both login and controller modules:

```yaml
      metadata:
        slurm_bucket_mount: "true"
```



Succesfull run:

```
$ journalctl -u google-startup-scripts.service
...
Jun 10 23:03:13 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + mkdir -p /slurm/scripts
Jun 10 23:03:13 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + URL=http://metadata.google.internal/computeMetadata/v1
Jun 10 23:03:13 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: ++ curl -sS --fail --header Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/attributes/slurm_cluster_name
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + CLUSTER_NAME=qq
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: ++ curl -sS --fail --header Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/attributes/slurm_bucket_mount
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + MOUNT_BUCKET=true
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + [[ true != \t\r\u\e ]]
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + echo 'qq-controller:/slurm/bucket /slurm/bucket     nfs     defaults,hard,intr,_netdev     0 0'
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + systemctl daemon-reload
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + mkdir -p /slurm/bucket
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + mount /slurm/bucket
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: mount.nfs: access denied by server while mounting qq-controller:/slurm/bucket
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + echo 'WARN: Could not mount config bucket, retrying in 5 seconds.'
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: WARN: Could not mount config bucket, retrying in 5 seconds.
Jun 10 23:03:14 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + sleep 5
Jun 10 23:03:19 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + mount /slurm/bucket
Jun 10 23:03:19 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + [[ ! -f /slurm/bucket/slurm-gcp-devel.zip ]]
Jun 10 23:03:19 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: + unzip -o /slurm/bucket/slurm-gcp-devel.zip -d /slurm/scripts
Jun 10 23:03:19 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: Archive:  /slurm/bucket/slurm-gcp-devel.zip
Jun 10 23:03:20 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script:   inflating: /slurm/scripts/conf.py
Jun 10 23:03:20 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script:   inflating: /slurm/scripts/file_cache.py
Jun 10 23:03:20 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script:   inflating: /slurm/scripts/get_tpu_vmcount.py
Jun 10 23:03:20 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script:   inflating: /slurm/scripts/job_submit.lua.tpl
...
Jun 10 23:03:22 qq-slurm-login-001 google_metadata_script_runner[1187]: startup-script: INFO: Done setting up login
```