### PR TITLE
Remove validation around gpu instances for DWS Flex

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/outputs.tf
@@ -48,11 +48,6 @@ output "nodeset" {
   }
 
   precondition {
-    condition     = local.nodeset.gpu != null || !var.dws_flex.enabled || var.dws_flex.use_bulk_insert
-    error_message = "DWS Flex-Start is only supported for GPU instances"
-  }
-
-  precondition {
     condition     = !var.enable_placement || !var.dws_flex.enabled
     error_message = "Cannot use DWS Flex with `enable_placement`."
   }


### PR DESCRIPTION
The initial assumption that caused the validation to be created is no longer true. Hence relaxing of validation around instances that can use DWS Flex.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
