### PR TITLE
Update variable name as the nodepool is not of static type

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
@@ -33,7 +33,7 @@ vars:
   # Installs NCCL library and Google NCCL plugin
   # Runs an init container on all H200 GPU nodes with the NCCL plugin image
   nccl_installer_path: $(ghpc_stage("./nccl-installer.yaml"))
-  static_gpu_count: 512
+  gpu_nominal_quota: 512
   system_node_pool_disk_size_gb: 100
   a3ultra_node_pool_disk_size_gb: 100
 
@@ -196,7 +196,7 @@ deployment_groups:
         install: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
-          num_gpus: $(vars.static_gpu_count)
+          num_gpus: $(vars.gpu_nominal_quota)
       jobset:
         install: true
       apply_manifests:


### PR DESCRIPTION
The nodepool created with DWS flex-start feature is dynamic and not static type. The variable name is updated to avoid confusion.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
