### PR TITLE
deprecation notice for branch 'cloudnext25'

### DIFF
--- a/examples/science/af3-slurm/README.md
+++ b/examples/science/af3-slurm/README.md
@@ -1,3 +1,6 @@
+> [!WARNING]
+>  **Deprecation Notice**: this branch is deprecated and will ultimately be removed. The content of this branch is now maintained in branch [develop](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/develop) and from there it will be eventually merged to [main](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main).
+
 # AlphaFold 3 High Throughput Solution
 Welcome to the Cluster Toolkit AlphaFold 3 High Throughput Solution!
 


### PR DESCRIPTION
The content of this branch (AlphaFold 3 solution) has been merged to 'develop' and will be maintained there and ultimately merged to 'main'. Therefore, we add a deprecation notice to the 'cloudnext25' branch to prepare for deletion of this no longer needed branch.  

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
