### PR TITLE
enable wait_for_rollout for kubectl dependencies

### DIFF
--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -61,6 +61,7 @@ module "install_kueue" {
   source            = "./kubectl"
   source_path       = local.install_kueue ? local.kueue_install_source : null
   server_side_apply = true
+  wait_for_rollout  = true
   depends_on        = [var.gke_cluster_exists]
 
   providers = {
@@ -86,6 +87,7 @@ module "install_jobset" {
   source            = "./kubectl"
   source_path       = local.install_jobset ? local.jobset_install_source : null
   server_side_apply = true
+  wait_for_rollout  = true
   depends_on        = [var.gke_cluster_exists, module.configure_kueue]
 
   providers = {
@@ -224,6 +226,7 @@ module "install_gib" {
   source_path       = local.install_gib ? var.gib.path : null
   server_side_apply = true
   template_vars     = var.gib.template_vars
+  wait_for_rollout  = true
 
   providers = {
     kubectl = kubectl


### PR DESCRIPTION
### Submission Checklist
 Webhook pod could be taking up some time before the endpoint is available and kubectl wasn't waiting for pod status to be read leading to errors in `nccl-jobset.yaml` application.


NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
