### PR TITLE
Add `per_unit_storage_throughput` field in managed lustre instance creation

### DIFF
--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -26,6 +26,25 @@ vars:
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
 
+terraform_providers:
+  google:
+    source: hashicorp/google
+    version: 6.41.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      compute_custom_endpoint: "https://www.googleapis.com/compute/beta/"
+
+  google-beta:
+    source: hashicorp/google-beta
+    version: 6.41.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      compute_custom_endpoint: "https://www.googleapis.com/compute/beta/"
+
 deployment_groups:
 - group: lustre
   modules:

--- a/examples/pfs-managed-lustre-vm.yaml
+++ b/examples/pfs-managed-lustre-vm.yaml
@@ -25,6 +25,25 @@ vars:
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
 
+terraform_providers:
+  google:
+    source: hashicorp/google
+    version: 6.41.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      compute_custom_endpoint: "https://www.googleapis.com/compute/beta/"
+
+  google-beta:
+    source: hashicorp/google-beta
+    version: 6.41.0
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      compute_custom_endpoint: "https://www.googleapis.com/compute/beta/"
+
 deployment_groups:
 - group: primary
   modules:

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -271,6 +271,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | Name of the Lustre instance | `string` | n/a | yes |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the instance is connected given in the format:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | Network self-link this instance will be on, required for checking private service access | `string` | n/a | yes |
+| <a name="input_per_unit_storage_throughput"></a> [per\_unit\_storage\_throughput](#input\_per\_unit\_storage\_throughput) | Throughput of the instance in MB/s/TiB. Valid values are 125, 250, 500, 1000. | `number` | `1000` | no |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection.<br/>If using new VPC, please use community/modules/network/private-service-access to create private-service-access and<br/>If using existing VPC with private-service-access enabled, set this manually." | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Lustre instance will be created. | `string` | n/a | yes |
 | <a name="input_remote_mount"></a> [remote\_mount](#input\_remote\_mount) | Remote mount point of the Managed Lustre instance | `string` | n/a | yes |

--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -65,8 +65,9 @@ resource "google_lustre_instance" "lustre_instance" {
   instance_id = local.instance_id
   location    = var.zone
 
-  filesystem   = var.remote_mount
-  capacity_gib = var.size_gib
+  filesystem                  = var.remote_mount
+  capacity_gib                = var.size_gib
+  per_unit_storage_throughput = var.per_unit_storage_throughput
 
   labels  = local.labels
   network = var.network_id

--- a/modules/file-system/managed-lustre/variables.tf
+++ b/modules/file-system/managed-lustre/variables.tf
@@ -77,6 +77,12 @@ variable "size_gib" {
   default     = 18000
 }
 
+variable "per_unit_storage_throughput" {
+  description = "Throughput of the instance in MB/s/TiB. Valid values are 125, 250, 500, 1000."
+  type        = number
+  default     = 1000
+}
+
 variable "labels" {
   description = "Labels to add to the Managed Lustre instance. Key-value pairs."
   type        = map(string)


### PR DESCRIPTION
This field is added to provider 6.41.0.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
