### PR TITLE
CHS Integration for A4

### DIFF
--- a/examples/gke-a4/chs-cronjob.yaml.tftpl
+++ b/examples/gke-a4/chs-cronjob.yaml.tftpl
@@ -1,0 +1,81 @@
+# Copyright 2024 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: cluster-health-scanner-cronjob
+spec:
+  schedule: "${cronjob_schedule}"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: workload-identity-k8s-sa
+          containers:
+          - name: chs-runner
+            image: python:3.11-slim-buster
+            imagePullPolicy: Always
+            command:
+            - /bin/bash
+            - -c
+            - |
+              set -ex
+              set -x
+              apt-get update && apt-get install -y git curl gnupg -y
+              git clone https://github.com/GoogleCloudPlatform/cluster-health-scanner
+              cd cluster-health-scanner
+              apt-get install -y apt-transport-https ca-certificates
+              curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+              echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+              apt-get update
+              apt-get install -y google-cloud-cli kubectl
+              apt-get install -y google-cloud-cli-gke-gcloud-auth-plugin
+              curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+              pip3 install -r cli/requirements.txt
+              gcloud container clusters get-credentials ${deployment_name} --region ${region} --project ${project_id}
+              OUTPUT_DIR="/mnt/output"
+              mkdir -p $OUTPUT_DIR
+              TIMESTAMP="`date "+%Y-%m-%d %H:%M:%S"`"
+              OUTPUT_FILENAME="${deployment_name}_healthscan_result_$TIMESTAMP.txt"
+              FULL_OUTPUT_PATH="$OUTPUT_DIR/$OUTPUT_FILENAME"
+              python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c gpu --run_only_on_available_nodes
+              python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c nccl --run_only_on_available_nodes
+              python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c straggler --run_only_on_available_nodes
+              python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c neper --run_only_on_available_nodes
+              python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c tinymax --run_only_on_available_nodes
+              #python3 cli/cluster_diag.py -o gke healthscan ${machine_type} -c status --run_only_on_available_nodes > "$FULL_OUTPUT_PATH" 2>&1
+              kubectl get nodes -o custom-columns="NODE:.metadata.name,NCCL_MARK:.metadata.labels.aiinfra/nccl-healthcheck-test,NCCL_BANDWIDTH:.metadata.labels.aiinfra/nccl-healthcheck-bandwidth,NCCL_RESULT:.metadata.labels.aiinfra/nccl-healthcheck-result,NCCL_RUNTIME:.metadata.labels.aiinfra/nccl-healthcheck-runtime-sec,TINYMAX_MARK:.metadata.labels.aiinfra/tinymax-healthcheck-test,TINYMAX_RESULT:.metadata.labels.aiinfra/tinymax-healthcheck-result,TINYMAX_RUNTIME:.metadata.labels.aiinfra/tinymax-healthcheck-runtime-sec,GPU_MARK:.metadata.labels.aiinfra/gpu-healthcheck-test,GPU_RESULT:.metadata.labels.aiinfra/gpu-healthcheck-result,GPU_RUNTIME:.metadata.labels.aiinfra/gpu-healthcheck-runtime-sec" > "$FULL_OUTPUT_PATH" 2>&1
+              echo "Health scan outputs saved to $OUTPUT_DIR"
+              echo "Final output file: $OUTPUT_FILENAME"
+            volumeMounts: 
+            - name: ${gcs_bucket}
+              mountPath: /mnt/output
+          volumes:
+          - name: ${gcs_bucket}
+            persistentVolumeClaim:
+              claimName: ${gcs_pvc}
+          restartPolicy: Never
+          tolerations:
+          - key: "nvidia.com/gpu"
+            operator: "Exists"
+            effect: "NoSchedule"
+          - key: "components.gke.io/gke-managed-components"
+            operator: "Exists"
+            effect: "NoSchedule"
+      backoffLimit: 0

--- a/examples/gke-a4/chs-permissions.yaml.tftpl
+++ b/examples/gke-a4/chs-permissions.yaml.tftpl
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: workload-identity-k8s-sa
+  namespace: default
+  annotations:
+    iam.gke.io/gcp-service-account: gke-wl-sa@${project_id}.iam.gserviceaccount.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-health-scanner-job-role
+rules:
+  - apiGroups: [""]
+    resources:
+    - "pods"
+    - "pods/log"   
+    - "pods/exec"
+    - "nodes"
+    - "events"
+    - "services"
+    - "secrets"
+    - "configmaps"
+    - "serviceaccounts"
+    verbs: ["list", "get", "create", "delete", "watch", "patch", "update"]
+
+  - apiGroups: ["apps"]
+    resources:
+    - "daemonsets"
+    - "deployments"
+    - "replicasets"
+    verbs: ["list", "get", "create", "delete", "watch", "patch", "update"]
+
+  - apiGroups: ["batch"]
+    resources:
+    - "jobs"
+    - "jobs/status"
+    verbs: ["list", "get", "create", "delete", "watch", "patch", "update"]
+
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources:
+    - "clusterrolebindings"
+    - "clusterroles"
+    - "roles"
+    - "rolebindings"
+    verbs: ["list", "get", "create", "delete", "watch", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-health-scanner-job-binding
+subjects:
+- kind: ServiceAccount
+  name: workload-identity-k8s-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: cluster-health-scanner-job-role
+  apiGroup: rbac.authorization.k8s.io

--- a/examples/gke-a4/chs-pvc.yaml.tftpl
+++ b/examples/gke-a4/chs-pvc.yaml.tftpl
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${pvc_name}
+spec:
+  accessModes:
+    - ${access_mode}
+  resources:
+    requests:
+      storage: ${capacity}
+  storageClassName: ${storage_class_name}
+  

--- a/examples/gke-a4/gke-a4-deployment.yaml
+++ b/examples/gke-a4/gke-a4-deployment.yaml
@@ -51,3 +51,6 @@ vars:
 
   # The disk size of a4 node pool for this deployment.
   a4_node_pool_disk_size_gb:
+
+  enable_periodic_health_checks: # Make this true to run CHS (healthchecks)
+  health_check_schedule:  # Run the health check at 12:00 AM (midnight) every Sunday

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -50,6 +50,14 @@ vars:
   accelerator_type: nvidia-b200
   version_prefix: "1.32."
 
+  enable_periodic_health_checks: false # Make this true to run CHS (healthchecks)
+  health_check_schedule: "0 0 * * 0" # Run the health check at 12:00 AM (midnight) every Sunday
+
+  permissions_file_staged_path: $(ghpc_stage("./chs-permissions.yaml.tftpl"))
+  chs_output_bucket_name: chs-result
+  chs_pvc_claim_name: chs-output-pvc
+  chs_cronjob_rendered_path: $(ghpc_stage("./chs-cronjob.yaml.tftpl"))
+  chs_pvc_rendered_path: $(ghpc_stage("./chs-pvc.yaml.tftpl"))
 
 deployment_groups:
 - group: primary
@@ -132,6 +140,7 @@ deployment_groups:
       - stackdriver.resourceMetadata.writer
       - storage.objectAdmin
       - artifactregistry.reader
+      - container.admin
 
   - id: training_bucket
     source: community/modules/file-system/cloud-storage-bucket
@@ -231,6 +240,27 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [a4-cluster]
     settings:
+      apply_manifests:
+      - source: $(vars.permissions_file_staged_path)
+        template_vars:
+          project_id: $(vars.project_id)
+      - source: $(vars.chs_pvc_rendered_path)
+        enable: $(vars.enable_periodic_health_checks)
+        template_vars:
+          pvc_name: $(vars.chs_pvc_claim_name)
+          access_mode: ReadWriteOnce
+          capacity: 1Gi
+          storage_class_name: standard-rwo
+      - source: $(vars.chs_cronjob_rendered_path)
+        enable: $(vars.enable_periodic_health_checks)
+        template_vars:
+          project_id: $(vars.project_id)
+          deployment_name: $(vars.deployment_name)
+          region: $(vars.region)
+          machine_type: a4-highgpu-8g
+          gcs_bucket: $(vars.chs_output_bucket_name)
+          gcs_pvc: $(vars.chs_pvc_claim_name)
+          cronjob_schedule: $(vars.health_check_schedule)
       kueue:
         install: true
         config_path: $(vars.kueue_configuration_path)


### PR DESCRIPTION
Feature: Implement Periodic Cluster Health Scanning (CHS) for GKE Clusters for A4

This PR introduces a new Kubernetes CronJob (cluster-health-scanner-cronjob) to enable periodic health checks on GKE clusters. It includes:

1. Automated CHS Execution: Runs various cluster diagnostics (GPU, NCCL, Straggler, Neper, Tinymax) on a defined schedule.
2. Persistent Storage: Configures a Persistent Volume Claim (PVC) for storing health scan outputs in a GCS bucket.
3. Required Permissions: Adds necessary Service Account and ClusterRoleBindings for CHS operations.
4. Enable/Disable Option: Introduces a variable to enable or disable the periodic CHS execution.
5. Configurable Schedule: Allows users to define the cronjob_schedule via a variable.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
