### PR TITLE
Update Slurm service-account permissions

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -66,11 +66,11 @@ deployment_groups:
     settings:
       name: controller
       project_roles:
+      - bigquery.dataOwner # needed if enable_bigquery_load is enabled
       - compute.instanceAdmin.v1
       - iam.serviceAccountUser
       - logging.logWriter
       - monitoring.metricWriter
-      - pubsub.admin
       - storage.objectViewer
 
   - id: login_sa
@@ -89,7 +89,7 @@ deployment_groups:
       project_roles:
       - logging.logWriter
       - monitoring.metricWriter
-      - storage.objectCreator
+      - storage.objectUser
 
   - id: homefs
     source: modules/file-system/filestore


### PR DESCRIPTION
* Add `bigquery.dataOwner` for slurm controller, as this is necessary when exporting accounting data to BigQuery.
* Change `storage.objectCreator` to `storage.objectUser` for compute nodes, as they need not only create files, but usually, also read them. Also, this will help compute nodes to read the startup scripts.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
