### PR TITLE
Remove Kueue topology annotation as DWS does not work with TAS (yet)

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-jobset-example.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-jobset-example.yaml
@@ -36,7 +36,6 @@ spec:
         template:
           metadata:
             annotations:
-              kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
               networking.gke.io/default-interface: 'eth0'
               networking.gke.io/interfaces: |
                 [

--- a/examples/gke-consumption-options/dws-flex-start/nccl-jobset-example.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/nccl-jobset-example.yaml
@@ -34,7 +34,6 @@ spec:
         template:
           metadata:
             annotations:
-              kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
               networking.gke.io/default-interface: 'eth0'
               networking.gke.io/interfaces: |
                 [


### PR DESCRIPTION
This flag was added to kueue-controller-manager deployment as part of the PR #4319: `--feature-gates=TopologyAwareScheduling=true` to support TAS on Kueue.

As DWS does not work with TAS at this time, the NCCL jobsets need to be updated to remove the Kueue topology annotation: `kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"`.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
