### PR TITLE
gke-node-pool module to use "google" instead of "google-beta" provider

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -279,16 +279,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.16 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.32 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.42.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 6.16 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.32 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.42.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
@@ -302,7 +300,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
-| [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
+| [google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
 | [null_resource.enable_tcpx_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -68,7 +68,7 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 resource "google_container_node_pool" "node_pool" {
-  provider = google-beta
+  provider = google
 
   count = max(var.num_node_pools, var.num_slices)
 

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -18,11 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.16"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 6.32"
+      version = ">= 6.42.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -31,8 +27,5 @@ terraform {
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.57.0"
-  }
-  provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.45.0"
   }
 }


### PR DESCRIPTION
Latest version taken from [here](https://screenshot.googleplex.com/4YFexGdr2HxBqdd)