### PR TITLE
Added capacity checks for reservations

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -305,6 +305,7 @@ limitations under the License.
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_machine_types.machine_info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_machine_types) | data source |
+| [google_compute_reservation.specific](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_reservation.specific_reservations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -67,6 +67,20 @@ data "google_container_cluster" "gke_cluster" {
   location = local.cluster_location
 }
 
+data "google_compute_reservation" "specific" {
+  count   = local.input_specific_reservations_count == 1 ? 1 : 0
+  project = var.project_id
+  zone    = var.zones[0]
+  name    = var.reservation_affinity.specific_reservations[0].name
+}
+
+locals {
+  reservation_available_count = (local.input_specific_reservations_count == 1) ? (
+    try(data.google_compute_reservation.specific[0].specific_reservation[0].count, 0) -
+    try(data.google_compute_reservation.specific[0].specific_reservation[0].in_use_count, 0)
+  ) : 0
+}
+
 resource "google_container_node_pool" "node_pool" {
   provider = google
 
@@ -378,6 +392,14 @@ resource "google_container_node_pool" "node_pool" {
     precondition {
       condition     = var.enable_flex_start == true ? (var.spot == false) : true
       error_message = "Both enable_flex_start and spot consumption option cannot be set to true at the same time."
+    }
+    precondition {
+      condition     = var.reservation_affinity.consume_reservation_type != "SPECIFIC_RESERVATION" || (var.static_node_count != null && var.static_node_count <= local.reservation_available_count)
+      error_message = "Requested static_node_count (${coalesce(var.static_node_count, "not set")}) exceeds the available reservation capacity (${local.reservation_available_count})."
+    }
+    precondition {
+      condition     = local.input_specific_reservations_count == 1 || var.reservation_affinity.consume_reservation_type != "SPECIFIC_RESERVATION"
+      error_message = "Exactly one reservation must be specified when using SPECIFIC_RESERVATION."
     }
   }
 }


### PR DESCRIPTION
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)

### **What this change does**

This change adds an early check (pre-validation) to make sure there's enough space (capacity) in a specific machine reservation *before* we try to create the cluster's nodes.

### Why this is important

Right now, if you ask for more machines than are available in a reservation, the cluster setup process only fails much later, when it tries to actually create those machines. This is a problem because:
* It wastes time and computing power trying to get machines that aren't there.
* You don't find out about the capacity problem right away.

### How it was implemented

I added a new section of code to the google_container_node_pool resource block to implement robust validation for reservation affinity. This involved creating two new precondition blocks. One to ensure a single reservation is specified when required, and another to verify that the requested node count does not exceed the available capacity of that reservation.
