### PR TITLE
Update compute cleanup script

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/scripts/cleanup_compute.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/scripts/cleanup_compute.sh
@@ -61,8 +61,8 @@ node_filter="name:${cluster_name}-${nodeset_name}-* labels.slurm_cluster_name=${
 running_nodes_filter="${node_filter} AND status!=STOPPING"
 # List all currently running instances and attempt to delete them
 gcloud compute instances list --format="value(selfLink)" --filter="${running_nodes_filter}" >"$tmpfile"
-# Do 10 instances at a time
-while batch="$(head -n 10)" && [[ ${#batch} -gt 0 ]]; do
+# Do 500 instances at a time
+while batch="$(head -n 500)" && [[ ${#batch} -gt 0 ]]; do
 	nodes=$(echo "$batch" | paste -sd " " -) # concat into a single space-separated line
 	# The lack of quotes around ${nodes} is intentional and causes each new space-separated "word" to
 	# be treated as independent arguments. See PR#2523
@@ -83,7 +83,7 @@ while true; do
 done
 
 echo "Deleting resource policies"
-policies_filter="name:${cluster_name}-${nodeset_name}-slurmgcp-managed-*"
+policies_filter="name:${cluster_name}-slurmgcp-managed-${nodeset_name}-*"
 gcloud compute resource-policies list --format="value(selfLink)" --filter="${policies_filter}" | while read -r line; do
 	echo "Deleting resource policy: $line"
 	gcloud compute resource-policies delete --quiet "${line}" || {


### PR DESCRIPTION
PR includes two changes
- Updates name filter for resource policies to reflect current name scheme
- Increases the number of compute nodes getting deleted at once


There was a bug with the resource policies are not getting deleted after `./gcluster destroy` since there is a typo in the name for the filter.

Before the change, below shows the policy getting created in the initial deployment
`INFO: created 1 placement groups (aresourcet-slurmgcp-managed-nodeset-0-0)`

I then destroyed the cluster, but can still see resource policy.
```
$ gcloud compute resource-policies list --project=dev-pool-prj3
NAME                                     DESCRIPTION  REGION                                                                             CREATION_TIMESTAMP
aresourcet-slurmgcp-managed-nodeset-0-0               https://www.googleapis.com/compute/v1/projects/dev-pool-prj3/regions/us-central1   2025-07-09T13:49:09.280-07:00
```

After the change, below shows the policy getting created in the initial deployment
`2025-07-09 21:09:27,613 INFO: created 1 placement groups (updatedres-slurmgcp-managed-nodeset-0-0)`

Then I destroyed the cluster. The resource policy cannot be seen using `gcloud compute resource-policies list`

Re-deployed and can see placement group re-created
`2025-07-09 21:26:20,639 INFO: created 1 placement groups (updatedres-slurmgcp-managed-nodeset-0-0)`
