### PR TITLE
Move google_compute_image into check block

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -66,9 +66,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.11 |
+No providers.
 
 ## Modules
 
@@ -79,9 +77,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+No resources.
 
 ## Inputs
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/source_image_logic.tf
@@ -32,46 +32,49 @@ locals {
   # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
   # https://cloud.google.com/apis/design/resource_names#relative_resource_name
   source_image_project_normalized = (can(var.instance_image.family) ?
-    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
-    "projects/${data.google_compute_image.slurm.project}/global/images"
+    "projects/${var.instance_image.project}/global/images/family" :
+    "projects/${var.instance_image.project}/global/images"
   )
-  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
-  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+  source_image_family = try(var.instance_image.family, "")
+  source_image        = try(var.instance_image.name, "")
 }
 
-data "google_compute_image" "slurm" {
-  family  = try(var.instance_image.family, null)
-  name    = try(var.instance_image.name, null)
-  project = var.instance_image.project
+check "image_validation" {
+  data "google_compute_image" "slurm" {
+    family  = try(var.instance_image.family, null)
+    name    = try(var.instance_image.name, null)
+    project = var.instance_image.project
+  }
 
-  lifecycle {
-    precondition {
-      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
-      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
-    }
+  assert {
+    condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+    error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+  }
 
-    postcondition {
-      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
-      error_message = <<-EOD
-      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+  assert {
+    condition     = var.instance_image_custom || contains(keys(local.known_project_families), data.google_compute_image.slurm.project)
+    error_message = <<-EOD
+      Images in project ${data.google_compute_image.slurm.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
       EOD
-    }
-    postcondition {
-      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
-      error_message = <<-EOD
-      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
-      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+  }
+
+  assert {
+    condition     = !contains(keys(local.known_project_families), data.google_compute_image.slurm.project) || try(contains(local.known_project_families[data.google_compute_image.slurm.project], data.google_compute_image.slurm.family), false)
+    error_message = <<-EOD
+      Image family ${data.google_compute_image.slurm.family} published by SchedMD in project ${data.google_compute_image.slurm.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[data.google_compute_image.slurm.project], []) : "\t\"${p}\""])}
       EOD
-    }
-    postcondition {
-      condition     = var.disk_size_gb >= self.disk_size_gb
-      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
-    }
-    postcondition {
-      # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
-      # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
-      condition     = var.allow_automatic_updates || anytrue([for license in self.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
-      error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
-    }
+  }
+
+  assert {
+    condition     = var.disk_size_gb >= data.google_compute_image.slurm.disk_size_gb
+    error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${data.google_compute_image.slurm.disk_size_gb}GB), please increase the blueprint disk size"
+  }
+
+  assert {
+    # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
+    # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
+    condition     = var.allow_automatic_updates || anytrue([for license in data.google_compute_image.slurm.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
+    error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -151,7 +151,6 @@ modules. For support with the underlying modules, see the instructions in the
 | Name | Type |
 |------|------|
 | [terraform_data.machine_type_zone_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
-| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_compute_machine_types.machine_types_by_zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_machine_types) | data source |
 | [google_compute_reservation.reservation](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/source_image_logic.tf
@@ -32,46 +32,49 @@ locals {
   # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
   # https://cloud.google.com/apis/design/resource_names#relative_resource_name
   source_image_project_normalized = (can(var.instance_image.family) ?
-    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
-    "projects/${data.google_compute_image.slurm.project}/global/images"
+    "projects/${var.instance_image.project}/global/images/family" :
+    "projects/${var.instance_image.project}/global/images"
   )
-  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
-  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+  source_image_family = try(var.instance_image.family, "")
+  source_image        = try(var.instance_image.name, "")
 }
 
-data "google_compute_image" "slurm" {
-  family  = try(var.instance_image.family, null)
-  name    = try(var.instance_image.name, null)
-  project = var.instance_image.project
+check "image_validation" {
+  data "google_compute_image" "slurm" {
+    family  = try(var.instance_image.family, null)
+    name    = try(var.instance_image.name, null)
+    project = var.instance_image.project
+  }
 
-  lifecycle {
-    precondition {
-      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
-      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
-    }
+  assert {
+    condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+    error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+  }
 
-    postcondition {
-      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
-      error_message = <<-EOD
-      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+  assert {
+    condition     = var.instance_image_custom || contains(keys(local.known_project_families), data.google_compute_image.slurm.project)
+    error_message = <<-EOD
+      Images in project ${data.google_compute_image.slurm.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
       EOD
-    }
-    postcondition {
-      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
-      error_message = <<-EOD
-      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
-      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+  }
+
+  assert {
+    condition     = !contains(keys(local.known_project_families), data.google_compute_image.slurm.project) || try(contains(local.known_project_families[data.google_compute_image.slurm.project], data.google_compute_image.slurm.family), false)
+    error_message = <<-EOD
+      Image family ${data.google_compute_image.slurm.family} published by SchedMD in project ${data.google_compute_image.slurm.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[data.google_compute_image.slurm.project], []) : "\t\"${p}\""])}
       EOD
-    }
-    postcondition {
-      condition     = var.disk_size_gb >= self.disk_size_gb
-      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
-    }
-    postcondition {
-      # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
-      # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
-      condition     = var.allow_automatic_updates || anytrue([for license in self.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
-      error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
-    }
+  }
+
+  assert {
+    condition     = var.disk_size_gb >= data.google_compute_image.slurm.disk_size_gb
+    error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${data.google_compute_image.slurm.disk_size_gb}GB), please increase the blueprint disk size"
+  }
+
+  assert {
+    # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
+    # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
+    condition     = var.allow_automatic_updates || anytrue([for license in data.google_compute_image.slurm.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
+    error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -299,7 +299,6 @@ limitations under the License.
 | [google_storage_bucket_iam_member.legacy_readers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_object.parition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
-| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
 | [google_project.controller_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf
@@ -32,46 +32,49 @@ locals {
   # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
   # https://cloud.google.com/apis/design/resource_names#relative_resource_name
   source_image_project_normalized = (can(var.instance_image.family) ?
-    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
-    "projects/${data.google_compute_image.slurm.project}/global/images"
+    "projects/${var.instance_image.project}/global/images/family" :
+    "projects/${var.instance_image.project}/global/images"
   )
-  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
-  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+  source_image_family = try(var.instance_image.family, "")
+  source_image        = try(var.instance_image.name, "")
 }
 
-data "google_compute_image" "slurm" {
-  family  = try(var.instance_image.family, null)
-  name    = try(var.instance_image.name, null)
-  project = var.instance_image.project
+check "image_validation" {
+  data "google_compute_image" "slurm" {
+    family  = try(var.instance_image.family, null)
+    name    = try(var.instance_image.name, null)
+    project = var.instance_image.project
+  }
 
-  lifecycle {
-    precondition {
-      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
-      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
-    }
+  assert {
+    condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+    error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+  }
 
-    postcondition {
-      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
-      error_message = <<-EOD
-      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+  assert {
+    condition     = var.instance_image_custom || contains(keys(local.known_project_families), data.google_compute_image.slurm.project)
+    error_message = <<-EOD
+      Images in project ${data.google_compute_image.slurm.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
       EOD
-    }
-    postcondition {
-      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
-      error_message = <<-EOD
-      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
-      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+  }
+
+  assert {
+    condition     = !contains(keys(local.known_project_families), data.google_compute_image.slurm.project) || try(contains(local.known_project_families[data.google_compute_image.slurm.project], data.google_compute_image.slurm.family), false)
+    error_message = <<-EOD
+      Image family ${data.google_compute_image.slurm.family} published by SchedMD in project ${data.google_compute_image.slurm.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[data.google_compute_image.slurm.project], []) : "\t\"${p}\""])}
       EOD
-    }
-    postcondition {
-      condition     = var.disk_size_gb >= self.disk_size_gb
-      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
-    }
-    postcondition {
-      # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
-      # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
-      condition     = var.allow_automatic_updates || anytrue([for license in self.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
-      error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
-    }
+  }
+
+  assert {
+    condition     = var.disk_size_gb >= data.google_compute_image.slurm.disk_size_gb
+    error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${data.google_compute_image.slurm.disk_size_gb}GB), please increase the blueprint disk size"
+  }
+
+  assert {
+    # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
+    # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
+    condition     = var.allow_automatic_updates || anytrue([for license in data.google_compute_image.slurm.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
+    error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -64,9 +64,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+No providers.
 
 ## Modules
 
@@ -76,9 +74,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [google_compute_image.slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
+No resources.
 
 ## Inputs
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/source_image_logic.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/source_image_logic.tf
@@ -32,46 +32,49 @@ locals {
   # https://github.com/terraform-google-modules/terraform-google-vm/blob/735bd415fc5f034d46aa0de7922e8fada2327c0c/modules/instance_template/main.tf#L28
   # https://cloud.google.com/apis/design/resource_names#relative_resource_name
   source_image_project_normalized = (can(var.instance_image.family) ?
-    "projects/${data.google_compute_image.slurm.project}/global/images/family" :
-    "projects/${data.google_compute_image.slurm.project}/global/images"
+    "projects/${var.instance_image.project}/global/images/family" :
+    "projects/${var.instance_image.project}/global/images"
   )
-  source_image_family = can(var.instance_image.family) ? data.google_compute_image.slurm.family : ""
-  source_image        = can(var.instance_image.name) ? data.google_compute_image.slurm.name : ""
+  source_image_family = try(var.instance_image.family, "")
+  source_image        = try(var.instance_image.name, "")
 }
 
-data "google_compute_image" "slurm" {
-  family  = try(var.instance_image.family, null)
-  name    = try(var.instance_image.name, null)
-  project = var.instance_image.project
+check "image_validation" {
+  data "google_compute_image" "slurm" {
+    family  = try(var.instance_image.family, null)
+    name    = try(var.instance_image.name, null)
+    project = var.instance_image.project
+  }
 
-  lifecycle {
-    precondition {
-      condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
-      error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
-    }
+  assert {
+    condition     = length(regexall("^projects/.+?/global/images/family$", var.instance_image.project)) == 0
+    error_message = "The \"project\" field in var.instance_image no longer supports a long-form ending in \"family\". Specify only the project ID."
+  }
 
-    postcondition {
-      condition     = var.instance_image_custom || contains(keys(local.known_project_families), self.project)
-      error_message = <<-EOD
-      Images in project ${self.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
+  assert {
+    condition     = var.instance_image_custom || contains(keys(local.known_project_families), data.google_compute_image.slurm.project)
+    error_message = <<-EOD
+      Images in project ${data.google_compute_image.slurm.project} are not published by SchedMD. Images must be created by compatible releases of the Terraform and Packer modules following the guidance at https://goo.gle/hpc-slurm-images. Set var.instance_image_custom to true to silence this error and acknowledge that you are using a compatible image.
       EOD
-    }
-    postcondition {
-      condition     = !contains(keys(local.known_project_families), self.project) || try(contains(local.known_project_families[self.project], self.family), false)
-      error_message = <<-EOD
-      Image family ${self.family} published by SchedMD in project ${self.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
-      ${join("\n", [for p in try(local.known_project_families[self.project], []) : "\t\"${p}\""])}
+  }
+
+  assert {
+    condition     = !contains(keys(local.known_project_families), data.google_compute_image.slurm.project) || try(contains(local.known_project_families[data.google_compute_image.slurm.project], data.google_compute_image.slurm.family), false)
+    error_message = <<-EOD
+      Image family ${data.google_compute_image.slurm.family} published by SchedMD in project ${data.google_compute_image.slurm.project} is not compatible with this release of the Terraform Slurm modules. Select from known compatible releases:
+      ${join("\n", [for p in try(local.known_project_families[data.google_compute_image.slurm.project], []) : "\t\"${p}\""])}
       EOD
-    }
-    postcondition {
-      condition     = var.disk_size_gb >= self.disk_size_gb
-      error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${self.disk_size_gb}GB), please increase the blueprint disk size"
-    }
-    postcondition {
-      # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
-      # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
-      condition     = var.allow_automatic_updates || anytrue([for license in self.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
-      error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
-    }
+  }
+
+  assert {
+    condition     = var.disk_size_gb >= data.google_compute_image.slurm.disk_size_gb
+    error_message = "'disk_size_gb: ${var.disk_size_gb}' is smaller than the image size (${data.google_compute_image.slurm.disk_size_gb}GB), please increase the blueprint disk size"
+  }
+
+  assert {
+    # Condition needs to check the suffix of the license, as prefix contains an API version which can change.
+    # Example license value: https://www.googleapis.com/compute/v1/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates
+    condition     = var.allow_automatic_updates || anytrue([for license in data.google_compute_image.slurm.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
+    error_message = "Disabling automatic updates is not supported with the selected VM image.  More information: https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates"
   }
 }


### PR DESCRIPTION
There was an issue with `./gcluster destroy` failing if the image used was missing / deleted. This PR puts the data block for the `google_compute_image` into a check block which makes it non-blocking for destroy. 

I have confirmed that the asserts are working as intended. To test, I deployed with an image that had no license which resulted in a successful deployment and gave the appropriate warning message.

```
Warning: Check block assertion failed

  on modules/embedded/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/source_image_logic.tf line 77, in check "slurm_image_validation":
  77:       condition     = var.allow_automatic_updates || anytrue([for license in data.google_compute_image.slurm.licenses : endswith(license, "/projects/cloud-hpc-image-public/global/licenses/hpc-vm-image-feature-disable-auto-updates")])
    ├────────────────
    │ data.google_compute_image.slurm.licenses is list of string with 1 element
    │ var.allow_automatic_updates is false

Disabling automatic updates is not supported with the selected VM image.
```