### PR TITLE
Remove ambiguous controller NFS server_ip

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -108,7 +108,7 @@ locals {
   slurm_log_dir        = var.slurm_log_dir != null ? abspath(var.slurm_log_dir) : null
 
   munge_mount = var.enable_hybrid ? {
-    server_ip     = lookup(var.munge_mount, "server_ip", coalesce(var.slurm_control_addr, var.slurm_control_host))
+    server_ip     = lookup(var.munge_mount, "server_ip", "$controller")
     remote_mount  = lookup(var.munge_mount, "remote_mount", "/etc/munge/")
     fs_type       = lookup(var.munge_mount, "fs_type", "nfs")
     mount_options = lookup(var.munge_mount, "mount_options", "")


### PR DESCRIPTION
* Remove usage of confusing functions `controller_mount_server_ip`, `control_host_addr`, and `host_lookup`;
* Avoid making system calls (`socket.gethostbyname`) while handling mounts;
* Incapsulate handling of "is NFS controller" within `NSMount`;
* Remove support for munge and slurm_key mounts from gsfuse (didn't work properly already).

**Motivation:** to simplify logic in landscape where controller and compute have different DNS names for controller.