### PR TITLE
Use setsid resume.py to reduce reconfigure time

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume_wrapper.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume_wrapper.sh
@@ -35,7 +35,6 @@ if [ -n "${SLURM_RESUME_FILE-}" ] && [ -f "$SLURM_RESUME_FILE" ]; then
 fi
 
 SLURM_RESUME_FILE="${UNIQUE_RESUME_FILE}"
-"${PYTHON_SCRIPT}" "${ALL_ARGS[@]}" &
-disown
+setsid "${PYTHON_SCRIPT}" "${ALL_ARGS[@]}" &
 
 exit 0


### PR DESCRIPTION
Using setsid instead of disown unlinks the resume.py process from the parent (slurmctld) process, allowing scontrol reconfigure to continue prior to the resume.py process exiting.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
