### PR TITLE
Update GKE release channel for a2 high Kueue integ. tests

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
@@ -80,7 +80,7 @@ deployment_groups:
     use: [network1, gpunets, workload_service_account]
     settings:
       enable_private_endpoint: false  # Allows for access from authorized public IPs
-      release_channel: 'RAPID'
+      release_channel: 'STABLE'
       configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine run kubectl command. It's required for the multi-network setup.


### PR DESCRIPTION
This is a follow-up PR for the discussion in original PR- https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/3315#discussion_r1861553780

#### Updates the default release_channel to `STABLE`
* Current default `kueue` version is `v0.12.4` https://github.com/kubernetes-sigs/kueue/releases/tag/v0.12.4
* The previous need for a non-stable channel was driven by the `TopologyAwareScheduling` (TAS) feature's beta status. TAS became GA in Kubernetes v1.29.
* Since the GKE STABLE channel now provides Kubernetes v1.30+, which is well beyond the requirement, we can safely and preferably default to STABLE for maximum reliability. https://cloud.google.com/kubernetes-engine/docs/release-notes



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
