### PR TITLE
namespace for gke-modules

### DIFF
--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -143,6 +143,7 @@ No modules.
 |------|------|
 | [kubectl_manifest.pv](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.pvc](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.pvc_namespace](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [local_file.debug_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
@@ -156,6 +157,7 @@ No modules.
 | <a name="input_filestore_id"></a> [filestore\_id](#input\_filestore\_id) | An identifier for a filestore with the format `projects/{{project}}/locations/{{location}}/instances/{{name}}`. | `string` | `null` | no |
 | <a name="input_gcs_bucket_name"></a> [gcs\_bucket\_name](#input\_gcs\_bucket\_name) | The gcs bucket to be used with the persistent volume. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy the storage PVC/PV | `string` | `"default"` | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | Network attached storage mount to be configured. | <pre>object({<br/>    server_ip             = string,<br/>    remote_mount          = string,<br/>    local_mount           = string,<br/>    fs_type               = string,<br/>    mount_options         = string,<br/>    client_install_runner = map(string)<br/>    mount_runner          = map(string)<br/>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/modules/file-system/gke-persistent-volume/templates/filestore-pvc.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/filestore-pvc.yaml.tftpl
@@ -3,6 +3,7 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-persistent-volume/templates/gcs-pvc.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/gcs-pvc.yaml.tftpl
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-persistent-volume/templates/namespace.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/namespace.yaml.tftpl
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}

--- a/modules/file-system/gke-persistent-volume/variables.tf
+++ b/modules/file-system/gke-persistent-volume/variables.tf
@@ -60,3 +60,9 @@ variable "labels" {
   description = "GCE resource labels to be applied to resources. Key-value pairs."
   type        = map(string)
 }
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy the storage PVC/PV"
+  type        = string
+  default     = "default"
+}

--- a/modules/file-system/gke-storage/README.md
+++ b/modules/file-system/gke-storage/README.md
@@ -116,6 +116,7 @@ No resources.
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the GKE cluster in the format `projects/{{project}}/locations/{{location}}/clusters/{{cluster}}` | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Controls the mountOptions for dynamically provisioned PersistentVolumes of this storage class. | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy the storage PVC/PV | `string` | `"default"` | no |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the VPC Network peering connection.<br/>If using new VPC, please use community/modules/network/private-service-access to create private-service-access and<br/>If using existing VPC with private-service-access enabled, set this manually follow [user guide](https://cloud.google.com/parallelstore/docs/vpc). | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to host the cluster in. | `string` | n/a | yes |
 | <a name="input_pv_mount_path"></a> [pv\_mount\_path](#input\_pv\_mount\_path) | Path within the container at which the volume should be mounted. Must not contain ':'. | `string` | `"/data"` | no |

--- a/modules/file-system/gke-storage/main.tf
+++ b/modules/file-system/gke-storage/main.tf
@@ -57,6 +57,13 @@ module "kubectl_apply" {
             topology_zones      = var.sc_topology_zones
         })
       },
+      var.namespace != "default" ? [{
+        content = templatefile(
+          "${path.module}/persistent-volume-claim/namespace.yaml.tftpl",
+          {
+            namespace = var.namespace
+        })
+      }] : [],
       # create PersistentVolumeClaim in the cluster
       flatten([
         for idx in range(var.pvc_count) : [
@@ -69,6 +76,7 @@ module "kubectl_apply" {
                 capacity           = "${var.capacity_gb}Gi"
                 access_mode        = var.access_mode
                 storage_class_name = local.storage_class_name
+                namespace          = var.namespace
               }
             )
           }

--- a/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-balanced-pvc.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-balanced-pvc.yaml.tftpl
@@ -1,7 +1,9 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-extreme-pvc.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-extreme-pvc.yaml.tftpl
@@ -1,7 +1,9 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-throughput-pvc.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/hyperdisk-throughput-pvc.yaml.tftpl
@@ -1,7 +1,9 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-storage/persistent-volume-claim/namespace.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/namespace.yaml.tftpl
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${namespace}

--- a/modules/file-system/gke-storage/persistent-volume-claim/parallelstore-pvc.yaml.tftpl
+++ b/modules/file-system/gke-storage/persistent-volume-claim/parallelstore-pvc.yaml.tftpl
@@ -1,7 +1,9 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ${pvc_name}
+  namespace: ${namespace}
   labels:
   %{~ for key, val in labels ~}
     ${key}: ${val}

--- a/modules/file-system/gke-storage/variables.tf
+++ b/modules/file-system/gke-storage/variables.tf
@@ -136,3 +136,9 @@ variable "private_vpc_connection_peering" {
   type        = string
   default     = null
 }
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy the storage PVC/PV"
+  type        = string
+  default     = "default"
+}


### PR DESCRIPTION
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)

**This PR enhances the GKE modules to allow users to specify a custom Kubernetes namespace for deployed resources.
Modules updated:**

- gke-persistent-volume
- gke-storage

Users can now provide a namespace variable to deploy resources into a desired namespace. If the namespace variable is not specified, the modules will continue to use their default namespace settings.
