### PR TITLE
add gcluster-build-info to hcs image build

### DIFF
--- a/examples/machine-learning/build-service-images/a3m/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/a3m/blueprint.yaml
@@ -30,6 +30,7 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - $(vars.runner_write_gcluster_build_info)
       - $(vars.runner_install_cluster_health_scanner)
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container

--- a/examples/machine-learning/build-service-images/build.sh
+++ b/examples/machine-learning/build-service-images/build.sh
@@ -29,6 +29,25 @@ if [[ ! -d "$RECIPE" ]]; then
 	exit 1
 fi
 
+GCLUSTER_VERSION="$(gcluster --version 2>&1 || echo 'gcluster not found')"
+readonly GCLUSTER_VERSION
+GIT_STATUS="$(git status --porcelain 2>&1 || echo 'not a git repository')"
+readonly GIT_STATUS
+
+INFO_STRING=$(
+	cat <<EOF
+gcluster version:
+$GCLUSTER_VERSION
+
+Git Status:
+$GIT_STATUS
+EOF
+)
+
+GCLUSTER_BUILD_INFO=$(echo -n "$INFO_STRING")
+readonly GCLUSTER_BUILD_INFO
+echo "$GCLUSTER_BUILD_INFO" >./gcluster-build-info
+
 readonly FAMILY="$RECIPE-$SUFFIX"
 LONG_DEPLOYMENT_NAME="$USER-$FAMILY"
 readonly DEPLOYMENT_NAME="${LONG_DEPLOYMENT_NAME:0:31}"

--- a/examples/machine-learning/build-service-images/common/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/common/blueprint.yaml
@@ -30,6 +30,7 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - $(vars.runner_write_gcluster_build_info)
       - $(vars.runner_install_cluster_health_scanner)
       - type: data  # see https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/4152
         destination: /etc/apt/preferences.d/block-broken-nvidia-container

--- a/examples/machine-learning/build-service-images/shared.yaml
+++ b/examples/machine-learning/build-service-images/shared.yaml
@@ -33,6 +33,11 @@ vars:
           APT::Periodic::Update-Package-Lists "0";
           APT::Periodic::Unattended-Upgrade "0";
 
+  runner_write_gcluster_build_info:
+    type: data
+    destination: /etc/gcluster-build-info
+    source: $(ghpc_stage("../gcluster-build-info"))
+
   runner_install_slurm:
     type: shell
     destination: install_slurm.sh


### PR DESCRIPTION
built a new A3M and common image and deployed an A3M and A3U cluster using built images. confirmed that `/etc/gcluster-build-info` is present on all nodes in both clusters.

```
cat /etc/gcluster-build-info
gcluster version:
WARNING: gcluster binary was built from a different commit (update_chs_commit/86c4816) than the current git branch in /home/user/hpc-toolkit-1/examples/machine-learning/build-service-images (add-gcluster-build-info/34fedc1). You can rebuild the binary by running 'make'
gcluster version - not built from official release
Built from 'update_chs_commit' branch.
Commit info: v1.57.2-70-g86c481685-dirty
Terraform version: 1.12.2

Git Status:
 M examples/machine-learning/build-service-images/a3m/blueprint.yaml
 M examples/machine-learning/build-service-images/build.sh
 M examples/machine-learning/build-service-images/common/blueprint.yaml
 M examples/machine-learning/build-service-images/shared.yaml
?? deploy.sh
?? examples/machine-learning/build-service-images/gcluster-build-info
```


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
