### PR TITLE
Revert "Added capacity checks for reservations"

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -305,7 +305,6 @@ limitations under the License.
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_machine_types.machine_info](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_machine_types) | data source |
-| [google_compute_reservation.specific](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_compute_reservation.specific_reservations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_reservation) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 


### PR DESCRIPTION
Reverts GoogleCloudPlatform/cluster-toolkit#4372

Reverting this because it's causing A4X deployment to fail. A4x operates differently from previous machines due to the added NVL72 domain topology, this causes the deployments to always fail unless we specify the exact number of assured nodes per subblock in separate gke-node-pool modules in the blueprint.