### PR TITLE
Added partial Slinky install option

### DIFF
--- a/community/modules/scheduler/slinky/README.md
+++ b/community/modules/scheduler/slinky/README.md
@@ -112,13 +112,19 @@ No modules.
 | <a name="input_cert_manager_values"></a> [cert\_manager\_values](#input\_cert\_manager\_values) | Value overrides for the Cert Manager release | `any` | <pre>{<br/>  "crds": {<br/>    "enabled": true<br/>  }<br/>}</pre> | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the GKE cluster resource with format projects/<project\_id>/locations/<region>/clusters/<name>. | `string` | n/a | yes |
 | <a name="input_install_kube_prometheus_stack"></a> [install\_kube\_prometheus\_stack](#input\_install\_kube\_prometheus\_stack) | Install the Kube Prometheus Stack. | `bool` | `false` | no |
+| <a name="input_install_slurm_chart"></a> [install\_slurm\_chart](#input\_install\_slurm\_chart) | Install slurm-operator chart. | `bool` | `true` | no |
+| <a name="input_install_slurm_operator_chart"></a> [install\_slurm\_operator\_chart](#input\_install\_slurm\_operator\_chart) | Install slurm-operator chart. | `bool` | `true` | no |
 | <a name="input_node_pool_names"></a> [node\_pool\_names](#input\_node\_pool\_names) | Names of node pools, for use in node affinities (Slinky system components). | `list(string)` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID that hosts the GKE cluster. | `string` | n/a | yes |
 | <a name="input_prometheus_chart_version"></a> [prometheus\_chart\_version](#input\_prometheus\_chart\_version) | Version of the Kube Prometheus Stack chart to install. | `string` | `"70.4.1"` | no |
 | <a name="input_prometheus_values"></a> [prometheus\_values](#input\_prometheus\_values) | Value overrides for the Prometheus release | `any` | <pre>{<br/>  "installCRDs": true<br/>}</pre> | no |
 | <a name="input_slurm_chart_version"></a> [slurm\_chart\_version](#input\_slurm\_chart\_version) | Version of the Slurm chart to install. | `string` | `"0.2.1"` | no |
+| <a name="input_slurm_namespace"></a> [slurm\_namespace](#input\_slurm\_namespace) | slurm namespace for charts | `string` | `"slurm"` | no |
 | <a name="input_slurm_operator_chart_version"></a> [slurm\_operator\_chart\_version](#input\_slurm\_operator\_chart\_version) | Version of the Slurm Operator chart to install. | `string` | `"0.2.1"` | no |
+| <a name="input_slurm_operator_namespace"></a> [slurm\_operator\_namespace](#input\_slurm\_operator\_namespace) | slurm namespace for charts | `string` | `"slinky"` | no |
+| <a name="input_slurm_operator_repository"></a> [slurm\_operator\_repository](#input\_slurm\_operator\_repository) | Value overrides for the Slinky release | `string` | `"oci://ghcr.io/slinkyproject/charts"` | no |
 | <a name="input_slurm_operator_values"></a> [slurm\_operator\_values](#input\_slurm\_operator\_values) | Value overrides for the Slinky release | `any` | `{}` | no |
+| <a name="input_slurm_repository"></a> [slurm\_repository](#input\_slurm\_repository) | Value overrides for the Slinky release | `string` | `"oci://ghcr.io/slinkyproject/charts"` | no |
 | <a name="input_slurm_values"></a> [slurm\_values](#input\_slurm\_values) | Value overrides for the Slurm release | `any` | `{}` | no |
 
 ## Outputs
@@ -126,4 +132,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_instructions"></a> [instructions](#output\_instructions) | Post deployment instructions. |
+| <a name="output_slurm_namespace"></a> [slurm\_namespace](#output\_slurm\_namespace) | namespace for the slurm chart |
+| <a name="output_slurm_operator_namespace"></a> [slurm\_operator\_namespace](#output\_slurm\_operator\_namespace) | namespace for the slinky operator chart |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/slinky/main.tf
+++ b/community/modules/scheduler/slinky/main.tf
@@ -68,11 +68,12 @@ resource "helm_release" "cert_manager" {
 }
 
 resource "helm_release" "slurm_operator" {
+  count            = var.install_slurm_operator_chart ? 1 : 0
   name             = "slurm-operator"
   chart            = "slurm-operator"
-  repository       = "oci://ghcr.io/slinkyproject/charts"
+  repository       = var.slurm_operator_repository
   version          = var.slurm_operator_chart_version
-  namespace        = "slinky"
+  namespace        = var.slurm_operator_namespace
   create_namespace = true
 
   # The Cert Manager webhook deployment must be running to provision the Operator
@@ -94,11 +95,12 @@ resource "helm_release" "slurm_operator" {
 }
 
 resource "helm_release" "slurm" {
+  count            = var.install_slurm_chart ? 1 : 0
   name             = "slurm"
   chart            = "slurm"
-  repository       = "oci://ghcr.io/slinkyproject/charts"
+  repository       = var.slurm_repository
   version          = var.slurm_chart_version
-  namespace        = "slurm"
+  namespace        = var.slurm_namespace
   create_namespace = true
 
   # The Slurm Operator must be running to provision Slurm clusters/nodesets

--- a/community/modules/scheduler/slinky/outputs.tf
+++ b/community/modules/scheduler/slinky/outputs.tf
@@ -27,3 +27,13 @@ output "instructions" {
       squeue
   EOT
 }
+
+output "slurm_namespace" {
+  description = "namespace for the slurm chart"
+  value       = var.slurm_namespace
+}
+
+output "slurm_operator_namespace" {
+  description = "namespace for the slinky operator chart"
+  value       = var.slurm_operator_namespace
+}

--- a/community/modules/scheduler/slinky/variables.tf
+++ b/community/modules/scheduler/slinky/variables.tf
@@ -89,3 +89,39 @@ variable "prometheus_values" {
     installCRDs = true
   }
 }
+
+variable "slurm_namespace" {
+  description = "slurm namespace for charts"
+  type        = string
+  default     = "slurm"
+}
+
+variable "slurm_operator_namespace" {
+  description = "slurm namespace for charts"
+  type        = string
+  default     = "slinky"
+}
+
+variable "install_slurm_chart" {
+  description = "Install slurm-operator chart."
+  type        = bool
+  default     = true
+}
+
+variable "install_slurm_operator_chart" {
+  description = "Install slurm-operator chart."
+  type        = bool
+  default     = true
+}
+
+variable "slurm_repository" {
+  description = "Value overrides for the Slinky release"
+  type        = string
+  default     = "oci://ghcr.io/slinkyproject/charts"
+}
+
+variable "slurm_operator_repository" {
+  description = "Value overrides for the Slinky release"
+  type        = string
+  default     = "oci://ghcr.io/slinkyproject/charts"
+}


### PR DESCRIPTION
- The below variables allow partial installation of helm charts: install_slurm_chart install_slurm_operator_chart

- Accept slurm_namespace and  slurm_operator_namespace as variables

- Accept slurm_operator_repository and slurm_repository variables (for dev purposes)