### PR TITLE
Adding license to j2 and ps1 files

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/c2_daemon/templates/ghpcfe_c2.yaml.j2
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/c2_daemon/templates/ghpcfe_c2.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 topic_path: {{ ansible_local.ghpcfe.config.fec2_topic }}
 subscription_path: {{ ansible_local.ghpcfe.config.fec2_subscription }}
 cluster_id: {{ ansible_local.ghpcfe.config.cluster_id }}

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/containers/templates/enroot_credentials.j2
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/containers/templates/enroot_credentials.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 # Enroot Credentials File
 # Managed by Ansible. Manual changes will be overwritten!
 

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/artifact_registry_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/artifact_registry_config.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 - source: community/modules/container/artifact-registry
   kind: terraform
   id: {{ registry_id }}

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/cloudsql_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/cloudsql_config.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 - source: community/modules/database/slurm-cloudsql-federation
   kind: terraform
   id: slurm-sql

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/cluster_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/cluster_config.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 blueprint_name: {{ cluster.cloud_id }}
 
 vars:

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/filesystem_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/filesystem_config.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 - source: modules/file-system/pre-existing-network-storage
   kind: terraform
   id: {{ storage_id }}

--- a/community/front-end/ofe/website/ghpcfe/templates/blueprint/partition_config.yaml.j2
+++ b/community/front-end/ofe/website/ghpcfe/templates/blueprint/partition_config.yaml.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 - source: community/modules/compute/schedmd-slurm-gcp-v6-partition
   kind: terraform
   id: {{ part_id }}

--- a/community/modules/scripts/windows-startup-script/templates/setx_http_proxy.ps1
+++ b/community/modules/scripts/windows-startup-script/templates/setx_http_proxy.ps1
@@ -1,3 +1,19 @@
+<#
+ Copyright 2025 "Google LLC"
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+#>
+
 #Requires -RunAsAdministrator
 
 setx http_proxy ${http_proxy} /m

--- a/examples/science/af3-slurm/examples/simple_job_launcher/launch_af3_job.sh.j2
+++ b/examples/science/af3-slurm/examples/simple_job_launcher/launch_af3_job.sh.j2
@@ -1,4 +1,20 @@
 #!/bin/bash
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 
 # --- Capture Launch Directory ---
 LAUNCH_DIR=$(pwd)

--- a/examples/science/af3-slurm/examples/simple_service_launcher/af3config.json.j2
+++ b/examples/science/af3-slurm/examples/simple_service_launcher/af3config.json.j2
@@ -1,3 +1,19 @@
+{#
+Copyright 2025 "Google LLC"
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
 {
     "bucket_name": "{{ bucket_name }}",
     "time_interval": 30,


### PR DESCRIPTION
The addlicense precommit check was updated overnight adding compatibility for .j2 and .ps1 files, breaking the current release merge back into develop.  A number of our files were committed without the proper license, so this attempts to fix that issue.