### PR TITLE
Fix inconsistent plan on Slurm cluster reconfigure

### DIFF
--- a/community/modules/internal/slurm-gcp/login/README.md
+++ b/community/modules/internal/slurm-gcp/login/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.84 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 
 ## Modules
 

--- a/community/modules/internal/slurm-gcp/login/main.tf
+++ b/community/modules/internal/slurm-gcp/login/main.tf
@@ -85,9 +85,10 @@ resource "google_storage_bucket_object" "startup_scripts" {
     ) => s.content
   }
 
-  bucket  = var.slurm_bucket_name
-  name    = "${var.slurm_bucket_dir}/${each.key}"
-  content = each.value
+  bucket         = var.slurm_bucket_name
+  name           = "${var.slurm_bucket_dir}/${each.key}"
+  content        = each.value
+  source_md5hash = md5(each.value)
 }
 
 locals {
@@ -101,9 +102,10 @@ locals {
 }
 
 resource "google_storage_bucket_object" "config" {
-  bucket  = var.slurm_bucket_name
-  name    = "${var.slurm_bucket_dir}/login_group_configs/${local.name}.yaml"
-  content = yamlencode(local.config)
+  bucket         = var.slurm_bucket_name
+  name           = "${var.slurm_bucket_dir}/login_group_configs/${local.name}.yaml"
+  content        = yamlencode(local.config)
+  source_md5hash = md5(yamlencode(local.config))
 
   # To ensure that login group "is not ready" until all startup scripts are written down
   depends_on = [google_storage_bucket_object.startup_scripts]

--- a/community/modules/internal/slurm-gcp/login/versions.tf
+++ b/community/modules/internal/slurm-gcp/login/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84"
+      version = ">= 6.41"
     }
   }
   provider_meta "google" {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -262,14 +262,14 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 4.84 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.0.0 |
 
 ## Modules

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.53 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
@@ -28,7 +28,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.53 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 | <a name="provider_local"></a> [local](#provider\_local) | ~> 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -302,7 +302,7 @@ resource "google_storage_bucket_object" "prolog_scripts" {
   name           = format("%s/slurm-prolog-script-%s", local.bucket_dir, each.key)
   content        = each.value.content
   source         = each.value.source
-  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : filemd5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "epilog_scripts" {
@@ -315,7 +315,7 @@ resource "google_storage_bucket_object" "epilog_scripts" {
   name           = format("%s/slurm-epilog-script-%s", local.bucket_dir, each.key)
   content        = each.value.content
   source         = each.value.source
-  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : filemd5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "task_prolog_scripts" {
@@ -328,7 +328,7 @@ resource "google_storage_bucket_object" "task_prolog_scripts" {
   name           = format("%s/slurm-task_prolog-script-%s", local.bucket_dir, each.key)
   content        = each.value.content
   source         = each.value.source
-  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : filemd5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "task_epilog_scripts" {
@@ -341,7 +341,7 @@ resource "google_storage_bucket_object" "task_epilog_scripts" {
   name           = format("%s/slurm-task_epilog-script-%s", local.bucket_dir, each.key)
   content        = each.value.content
   source         = each.value.source
-  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : filemd5(each.value.source)
 }
 
 ############################

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -119,9 +119,10 @@ locals {
 }
 
 resource "google_storage_bucket_object" "config" {
-  bucket  = data.google_storage_bucket.this.name
-  name    = "${local.bucket_dir}/config.yaml"
-  content = yamlencode(local.config)
+  bucket         = data.google_storage_bucket.this.name
+  name           = "${local.bucket_dir}/config.yaml"
+  content        = yamlencode(local.config)
+  source_md5hash = md5(yamlencode(local.config))
 
   # Take dependency on all other "config artifacts" so creation of `config.yaml`
   # can be used as a signal for setup.py that "everything is ready".
@@ -141,25 +142,28 @@ resource "google_storage_bucket_object" "nodeset_config" {
     instance_properties = jsondecode(ns.instance_properties_json)
   }) }
 
-  bucket  = data.google_storage_bucket.this.name
-  name    = "${local.bucket_dir}/nodeset_configs/${each.key}.yaml"
-  content = yamlencode(each.value)
+  bucket         = data.google_storage_bucket.this.name
+  name           = "${local.bucket_dir}/nodeset_configs/${each.key}.yaml"
+  content        = yamlencode(each.value)
+  source_md5hash = md5(yamlencode(each.value))
 }
 
 resource "google_storage_bucket_object" "nodeset_dyn_config" {
   for_each = { for ns in var.nodeset_dyn : ns.nodeset_name => ns }
 
-  bucket  = data.google_storage_bucket.this.name
-  name    = "${local.bucket_dir}/nodeset_dyn_configs/${each.key}.yaml"
-  content = yamlencode(each.value)
+  bucket         = data.google_storage_bucket.this.name
+  name           = "${local.bucket_dir}/nodeset_dyn_configs/${each.key}.yaml"
+  content        = yamlencode(each.value)
+  source_md5hash = md5(yamlencode(each.value))
 }
 
 resource "google_storage_bucket_object" "nodeset_tpu_config" {
   for_each = { for n in var.nodeset_tpu[*].nodeset : n.nodeset_name => n }
 
-  bucket  = data.google_storage_bucket.this.name
-  name    = "${local.bucket_dir}/nodeset_tpu_configs/${each.key}.yaml"
-  content = yamlencode(each.value)
+  bucket         = data.google_storage_bucket.this.name
+  name           = "${local.bucket_dir}/nodeset_tpu_configs/${each.key}.yaml"
+  content        = yamlencode(each.value)
+  source_md5hash = md5(yamlencode(each.value))
 }
 
 #########
@@ -245,9 +249,10 @@ data "archive_file" "slurm_gcp_devel_compute_zip" {
 }
 
 resource "google_storage_bucket_object" "devel" {
-  bucket = var.bucket_name
-  name   = local.slurm_gcp_devel_zip_bucket
-  source = data.archive_file.slurm_gcp_devel_controller_zip.output_path
+  bucket         = var.bucket_name
+  name           = local.slurm_gcp_devel_zip_bucket
+  source         = data.archive_file.slurm_gcp_devel_controller_zip.output_path
+  source_md5hash = data.archive_file.slurm_gcp_devel_controller_zip.output_md5
 }
 
 resource "google_storage_bucket_object" "devel_compute" {
@@ -266,9 +271,10 @@ resource "google_storage_bucket_object" "controller_startup_scripts" {
     : replace(basename(x.filename), "/[^a-zA-Z0-9-_]/", "_") => x
   }
 
-  bucket  = var.bucket_name
-  name    = format("%s/slurm-controller-script-%s", local.bucket_dir, each.key)
-  content = each.value.content
+  bucket         = var.bucket_name
+  name           = format("%s/slurm-controller-script-%s", local.bucket_dir, each.key)
+  content        = each.value.content
+  source_md5hash = md5(each.value.content)
 }
 
 resource "google_storage_bucket_object" "nodeset_startup_scripts" {
@@ -280,9 +286,10 @@ resource "google_storage_bucket_object" "nodeset_startup_scripts" {
       name = format("slurm-nodeset-%s-script-%s", nodeset, replace(basename(s.filename), "/[^a-zA-Z0-9-_]/", "_")) }
   ]]) : x.name => x.content }
 
-  bucket  = var.bucket_name
-  name    = format("%s/%s", local.bucket_dir, each.key)
-  content = each.value
+  bucket         = var.bucket_name
+  name           = format("%s/%s", local.bucket_dir, each.key)
+  content        = each.value
+  source_md5hash = md5(each.value)
 }
 
 resource "google_storage_bucket_object" "prolog_scripts" {
@@ -291,10 +298,11 @@ resource "google_storage_bucket_object" "prolog_scripts" {
     : replace(basename(x.filename), "/[^a-zA-Z0-9-_]/", "_") => x
   }
 
-  bucket  = var.bucket_name
-  name    = format("%s/slurm-prolog-script-%s", local.bucket_dir, each.key)
-  content = each.value.content
-  source  = each.value.source
+  bucket         = var.bucket_name
+  name           = format("%s/slurm-prolog-script-%s", local.bucket_dir, each.key)
+  content        = each.value.content
+  source         = each.value.source
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "epilog_scripts" {
@@ -303,10 +311,11 @@ resource "google_storage_bucket_object" "epilog_scripts" {
     : replace(basename(x.filename), "/[^a-zA-Z0-9-_]/", "_") => x
   }
 
-  bucket  = var.bucket_name
-  name    = format("%s/slurm-epilog-script-%s", local.bucket_dir, each.key)
-  content = each.value.content
-  source  = each.value.source
+  bucket         = var.bucket_name
+  name           = format("%s/slurm-epilog-script-%s", local.bucket_dir, each.key)
+  content        = each.value.content
+  source         = each.value.source
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "task_prolog_scripts" {
@@ -315,10 +324,11 @@ resource "google_storage_bucket_object" "task_prolog_scripts" {
     : replace(basename(x.filename), "/[^a-zA-Z0-9-_]/", "_") => x
   }
 
-  bucket  = var.bucket_name
-  name    = format("%s/slurm-task_prolog-script-%s", local.bucket_dir, each.key)
-  content = each.value.content
-  source  = each.value.source
+  bucket         = var.bucket_name
+  name           = format("%s/slurm-task_prolog-script-%s", local.bucket_dir, each.key)
+  content        = each.value.content
+  source         = each.value.source
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
 }
 
 resource "google_storage_bucket_object" "task_epilog_scripts" {
@@ -327,10 +337,11 @@ resource "google_storage_bucket_object" "task_epilog_scripts" {
     : replace(basename(x.filename), "/[^a-zA-Z0-9-_]/", "_") => x
   }
 
-  bucket  = var.bucket_name
-  name    = format("%s/slurm-task_epilog-script-%s", local.bucket_dir, each.key)
-  content = each.value.content
-  source  = each.value.source
+  bucket         = var.bucket_name
+  name           = format("%s/slurm-task_epilog-script-%s", local.bucket_dir, each.key)
+  content        = each.value.content
+  source         = each.value.source
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
 }
 
 ############################

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -256,9 +256,10 @@ resource "google_storage_bucket_object" "devel" {
 }
 
 resource "google_storage_bucket_object" "devel_compute" {
-  bucket = var.bucket_name
-  name   = local.slurm_gcp_devel_compute_zip_bucket
-  source = data.archive_file.slurm_gcp_devel_compute_zip.output_path
+  bucket         = var.bucket_name
+  name           = local.slurm_gcp_devel_compute_zip_bucket
+  source         = data.archive_file.slurm_gcp_devel_compute_zip.output_path
+  source_md5hash = data.archive_file.slurm_gcp_devel_compute_zip.output_md5
 }
 
 ###########

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
@@ -23,7 +23,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53"
+      version = ">= 6.41"
     }
     random = {
       source  = "hashicorp/random"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -162,9 +162,10 @@ module "nodeset_cleanup_tpu" {
 resource "google_storage_bucket_object" "parition_config" {
   for_each = { for p in var.partitions : p.partition_name => p }
 
-  bucket  = module.slurm_files.bucket_name
-  name    = "${module.slurm_files.bucket_dir}/partition_configs/${each.key}.yaml"
-  content = yamlencode(each.value)
+  bucket         = module.slurm_files.bucket_name
+  name           = "${module.slurm_files.bucket_dir}/partition_configs/${each.key}.yaml"
+  content        = yamlencode(each.value)
+  source_md5hash = md5(yamlencode(each.value))
 }
 
 moved {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -20,7 +20,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.84"
+      version = ">= 6.41"
     }
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -283,7 +283,7 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
@@ -291,7 +291,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -280,11 +280,12 @@ resource "google_storage_bucket_iam_binding" "viewers" {
 
 resource "google_storage_bucket_object" "scripts" {
   # this writes all scripts exactly once into GCS
-  for_each = local.runners_map
-  name     = "${local.storage_folder_path_prefix}${each.key}-${substr(try(md5(each.value.content), filemd5(each.value.source)), 0, 4)}"
-  content  = each.value.content
-  source   = each.value.source
-  bucket   = local.storage_bucket_name
+  for_each       = local.runners_map
+  name           = "${local.storage_folder_path_prefix}${each.key}-${substr(try(md5(each.value.content), filemd5(each.value.source)), 0, 4)}"
+  content        = each.value.content
+  source         = each.value.source
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  bucket         = local.storage_bucket_name
   timeouts {
     create = "10m"
     update = "10m"

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -284,7 +284,7 @@ resource "google_storage_bucket_object" "scripts" {
   name           = "${local.storage_folder_path_prefix}${each.key}-${substr(try(md5(each.value.content), filemd5(each.value.source)), 0, 4)}"
   content        = each.value.content
   source         = each.value.source
-  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : md5(each.value.source)
+  source_md5hash = each.value.content != null && each.value.content != "" ? md5(each.value.content) : filemd5(each.value.source)
   bucket         = local.storage_bucket_name
   timeouts {
     create = "10m"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.83"
+      version = ">= 6.41"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
When changing startup script content or changing partitions, following error may occur:
```
╷
│ Error: Provider produced inconsistent final plan │
│ When expanding the plan for module.slurm_controller.module.slurm_files.google_storage_bucket_object.nodeset_config["flexnodeset"] to include new values learned so far during apply, provider "registry.terraform.io/hashicorp/google" produced an invalid new value for .md5hash: was known, but now unknown. │
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
```
By adding `source_md5hash` attribute to `google_storage_bucket_object` this problem is no longer reproducible.

Bumped version of the provider to v6.41 as this is when `source_md5hash` was introduced.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)

b/398227662
