### PR TITLE
Add GPU type to Slurm's gres.config

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
@@ -190,3 +190,25 @@ def test_conflines(cfg, want):
 
     cfg.cloud_parameters = addict.Dict(cfg.cloud_parameters)
     assert conf.conflines(util.Lookup(cfg)) == want
+
+
+@pytest.mark.parametrize(
+    "cfg,gputype,gpucount,want",
+    [
+        (TstCfg(),
+        "",
+        0,
+         "\n"),
+        (TstCfg(
+            nodeset={"turbo": TstNodeset("turbo")}
+        ), 
+        "Popov",
+        8,
+         "Name=gpu Type=Popov File=/dev/nvidia[0-7]\n\n"),
+    ])
+def test_gen_cloud_gres_conf_lines(cfg, gputype, gpucount, want):
+    lkp = util.Lookup(cfg)
+    lkp.template_info = Mock(return_value=TstTemplateInfo(
+        gpu=util.AcceleratorInfo(type=gputype, count=gpucount)
+    ))
+    assert conf.gen_cloud_gres_conf_lines(lkp) == want


### PR DESCRIPTION
GPU type is missing in the cloud_gres.config file.
This changes add the type to the config.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
