### PR TITLE
Add validation for disk compatibility

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -73,6 +73,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../../../modules/internal/gpu-definition | n/a |
+| <a name="module_instance_validation"></a> [instance\_validation](#module\_instance\_validation) | ../../../../modules/internal/instance_validations | n/a |
 | <a name="module_slurm_nodeset_template"></a> [slurm\_nodeset\_template](#module\_slurm\_nodeset\_template) | ../../internal/slurm-gcp/instance_template | n/a |
 
 ## Resources

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/main.tf
@@ -17,6 +17,13 @@ locals {
   labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-nodeset-dynamic", ghpc_role = "compute" })
 }
 
+module "instance_validation" {
+  source = "../../../../modules/internal/instance_validations"
+
+  machine_type = var.machine_type
+  disk_type    = var.disk_type
+}
+
 module "gpu" {
   source = "../../../../modules/internal/gpu-definition"
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -145,6 +145,7 @@ modules. For support with the underlying modules, see the instructions in the
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../../../modules/internal/gpu-definition | n/a |
+| <a name="module_instance_validation"></a> [instance\_validation](#module\_instance\_validation) | ../../../../modules/internal/instance_validations | n/a |
 
 ## Resources
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/main.tf
@@ -17,6 +17,13 @@ locals {
   labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-nodeset", ghpc_role = "compute" })
 }
 
+module "instance_validation" {
+  source = "../../../../modules/internal/instance_validations"
+
+  machine_type = var.machine_type
+  disk_type    = var.disk_type
+}
+
 module "gpu" {
   source = "../../../../modules/internal/gpu-definition"
 

--- a/community/modules/internal/slurm-gcp/instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/instance_template/README.md
@@ -17,6 +17,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_instance_template"></a> [instance\_template](#module\_instance\_template) | ../internal_instance_template | n/a |
+| <a name="module_instance_validation"></a> [instance\_validation](#module\_instance\_validation) | ../../../../../modules/internal/instance_validations | n/a |
 
 ## Resources
 

--- a/community/modules/internal/slurm-gcp/instance_template/main.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/main.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+module "instance_validation" {
+  source = "../../../../../modules/internal/instance_validations"
+
+  machine_type = var.machine_type
+  disk_type    = var.disk_type
+}
+
 ##########
 # LOCALS #
 ##########

--- a/community/modules/internal/slurm-gcp/internal_instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/README.md
@@ -16,7 +16,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_instance_validation"></a> [instance\_validation](#module\_instance\_validation) | ../../../../../modules/internal/instance_validations | n/a |
 
 ## Resources
 

--- a/community/modules/internal/slurm-gcp/internal_instance_template/main.tf
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/main.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+module "instance_validation" {
+  source = "../../../../../modules/internal/instance_validations"
+
+  machine_type = var.machine_type
+  disk_type    = var.disk_type
+}
+
 #########
 # Locals
 #########

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -71,6 +71,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../../../modules/internal/gpu-definition | n/a |
+| <a name="module_instance_validation"></a> [instance\_validation](#module\_instance\_validation) | ../../../../modules/internal/instance_validations | n/a |
 
 ## Resources
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/main.tf
@@ -17,6 +17,13 @@ locals {
   labels = merge(var.labels, { ghpc_module = "schedmd-slurm-gcp-v6-login", ghpc_role = "scheduler" })
 }
 
+module "instance_validation" {
+  source = "../../../../modules/internal/instance_validations"
+
+  machine_type = var.machine_type
+  disk_type    = var.disk_type
+}
+
 module "gpu" {
   source = "../../../../modules/internal/gpu-definition"
 

--- a/modules/internal/instance_validations/README.md
+++ b/modules/internal/instance_validations/README.md
@@ -1,0 +1,30 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | The disk type to validate. | `string` | n/a | yes |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type to validate. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/internal/instance_validations/main.tf
+++ b/modules/internal/instance_validations/main.tf
@@ -1,0 +1,52 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+check "disk_type_c4_compatibility" {
+  assert {
+    condition     = !(can(regex("^c4-", var.machine_type)) && var.disk_type == "pd-ssd")
+    error_message = "The C4 machine series does not support pd-ssd. Please use hyperdisk-balanced or another compatible disk type."
+  }
+}
+
+
+check "disk_type_c2_compatibility" {
+  assert {
+    condition     = !(can(regex("^c2-", var.machine_type)) && can(regex("hyperdisk", var.disk_type)))
+    error_message = "The C2 machine series does not support Hyperdisk as a boot disk. Please use a compatible disk type like pd-ssd, pd-standard, or pd-balanced."
+  }
+}
+
+
+check "disk_type_pd_extreme_compatibility" {
+  assert {
+    condition     = var.disk_type != "pd-extreme" || can(regex("^(m1-|m2-|m3-|n2-|n2d-)", var.machine_type))
+    error_message = "pd-extreme disks are only supported for M1, M2, M3, N2, and N2D machine series."
+  }
+}
+
+
+check "disk_type_hyperdisk_extreme_compatibility" {
+  assert {
+    condition     = var.disk_type != "hyperdisk-extreme" || can(regex("^(c3-|m1-|m3-|n2-)", var.machine_type))
+    error_message = "hyperdisk-extreme disks are only supported for C3, M1, M3, and N2 machine series."
+  }
+}
+
+
+check "disk_type_hyperdisk_throughput_compatibility" {
+  assert {
+    condition     = var.disk_type != "hyperdisk-throughput" || can(regex("^(c3-|c3d-|n4-|n2-|n2d-|n1-|t2d-|m1-)", var.machine_type))
+    error_message = "hyperdisk-throughput disks are only supported for C3, C3D, N4, N2, N2D, N1, T2D, and M1 machine series."
+  }
+}

--- a/modules/internal/instance_validations/variables.tf
+++ b/modules/internal/instance_validations/variables.tf
@@ -1,0 +1,23 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "machine_type" {
+  type        = string
+  description = "The machine type to validate."
+}
+
+variable "disk_type" {
+  type        = string
+  description = "The disk type to validate."
+}

--- a/modules/internal/instance_validations/versions.tf
+++ b/modules/internal/instance_validations/versions.tf
@@ -1,0 +1,17 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 0.15.0"
+}


### PR DESCRIPTION
This PR adds a set of validation rules to prevent the use of incompatible machine types and disk types across various modules that create compute instances. This will prevent deployment-time errors and
  provide users with clear, actionable feedback when they select an invalid combination.

  Key Changes

   * Added Comprehensive Validation: Introduced validation for the following known incompatibilities:
       * C4 machine series with pd-ssd
       * C2 machine series with any hyperdisk type
       * pd-extreme with incompatible machine types (M1, M2, M3, N2, and N2D are now required)
       * hyperdisk-extreme with incompatible machine types (C3, M1, M3, and N2 are now required)
       * hyperdisk-throughput with incompatible machine types (C3, C3D, N4, N2, N2D, N1, T2D, and M1 are now required)

   * Applied to Multiple Modules: The validation logic has been added to the variables.tf file of the following modules:
       * community/modules/scheduler/schedmd-slurm-gcp-v6-login
       * community/modules/compute/schedmd-slurm-gcp-v6-nodeset
       * community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic
       * community/modules/internal/slurm-gcp/internal_instance_template
       * community/modules/internal/slurm-gcp/instance_template
       * modules/compute/vm-instance

  Testing

   1. Created a test blueprint (test-c4-validation.yaml) that used the slurm_login module with the incompatible combination of machine_type: c4-standard-32 and disk_type: "pd-ssd".
   2. Ran ./gcluster create test-c4-validation.yaml --skip-validators=... to generate the Terraform deployment files.
   3. Ran terraform plan on the generated files in the test-c4-validation/primary directory.
   4. Verified that terraform plan failed with the expected validation error: The C4 machine series does not support pd-ssd. Please use hyperdisk-balanced or another compatible disk type.
   5. Ran the full test suite with make tests to ensure no regressions were introduced.