### PR TITLE
updating example to use jax ai images

### DIFF
--- a/community/examples/gke-tpu-v6/tpu-multislice.yaml
+++ b/community/examples/gke-tpu-v6/tpu-multislice.yaml
@@ -41,7 +41,7 @@ spec:
               cloud.google.com/gke-tpu-topology: 4x4
             containers:
             - name: jax-tpu
-              image: python:3.10
+              image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:latest
               ports:
               - containerPort: 8471
               - containerPort: 8080
@@ -52,7 +52,6 @@ spec:
               - bash
               - -c
               - |
-                pip install "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
                 python -c 'import jax; print("Global device count:", jax.device_count())'
                 sleep 60
               resources:


### PR DESCRIPTION
Updating the code example to use the [jax ai image](https://cloud.google.com/ai-hypercomputer/docs/images#current_jax_ai_images) rather than installing the jax[tpu], which should help avoid any package version mismatches that can happen.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
