### PR TITLE
Surface Managed Lustre support in a4x

### DIFF
--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -29,7 +29,7 @@ vars:
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100
   built_image_family: slurm-ubuntu2404-accelerator-arm64-64k
-  build_from_git_ref: 6.10.1
+  build_from_git_ref: 6.10.5
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -93,6 +93,10 @@ deployment_groups:
               loop: "{{ nvidia_packages_to_hold }}"
 
       - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+      - type: data
         destination: /etc/security/limits.d/99-unlimited.conf
         content: |
           * - memlock unlimited
@@ -128,6 +132,7 @@ deployment_groups:
             "install_cuda": false,
             "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
+            install_managed_lustre: false,
           }
       - type: shell
         destination: install_slurm.sh
@@ -323,6 +328,27 @@ deployment_groups:
     outputs:
     - network_storage
 
+  # - id: private_service_access
+  #   source: community/modules/network/private-service-access
+  #   use: [a4x-slurm-net-0]
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - a4x-slurm-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: 18000
+  #     name: lustre-instance1
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #   outputs:
+  #   - network_storage
+
   # The following four modules create and mount a Cloud Storage Bucket with
   # gcsfuse.  They are optional but recommended for many use cases.
   # (Optional) The following creates a GCS bucket that will be mounted
@@ -454,6 +480,7 @@ deployment_groups:
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
           ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data

--- a/examples/machine-learning/build-service-images/a4x/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/a4x/blueprint.yaml
@@ -81,10 +81,6 @@ deployment_groups:
         destination: /etc/enroot/enroot.conf
         content: |
           ENROOT_CONFIG_PATH     ${HOME}/.enroot
-          ENROOT_RUNTIME_PATH    /mnt/localssd/${UID}/enroot/runtime
-          ENROOT_CACHE_PATH      /mnt/localssd/${UID}/enroot/cache
-          ENROOT_DATA_PATH       /mnt/localssd/${UID}/enroot/data
-          ENROOT_TEMP_PATH       /mnt/localssd/${UID}/enroot
       - type: ansible-local
         destination: update_settings.yml
         content: |


### PR DESCRIPTION
This PR does the below:
- updates slurm gcp tag from 6.10.1 to 6.10.5 as a4x support for managed lustre is introduced in 6.10.5
- adds managed lustre as an option in the A4X blueprint.
- fixes enroot configuration in a4x image and a4x nodeset startup script


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
