### PR TITLE
Revert gke-node-pool module to using google-beta provider

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -279,14 +279,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.46 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.46 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.46 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 6.46 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 
 ## Modules
@@ -300,7 +302,7 @@ limitations under the License.
 
 | Name | Type |
 |------|------|
-| [google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool) | resource |
+| [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
 | [null_resource.enable_tcpx_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -68,7 +68,7 @@ data "google_container_cluster" "gke_cluster" {
 }
 
 resource "google_container_node_pool" "node_pool" {
-  provider = google
+  provider = google-beta
 
   count = max(var.num_node_pools, var.num_slices)
 

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -18,7 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.41"
+      version = ">= 6.46"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = ">= 6.46"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
 `host_maintenance_policy` with `maintenance_interval = "PERIODIC"` requires the google-beta provider.

6.46 is the latest allowed version based on the constraints.

`make tests` are passing.