### PR TITLE
Add Google Cloud NetApp Volumes support

### DIFF
--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -5,6 +5,7 @@ storage.
 
 The Toolkit contains modules that will **provision**:
 
+- [Google Cloud NetApp Volumes (GCP managed enterprise NFS and SMB)][netapp-volumes]
 - [Filestore (GCP managed NFS)][filestore]
 - [DDN EXAScaler lustre][ddn-exascaler] (Deprecated, removal on July 1, 2025)
 - [Managed Lustre][managed-lustre]
@@ -106,6 +107,7 @@ nfs-server | via USE | via USE | via USE | via STARTUP | via USE | via USE
 cloud-storage-bucket (GCS)| via USE | via USE | via USE | via STARTUP | via USE | via USE
 DDN EXAScaler lustre | via USE | via USE | via USE | Needs Testing | via USE | via USE
 Managed Lustre | via USE | Needs Testing | via USE | Needs Testing | Needs Testing |  Needs Testing
+netapp-volume | Needs Testing | Needs Testing | via USE | Needs Testing | Needs Testing | Needs Testing
   |  |   |   |   |   |  
 filestore (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | via USE
 nfs-server (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | via USE
@@ -129,3 +131,4 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE | 
 [ddn-exascaler]: ../community/modules/file-system/DDN-EXAScaler/README.md
 [managed-lustre]: ../modules/file-system/managed-lustre/README.md
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md
+[netapp-volumes]: ../modules/file-system/netapp-volume/README.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [xpk-n2-filestore](#xpk-n2-filestore--) ![community-badge] ![experimental-badge]
   * [gke-h4d](#gke-h4d-) ![core-badge]
   * [gke-g4](#gke-g4-) ![core-badge]
+  * [netapp-volumes.yaml](#netapp-volumesyaml--) ![core-badge]
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Blueprint Boilerplate](#blueprint-boilerplate)
@@ -1641,6 +1642,61 @@ This blueprint uses GKE to provision a Kubernetes cluster and a H4D node pool, a
 This blueprint uses GKE to provision a Kubernetes cluster and a G4 node pool, along with networks and service accounts. Information about G4 machines can be found [here](https://cloud.google.com/blog/products/compute/introducing-g4-vm-with-nvidia-rtx-pro-6000). The deployment instructions can be found in the [README](/examples/gke-g4/README.md).
 
 [gke-g4]: ../examples/gke-g4
+
+### [netapp-volumes.yaml] ![core-badge]
+
+This blueprint demonstrates how to provision NFS volumes as shared filesystems for compute VMs, using Google Cloud NetApp Volumes. It can be used as an alternative to FileStore in blueprints.
+
+NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+
+NetApp Volume provides:
+
+* robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
+* a [rich feature set][service-levels]
+* scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
+* FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+* [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+
+Support for NetApp Volumes is split into two modules.
+
+* **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
+* **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume is a file-system which is shared using NFS or SMB. It provides advanced data management capabilities.
+
+You can provision multiple volumes in a pool. For service levels Standard, Premium and Extreme the throughput capability depends on volume size and service level. Every GiB of provisioned volume space adds 16/64/128 KiBps of throughput capability.
+
+#### Steps to deploy the blueprint
+
+To provision the bluebrint, please run:
+
+```shell
+./gcluster create examples/netapp-volumes.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}" --vars region=us-central1 --vars zone=us-central1-a
+./gcluster deploy netapp-volumes
+```
+
+After the blueprint deployed, you can login to the VM created:
+
+```shell
+gcloud compute ssh --zone "us-central1-a" "netapp-volumes-0" --project ${GOOGLE_CLOUD_PROJECT} --tunnel-through-iap
+```
+
+A NetApp Volumes volume is provisioned and mounted to /home in all the provisioned VMs. A home directory for your user is created automatically:
+
+```shell
+pwd
+df -h -t nfs
+```
+
+#### Clean Up
+To destroy all resources associated with creating the GKE cluster, run the following command:
+
+```sh
+./gcluster destroy netapp-volumes
+```
+
+[netapp-storage-pool]: ../netapp-storage-pool/README.md
+[service-levels]: https://cloud.google.com/netapp/volumes/docs/discover/service-levels
+[auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
+[netapp-volumes.yaml]: ../examples/netapp-volumes.yaml
 
 ## Blueprint Schema
 

--- a/examples/netapp-volumes.yaml
+++ b/examples/netapp-volumes.yaml
@@ -1,0 +1,107 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# This blueprint show how to provision shared file systems with Google Cloud NetApp Volumes.
+# It creates a NetApp storage pool and a volume for use by VM instances.
+# It can be used to build compute clusters on top of it and as a drop-in replacement
+# for Filestore in existing blueprints.
+
+blueprint_name: netapp-volumes
+
+vars:
+  project_id: ## Set GCP Project ID Here ##
+  deployment_name: netapp-volumes
+  region:     ## Set GCP Region Here ##
+  zone:       ## Set GCP Zone Here ##
+  pool_service_level: "EXTREME"  # Options: "STANDARD", "PREMIUM", "EXTREME"
+
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/cluster-toolkit
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  # Private Service Access (PSA) requires the compute.networkAdmin role which is
+  # included in the Owner role, but not Editor.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24
+      service_name: "netapp.servicenetworking.goog"
+      deletion_policy: "ABANDON"
+
+  - id: netapp_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: $(vars.deployment_name)-netapp-pool
+      capacity_gib: 2048
+      service_level: $(vars.pool_service_level)
+      region: $(vars.region)
+      # allow_auto_tiering: true
+
+  - id: homefs
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]             # Create this pool using the netapp-storage-pool module
+    settings:
+      region: $(vars.region)
+      volume_name: $(vars.deployment_name)-homefs
+      capacity_gib: 2048           # Size up to available capacity in the pool
+      large_capacity: false
+      local_mount: "/home"         # Mount point at client when client uses USE directive
+      # mount_options: "..."       # Use custom mount_options for special use cases. Defaults are sane.
+      protocols: ["NFSV3"]         # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
+      unix_permissions: "0777"     # Specify default permissions for root inode owned by root:root
+      # If no export policy is specified, a permissive default policy will be applied, which is:
+      #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
+      #  has_root_access = true      # no_root_squash enabled
+      #  access_type = "READ_WRITE"
+      # export_policy_rules:
+      # - allowed_clients: "10.10.20.8,10.10.20.9"
+      #   has_root_access: true      # no_root_squash enabled
+      #   access_type: "READ_WRITE"
+      #   nfsv3: true
+      #   nfsv4: false
+      # - allowed_clients: "10.0.0.0/8"
+      #   has_root_access: false     # no_root_squash disabled
+      #   access_type: "READ_WRITE"
+      #   nfsv3: true
+      #   nfsv4: false
+      # tiering_policy:              # Enable auto-tiering. Requires auto-tiering enabled storage pool
+      #   tier_action: "ENABLED"
+      #   cooling_threshold_days: 31 # tier data blocks which have not been touched for 31 days
+      # description: "Shared volume for EDA job"
+      # labels:
+      #   department: eda
+
+  # Example VMs which use homefs
+  - id: gcnv_ubuntu_instances
+    source: modules/compute/vm-instance
+    use: [network, homefs]
+    settings:
+      instance_count: 1
+      machine_type: n2-standard-2
+
+  - id: wait-for-vms
+    source: community/modules/scripts/wait-for-startup
+    settings:
+      instance_names: $(gcnv_ubuntu_instances.name)
+      timeout: 7200

--- a/modules/file-system/netapp-storage-pool/README.md
+++ b/modules/file-system/netapp-storage-pool/README.md
@@ -1,0 +1,193 @@
+## Description
+
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
+storage pool.
+
+NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volume provides:
+
+- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
+- a [rich feature set][service-levels]
+- scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
+- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+
+Support for NetApp Volumes is split into two modules.
+
+- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+
+For more information on this and other network storage options in the Cluster
+Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
+
+### NetApp storage pool service levels
+
+The netapp-storage-pool module currently supports the following NetApp Volumes [service levels][service-levels]:
+
+- Standard: 16 KiBps throughput per provisioned KiB of volume capacity.
+- Premium: 64 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
+- Extreme: 128 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
+
+Check the [service level matrix][service-levels] for additional information on capability differences between service levels. Flex service levels are currently not supported, but you can connect to existing Flex volumes using the [pre-existing-network-storage module][pre-existing].
+
+### On-boarding NetApp Volumes
+NetApp Volumes uses [Private Service Access](https://cloud.google.com/vpc/docs/private-services-access) (PSA) to connect volumes to your network. Before you create a storage pool, make sure to [connect NetApp Volumes to your network](https://cloud.google.com/netapp/volumes/docs/get-started/configure-access/networking).
+
+Example of creating a storage pool using a new network:
+
+```yaml
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+    settings:
+      region: $(vars.region)
+
+  - id: private_service_access
+    source: community/modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24
+      service_name: "netapp.servicenetworking.goog"
+      deletion_policy: "ABANDON"
+
+  - id: netapp_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: $(vars.deployment_name)-eda-pool
+      capacity_gib: 20000
+      service_level: "EXTREME"
+      region: $(vars.region)
+```
+
+Example of creating a storage pool using an existing network which was already PSA-peered with NetApp Volume:
+
+```yaml
+deployment_groups:
+ - group: primary
+  modules:
+  - id: network
+    source: modules/network/pre-existing-vpc
+    settings:
+      project_id: $(vars.project_id)
+      region: $(vars.region)
+      network_name: $(vars.network)
+
+  - id: netapp_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network]
+    settings:
+      pool_name: "eda-pool"
+      capacity_gib: 20000
+      service_level: "EXTREME"
+      region: $(vars.region)
+```
+
+### Storage pool example
+
+The following example shows all available parameters in use:
+
+```yaml
+  - id: netapp_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "mypool"
+      region: "us-west4"
+      capacity_gib: 2048
+      service_level: "EXTREME"
+      active_directory_policy: "projects/myproject/locations/us-east4/activeDirectories/my-ad"
+      cmek_policy: "projects/myproject/locations/us-east4/kmsConfigs/my-cmek-policy"
+      ldap_enabled: false
+      allow_auto_tiering: false
+      description: "Demo storage pool"
+      labels:
+        owner: bob
+```
+
+### NetApp Volumes quota
+
+Your project must have unused quota for NetApp Volumes in the region you will
+provision the storage pool. This can be found by browsing to the [Quota tab within IAM & Admin](https://console.cloud.google.com/iam-admin/quotas) in the Cloud Console.
+Please note that there are separate quota limits for Standard and Premium/Extreme service levels.
+
+See also NetApp Volumes [default quotas](https://cloud.google.com/netapp/volumes/docs/quotas#netapp-volumes-default-quotas).
+
+[service-levels]: https://cloud.google.com/netapp/volumes/docs/discover/service-levels
+[auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
+[pre-existing]: ../pre-existing-network-storage/README.md
+[matrix]: ../../../docs/network_storage.md#compatibility-matrix
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.45.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_netapp_storage_pool.netapp_storage_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/netapp_storage_pool) | resource |
+| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [google_compute_network_peering.private_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network_peering) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_active_directory_policy"></a> [active\_directory\_policy](#input\_active\_directory\_policy) | The ID of the Active Directory policy to apply to the storage pool in the format:<br/>`projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>` | `string` | `null` | no |
+| <a name="input_allow_auto_tiering"></a> [allow\_auto\_tiering](#input\_allow\_auto\_tiering) | Whether to allow automatic tiering for the storage pool. | `bool` | `false` | no |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the storage pool in GiB. | `number` | `2048` | no |
+| <a name="input_cmek_policy"></a> [cmek\_policy](#input\_cmek\_policy) | The ID of the Customer Managed Encryption Key (CMEK) policy to apply to the storage pool in the format:<br/>`projects/<project>/locations/<location>/kmsConfigs/<name>` | `string` | `null` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment, used as name of the NetApp storage pool if no name is specified. | `string` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | A description of the NetApp storage pool. | `string` | `""` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp storage pool. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_ldap_enabled"></a> [ldap\_enabled](#input\_ldap\_enabled) | Whether to enable LDAP for the storage pool. | `bool` | `false` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the NetApp storage pool is connected given in the format:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
+| <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | Network self-link the pool will be on, required for checking private service access | `string` | n/a | yes |
+| <a name="input_pool_name"></a> [pool\_name](#input\_pool\_name) | The name of the storage pool. Leave empty to generate name based on deployment name. | `string` | `null` | no |
+| <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the private VPC connection peering. | `string` | `"sn-netapp-prod"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
+| <a name="input_service_level"></a> [service\_level](#input\_service\_level) | The service level of the storage pool. | `string` | `"PREMIUM"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | Storage pool capacity in GiB. |
+| <a name="output_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#output\_netapp\_storage\_pool\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}` |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/netapp-storage-pool/main.tf
+++ b/modules/file-system/netapp-storage-pool/main.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "netapp-storage-pool", ghpc_role = "file-system" })
+}
+
+resource "random_id" "resource_name_suffix" {
+  byte_length = 4
+}
+
+data "google_compute_network_peering" "private_peering" {
+  name    = var.private_vpc_connection_peering
+  network = var.network_self_link
+}
+
+resource "google_netapp_storage_pool" "netapp_storage_pool" {
+  project = var.project_id
+
+  name          = var.pool_name != null ? var.pool_name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
+  location      = var.region
+  network       = var.network_id
+  service_level = var.service_level
+  capacity_gib  = var.capacity_gib
+
+  active_directory   = var.active_directory_policy
+  kms_config         = var.cmek_policy
+  ldap_enabled       = var.ldap_enabled
+  allow_auto_tiering = var.allow_auto_tiering
+
+  description = var.description
+  labels      = local.labels
+
+  depends_on = [data.google_compute_network_peering.private_peering]
+
+  lifecycle {
+    precondition {
+      condition     = data.google_compute_network_peering.private_peering.state == "ACTIVE"
+      error_message = "The network for the storage pool must have private service access."
+    }
+  }
+}

--- a/modules/file-system/netapp-storage-pool/metadata.yaml
+++ b/modules/file-system/netapp-storage-pool/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - netapp.googleapis.com
+    - servicenetworking.googleapis.com

--- a/modules/file-system/netapp-storage-pool/outputs.tf
+++ b/modules/file-system/netapp-storage-pool/outputs.tf
@@ -1,0 +1,23 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "netapp_storage_pool_id" {
+  description = "An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}`"
+  value       = google_netapp_storage_pool.netapp_storage_pool.id
+}
+
+output "capacity_gb" {
+  description = "Storage pool capacity in GiB."
+  value       = google_netapp_storage_pool.netapp_storage_pool.capacity_gib
+}

--- a/modules/file-system/netapp-storage-pool/variables.tf
+++ b/modules/file-system/netapp-storage-pool/variables.tf
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "ID of project in which the NetApp storage pool will be created."
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Name of the deployment, used as name of the NetApp storage pool if no name is specified."
+  type        = string
+}
+
+variable "region" {
+  description = "Location for NetApp storage pool."
+  type        = string
+}
+
+variable "network_id" {
+  description = <<-EOT
+    The ID of the GCE VPC network to which the NetApp storage pool is connected given in the format:
+    `projects/<project_id>/global/networks/<network_name>`"
+    EOT
+  type        = string
+  validation {
+    condition     = length(split("/", var.network_id)) == 5
+    error_message = "The network id must be provided in the following format: projects/<project_id>/global/networks/<network_name>."
+  }
+}
+
+variable "network_self_link" {
+  description = "Network self-link the pool will be on, required for checking private service access"
+  type        = string
+  nullable    = false
+}
+
+variable "private_vpc_connection_peering" {
+  description = "The name of the private VPC connection peering."
+  type        = string
+  default     = "sn-netapp-prod"
+}
+
+variable "pool_name" {
+  description = "The name of the storage pool. Leave empty to generate name based on deployment name."
+  type        = string
+  default     = null
+}
+
+variable "service_level" {
+  description = "The service level of the storage pool."
+  type        = string
+  default     = "PREMIUM"
+  validation {
+    condition     = contains(["STANDARD", "PREMIUM", "EXTREME"], var.service_level)
+    error_message = "Allowed values for service_level are 'STANDARD', 'PREMIUM', or 'EXTREME'."
+  }
+}
+
+variable "capacity_gib" {
+  description = "The capacity of the storage pool in GiB."
+  type        = number
+  default     = 2048
+  validation {
+    condition     = var.capacity_gib >= 2048
+    error_message = "The minimum capacity for the storage pool is 2048 GiB."
+  }
+}
+
+variable "active_directory_policy" {
+  description = <<-EOT
+    The ID of the Active Directory policy to apply to the storage pool in the format:
+    `projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>`
+    EOT
+  type        = string
+  default     = null
+  validation {
+    condition     = var.active_directory_policy == null ? true : length(split("/", var.active_directory_policy)) == 6
+    error_message = "The active directory policy must be provided in the following format: projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>."
+  }
+}
+
+variable "cmek_policy" {
+  description = <<-EOT
+    The ID of the Customer Managed Encryption Key (CMEK) policy to apply to the storage pool in the format:
+    `projects/<project>/locations/<location>/kmsConfigs/<name>`
+    EOT
+  type        = string
+  default     = null
+  validation {
+    condition     = var.cmek_policy == null ? true : length(split("/", var.cmek_policy)) == 6
+    error_message = "The CMEK policy must be provided in the following format: projects/<project>/locations/<location>/kmsConfigs/<name>."
+  }
+}
+
+variable "ldap_enabled" {
+  description = "Whether to enable LDAP for the storage pool."
+  type        = bool
+  default     = false
+}
+
+variable "allow_auto_tiering" {
+  description = "Whether to allow automatic tiering for the storage pool."
+  type        = bool
+  default     = false
+}
+
+variable "description" {
+  description = "A description of the NetApp storage pool."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.description) <= 2048
+    error_message = "NetApp storage pool description must be 2048 characters or fewer"
+  }
+}
+
+variable "labels" {
+  description = "Labels to add to the NetApp storage pool. Key-value pairs."
+  type        = map(string)
+}

--- a/modules/file-system/netapp-storage-pool/versions.tf
+++ b/modules/file-system/netapp-storage-pool/versions.tf
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.45.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.70.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.70.0"
+  }
+
+  required_version = ">= 1.5.7"
+}

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -1,0 +1,201 @@
+## Description
+
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
+volume.
+
+NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volume provides:
+
+- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
+- a [rich feature set][service-levels]
+- scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
+- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+
+Support for NetApp Volumes is split into two modules.
+
+- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+
+For more information on this and other network storage options in the Cluster
+Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
+
+## Deletion protection
+The netapp-volume module currently doesn't implement volume deletion protection. If you create a volume with Cluster Toolkit by using this module, Cluster Toolkit will also delete it when you run `gcluster destroy`. All the data in the volume will be gone. If you want to retain the volume instead, it is advised to [use existing volumes not created by Cluster Toolkit](#using-existing-volumes-not-created-by-cluster-toolkit).
+
+## Volumes overview
+Volumes are filesystem containers which can be shared using NFS or SMB filesharing protocols. Volumes *live* inside of [storage pools](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview), which can be provisioned using the [netapp-storage-pool] module. Volumes inherit fundamental settings from the pool. They *consume* capacity provided by the pool. You can create one or multiple volumes *inside* a pool.
+
+[netapp-storage-pool]: ../netapp-storage-pool/README.md
+[service-levels]: https://cloud.google.com/netapp/volumes/docs/discover/service-levels
+[auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
+[pre-existing]: ../pre-existing-network-storage/README.md
+[matrix]: ../../../docs/network_storage.md#compatibility-matrix
+
+## Volume examples
+The following examples show the use of netapp-volume. They builds on top of an storage pool which can be provisioned using the [netapp-storage-pool][netapp-storage-pool] module.
+
+### Example with minimal parameters
+
+```yaml
+  - id: home_volume
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]  # Create this pool using the netapp-storage-pool module
+    settings:
+      volume_name: "eda-home"
+      capacity_gib: 1024               # Size up to available capacity in the pool
+      local_mount: "/eda-home"         # Mount point at client when client uses USE directive
+      protocols: ["NFSV3"]
+      region: $(vars.region)
+    # Default export policy exports to "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" and no_root_squash
+```
+
+### Example with all parameters
+
+```yaml
+  - id: shared_volume
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]              # Create this pool using the netapp-storage-pool module
+    settings:
+      volume_name: "eda-shared"
+      capacity_gib: 25000           # Size up to available capacity in the pool
+      large_capacity: true
+      local_mount: "/shared"        # Mount point at client when client uses USE directive
+      mount_options: "rw"           # Allows customizing mount options for special workloads
+      protocols: ["NFSV3","NFSV4"]  # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
+      region: $(vars.region)
+      unix_permissions: "0777"      # Specify default permissions for roo inode owned by root:root
+      # If no export policy is specified, a permissive default policy will be applied, which is:
+      #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
+      #  has_root_access = true      # no_root_squash enabled
+      #  access_type = "READ_WRITE"
+      export_policy:
+      - allowed_clients: "10.10.20.8,10.10.20.9"
+        has_root_access: true       # no_root_squash enabled
+        access_type: "READ_WRITE"
+        nfsv3: false                # allow only NFSv4 for these hosts
+        nfsv4: true
+      - allowed_clients: "10.0.0.0/8"
+        has_root_access: false      # no_root_squash disabled
+        access_type: "READ_WRITE"      
+        nfsv3: true                 # allow only NFSv3 for these hosts
+        nfsv4: false
+      tiering_policy:               # Enable auto-tiering. Requires auto-tiering enabled storage pool
+        tier_action: "ENABLED"
+        cooling_threshold_days: 31  # tier data blocks which have not been touched for 31 days
+
+      description: "Shared volume for EDA job"
+      labels:
+        owner: bob
+```
+
+## Protocol support
+Since Cluster Toolkit is currently built to provision Linux-based compute clusters, this module supports NFSv3 and NFSv4.1 only. SMB is blocked.
+
+## Large volumes
+Volumes larger than 15 TiB can be created as [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes). Such volumes can grow up to 3 PiB and can scale read performance up to 29 GiBps. They provide six IP addresses to the volume. They are exported via the `server_ips` output. When connecting a large volume to a client using the USE directive, cluster toolkit currently uses the first IP only. This will be improved in the future.
+
+This feature is allow-listed GA. To request allow-listing, see [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes).
+
+## Auto-tiering support
+For auto-tiering enabled storage pools you can enable auto-tiering on the volume. For more information, see [manage auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering).
+
+## Using existing volumes not created by Cluster Toolkit
+NetApp Volumes volumes are regular NFS exports. You can use the [pre-existing-network-storage] module to integrate them into Cluster Toolkit.
+
+Example code:
+
+```yaml
+- id: homefs
+  source: modules/file-system/pre-existing-network-storage
+  settings:
+    server_ip: ## Set server IP here ##
+    remote_mount: nfsshare
+    local_mount: /home
+    fs_type: nfs
+```
+
+This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/home` by clients which mount if via USE directive.
+
+Note that the `server_ip` must be known before deployment and this module does not allow
+to specify a list of IPs for large volumes.
+
+[pre-existing-network-storage]: ../pre-existing-network-storage/README.md
+
+## FlexCache support
+NetApp FlexCache technology accelerates data access, reduces WAN latency and lowers WAN bandwidth costs for read-intensive workloads, especially where clients need to access the same data repeatedly. When you create a FlexCache volume, you create a remote cache of an already existing (origin) volume that contains only the actively accessed data (hot data) of the origin volume.
+
+The FlexCache support in Google Cloud NetApp Volumes allows you to provision a cache volume in your Google network to improve performance for hybrid cloud environments. A FlexCache volume can help you transition workloads to the hybrid cloud by caching data from an on-premises data center to cloud.
+
+Deploying FlexCache volumes requires manual steps on the ONTAP origin side, which are not automated. Therefore this module has no support to deploy FlexCache volumes today. Deploy them manually and use the [pre-existing-network-storage](#using-existing-volumes-not-created-by-cluster-toolkit) instead.
+
+## License
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.45.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_netapp_volume.netapp_volume](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/netapp_volume) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. | `number` | `1024` | no |
+| <a name="input_description"></a> [description](#input\_description) | A description of the NetApp volume. | `string` | `""` | no |
+| <a name="input_export_policy_rules"></a> [export\_policy\_rules](#input\_export\_policy\_rules) | Define NFS export policy. | <pre>list(object({<br/>    allowed_clients = optional(string)<br/>    has_root_access = optional(bool, false)<br/>    access_type     = optional(string, "READ_WRITE")<br/>    nfsv3           = optional(bool)<br/>    nfsv4           = optional(bool)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "access_type": "READ_WRITE",<br/>    "allowed_clients": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",<br/>    "has_root_access": true<br/>  }<br/>]</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp volume. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity.<br/>Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB. | `bool` | `false` | no |
+| <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this volume. | `string` | `"/shared"` | no |
+| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"rw,hard,rsize=65536,wsize=65536,tcp"` | no |
+| <a name="input_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#input\_netapp\_storage\_pool\_id) | The ID of the NetApp storage pool to use for the volume. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported. | `list(string)` | <pre>[<br/>  "NFSV3"<br/>]</pre> | no |
+| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
+| <a name="input_tiering_policy"></a> [tiering\_policy](#input\_tiering\_policy) | Define the tiering policy for the NetApp volume. | <pre>object({<br/>    tier_action            = optional(string)<br/>    cooling_threshold_days = optional(number)<br/>  })</pre> | `null` | no |
+| <a name="input_unix_permissions"></a> [unix\_permissions](#input\_unix\_permissions) | UNIX permissions for root inode in the volume. | `string` | `"0777"` | no |
+| <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | The name of the volume. Needs to be unique within the storage pool. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | Volume capacity in GiB. |
+| <a name="output_install_nfs_client"></a> [install\_nfs\_client](#output\_install\_nfs\_client) | Script for installing NFS client |
+| <a name="output_install_nfs_client_runner"></a> [install\_nfs\_client\_runner](#output\_install\_nfs\_client\_runner) | Runner to install NFS client using the startup-script module |
+| <a name="output_mount_runner"></a> [mount\_runner](#output\_mount\_runner) | Runner to mount the file-system using an ansible playbook. The startup-script<br/>module will automatically handle installation of ansible.<br/>- id: example-startup-script<br/>  source: modules/scripts/startup-script<br/>  settings:<br/>    runners:<br/>    - $(your-fs-id.mount\_runner)<br/>... |
+| <a name="output_netapp_volume_id"></a> [netapp\_volume\_id](#output\_netapp\_volume\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/volumes/{{name}}` |
+| <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a NetApp Volumes volume. |
+| <a name="output_server_ips"></a> [server\_ips](#output\_server\_ips) | List of IP addresses of the volume. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/netapp-volume/main.tf
+++ b/modules/file-system/netapp-volume/main.tf
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "netapp-volume", ghpc_role = "file-system" })
+}
+
+# resource "random_id" "resource_name_suffix" {
+#   byte_length = 4
+# }
+
+locals {
+  full_path    = split(":", google_netapp_volume.netapp_volume.mount_options[0].export_full)
+  server_ip    = local.full_path[0]
+  remote_mount = local.full_path[1]
+  # Large volumes will have 6 IPs
+  server_ips    = [for ip in google_netapp_volume.netapp_volume.mount_options[*].export_full : split(":", ip)[0]]
+  fs_type       = "nfs"
+  mount_options = var.mount_options
+
+  install_nfs_client_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/install-nfs-client.sh"
+    "destination" = "install-nfs${replace(var.local_mount, "/", "_")}.sh"
+  }
+  mount_runner = {
+    "type"        = "shell"
+    "source"      = "${path.module}/scripts/mount.sh"
+    "args"        = "\"${join(",", local.server_ips)}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
+    "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
+  }
+
+  split_pool_id = split("/", var.netapp_storage_pool_id)
+  pool_name     = local.split_pool_id[5]
+}
+
+resource "google_netapp_volume" "netapp_volume" {
+  project = var.project_id
+
+  name               = var.volume_name
+  share_name         = var.volume_name
+  location           = var.region
+  protocols          = var.protocols
+  capacity_gib       = var.capacity_gib
+  large_capacity     = var.large_capacity
+  multiple_endpoints = var.large_capacity == true ? true : null
+  storage_pool       = local.pool_name
+  unix_permissions   = var.unix_permissions
+
+  dynamic "tiering_policy" {
+    for_each = var.tiering_policy == null ? [] : [0]
+    content {
+      cooling_threshold_days = lookup(var.tiering_policy, "cooling_threshold_days", null)
+      tier_action            = lookup(var.tiering_policy, "tier_action", null)
+    }
+  }
+
+  description = var.description
+  labels      = local.labels
+
+  dynamic "export_policy" {
+    for_each = var.export_policy_rules == null ? [] : [0]
+    content {
+      dynamic "rules" {
+        for_each = var.export_policy_rules
+        content {
+          access_type     = rules.value.access_type
+          allowed_clients = rules.value.allowed_clients
+          has_root_access = rules.value.has_root_access
+          nfsv3           = rules.value.nfsv3 == null ? contains([for p in var.protocols : lower(p)], "nfsv3") : rules.value.nfsv3
+          nfsv4           = rules.value.nfsv4 == null ? contains([for p in var.protocols : lower(p)], "nfsv4") : rules.value.nfsv4
+        }
+      }
+    }
+  }
+
+  depends_on = [var.netapp_storage_pool_id]
+}

--- a/modules/file-system/netapp-volume/metadata.yaml
+++ b/modules/file-system/netapp-volume/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - netapp.googleapis.com

--- a/modules/file-system/netapp-volume/outputs.tf
+++ b/modules/file-system/netapp-volume/outputs.tf
@@ -1,0 +1,66 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+output "network_storage" {
+  description = "Describes a NetApp Volumes volume."
+  value = {
+    server_ip             = local.server_ip
+    remote_mount          = local.remote_mount
+    local_mount           = var.local_mount
+    fs_type               = local.fs_type
+    mount_options         = local.mount_options
+    client_install_runner = local.install_nfs_client_runner
+    mount_runner          = local.mount_runner
+  }
+}
+
+output "install_nfs_client" {
+  description = "Script for installing NFS client"
+  value       = file("${path.module}/scripts/install-nfs-client.sh")
+}
+
+output "install_nfs_client_runner" {
+  description = "Runner to install NFS client using the startup-script module"
+  value       = local.install_nfs_client_runner
+}
+
+output "mount_runner" {
+  description = <<-EOT
+  Runner to mount the file-system using an ansible playbook. The startup-script
+  module will automatically handle installation of ansible.
+  - id: example-startup-script
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - $(your-fs-id.mount_runner)
+  ...
+  EOT
+  value       = local.mount_runner
+}
+
+output "netapp_volume_id" {
+  description = "An identifier for the resource with format `projects/{{project}}/locations/{{location}}/volumes/{{name}}`"
+  value       = google_netapp_volume.netapp_volume.id
+}
+
+output "capacity_gb" {
+  description = "Volume capacity in GiB."
+  value       = google_netapp_volume.netapp_volume.capacity_gib
+}
+
+output "server_ips" {
+  description = "List of IP addresses of the volume."
+  value       = local.server_ips
+}

--- a/modules/file-system/netapp-volume/scripts/install-nfs-client.sh
+++ b/modules/file-system/netapp-volume/scripts/install-nfs-client.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ ! "$(which mount.nfs)" ]; then
+	if [ -f /etc/centos-release ] || [ -f /etc/redhat-release ] ||
+		[ -f /etc/oracle-release ] || [ -f /etc/system-release ]; then
+		major_version=$(rpm -E "%{rhel}")
+		enable_repo=""
+		if [ "${major_version}" -eq "7" ]; then
+			enable_repo="base,epel"
+		elif [ "${major_version}" -eq "8" ] || [ "${major_version}" -eq "9" ]; then
+			enable_repo="baseos"
+		else
+			echo "Unsupported version of centos/RHEL/Rocky"
+			return 1
+		fi
+		yum install --disablerepo="*" --enablerepo=${enable_repo} -y nfs-utils
+	elif [ -f /etc/debian_version ] || grep -qi ubuntu /etc/lsb-release || grep -qi ubuntu /etc/os-release; then
+		apt-get update --allow-releaseinfo-change-origin --allow-releaseinfo-change-label
+		apt-get -y install nfs-common
+	else
+		echo 'Unsupported distribution'
+		return 1
+	fi
+fi

--- a/modules/file-system/netapp-volume/scripts/mount.sh
+++ b/modules/file-system/netapp-volume/scripts/mount.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -e
+SERVER_IPS=$1
+REMOTE_MOUNT=$2
+LOCAL_MOUNT=$3
+FS_TYPE=$4
+MOUNT_OPTIONS=$5
+
+# accept a list of colon-separated IPs and randomly pick one to enable load balancing
+# In recent changes cluster toolkit doesn't seem to use this file anymore,
+# which makes all mounts use the first IP in the list. Needs to be investigated in future.
+IFS="," read -r -a arrIPS <<<"${SERVER_IPS}"
+rand1=$(od -vAn -t d -N1 </dev/urandom)
+rand=$((rand1 % ${#arrIPS[@]}))
+SERVER_IP=${arrIPS[$rand]}
+
+[[ -z "${MOUNT_OPTIONS}" ]] && POPULATED_MOUNT_OPTIONS="defaults" || POPULATED_MOUNT_OPTIONS="${MOUNT_OPTIONS}"
+
+if [ "${FS_TYPE}" = "gcsfuse" ]; then
+	FS_SPEC="${REMOTE_MOUNT}"
+else
+	FS_SPEC="${SERVER_IP}:${REMOTE_MOUNT}"
+fi
+
+SAME_LOCAL_IDENTIFIER="^[^#].*[[:space:]]${LOCAL_MOUNT}"
+EXACT_MATCH_IDENTIFIER="${FS_SPEC}[[:space:]]${LOCAL_MOUNT}[[:space:]]${FS_TYPE}[[:space:]]${POPULATED_MOUNT_OPTIONS}[[:space:]]0[[:space:]]0"
+
+grep -q "${SAME_LOCAL_IDENTIFIER}" /etc/fstab && SAME_LOCAL_IN_FSTAB=true || SAME_LOCAL_IN_FSTAB=false
+grep -q "${EXACT_MATCH_IDENTIFIER}" /etc/fstab && EXACT_IN_FSTAB=true || EXACT_IN_FSTAB=false
+findmnt --source "${SERVER_IP}":"${REMOTE_MOUNT}" --target "${LOCAL_MOUNT}" &>/dev/null && EXACT_MOUNTED=true || EXACT_MOUNTED=false
+
+# Do nothing and success if exact entry is already in fstab and mounted
+if [ "$EXACT_IN_FSTAB" = true ] && [ "${EXACT_MOUNTED}" = true ]; then
+	echo "Skipping mounting source: ${FS_SPEC}, already mounted to target:${LOCAL_MOUNT}"
+	exit 0
+fi
+
+# Fail if previous fstab entry is using same local mount
+if [ "$SAME_LOCAL_IN_FSTAB" = true ] && [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Mounting failed as local mount: ${LOCAL_MOUNT} was already in use in fstab"
+	exit 1
+fi
+
+# Add to fstab if entry is not already there
+if [ "${EXACT_IN_FSTAB}" = false ]; then
+	echo "Adding ${FS_SPEC} -> ${LOCAL_MOUNT} to /etc/fstab"
+	echo "${FS_SPEC} ${LOCAL_MOUNT} ${FS_TYPE} ${POPULATED_MOUNT_OPTIONS} 0 0" >>/etc/fstab
+fi
+
+# Mount from fstab
+echo "Mounting --target ${LOCAL_MOUNT} from fstab"
+mkdir -p "${LOCAL_MOUNT}"
+mount --target "${LOCAL_MOUNT}"

--- a/modules/file-system/netapp-volume/variables.tf
+++ b/modules/file-system/netapp-volume/variables.tf
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "ID of project in which the NetApp storage pool will be created."
+  type        = string
+}
+
+variable "netapp_storage_pool_id" {
+  description = "The ID of the NetApp storage pool to use for the volume."
+  type        = string
+  validation {
+    condition     = length(split("/", var.netapp_storage_pool_id)) == 6
+    error_message = "The storage pool id must be provided in the following format: projects/<project_id>/locations/<location>/storagePools/<pool_name>."
+  }
+}
+
+variable "region" {
+  description = "Location for NetApp storage pool."
+  type        = string
+}
+
+variable "volume_name" {
+  description = "The name of the volume. Needs to be unique within the storage pool."
+  type        = string
+  default     = null
+}
+
+variable "capacity_gib" {
+  description = "The capacity of the volume in GiB."
+  type        = number
+  default     = 1024
+  validation {
+    condition     = var.capacity_gib >= 100
+    error_message = "The minimum capacity for the volume is 100 GiB."
+  }
+}
+
+variable "protocols" {
+  description = "The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported."
+  type        = list(string)
+  default     = ["NFSV3"]
+  validation {
+    condition     = alltrue([for p in var.protocols : contains(["NFSV3", "NFSV4"], p)])
+    error_message = "Allowed values for protocols are 'NFSV3' or 'NFSV4'."
+  }
+}
+
+variable "description" {
+  description = "A description of the NetApp volume."
+  type        = string
+  default     = ""
+  validation {
+    condition     = length(var.description) <= 2048
+    error_message = "NetApp volume description must be 2048 characters or fewer"
+  }
+}
+
+variable "labels" {
+  description = "Labels to add to the NetApp volume. Key-value pairs."
+  type        = map(string)
+}
+
+variable "local_mount" {
+  description = "Mountpoint for this volume."
+  type        = string
+  default     = "/shared"
+}
+
+variable "mount_options" {
+  description = "NFS mount options to mount file system."
+  type        = string
+  default     = "rw,hard,rsize=65536,wsize=65536,tcp"
+}
+
+variable "large_capacity" {
+  description = <<-EOT
+    If true, the volume will be created with large capacity.
+    Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB.
+    EOT
+  type        = bool
+  default     = false
+}
+
+variable "unix_permissions" {
+  description = "UNIX permissions for root inode in the volume."
+  type        = string
+  default     = "0777"
+  validation {
+    condition     = length(var.unix_permissions) <= 4
+    error_message = "UNIX permissions must be a 4-digit octal number."
+  }
+}
+
+variable "tiering_policy" {
+  description = "Define the tiering policy for the NetApp volume."
+  type = object({
+    tier_action            = optional(string)
+    cooling_threshold_days = optional(number)
+  })
+  default = null
+}
+
+variable "export_policy_rules" {
+  description = "Define NFS export policy."
+  type = list(object({
+    allowed_clients = optional(string)
+    has_root_access = optional(bool, false)
+    access_type     = optional(string, "READ_WRITE")
+    nfsv3           = optional(bool)
+    nfsv4           = optional(bool)
+  }))
+  # Permissive default if user does not specify nfs_export_options. Allow all RFC1918 CIDRS with no_root_squash
+  default = [{
+    allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+    has_root_access = true,
+    access_type     = "READ_WRITE",
+  }]
+  nullable = true
+}

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 6.45.0"
+    }
+  }
+  provider_meta "google" {
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.70.0"
+  }
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.70.0"
+  }
+
+  required_version = ">= 1.5.7"
+}

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.vpc
+- m.private-service-access
+- m.netapp-storage-pool
+- m.netapp-volume
+- m.vm-instance
+- m.wait-for-startup
+- vm
+
+timeout: 14400s  # 4hr
+steps:
+- id: ansible-vm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml"

--- a/tools/cloud-build/daily-tests/tests/netapp-volumes.yml
+++ b/tools/cloud-build/daily-tests/tests/netapp-volumes.yml
@@ -1,0 +1,31 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+test_name: "netapp-volumes"
+deployment_name: "netapp-volumes-{{ build }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/netapp-volumes.yaml"
+region: us-central1
+zone: us-central1-a
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+custom_vars:
+  mounts:
+  - /home
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2022 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ check_background() {
 	fi
 }
 
-CONFIGS=$(find examples/ community/examples/ tools/validate_configs/test_configs/ docs/tutorials/ docs/videos/build-your-own-blueprint/ -name "*.yaml" -type f -not -path 'examples/machine-learning/a3-megagpu-8g/*' -not -path 'examples/machine-learning/a3-ultragpu-8g/*' -not -path 'examples/machine-learning/build-service-images/*' -not -path 'examples/gke-a3-ultragpu/*' -not -path 'examples/hypercompute_clusters/*' -not -path 'examples/gke-consumption-options/*' -not -path 'examples/gke-a4/*' -not -path 'examples/gke-a3-megagpu/*' -not -path 'examples/machine-learning/a4-highgpu-8g/*' -not -path 'examples/machine-learning/a4x-highgpu-4g/*' -not -path 'community/examples/gke-tpu-v6/*' -not -path 'community/examples/xpk-n2-filestore/*' -not -path 'examples/gke-a4x/*' -not -path 'examples/science/af3-slurm/*' -not -path 'examples/gke-h4d/*' -not -path 'community/examples/hpc-slinky/*' -not -path 'examples/gke-g4/*' -not -path 'community/examples/slurm-gke/*' -not -path 'examples/hpc-slurm-h4d/*' -not -path 'examples/machine-learning/a3-highgpu-8g/*')
+CONFIGS=$(find examples/ community/examples/ tools/validate_configs/test_configs/ docs/tutorials/ docs/videos/build-your-own-blueprint/ -name "*.yaml" -type f -not -path 'examples/machine-learning/a3-megagpu-8g/*' -not -path 'examples/machine-learning/a3-ultragpu-8g/*' -not -path 'examples/machine-learning/build-service-images/*' -not -path 'examples/gke-a3-ultragpu/*' -not -path 'examples/hypercompute_clusters/*' -not -path 'examples/gke-consumption-options/*' -not -path 'examples/gke-a4/*' -not -path 'examples/gke-a3-megagpu/*' -not -path 'examples/machine-learning/a4-highgpu-8g/*' -not -path 'examples/machine-learning/a4x-highgpu-4g/*' -not -path 'community/examples/gke-tpu-v6/*' -not -path 'community/examples/xpk-n2-filestore/*' -not -path 'examples/gke-a4x/*' -not -path 'examples/science/af3-slurm/*' -not -path 'examples/gke-h4d/*' -not -path 'community/examples/hpc-slinky/*' -not -path 'examples/gke-g4/*' -not -path 'community/examples/slurm-gke/*' -not -path 'examples/hpc-slurm-h4d/*' -not -path 'examples/machine-learning/a3-highgpu-8g/*' -not -path 'examples/netapp-volumes.yaml')
 # Exclude blueprints that use v5 modules.
 declare -A EXCLUDE_EXAMPLE
 EXCLUDE_EXAMPLE["tools/validate_configs/test_configs/two-clusters-sql.yaml"]=


### PR DESCRIPTION
Hello,

here is a PR to add support for Google Cloud NetApp Volume, which provides NFS/SMB shared file-system.

It has two new modules:
- netapp-storage-pool: A capacity container to host volumes
- netapp-volume: Volumes are file-systems

The PR contains code and documentation for the two new modules, an example blueprint and updates to the blueprint readme and network_storage.md.

I am unsure if this needs to be a community contribution or a core one. GCNV is a Google first party service and I am part of the GCNV product team. So I consider it "core" contribution, but in the end it depends on how the CT team defines core vs community. Please advise.

I also need guidance if I need to add tests.

Looking forward to the review process.