### PR TITLE
Initial checkin of G4 Blueprint

### DIFF
--- a/examples/ml-slurm-g4.yaml
+++ b/examples/ml-slurm-g4.yaml
@@ -1,0 +1,81 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: ml-slurm-g4
+
+vars:
+  project_id: ## Set GCP Project ID Here ##
+  deployment_name:   ## Set Deployment Name Here ##
+  region: ## Set GCP Region Here ##
+  zone: ## Set GCP Zone ID Here ##
+  new_image:
+    family: slurm-gcp-6-11-ubuntu-2204-lts-nvidia-570
+    project: schedmd-slurm-public
+  disk_size_gb: 200
+
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+    settings:
+
+- group: cluster
+  modules:
+
+  - id: g4_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network]
+    settings:
+      node_count_dynamic_max: 0
+      enable_placement: false
+      node_count_static: 1
+      bandwidth_tier: gvnic_enabled
+      machine_type: g4-standard-48
+      disk_type: hyperdisk-balanced
+      instance_image: $(vars.new_image)
+      instance_image_custom: true
+
+  - id: g4_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [g4_nodeset]
+    settings:
+      partition_name: g4
+      exclusive: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      machine_type: e2-standard-2
+      enable_login_public_ips: true
+      instance_image: $(vars.new_image)
+      instance_image_custom: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - g4_partition
+    - slurm_login
+    settings:
+      machine_type: e2-standard-2
+      endpoint_versions:
+      enable_controller_public_ips: true
+      instance_image: $(vars.new_image)
+      instance_image_custom: true
+    


### PR DESCRIPTION
This is the Initial checkin of the G4 Blueprint. It has been regressed for up to 2 nodes. The [G4 ](https://cloud.google.com/blog/products/compute/introducing-g4-vm-with-nvidia-rtx-pro-6000) VM-type was introduced in June 2025 and is a family of VMs with NVIDIA RTX PRO 6000 Blackwell.

The G4 VMs can power a variety of workloads, from cost-efficient inference, to advanced physical AI, robotics simulations, generative AI-enabled content creation, and next-generation game rendering.