### PR TITLE
Add proxy check for verifying rank ordering [A3M]

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue-config.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-kueue-config.yml
@@ -105,6 +105,20 @@
     retries: 5
     delay: 5
 
+  - name: Check for host topologyAssignment in workloads
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get workloads -o yaml | grep "topologyAssignment" -A 5
+    register: tas_check_host
+    until: tas_check_host.stdout | length > 0
+    retries: 20
+    delay: 5
+    changed_when: false
+
+  - name: Print the topologyAssignment details
+    ansible.builtin.debug:
+      msg: "Found topologyAssignment in workload status:\n{{ tas_check_host.stdout }}"
+
   - name: Ensure all pods are on the same host
     delegate_to: localhost
     ansible.builtin.shell: |
@@ -134,6 +148,20 @@
       executable: /bin/bash
     changed_when: False
 
+  - name: Check for rack topologyAssignment in workloads
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get workloads -o yaml | grep "topologyAssignment" -A 5
+    register: tas_check_rack
+    until: tas_check_rack.stdout | length > 0
+    retries: 20
+    delay: 5
+    changed_when: false
+
+  - name: Print the topologyAssignment details
+    ansible.builtin.debug:
+      msg: "Found topologyAssignment in workload status:\n{{ tas_check_rack.stdout }}"
+
   - name: Ensure all pods are on the same rack
     delegate_to: localhost
     ansible.builtin.shell: |
@@ -162,6 +190,20 @@
     args:
       executable: /bin/bash
     changed_when: False
+
+  - name: Check for block topologyAssignment in workloads
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get workloads -o yaml | grep "topologyAssignment" -A 5
+    register: tas_check_block
+    until: tas_check_block.stdout | length > 0
+    retries: 20
+    delay: 5
+    changed_when: false
+
+  - name: Print the topologyAssignment details
+    ansible.builtin.debug:
+      msg: "Found topologyAssignment in workload status:\n{{ tas_check_block.stdout }}"
 
   - name: Ensure all pods are on the same block
     delegate_to: localhost


### PR DESCRIPTION
This PR extends the integration tests for Kueue's Topology-Aware Scheduling (TAS) to support A3 machine types. It builds upon the work from #4466, which successfully enabled these tests for A2 VMs.

We need to ensure they are created with a compact placement policy, which provides the necessary topology information (block, rack, host) as node labels.
 1. The `settings` of the node_pool module in the blueprint needs to be updated to support placement_policy settings. This allows us to create node pools with a specified placement policy, which is a prerequisite for TAS. The configuration looks like this:

  ```
  placement_policy: {
    name: "a3-compact"
    type: "COMPACT"
  }
  ```
2. A compact placement policy is a regional resource and must exist in the target region before the GKE node pool is created. As part of our test setup, this policy needs to be created using the following gcloud command:

```
gcloud compute resource-policies create group-placement POLICY_NAME \
    --region REGION \
    --collocation collocated
```
(As documented in the [official GKE guide for compact placement](https://www.google.com/url?sa=E&q=https%3A%2F%2Fcloud.google.com%2Fkubernetes-engine%2Fdocs%2Fhow-to%2Fcompact-placement%23create_a_compact_placement_policy)).



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
