### PR TITLE
Update Managed lustre gke blueprint

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -320,7 +320,7 @@ deployment_groups:
     use: [gcs-training, a3-ultragpu-cluster]
     settings:
       gcs_bucket_name: $(training_bucket.gcs_bucket_name)
-      capacity_gb: 1000000
+      capacity_gib: 1000000
 
   # Persistent Volume for checkpoint data
   - id: checkpointing-pv
@@ -328,7 +328,7 @@ deployment_groups:
     use: [gcs-checkpointing, a3-ultragpu-cluster]
     settings:
       gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
-      capacity_gb: 1000000
+      capacity_gib: 1000000
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -336,7 +336,7 @@ deployment_groups:
     use: [gcs-training, a4-cluster]
     settings:
       gcs_bucket_name: $(training_bucket.gcs_bucket_name)
-      capacity_gb: 1000000
+      capacity_gib: 1000000
 
   # Persistent Volume for checkpoint data
   - id: checkpointing-pv
@@ -344,7 +344,7 @@ deployment_groups:
     use: [gcs-checkpointing, a4-cluster]
     settings:
       gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
-      capacity_gb: 1000000
+      capacity_gib: 1000000
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -27,6 +27,7 @@ vars:
   authorized_cidr: <your-ip-address>/32
   version_prefix: "1.33."
   base_network_name: $(vars.deployment_name)
+  # Managed-Lustre instance name. This should be unique for each deployment.
   lustre_instance_id: gke-lustre-instance
   # The values of size_gib and per_unit_storage_throughput are co-related
   # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
@@ -133,7 +134,7 @@ deployment_groups:
     source: modules/file-system/gke-persistent-volume
     use: [managed-lustre, gke_cluster]
     settings:
-      capacity_gb: $(vars.size_gib)
+      capacity_gib: $(vars.size_gib)
 
   - id: gke-lustre-pool
     source: modules/compute/gke-node-pool

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -97,7 +97,7 @@ deployment_groups:
   - id: data-bucket-pv
     source: modules/file-system/gke-persistent-volume
     use: [gke_cluster, data-bucket]
-    settings: {capacity_gb: 5000}
+    settings: {capacity_gib: 5000}
 
   ### Filestore ###
 

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -152,7 +152,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_capacity_gb"></a> [capacity\_gb](#input\_capacity\_gb) | The storage capacity with which to create the persistent volume. | `number` | n/a | yes |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The storage capacity with which to create the persistent volume. | `number` | n/a | yes |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the GKE cluster in the format `projects/{{project}}/locations/{{location}}/clusters/{{cluster}}` | `string` | n/a | yes |
 | <a name="input_filestore_id"></a> [filestore\_id](#input\_filestore\_id) | An identifier for a filestore with the format `projects/{{project}}/locations/{{location}}/instances/{{name}}`. | `string` | `null` | no |
 | <a name="input_gcs_bucket_name"></a> [gcs\_bucket\_name](#input\_gcs\_bucket\_name) | The gcs bucket to be used with the persistent volume. | `string` | `null` | no |

--- a/modules/file-system/gke-persistent-volume/main.tf
+++ b/modules/file-system/gke-persistent-volume/main.tf
@@ -48,7 +48,7 @@ locals {
     "${path.module}/templates/filestore-pv.yaml.tftpl",
     {
       pv_name        = local.pv_name
-      capacity       = "${var.capacity_gb}Gi"
+      capacity       = "${var.capacity_gib}Gi"
       location       = local.location
       filestore_name = local.filestore_name
       share_name     = local.filestore_share_name
@@ -63,7 +63,7 @@ locals {
     "${path.module}/templates/filestore-pvc.yaml.tftpl",
     {
       pv_name   = local.pv_name
-      capacity  = "${var.capacity_gb}Gi"
+      capacity  = "${var.capacity_gib}Gi"
       pvc_name  = local.pvc_name
       labels    = local.labels
       namespace = var.namespace
@@ -74,7 +74,7 @@ locals {
     "${path.module}/templates/gcs-pv.yaml.tftpl",
     {
       pv_name       = local.pv_name
-      capacity      = "${var.capacity_gb}Gi"
+      capacity      = "${var.capacity_gib}Gi"
       labels        = local.labels
       mount_options = local.is_gcs ? local.list_mount_options : null
       bucket_name   = local.is_gcs ? var.gcs_bucket_name : ""
@@ -89,7 +89,7 @@ locals {
       pv_name   = local.pv_name
       pvc_name  = local.pvc_name
       labels    = local.labels
-      capacity  = "${var.capacity_gb}Gi"
+      capacity  = "${var.capacity_gib}Gi"
       namespace = var.namespace
     }
   )
@@ -98,13 +98,15 @@ locals {
     "${path.module}/templates/managed-lustre-pv.yaml.tftpl",
     {
       pv_name         = local.pv_name
-      capacity        = "${var.capacity_gb}Gi"
+      capacity        = "${var.capacity_gib}Gi"
       location        = local.location
       project         = split("/", var.cluster_id)[1]
       labels          = local.labels
       instance_name   = local.base_name
       server_ip       = split("@", var.network_storage.server_ip)[0]
       filesystem_name = var.network_storage.remote_mount
+      pvc_name        = local.pvc_name
+      namespace       = var.namespace
     }
   )
 
@@ -114,7 +116,7 @@ locals {
       pv_name   = local.pv_name
       pvc_name  = local.pvc_name
       labels    = local.labels
-      capacity  = "${var.capacity_gb}Gi"
+      capacity  = "${var.capacity_gib}Gi"
       namespace = var.namespace
     }
   )

--- a/modules/file-system/gke-persistent-volume/templates/managed-lustre-pv.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/managed-lustre-pv.yaml.tftpl
@@ -15,6 +15,9 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   volumeMode: Filesystem
+  claimRef:
+    namespace: ${namespace}
+    name: ${pvc_name}
   csi:
     driver: lustre.csi.storage.gke.io
     volumeHandle: "${project}/${location}/${instance_name}/default-pool/default-container"

--- a/modules/file-system/gke-persistent-volume/variables.tf
+++ b/modules/file-system/gke-persistent-volume/variables.tf
@@ -64,7 +64,7 @@ variable "gcs_bucket_name" {
   default     = null
 }
 
-variable "capacity_gb" {
+variable "capacity_gib" {
   description = "The storage capacity with which to create the persistent volume."
   type        = number
 }


### PR DESCRIPTION
This PR updates the GKE managed lustre to:

1. Add Claim_ref to the the PersistentVolume of Managed Lustre. The claimRef field is used by Kubernetes to bind a specific PersistentVolumeClaim (PVC) to a PersistentVolume in static provisioning.
2. Updated `capacity_gb` to `capacity_gib` in gke-persistent-volume module to maintain consistency.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
