### PR TITLE
Updating daily build tests in temporal constraints

### DIFF
--- a/tools/cloud-build/provision/list_tests.py
+++ b/tools/cloud-build/provision/list_tests.py
@@ -49,7 +49,8 @@ TEMPORAL_CONSTAINTS = [
     # (set_of_tests, min_distance)
     (("ml-a4-highgpu-slurm", "gke-a4"), 2*60),
     (("ml-a3-ultragpu-slurm", "ml-a3-ultragpu-jbvms", "gke-a3-ultragpu"), 1*60),
-    (("ml-a3-megagpu-slurm", "ml-a3-megagpu-slurm-ubuntu", "gke-a3-megagpu"), 1*60),
+    (("ml-a3-megagpu-slurm-ubuntu", "gke-a3-megagpu"), 1*60),
+    (("ml-a3-highgpu-slurm", "gke-a3-highgpu"), 1*60),
 ]
 # TODO:
 # * Consider defining constraints (e.g. reservations used) as a tags within tests yamls


### PR DESCRIPTION
Updating the daily build tests spacing to accomodate for the right set of machines.


Post merge - will redeploy the triggers to match the IST midnight timezone