### PR TITLE
Making separate integration test for nccl test in gke a3 ultra

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-nccl.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-nccl.yaml
@@ -1,0 +1,67 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.gke-job-template
+- gke
+- m.gke-cluster
+- m.gke-node-pool
+- m.service-account
+- m.gpu-rdma-vpc
+- m.kubectl-apply
+- m.vpc
+- m.cloud-storage-bucket
+- m.gke-persistent-volume
+- m.pre-existing-network-storage
+
+timeout: 14400s  # 4hr
+steps:
+- id: gke-a3-ultragpu-nccl
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace && make
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    EXAMPLE_BP=examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+
+    # adding vm to act as remote node
+    echo '  - id: remote-node'                           >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
+    echo '    use: [gke-a3-ultra-net-0]'                 >> $${EXAMPLE_BP}
+    echo '    settings:'                                 >> $${EXAMPLE_BP}
+    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
+    echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
+    echo ''
+    echo '  - id: job_template_hostname'                       >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/gke-job-template'        >> $${EXAMPLE_BP}
+    echo '    use: [a3-ultragpu-pool]'                         >> $${EXAMPLE_BP}
+    echo '    settings:'                                       >> $${EXAMPLE_BP}
+    echo '      image: nvidia/cuda:11.0.3-runtime-ubuntu20.04' >> $${EXAMPLE_BP}
+    echo '      command:'                                      >> $${EXAMPLE_BP}
+    echo '      - nvidia-smi'                                  >> $${EXAMPLE_BP}
+    echo '      node_count: 1'                                 >> $${EXAMPLE_BP}
+    echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-nccl.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-nccl.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-nccl.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Google LLC
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 # region, zone must be defined
 # in build file with --extra-vars flag!
-test_name: gke-a3ultra
+test_name: gke-a3ultra-nccl
 deployment_name: gke-a3ultra-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml"
@@ -36,8 +36,8 @@ cli_deployment_vars:
   reservation: "{{ extended_reservation }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
+  is_integration_test: true
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
-- test-validation/test-gke-job.yml
-- test-validation/test-gke-kueue-config.yml
+- test-validation/test-gke-a3-ultra.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-nccl.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-nccl.yml
@@ -36,7 +36,6 @@ cli_deployment_vars:
   reservation: "{{ extended_reservation }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
-  is_integration_test: true
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:


### PR DESCRIPTION
This PR refactors the monolithic gke-a3-ultragpu integration test into two distinct, focused tests: a lightweight Kueue validation test and a heavyweight NCCL performance test.
This change is critical to address a series of severe stability issues discovered during the Kueue-on-Helm migration. The previous, single-test structure was found to be brittle and was the root cause of CI failures where the cluster would self-destruct by scaling its own GPU nodes to zero. This new structure is more stable, provides faster feedback, is more resource-efficient, and completely avoids this failure.


### Submission Checklist


NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
