### PR TITLE
Adding "datacenter-gpu-manager-4-dev" as an additional installation in A* YAML files.

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/a3u-slurm-ubuntu-gcs.yaml
@@ -474,6 +474,7 @@ deployment_groups:
               nvidia_packages:
               - cuda-toolkit-12-8
               - datacenter-gpu-manager
+              - datacenter-gpu-manager-4-dev
               - libnvidia-cfg1-570-server
               - libnvidia-nscq-570
               - nvidia-compute-utils-570-server

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -185,6 +185,7 @@ deployment_groups:
           apt install -y cuda-toolkit-12-8
           apt install -y nvidia-container-toolkit
           apt install -y datacenter-gpu-manager-4-cuda12
+          apt install -y datacenter-gpu-manager-4-dev
       # this duplicates the ulimits configuration of the HPC VM Image
       - type: data
         destination: /etc/security/limits.d/99-unlimited.conf
@@ -213,6 +214,7 @@ deployment_groups:
             vars:
               enable_ops_agent: $(vars.enable_ops_agent)
               enable_nvidia_dcgm: $(vars.enable_nvidia_dcgm)
+
             tasks:
             - name: Create nvidia-persistenced override directory
               ansible.builtin.file:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -214,7 +214,6 @@ deployment_groups:
             vars:
               enable_ops_agent: $(vars.enable_ops_agent)
               enable_nvidia_dcgm: $(vars.enable_nvidia_dcgm)
-
             tasks:
             - name: Create nvidia-persistenced override directory
               ansible.builtin.file:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-gcsfuse-lssd-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-gcsfuse-lssd-blueprint.yaml
@@ -478,7 +478,8 @@ deployment_groups:
               enable_nvidia_dcgm: $(vars.enable_nvidia_dcgm)
               nvidia_packages:
               - cuda-toolkit-12-8
-              - datacenter-gpu-manager
+              - datacenter-gpu-manager-4-cuda12
+              - datacenter-gpu-manager-4-dev
               - libnvidia-cfg1-570-server
               - libnvidia-nscq-570
               - nvidia-compute-utils-570-server

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -142,6 +142,7 @@ deployment_groups:
           add-nvidia-repositories -y
           apt install -y cuda-toolkit-12-8
           apt install -y datacenter-gpu-manager-4-cuda12
+          apt install -y datacenter-gpu-manager-4-dev
       - type: ansible-local
         destination: settings_nvidia_dcgm.yml
         content: |

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -144,6 +144,7 @@ deployment_groups:
           apt update -y
           apt install -y cuda-toolkit-12-8
           apt install -y datacenter-gpu-manager-4-cuda12
+          apt install -y datacenter-gpu-manager-4-dev
       - type: ansible-local
         destination: configure_cuda_dcgm.yml
         content: |
@@ -153,6 +154,7 @@ deployment_groups:
             become: true
             vars:
               enable_nvidia_dcgm: false
+
             tasks:
             - name: Reduce NVIDIA repository priority
               ansible.builtin.copy:

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -154,7 +154,6 @@ deployment_groups:
             become: true
             vars:
               enable_nvidia_dcgm: false
-
             tasks:
             - name: Reduce NVIDIA repository priority
               ansible.builtin.copy:

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -161,6 +161,7 @@ deployment_groups:
               nvidia_packages:
               - cuda-toolkit-12-8
               - datacenter-gpu-manager-4-cuda12
+              - datacenter-gpu-manager-4-dev
             tasks:
             - name: Download NVIDIA repository package
               ansible.builtin.get_url:

--- a/examples/machine-learning/build-service-images/common/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/common/blueprint.yaml
@@ -100,6 +100,7 @@ deployment_groups:
               nvidia_packages:
               - cuda-toolkit-12-8
               - datacenter-gpu-manager-4-cuda12
+              - datacenter-gpu-manager-4-dev
             tasks:
             - name: Download NVIDIA repository package
               ansible.builtin.get_url:


### PR DESCRIPTION
This change updates all A* Slurm/VM blueprints that install dcgm v4 to also install the `datacenter-gpu-manager-4-dev` package. This is necessary for the ops-agent to function properly.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
