### PR TITLE
revert a3 ultra integ test changes

### DIFF
--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
@@ -40,4 +40,5 @@ custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
 - test-validation/test-gke-job.yml
+- test-validation/test-gke-a3-ultra.yml
 - test-validation/test-gke-kueue-config.yml


### PR DESCRIPTION
It reverts the a3 ultra integ. changes.
https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/4622
This is done to ensure backward compatibility. Once the new tests are tested thoroughly, we will remove the old tests.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
