### PR TITLE
Update H4D blueprint: disable automatic updates, provide image info, and delete duplicate filestore

### DIFF
--- a/examples/hpc-slurm-h4d.yaml
+++ b/examples/hpc-slurm-h4d.yaml
@@ -19,6 +19,9 @@ vars:
   region: us-central1
   zone: us-central1-a
   rdma_net_range: 192.168.128.0/18
+  instance_image:
+    family: slurm-gcp-6-11-hpc-rocky-linux-8
+    project: schedmd-slurm-public
 
   #Provisioning model, select one, lack of selection will rely on on-demand capacity
   h4d_dws_flex_enabled: false
@@ -61,15 +64,6 @@ deployment_groups:
       filestore_share_name: homeshare
       local_mount: /home
 
-  - id: appsfs
-    source: modules/file-system/filestore
-    use: [h4d-slurm-net-0]
-    settings:
-      filestore_tier: BASIC_SSD
-      size_gb: 2560
-      filestore_share_name: appsshare
-      local_mount: /apps
-
   - id: h4d_startup
     source: modules/scripts/startup-script
     settings:
@@ -83,6 +77,9 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [h4d_startup, h4d-slurm-net-0]
     settings:
+      # Unattended upgrades are disabled to prevent automatic daily updates which may lead to potential instability.
+      # For more details, see https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates
+      allow_automatic_updates: false
       bandwidth_tier: gvnic_enabled
       machine_type: h4d-highmem-192-lssd
       node_count_static: 2
@@ -133,7 +130,7 @@ deployment_groups:
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
-    use: [h4d-slurm-net-0, h4d_partition, slurm_login, homefs, appsfs]
+    use: [h4d-slurm-net-0, h4d_partition, slurm_login, homefs]
     settings:
       enable_controller_public_ips: true
       cloud_parameters:


### PR DESCRIPTION
The PR makes the following changes to the H4D blueprint:

1> Disable automatic updates to prevent unattended updates leading to unstable clusters.

2> Explicitly mention the image used for nodeset, controller and login nodes within the blueprint instead of relying solely on the default in CTK.

3> Removes duplicate file store "appfs". There's no benefit of having two separate file store instances in the base blueprint. There are probably use cases of using separate file stores for specific apps but is not a general practice and hence needs to be removed.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
