### PR TITLE
Add nvidia-imex-* to list of held packages

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -99,6 +99,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -91,6 +91,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -92,6 +92,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -84,6 +84,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/build-service-images/a3m/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/a3m/blueprint.yaml
@@ -59,6 +59,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/build-service-images/a4x/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/a4x/blueprint.yaml
@@ -57,6 +57,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:

--- a/examples/machine-learning/build-service-images/common/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/common/blueprint.yaml
@@ -59,6 +59,7 @@ deployment_groups:
               - nvidia-compute-utils-*-server
               - nvidia-fabricmanager-*
               - nvidia-utils-*-server
+              - nvidia-imex-*
             tasks:
             - name: Hold nvidia packages
               ansible.builtin.command:


### PR DESCRIPTION
I opted to add them everywhere for consistency (when really only needed on A4X).

Tested: confirmed that holding on image that does not have package installed does not fail.