### PR TITLE
fix(gke-hyperdisk-test): Replace the tensor flow jobs with FIO jobs

### DIFF
--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -150,6 +150,18 @@ deployment_groups:
       - |
 
         set -eux
+
+        cleanup() {
+          # This function will be called on script exit
+          if [ -n "${TAG:-}" ]; then
+            echo "--- Cleaning up temporary directories for tag ${TAG} ---"
+            rm -rf "/data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG}"
+            rm -rf "/data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG}"
+            rm -rf "/data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG}"
+          fi
+          }
+        trap cleanup EXIT
+
         export DEBIAN_FRONTEND=noninteractive
 
         # Install fio
@@ -165,32 +177,27 @@ deployment_groups:
         mountpoint /data/hyperdisk-throughput-pvc-0
 
         # Create temporary directory for fio benchmarks
-        mkdir -p /data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG}
-        mkdir -p /data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG}
-        mkdir -p /data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG}
+        mkdir -p "/data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG}"
+        mkdir -p "/data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG}"
+        mkdir -p "/data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG}"
 
         # Perform hyperdisk balanced performance (Mixed IOPS) test
         fio --name=hyperdisk-balanced-iops --ioengine=libaio --iodepth=256 --rw=randrw \
         --bs=4k --direct=1 --size=10G --numjobs=16 --group_reporting --time_based --runtime=300s \
         --ramp_time=10s --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 \
-        --directory=/data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG} --filename_format=fiotest-balanced-iops
+        --directory="/data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG}" --filename_format=fiotest-balanced-iops
 
         # Perform hyperdisk extreme performance test (Max IOPS)
         fio --name=hyperdisk-extreme-iops --ioengine=libaio --iodepth=256 --rw=randwrite \
         --bs=4k --direct=1 --size=10G --numjobs=32 --group_reporting --time_based --runtime=300s --ramp_time=10s \
         --iodepth_batch_submit=256 --iodepth_batch_complete_max=256 \
-        --directory=/data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG} --filename_format=fiotest-extreme-iops
+        --directory="/data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG}" --filename_format=fiotest-extreme-iops
 
         # Perform hyperdisk throughput performance test
         fio --name=hyperdisk-throughput-bw --ioengine=libaio --iodepth=64 --rw=write --bs=1M \
         --direct=1 --size=10G --numjobs=32 --group_reporting --time_based --runtime=300s --ramp_time=10s \
         --iodepth_batch_submit=64 --iodepth_batch_complete_max=64 \
-        --directory=/data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG} --filename_format=fiotest-throughput-bw
-
-        # Clean up temporary directories for fio benchmarks
-        rm -rf /data/hyperdisk-balanced-pvc-0/fio-benchmarks-${TAG}
-        rm -rf /data/hyperdisk-extreme-pvc-0/fio-benchmarks-${TAG}
-        rm -rf /data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG}
+        --directory="/data/hyperdisk-throughput-pvc-0/fio-benchmarks-${TAG}" --filename_format=fiotest-throughput-bw
       node_count: 1
 
     outputs: [instructions]

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-hyperdisk.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-hyperdisk.yml
@@ -39,23 +39,18 @@
 - name: Wait for FIO Job to complete
   # The FIO job should take approximately 20 minutes, process times out after a max wait of 40 mins
   delegate_to: localhost
-  ansible.builtin.shell: "kubectl get job {{ fio_job_name }} -o jsonpath='{.status.succeeded}'"
-  register: fio_job_status
-  until: fio_job_status.stdout == '1'
-  retries: 80
-  delay: 30
+  ansible.builtin.command: "kubectl wait --for=condition=complete --timeout=40m job/{{ fio_job_name }}"
+  changed_when: false
 
 - name: Fetch logs from the FIO job pod and save to fio_pod_logs.txt
   delegate_to: localhost
   ansible.builtin.shell: |
     pod_name="$(kubectl get pods -l job-name={{ fio_job_name }} -o jsonpath='{.items[0].metadata.name}')"
     kubectl logs "$pod_name" > fio_pod_logs.txt
-    cat fio_pod_logs.txt
-  register: fio_test_logs
 
 - name: Print the FIO test logs
   debug:
-    msg: "{{fio_test_logs.stdout}}"
+    msg: "{{ lookup('file', 'fio_pod_logs.txt') }}"
 
 - name: Clean up FIO job
   delegate_to: localhost


### PR DESCRIPTION
**Rationale for the Change**
The original implementation used TensorFlow jobs to test the GKE Hyperdisk volumes. However, the test has been failing continuously due to changes in dependency module versions (e.g., transformers and datasets).
Pinning dependency versions was deemed an inadequate fix, as the test should not rely on a specific version of a non-core component like the TensorFlow example.

**Implementation Details**
Following an offline discussion, the approach has been changed to replace the problematic TensorFlow jobs with FIO (Flexible I/O Tester) jobs. FIO is a standard benchmarking and stress tool used to measure I/O performance.

- The change in examples/gke-managed-hyperdisk.yaml replaces the three separate TensorFlow jobs (for Hyperdisk Balanced, Extreme, and Throughput) with a single FIO-based benchmark job.
- The new FIO job is configured to perform I/O tests against the Hyperdisk volumes, including a randrw test for Balanced, a randwrite test for Extreme, and a write test for Throughput.
- The deployment now uses a simpler ubuntu:latest image, installs FIO, and executes the benchmarks.
- The validation logic in tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-hyperdisk.yml has been updated to specifically run the single FIO job, wait for its completion, fetch the pod logs, and print the FIO test results.
- This approach ensures the test focuses squarely on the I/O performance and mounting of the Hyperdisk volumes rather than being dependent on external machine learning libraries and their changing APIs.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
