### PR TITLE
Fixing output for gke-storage module

### DIFF
--- a/modules/file-system/gke-storage/outputs.tf
+++ b/modules/file-system/gke-storage/outputs.tf
@@ -19,9 +19,10 @@ output "persistent_volume_claims" {
   value = flatten([
     for idx in range(var.pvc_count) : [{
       name          = "${local.pvc_name_prefix}-${idx}"
+      namespace     = var.namespace
       mount_path    = "${var.pv_mount_path}/${local.pvc_name_prefix}-${idx}"
       mount_options = var.mount_options
-      is_gcs        = false
+      storage_type  = local.storage_type
     }]
   ])
 }


### PR DESCRIPTION
Fixing the output attributes for gke-storage module to make it compatible to the same variable in varaibles.tf of gke-job-template module. This fixes the issue for gke-managed-hyperdisk blueprint wherein the gke-storage module was being used by the gke-managed-hyperdisk module at various places within blueprint.

