### PR TITLE
minor bug fix on MFT version comparison

### DIFF
--- a/community/gce-cos-nvidia-bug-report/app/gce-cos-nvidia-bug-report.py
+++ b/community/gce-cos-nvidia-bug-report/app/gce-cos-nvidia-bug-report.py
@@ -725,8 +725,9 @@ def IdentifyMftKernelModules(
     )
 
   latest_blob = None
-  latest_build_version = None
-  latest_version = None
+  latest_build_version_str = None
+  latest_version_str = None
+  latest_version_obj = None
   version_regex = re.compile(r"mft-kernel-modules-([\d\.]+)-(\d+)-.*\.tgz$")
   for blob in mft_kernel_module_blobs:
     match = version_regex.search(blob.name)
@@ -734,19 +735,20 @@ def IdentifyMftKernelModules(
       continue
     current_version_str = match.group(1)
     build_version_str = match.group(2)
-    current_version = version.parse(
+    current_version_obj = version.parse(
         f"{current_version_str}.{build_version_str}"
     )
-    if latest_version is None or current_version > latest_version:
-      latest_version = current_version_str
-      latest_build_version = build_version_str
+    if latest_version_obj is None or current_version_obj > latest_version_obj:
+      latest_version_str = current_version_str
+      latest_version_obj = current_version_obj
+      latest_build_version_str = build_version_str
       latest_blob = blob
   logging.info(
       "The latest MFT kernel modules available on COS tools is: %s-%s",
-      latest_version,
-      latest_build_version,
+      latest_version_str,
+      latest_build_version_str,
   )
-  return latest_blob, latest_version, latest_build_version
+  return latest_blob, latest_version_str, latest_build_version_str
 
 
 def DownloadMftKernelModulesFromCosTools(


### PR DESCRIPTION
Minor bug fix on MFT version comparisons.

When there are multiple MFT version available, there is a minor bug in the comparison logic and would resulted in the following failrue:

```python3
  File "/app/gce-cos-nvidia-bug-report.py", line 740, in IdentifyMftKernelModules
    if latest_version is None or current_version > latest_version:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'Version' and 'str'
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
