### PR TITLE
Add dedicated IAM Service Accounts and expose disk_size vars in gke-tpu-v6e blueprint yaml files

### DIFF
--- a/community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml
@@ -55,3 +55,9 @@ vars:
 
   # The name of the compute engine reservation of TPU v6 nodes
   reservation:
+
+  # The disk size of system node pool for this deployment.
+  system_node_pool_disk_size_gb:
+
+  # The disk size of v6e node pool for this deployment.
+  v6e_node_pool_disk_size_gb:

--- a/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
@@ -49,6 +49,9 @@ vars:
   # The name of the compute engine reservation of TPU v6 nodes
   reservation:
 
+  system_node_pool_disk_size_gb: 200
+  v6e_node_pool_disk_size_gb: 100
+
 
 deployment_groups:
 - group: primary
@@ -77,13 +80,40 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+      - container.admin
+
   - id: gke-tpu-v6-cluster
     source: modules/scheduler/gke-cluster
-    use: [gke-tpu-v6-net]
+    use: [gke-tpu-v6-net, workload_service_account]
     settings:
       system_node_pool_machine_type: "n2-standard-8"
+      system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
+      configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
@@ -100,7 +130,7 @@ deployment_groups:
 
   - id: gke-tpu-v6-pool
     source: modules/compute/gke-node-pool
-    use: [gke-tpu-v6-cluster]
+    use: [gke-tpu-v6-cluster, node_pool_service_account]
     settings:
       num_slices: $(vars.num_slices)
       name: gke-tpu-v6-pool
@@ -108,6 +138,7 @@ deployment_groups:
       machine_type: $(vars.machine_type)
       auto_upgrade: true
       zones: [$(vars.zone)]
+      disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION


### PR DESCRIPTION
Added workload_service_account and node_pool_service_account modules to implement dedicated service accounts to be created for gke-tpu-v6e. Also, exposed the disk_size_gb vars to set the boot disk sizes for each node of the system and v6e node pools as and when required by the user.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
