### PR TITLE
GKE H4D Taint Fix and remove zonal cluster

### DIFF
--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -115,7 +115,6 @@ deployment_groups:
       system_node_pool_taints: []
       enable_multi_networking: true
       enable_dcgm_monitoring: true
-      enable_gcsfuse_csi: true
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       master_authorized_networks:

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -21,7 +21,7 @@ vars:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: gke-h4d
+  deployment_name:
 
   # The GCP Region used for this deployment.
   region:

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -21,7 +21,7 @@ vars:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name:
+  deployment_name: gke-h4d
 
   # The GCP Region used for this deployment.
   region:

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -116,7 +116,6 @@ deployment_groups:
       enable_multi_networking: true
       enable_dcgm_monitoring: true
       enable_gcsfuse_csi: true
-      cluster_availability_type: "ZONAL"
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       master_authorized_networks:
@@ -168,10 +167,10 @@ deployment_groups:
       # - key: "node-type"
       #   operator: "Equal"
       #   value: "h4d"
-      #   effect: "NoSchedule"
-      - key: node-type
-        value: h4d
-        effect: NoSchedule
+      #   effect: "NO_SCHEDULE"
+      - key: "node-type"
+        value: "h4d"
+        effect: "NO_SCHEDULE"
       placement_policy:
         type: COMPACT
       additional_networks:


### PR DESCRIPTION
- Changed taint to "NO_SCHEDULE"
- Removed zonal cluster because causes cluster not found during node-pool creation
- Removed enable_gcsfuse_csi
