### PR TITLE
Install mpi-operator and add a reference link to the test for GKE H4D blueprint example

### DIFF
--- a/examples/gke-h4d/README.md
+++ b/examples/gke-h4d/README.md
@@ -53,6 +53,9 @@ This blueprint uses GKE to provision a Kubernetes cluster and a H4D node pool, a
 
    Type `a` and hit enter to create the cluster.
 
+## Run a test using the MPI Operator
+The MPI Operator is installed on the cluster during the deployment. To run a test using the MPI Operator on the GKE H4D cluster, refer to https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/main/hpc/mpi.
+
 ## Clean Up
 To destroy all resources associated with creating the GKE cluster, run the following command:
 

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -208,3 +208,6 @@ deployment_groups:
         install: true
       jobset:
         install: true
+      apply_manifests:
+      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.6.0/deploy/v2beta1/mpi-operator.yaml"
+        server_side_apply: true


### PR DESCRIPTION
Update the GKE H4D blueprint example to install [MPI Operator](https://github.com/kubeflow/mpi-operator) during cluster deployment using `modules/management/kubectl-apply` module. Add a link to the [test](https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/main/hpc/mpi) a user can run with the MPI Operator on H4D machines.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
