### PR TITLE
Add reservation, update taint in gke h4d blueprint, and update gke h4d test build with reservation info

### DIFF
--- a/examples/gke-h4d/README.md
+++ b/examples/gke-h4d/README.md
@@ -28,6 +28,8 @@ This blueprint uses GKE to provision a Kubernetes cluster and a H4D node pool, a
     1. `zone`: Compute zone used for the deployment.
     1. `static_node_count`: Number of nodes to create.
     1. `authorized_cidr`: update the IP address in `<your-ip-address>/32`.
+    1. `reservation`: The name of the compute engine reservation in the form of <reservation-name>. To target a BLOCK_NAME, the name of the extended reservation can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>.
+
 1. Build the Cluster Toolkit binary
 
    ```sh

--- a/examples/gke-h4d/gke-h4d-deployment.yaml
+++ b/examples/gke-h4d/gke-h4d-deployment.yaml
@@ -38,3 +38,9 @@ vars:
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
   authorized_cidr: IP_ADDRESS/SUFFIX
+
+  # The name of the compute engine reservation in the form of
+  # <reservation-name>
+  # To target a BLOCK_NAME, the name of the extended reservation
+  # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
+  reservation:

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -36,6 +36,12 @@ vars:
   # The following line must be updated for this example to work.
   authorized_cidr:
 
+  # The name of the compute engine reservation in the form of
+  # <reservation-name>
+  # To target a BLOCK_NAME, the name of the extended reservation
+  # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
+  reservation:
+
   system_node_pool_disk_size_gb: 100
   h4d_node_pool_disk_size_gb: 100
 
@@ -115,8 +121,6 @@ deployment_groups:
       system_node_pool_taints: []
       enable_multi_networking: true
       enable_dcgm_monitoring: true
-      enable_gcsfuse_csi: true
-      cluster_availability_type: "ZONAL"
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       master_authorized_networks:
@@ -157,6 +161,10 @@ deployment_groups:
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.h4d_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
+      reservation_affinity:
+        consume_reservation_type: SPECIFIC_RESERVATION
+        specific_reservations:
+        - name: $(vars.reservation)
       taints:
       # (Optional, but suggested)
       # In order prevent scheduling of generic workloads onto the H4D nodepool,
@@ -171,7 +179,7 @@ deployment_groups:
       #   effect: "NoSchedule"
       - key: node-type
         value: h4d
-        effect: NoSchedule
+        effect: NO_SCHEDULE
       placement_policy:
         type: COMPACT
       additional_networks:

--- a/tools/cloud-build/daily-tests/tests/gke-h4d.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-h4d.yml
@@ -25,10 +25,12 @@ region: us-central1
 zone: us-central1-b
 remote_node: "{{ deployment_name }}-remote-node-0"
 static_node_count: 2
+reservation: h4d-9amhwllf9r5w4
 cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"
   static_node_count: "{{ static_node_count }}"
+  reservation: "{{ reservation }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
 custom_vars:
   project: "{{ project }}"


### PR DESCRIPTION
Updates:
1. Add reservation to the GKE H4D blueprint.
2. Update the taint with appropriate effect value "NO_SCHEDULE"
3. Remove the `enable_gcsfuse_csi: true` setting as GCS Fuse is not used in the example
4. Update integration to use a H4D reservation. This helps avoid the build failures due to capacity issue.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
