### PR TITLE
updating startup script wait message to fix build failures.

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/wait-for-startup-script.yml
@@ -19,7 +19,7 @@
 
 - name: Wait for startup script to complete
   become: true
-  ansible.builtin.shell: journalctl -u google-startup-scripts.service -b | grep "Started Google Compute Engine Startup Scripts."
+  ansible.builtin.shell: journalctl -u google-startup-scripts.service -b | grep -E "Started Google Compute Engine Startup Scripts\.|Finished Google Compute Engine Startup Scripts\.|Finished google-startup-scripts.service - Google Compute Engine Startup Scripts\."
   register: result
   until: result.rc == 0
   retries: "{{ (timeout_seconds/5)|int }}"


### PR DESCRIPTION
 Updated the shell command in `wait-for-startup-script.yml` to match additional log messages indicating both the start and completion of the Google Compute Engine Startup Scripts service. This helps ensure the playbook accurately detects when the startup process has finished.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
