### PR TITLE
Add Filestore, PV, and sample job template snippets to the GKE H4D blueprint

### DIFF
--- a/examples/gke-h4d/README.md
+++ b/examples/gke-h4d/README.md
@@ -53,6 +53,8 @@ This blueprint uses GKE to provision a Kubernetes cluster and a H4D node pool, a
 
    Type `a` and hit enter to create the cluster.
 
+1. Additionally, this example blueprint provisions a filestore and connects it to the GKE Cluster via Persistent Volume (PV). An example job template is included in the blueprint which runs a parallel job that reads and writes data to this shared storage. A command similar to `kubectl create -f <file-path>` is displayed in the deployment outputs which can be used to trigger the sample job.
+
 ## Run a test using the MPI Operator
 The MPI Operator is installed on the cluster during the deployment. To run a test using the MPI Operator on the GKE H4D cluster, refer to https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/main/hpc/mpi.
 

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -211,3 +211,44 @@ deployment_groups:
       apply_manifests:
       - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.6.0/deploy/v2beta1/mpi-operator.yaml"
         server_side_apply: true
+
+  # Filestore
+  - id: filestore
+    source: modules/file-system/filestore
+    use: [gke-h4d-net]
+    settings: {local_mount: /mnt/h4d-filestore}
+
+  - id: shared-filestore-pv
+    source: modules/file-system/gke-persistent-volume
+    use: [h4d-cluster, filestore]
+
+  # Shared Filestore Job
+  - id: shared-fs-job
+    source: modules/compute/gke-job-template
+    use:
+    - h4d-cluster
+    - h4d-pool
+    - shared-filestore-pv
+    settings:
+      image: alpine/git:latest
+      command:
+      - sh
+      - -c
+      - |
+        echo "Pod ${HOSTNAME} is starting..."
+        SHARED_DIR=/mnt/h4d-filestore
+        mkdir -p $SHARED_DIR
+        cd $SHARED_DIR
+
+        # Simulate some work and write to a shared file
+        cmd="date +%s"
+        TIMESTAMP=`$cmd`
+        echo "Pod ${HOSTNAME} writing data at $$TIMESTAMP" >> shared_output.txt
+        echo "Displaying content of shared_output.txt:"
+        echo "---"
+        cat shared_output.txt # Read the content to show it's shared
+        echo "---"
+        sleep 120
+        echo "Pod ${HOSTNAME} finished."
+      node_count: 2
+    outputs: [instructions]

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -20,6 +20,9 @@ tags:
 - m.service-account
 - m.vpc
 - m.kubectl-apply
+- m.filestore
+- m.gke-job-template
+- m.gke-persistent-volume
 
 timeout: 14400s  # 4hr
 steps:


### PR DESCRIPTION
The GKE H4D blueprint is being updated to include the filestore, PV, and a simple job template that showcases how the filestore can be used.

This helps a user when they want to follow the MPI Operator example included in the README.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
