### PR TITLE
Update vpc and cloud_router versions in VPC network module

### DIFF
--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -180,7 +180,7 @@ resource "terraform_data" "network_profile_firewall_validation" {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 10.0"
+  version = "~> 12.0"
 
   depends_on = [terraform_data.network_profile_firewall_validation]
 
@@ -235,7 +235,7 @@ module "nat_ip_addresses" {
 
 module "cloud_router" {
   source  = "terraform-google-modules/cloud-router/google"
-  version = "~> 6.0"
+  version = "~> 7.3"
 
   depends_on = [terraform_data.cloud_nat_validation]
 


### PR DESCRIPTION
Update vpc and cloud_router versions in VPC network module to be able to use >=7.2 terraform google provider version

The older versions restrain the TF google provider version to be <7.0, which is causing issues in being able to use the newer versions.

