### PR TITLE
Update vpc and cloud_router versions in VPC network module

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -173,9 +173,9 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | ~> 6.0 |
+| <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | ~> 7.3 |
 | <a name="module_nat_ip_addresses"></a> [nat\_ip\_addresses](#module\_nat\_ip\_addresses) | terraform-google-modules/address/google | ~> 4.1 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 10.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 12.0 |
 
 ## Resources
 

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -180,7 +180,7 @@ resource "terraform_data" "network_profile_firewall_validation" {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 10.0"
+  version = "~> 12.0"
 
   depends_on = [terraform_data.network_profile_firewall_validation]
 
@@ -235,7 +235,7 @@ module "nat_ip_addresses" {
 
 module "cloud_router" {
   source  = "terraform-google-modules/cloud-router/google"
-  version = "~> 6.0"
+  version = "~> 7.3"
 
   depends_on = [terraform_data.cloud_nat_validation]
 


### PR DESCRIPTION
Update vpc and cloud_router versions in VPC network module to be able to use >=7.2 terraform google provider version.

The older versions restrain the TF google provider version to be <7.0, which is causing issues in being able to use the newer versions.

Before the change:

```
user@w-kadupoornima-mct8nk3p:~/cluster-toolkit-2/modules/network/vpc$ terraform providers

Providers required by configuration:
.
├── provider[terraform.io/builtin/terraform]
├── module.nat_ip_addresses
│   └── provider[registry.terraform.io/hashicorp/google] >= 5.2.0, < 8.0.0
├── module.vpc
│   ├── provider[registry.terraform.io/hashicorp/google] >= 4.64.0, < 7.0.0
│   ├── provider[registry.terraform.io/hashicorp/google-beta] >= 4.64.0, < 7.0.0
│   ├── module.routes
│       └── provider[registry.terraform.io/hashicorp/google] >= 3.83.0, < 7.0.0
│   ├── module.subnets
│       └── provider[registry.terraform.io/hashicorp/google] >= 4.25.0, < 7.0.0
│   ├── module.vpc
│       ├── provider[registry.terraform.io/hashicorp/google] >= 4.64.0, < 7.0.0
│       └── provider[registry.terraform.io/hashicorp/google-beta] >= 6.13.0, < 7.0.0
│   └── module.firewall_rules
│       └── provider[registry.terraform.io/hashicorp/google] >= 3.33.0, < 7.0.0
└── module.cloud_router
    └── provider[registry.terraform.io/hashicorp/google] >= 4.51.0, < 7.0.0
```

After the change:

```
user@w-kadupoornima-mct8nk3p:~/cluster-toolkit-2/modules/network/vpc$ terraform providers

Providers required by configuration:
.
├── provider[terraform.io/builtin/terraform]
├── module.nat_ip_addresses
│   └── provider[registry.terraform.io/hashicorp/google] >= 5.2.0, < 8.0.0
├── module.vpc
│   ├── provider[registry.terraform.io/hashicorp/google-beta] >= 4.64.0, < 8.0.0
│   ├── provider[registry.terraform.io/hashicorp/google] >= 4.64.0, < 8.0.0
│   ├── module.routes
│       └── provider[registry.terraform.io/hashicorp/google] >= 3.83.0, < 8.0.0
│   ├── module.subnets
│       └── provider[registry.terraform.io/hashicorp/google] >= 4.25.0, < 8.0.0
│   ├── module.vpc
│       ├── provider[registry.terraform.io/hashicorp/google] >= 6.19.0, < 8.0.0
│       └── provider[registry.terraform.io/hashicorp/google-beta] >= 6.19.0, < 8.0.0
│   └── module.firewall_rules
│       └── provider[registry.terraform.io/hashicorp/google] >= 3.33.0, < 8.0.0
└── module.cloud_router
    └── provider[registry.terraform.io/hashicorp/google] >= 4.51.0, < 8.0.0

