### PR TITLE
Enable Spot VM Provisioning For H4D

### DIFF
--- a/examples/hpc-slurm-h4d.yaml
+++ b/examples/hpc-slurm-h4d.yaml
@@ -26,6 +26,7 @@ vars:
   #Provisioning model, select one, lack of selection will rely on on-demand capacity
   h4d_dws_flex_enabled: false
   h4d_reservation_name: ""
+  h4d_enable_spot_vm: false
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -85,6 +86,7 @@ deployment_groups:
       node_count_static: 2
       node_count_dynamic_max: 0
       enable_placement: false
+      enable_spot_vm: $(vars.h4d_enable_spot_vm)
 
       #Provisioning models
       reservation_name: $(vars.h4d_reservation_name)


### PR DESCRIPTION
This change introduces the ability to use Spot VMs for the h4d compute partition within the hpc-slurm-h4d.yaml blueprint.




### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
