### PR TITLE
Update multi-approvers Github workflow to trigger the job upon a new approval

### DIFF
--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -40,6 +40,7 @@ concurrency:
 
 jobs:
   multi-approvers:
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' && (github.event.review.state == 'approved' ||  github.event.action == 'dismissed')
     uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
     with:
       org-members-path: 'GoogleCloudPlatform/cluster-toolkit/develop/cluster-toolkit-writers.json'


### PR DESCRIPTION
In some PRs, upon an additional approval on the PR, the `multi-approvers` test that failed earlier is not triggered again. One has to either manually re-run the tests by selecting the _re-run failed builds_ option against the options available to the right corner of the PR test, or run the test using the babysit tool.

This update to the multi-approvers workflow will ensure this test re-runs when a new approval is added to the PR.

Note: The if condition includes the pull_request_review of 'dismissed' type as the multi-approvers job should re-run and fail if there are not enough approvals.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
