### PR TITLE
PSA update

### DIFF
--- a/community/modules/network/private-service-access/README.md
+++ b/community/modules/network/private-service-access/README.md
@@ -57,7 +57,7 @@ Connecting [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-Copyright 2024 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/community/modules/network/private-service-access/main.tf
+++ b/community/modules/network/private-service-access/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2024 Google LLC
+ * Copyright 2025 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   service                 = var.service_name
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
   deletion_policy         = var.deletion_policy
+  update_on_creation_fail = var.deletion_policy == "ABANDON" ? true : null
 }
 
 # Google Cloud NetApp Volumes need enablement of custom_route import and export


### PR DESCRIPTION
Small update to private-service-access (PSA) module.

The problem it solves:
[google_service_networking_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) doesn't delete peerings if there are still resources like cloud router are still attached to it. But some services delete such resources lazily (not immediately after they got deleted), e.g. Cloud SQL and NetApp Volumes.

Since deleting such peerings will fail, the authors of [google_service_networking_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) added the option to  [abandon](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection#deletion_policy-1) peerings.

But abandoning peerings introduces a new problem: Creating a new peering with a different psaRange fails, since servicenetworking still tracks the old peering. This even happens if the user deletes the peered VPC and re-creates it with the same name. Creating the peering still fails.

To fix this, the "existing shadow peering" (it is not visible when deleting and re-creating the VPC) needs to be updated instead of created. The  google_service_networking_connection resource supports this through the [update_on_creation_fail](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection#update_on_creation_fail-1) parameter.

This PR changes the PSA module to set `update_on_creation_fail = true` if `deletion_policy == ABANDON`.

I used that approach to be minimal invasive to non-GCNV deployments, but believe there is no harm in setting `update_on_creation_fail` always to true for all connections. I like the reviewer to weigh in on that design decision.

I ran deploy->delete->re-deploy->delete tests for "servicenetworking.googleapis.com" type connections and for "netapp.servicenetworking.goog" + "deletion_policy == ABANDON" connections. All worked as expected.