### PR TITLE
updating image used in a3ultra vm blueprint - older image is deprecated.

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -25,7 +25,7 @@ vars:
   a3u_provisioning_model: RESERVATION_BOUND
   instance_image:
     project: ubuntu-os-accelerator-images
-    family: ubuntu-accelerator-2204-amd64-with-nvidia-550
+    family: ubuntu-accelerator-2204-amd64-with-nvidia-570
   net0_range: 192.168.0.0/19
   net1_range: 192.168.64.0/18
   filestore_ip_range: 192.168.32.0/29


### PR DESCRIPTION
updating VM configuration for the A3 Ultra GPU example. The change updates the image family to use a newer NVIDIA driver version.

* Updated the `instance_image.family` in `a3ultra-vm.yaml` to use `ubuntu-accelerator-2204-amd64-with-nvidia-570` instead of `nvidia-550` for improved compatibility and performance.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
