### PR TITLE
Removing support for maintenance_interval for reservations created by TAMs

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/README.md
+++ b/examples/machine-learning/a3-highgpu-8g/README.md
@@ -131,18 +131,12 @@ Cloud representative. Set them at approximately lines 33 and 34 of
 > skip this step and proceed to [manual reservation creation](#manual-creation-of-reservation).
 
 Set the deployment variable `a3_reservation_name` at approximately line 38 of
-`ml-slurm-a3-2-cluster.yaml` to the reservation name provided by Google. The
-value for `a3_maintenance_interval` should also be set as directed by Google
-staff. A common setting is `PERIODIC`, shown below, but this value must be
-confirmed with Google staff.
+`ml-slurm-a3-2-cluster.yaml` to the reservation name provided by Google.
 
 ```yaml
   # a3_reservation_name must be specified; if Google staff have provided you
   # with a reservation name, use it. Otherwise supply user-created reservation.
   a3_reservation_name: reservation-name-provided-by-google
-  # a3_maintenance_interval should be empty string by default; if Google staff
-  # have created a reservation, they will also provide a3_maintenance_interval
-  a3_maintenance_interval: PERIODIC
 ```
 
 ### Manual creation of reservation
@@ -167,8 +161,7 @@ gcloud compute reservations create a3-reservation-0 \
 
 This reservation be must be specified when creating VMs with matching parameters
 (e.g. a3-highgpu-8g VM in configured zone). If you executed the command above
-without modification, you may leave `a3_reservation_name` and
-`a3_maintenance_interval` at their default values in
+without modification, you may leave `a3_reservation_name` at their default values in
 `ml-slurm-a3-2-cluster.yaml`. Otherwise, ensure that the reservation name in the
 blueprint matches the name of the user-created reservation.
 
@@ -176,9 +169,6 @@ blueprint matches the name of the user-created reservation.
   # a3_reservation_name must be specified; if Google staff have provided you
   # with a reservation name, use it. Otherwise supply user-created reservation.
   a3_reservation_name: a3-reservation-0
-  # a3_maintenance_interval should be empty string by default; if Google staff
-  # have created a reservation, they will also provide a3_maintenance_interval
-  a3_maintenance_interval: ""
 ```
 
 ### Using Spot VM or DWS Flex

--- a/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/ml-slurm-a3-2-cluster.yaml
@@ -45,9 +45,6 @@ vars:
   a3_dws_flex_enabled: false
   a3_enable_spot_vm: false
 
-  # a3_maintenance_interval should be empty string by default; if Google staff
-  # have created a reservation, they will also provide a3_maintenance_interval
-  a3_maintenance_interval: ""
   # network parameters must match base blueprint deployment_name!
   # these values are accurate if deployment_name was not modified from example
   network_name_system: slurm-a3-base-sysnet
@@ -188,7 +185,6 @@ deployment_groups:
       enable_spot_vm: $(vars.a3_enable_spot_vm)
       dws_flex:
         enabled: $(vars.a3_dws_flex_enabled)
-      maintenance_interval: $(vars.a3_maintenance_interval)
       node_count_static: $(vars.a3_static_cluster_size)
       node_count_dynamic_max: 0
       disk_type: pd-ssd

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -27,7 +27,6 @@ vars:
   source_image_family: ubuntu-accelerator-2204-amd64-with-nvidia-570
   source_image_project_id: [ubuntu-os-accelerator-images]
   a3mega_partition_name: a3mega
-  a3mega_maintenance_interval: ""
   local_mount_homefs: /home
   instance_image:
     family: $(vars.final_image_family)
@@ -549,7 +548,6 @@ deployment_groups:
       enable_spot_vm: $(vars.a3mega_enable_spot_vm)
       dws_flex:
         enabled: $(vars.a3mega_dws_flex_enabled)
-      maintenance_interval: $(vars.a3mega_maintenance_interval)
       startup_script: $(a3mega_startup.startup_script)
 
   - id: a3mega_partition

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
@@ -31,7 +31,6 @@ vars:
   disk_size_gb: 200
   final_image_family: slurm-a3mega
   slurm_cluster_name: a3mega
-  a3mega_maintenance_interval: ""
   a3mega_cluster_size: 2 # supply cluster size
   a3mega_reservation_name: "" # supply reservation name
   # Additional provisioning models (pick only one), can be used to substitute `a3mega_reservation_name`:


### PR DESCRIPTION
This pull request removes support for the maintenance_interval parameter for reservations created by Technical Account Managers (TAMs) for Slurm clusters using A3 virtual machines.

The changes in this pull request simplify the configuration process for users by removing the a3_maintenance_interval and a3mega_maintenance_interval variables from the example deployment files. 