### PR TITLE
Add automated TPU support and GCS integration in TPU v6 blueprint

### DIFF
--- a/community/examples/gke-tpu-v6/README.md
+++ b/community/examples/gke-tpu-v6/README.md
@@ -90,6 +90,38 @@ This section guides you through the cluster creation process, ensuring that your
     community/examples/gke-tpu-v6/gke-tpu-v6.yaml
    ```
 
+## Advanced Blueprint: GKE TPU with GCS Integration
+
+This repository also includes an advanced blueprint, `gke-tpu-v6-gcs.yaml`, designed for production-ready workloads. It builds on the basic blueprint by adding several key features:
+* **Dedicated Service Accounts** for nodes and workloads, following security best practices.
+* **Automatic creation of two GCS buckets** for training data and checkpoints.
+* **Performance-tuned GCS FUSE mounts** pre-configured in the cluster as Persistent Volumes.
+
+### Deploying the Advanced Blueprint
+
+The process is nearly identical to the basic deployment.
+
+1. Ensure you have completed steps 1-7 from the "Create a cluster" section above. The same `gke-tpu-v6-deployment.yaml` file can be used.
+
+1. In the final deploy command, simply point to the `gke-tpu-v6-advanced.yaml` blueprint instead.
+
+    ```sh
+    cd ~/cluster-toolkit
+    ./gcluster deploy -d \
+    community/examples/gke-tpu-v6/gke-tpu-v6-deployment.yaml \
+    community/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
+    ```
+
+1. After deployment, the blueprint will output instructions for running a fio benchmark job. This job serves as a validation test to confirm that the GCS mounts are working correctly for both reading and writing. Follow the printed instructions to run the test.
+
+### Understanding the GCS Integration
+
+The advanced blueprint provisions several key technologies to create a robust data pipeline for your TPU workloads. Here are some resources to understand how they work together:
+* [Cloud Storage Overview](https://cloud.google.com/storage/docs/introduction#quickstarts): Start here to understand what Cloud Storage buckets are and their role in storing large-scale data.
+* [Cloud TPU Storage Options](https://cloud.google.com/tpu/docs/storage-options): Learn about the recommended storage patterns for Cloud TPUs, including why GCS FUSE is a best practice for providing training data.
+* [Access GCS Buckets with the GCS FUSE CSI Driver](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver): This is the core technical guide explaining how GKE mounts GCS buckets into your pods, which this blueprint automates.
+* [Configure Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity): Read this to understand the secure, recommended method for GKE applications to access Google Cloud services like GCS, which this blueprint configures for you.
+
 ## Run the sample job
 
 The [tpu-available-chips.yaml](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/community/examples/gke-tpu-v6/tpu-available-chips.yaml) file creates a service and a job resource in kubernetes. It is based on https://cloud.google.com/kubernetes-engine/docs/how-to/tpus#tpu-chips-node-pool. The  workload returns the number of TPU chips across all of the nodes in a multi-host TPU slice.

--- a/community/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
@@ -1,0 +1,287 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+blueprint_name: gke-tpu-v6
+
+vars:
+  # The following variables should be over-written in the deployment.yaml file.
+  # Your GCP Project ID
+  project_id:
+
+  # This should be unique across all of your Cluster
+  # Toolkit Deployments.
+  deployment_name: gke-tpu-v6
+
+  # The GCP Region used for this deployment.
+  region:
+
+  # The GCP Zone used for this deployment.
+  zone:
+
+  # The number of TPU slices to create
+  num_slices:
+
+  # Machine type
+  machine_type:
+
+  # The TPU placement topology for pod slice node pool.
+  tpu_topology:
+
+  # The number of nodes to be created in each nodepool
+  static_node_count:
+
+  # Cidr block containing the IP of the machine calling terraform.
+  # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
+  # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
+  authorized_cidr:
+
+  # The name of the compute engine reservation of TPU v6 nodes
+  reservation:
+
+  system_node_pool_disk_size_gb: 200
+  v6e_node_pool_disk_size_gb: 100
+
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: gke-tpu-v6-net
+    source: modules/network/vpc
+    settings:
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-sub-0
+        subnet_region: $(vars.region)
+        subnet_ip: 192.168.0.0/18
+      secondary_ranges_list:
+      - subnetwork_name: $(vars.deployment_name)-sub-0
+        ranges:
+        - range_name: pods
+          ip_cidr_range: 10.4.0.0/14
+        - range_name: services
+          ip_cidr_range: 10.0.32.0/20
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-0
+        ranges: [192.168.0.0/18]
+        allow:
+        - protocol: tcp
+          ports: ["0-65535"]
+        - protocol: udp
+          ports: ["0-65535"]
+        - protocol: icmp
+
+  - id: node_pool_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: community/modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+      - container.admin
+
+  - id: training_bucket
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      local_mount: /training-data
+      name_prefix: training-data
+      random_suffix: true
+      force_destroy: false
+      enable_hierarchical_namespace: true
+
+  - id: checkpoint_bucket
+    source: community/modules/file-system/cloud-storage-bucket
+    settings:
+      local_mount: /checkpoint-data
+      name_prefix: checkpoint-data
+      random_suffix: true
+      force_destroy: false
+      enable_hierarchical_namespace: true
+
+  - id: gke-tpu-v6-cluster
+    source: modules/scheduler/gke-cluster
+    use: [gke-tpu-v6-net, workload_service_account]
+    settings:
+      system_node_pool_machine_type: "n2-standard-8"
+      system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
+      system_node_pool_taints: []
+      enable_private_endpoint: false # Allows access from authorized public IPs
+      configure_workload_identity_sa: true
+      enable_gcsfuse_csi: true
+      master_authorized_networks:
+      - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
+        display_name: "kubectl-access-network"
+      # Cluster versions cannot be updated through the toolkit after creation
+      # Please manage cluster version from the Google Cloud Console directly
+      version_prefix: "1.32."
+      release_channel: RAPID
+      maintenance_exclusions:
+      - name: no-minor-or-node-upgrades-indefinite
+        start_time: "2024-12-01T00:00:00Z"
+        end_time: "2025-12-22T00:00:00Z"
+        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
+    outputs: [instructions]
+
+  - id: gke-tpu-v6-pool
+    source: modules/compute/gke-node-pool
+    use: [gke-tpu-v6-cluster, node_pool_service_account]
+    settings:
+      num_slices: $(vars.num_slices)
+      name: gke-tpu-v6-pool
+      disk_type: hyperdisk-balanced
+      machine_type: $(vars.machine_type)
+      auto_upgrade: true
+      zones: [$(vars.zone)]
+      disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
+      static_node_count: $(vars.static_node_count)
+      reservation_affinity:
+        consume_reservation_type: SPECIFIC_RESERVATION
+        specific_reservations:
+        - name: $(vars.reservation)
+      placement_policy:
+        type: COMPACT
+        tpu_topology: $(vars.tpu_topology)
+    outputs: [instructions]
+
+  - id: workload-manager-install
+    source: modules/management/kubectl-apply
+    use: [gke-tpu-v6-cluster]
+    settings:
+      jobset:
+        install: true
+
+  - id: gcs-training
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      remote_mount: $(training_bucket.gcs_bucket_name)
+      local_mount: /training-data
+      fs_type: gcsfuse
+      mount_options: >-
+        implicit-dirs,
+        metadata-cache:ttl-secs:-1,
+        metadata-cache:stat-cache-max-size-mb:-1,
+        metadata-cache:type-cache-max-size-mb:-1,
+        file-cache:max-size-mb:-1,
+        file-cache:cache-file-for-range-read:true
+
+  - id: gcs-checkpointing
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
+      local_mount: /checkpoint-data
+      fs_type: gcsfuse
+      mount_options: >-
+        implicit-dirs,
+        metadata-cache:ttl-secs:-1,
+        metadata-cache:stat-cache-max-size-mb:-1,
+        metadata-cache:type-cache-max-size-mb:-1,
+        file-cache:max-size-mb:-1,
+        file-cache:cache-file-for-range-read:true,
+        file-cache:enable-parallel-downloads:true,
+        rename-dir-limit=200000
+
+  # Persistent Volume for training data
+  - id: training-pv
+    source: modules/file-system/gke-persistent-volume
+    use: [gcs-training, gke-tpu-v6-cluster]
+    settings:
+      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
+      capacity_gib: 1000000
+
+  # Persistent Volume for checkpoint data
+  - id: checkpointing-pv
+    source: modules/file-system/gke-persistent-volume
+    use: [gcs-checkpointing, gke-tpu-v6-cluster]
+    settings:
+      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
+      capacity_gib: 1000000
+
+  # This is an example job that will install and run an `fio`
+  # benchmark against the training and checkpointing buckets.
+  - id: fio-bench-job-template
+    source: modules/compute/gke-job-template
+    use: [checkpointing-pv, training-pv, gke-tpu-v6-pool]
+    settings:
+      node_count: $(vars.static_node_count)
+      security_context:  # to make sure the job have enough access to install the fio packages
+      - key: runAsUser
+        value: 0
+      - key: runAsGroup
+        value: 100
+      - key: fsGroup
+        value: 100
+
+      k8s_service_account_name: workload-identity-k8s-sa
+      requested_cpu_per_pod: 8
+      image: ubuntu:latest
+
+      command:
+      - bash
+      - -c
+      - |
+
+        set -eux
+        export DEBIAN_FRONTEND=noninteractive
+
+        # Install fio
+        apt update -y && apt install -y fio
+
+        # Use a tag to create a unique path for tests
+        TAG=`date +%s`
+
+        # Verify mountpoints
+        df -h
+        mountpoint /checkpoint-data
+        mountpoint /training-data
+
+        # Create temporary directory for fio benchmarks
+        mkdir -p /{training,checkpoint}-data/fio-benchmarks-${TAG}
+
+        # The following will take roughly 5 minutes to complete
+
+        # Test reading from the training bucket
+        fio --ioengine=libaio --filesize=1G --ramp_time=2s --runtime=30s \
+          --numjobs=8 --create_serialize=0 --direct=1 --verify=0 \
+          --randrepeat=0 --group_reporting --directory=/training-data/fio-benchmarks-${TAG} \
+          --name=training-read --blocksize=1m --iodepth=16 --readwrite=randread
+
+        # Test writing to the checkpointing bucket
+        fio --ioengine=libaio --filesize=1G --ramp_time=2s --runtime=30s \
+          --numjobs=8 --create_serialize=0 --direct=1 --verify=0 \
+          --randrepeat=0 --group_reporting --directory=/checkpoint-data/fio-benchmarks-${TAG} \
+          --name=checkpoint-write --blocksize=10m --iodepth=16 --readwrite=write
+
+        # Perform checkpoint data reading performance test
+        fio --ioengine=libaio --filesize=1G --ramp_time=2s --runtime=30s \
+          --numjobs=8 --create_serialize=0 --direct=1 --verify=0 \
+          --randrepeat=0 --group_reporting --directory=/checkpoint-data/fio-benchmarks-${TAG} \
+          --name=checkpoint-read --blocksize=10m --iodepth=16 --readwrite=read
+
+        rm -rf /{training,checkpoint}-data/fio-benchmarks-${TAG}
+
+    outputs: [instructions]

--- a/modules/compute/gke-job-template/README.md
+++ b/modules/compute/gke-job-template/README.md
@@ -121,6 +121,9 @@ No modules.
 | <a name="input_restart_policy"></a> [restart\_policy](#input\_restart\_policy) | Job restart policy. Only a RestartPolicy equal to `Never` or `OnFailure` is allowed. | `string` | `"Never"` | no |
 | <a name="input_security_context"></a> [security\_context](#input\_security\_context) | The security options the container should be run with. More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ | <pre>list(object({<br/>    key   = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations allow the scheduler to schedule pods with matching taints. Generally populated from gke-node-pool via `use` field. | <pre>list(object({<br/>    key      = string<br/>    operator = string<br/>    value    = string<br/>    effect   = string<br/>  }))</pre> | <pre>[<br/>  {<br/>    "effect": "NoSchedule",<br/>    "key": "user-workload",<br/>    "operator": "Equal",<br/>    "value": "true"<br/>  }<br/>]</pre> | no |
+| <a name="input_tpu_accelerator_type"></a> [tpu\_accelerator\_type](#input\_tpu\_accelerator\_type) | The TPU accelerator type label. Populated from gke-node-pool via `use` field. | `list(string)` | <pre>[<br/>  null<br/>]</pre> | no |
+| <a name="input_tpu_chips_per_node"></a> [tpu\_chips\_per\_node](#input\_tpu\_chips\_per\_node) | The number of TPU chips per node. Populated from gke-node-pool via `use` field. | `list(string)` | <pre>[<br/>  null<br/>]</pre> | no |
+| <a name="input_tpu_topology"></a> [tpu\_topology](#input\_tpu\_topology) | The TPU topology label. Populated from gke-node-pool via `use` field. | `list(string)` | <pre>[<br/>  null<br/>]</pre> | no |
 
 ## Outputs
 

--- a/modules/compute/gke-job-template/main.tf
+++ b/modules/compute/gke-job-template/main.tf
@@ -20,6 +20,18 @@ locals {
 }
 
 locals {
+  tpu_accelerator_node_selector = var.tpu_accelerator_type[0] != null ? [{
+    key   = "cloud.google.com/gke-tpu-accelerator"
+    value = var.tpu_accelerator_type[0]
+  }] : []
+
+  tpu_topology_node_selector = var.tpu_topology[0] != null ? [{
+    key   = "cloud.google.com/gke-tpu-topology"
+    value = var.tpu_topology[0]
+  }] : []
+}
+
+locals {
   # Start with the minimum cpu available of used node pools
   min_allocatable_cpu = min(var.allocatable_cpu_per_node...)
   full_node_cpu_request = (
@@ -107,7 +119,7 @@ locals {
     key   = "cloud.google.com/machine-family"
     value = var.machine_family
   }] : []
-  node_selectors = concat(local.machine_family_node_selector, local.local_ssd_node_selector, var.node_selectors)
+  node_selectors = concat(local.machine_family_node_selector, local.local_ssd_node_selector, local.tpu_accelerator_node_selector, local.tpu_topology_node_selector, var.node_selectors)
 
   any_gcs = anytrue([for pvc in var.persistent_volume_claims :
     pvc.storage_type == "gcs"
@@ -125,6 +137,7 @@ locals {
       k8s_service_account_name = var.k8s_service_account_name
       node_pool_names          = var.node_pool_names
       node_selectors           = local.node_selectors
+      tpu_limit                = var.tpu_chips_per_node[0]
       full_node_request        = local.full_node_request
       cpu_request              = local.cpu_request_string
       gpu_limit                = local.gpu_limit_string

--- a/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
+++ b/modules/compute/gke-job-template/templates/gke-job-base.yaml.tftpl
@@ -58,21 +58,29 @@ spec:
         image: ${image}
         command:
         %{for s in command}- ${indent(8, yamlencode(s))}%{~ endfor }
-        %{~ if gpu_limit != null || cpu_request != null ~}
+        %{~ if gpu_limit != null || cpu_request != null || tpu_limit != null ~}
         resources:
-          %{~ if gpu_limit != null ~}
+          %{~ if gpu_limit != null || tpu_limit != null ~}
           limits:
+            %{~ if gpu_limit != null ~}
             # GPUs should only be specified as limits
             # https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/
             nvidia.com/gpu: ${gpu_limit}
+            %{~ endif ~}
+            %{~ if tpu_limit != null ~}
+            google.com/tpu: ${tpu_limit}
+            %{~ endif ~}
           %{~ endif ~}
-          %{~ if cpu_request != null || memory_request != null || ephemeral_request != null ~}
+          %{~ if cpu_request != null || memory_request != null || ephemeral_request != null || tpu_limit != null ~}
           requests:
             %{~ if full_node_request ~}
             # cpu request attempts full node per pod
             %{~ endif ~}
             %{~ if cpu_request != null ~}
             cpu: ${cpu_request}
+            %{~ endif ~}
+            %{~ if tpu_limit != null ~}
+            google.com/tpu: ${tpu_limit}
             %{~ endif ~}
             %{~ if memory_request != null ~}
             memory: ${memory_request}

--- a/modules/compute/gke-job-template/variables.tf
+++ b/modules/compute/gke-job-template/variables.tf
@@ -186,3 +186,21 @@ variable "labels" {
   description = "Labels to add to the GKE job template. Key-value pairs."
   type        = map(string)
 }
+
+variable "tpu_accelerator_type" {
+  description = "The TPU accelerator type label. Populated from gke-node-pool via `use` field."
+  type        = list(string)
+  default     = [null]
+}
+
+variable "tpu_topology" {
+  description = "The TPU topology label. Populated from gke-node-pool via `use` field."
+  type        = list(string)
+  default     = [null]
+}
+
+variable "tpu_chips_per_node" {
+  description = "The number of TPU chips per node. Populated from gke-node-pool via `use` field."
+  type        = list(string)
+  default     = [null]
+}

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -297,6 +297,7 @@ limitations under the License.
 |------|--------|---------|
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../internal/gpu-definition | n/a |
 | <a name="module_kubectl_apply"></a> [kubectl\_apply](#module\_kubectl\_apply) | ../../management/kubectl-apply | n/a |
+| <a name="module_tpu"></a> [tpu](#module\_tpu) | ../../internal/tpu-definition | n/a |
 
 ## Resources
 
@@ -381,4 +382,7 @@ limitations under the License.
 | <a name="output_node_pool_names"></a> [node\_pool\_names](#output\_node\_pool\_names) | Names of the node pools. |
 | <a name="output_static_gpu_count"></a> [static\_gpu\_count](#output\_static\_gpu\_count) | Total number of GPUs in the node pool. Available only for static node pools. |
 | <a name="output_tolerations"></a> [tolerations](#output\_tolerations) | Tolerations needed for a pod to be scheduled on this node pool. |
+| <a name="output_tpu_accelerator_type"></a> [tpu\_accelerator\_type](#output\_tpu\_accelerator\_type) | The label value for the TPU accelerator type (e.g., 'tpu-v6e-slice'). |
+| <a name="output_tpu_chips_per_node"></a> [tpu\_chips\_per\_node](#output\_tpu\_chips\_per\_node) | The number of TPU chips on each node in the pool. |
+| <a name="output_tpu_topology"></a> [tpu\_topology](#output\_tpu\_topology) | The topology of the TPU slice (e.g., '4x4'). |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -61,6 +61,13 @@ locals {
   cluster_location = local.cluster_id_parts[3]
 }
 
+module "tpu" {
+  source = "../../internal/tpu-definition"
+
+  machine_type     = var.machine_type
+  placement_policy = var.placement_policy
+}
+
 
 data "google_container_cluster" "gke_cluster" {
   name     = local.cluster_name
@@ -160,7 +167,7 @@ resource "google_container_node_pool" "node_pool" {
     }
 
     dynamic "taint" {
-      for_each = concat(var.taints, local.gpu_taint)
+      for_each = concat(var.taints, local.gpu_taint, module.tpu.tpu_taint)
       content {
         key    = taint.value.key
         value  = taint.value.value

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -135,3 +135,18 @@ output "instance_templates" {
   description = "The URLs of Instance Templates"
   value       = [for key, template in data.google_compute_region_instance_template.instance_template : template.self_link]
 }
+
+output "tpu_accelerator_type" {
+  description = "The label value for the TPU accelerator type (e.g., 'tpu-v6e-slice')."
+  value       = module.tpu.is_tpu ? module.tpu.tpu_accelerator_type : null
+}
+
+output "tpu_topology" {
+  description = "The topology of the TPU slice (e.g., '4x4')."
+  value       = module.tpu.is_tpu ? module.tpu.tpu_topology : null
+}
+
+output "tpu_chips_per_node" {
+  description = "The number of TPU chips on each node in the pool."
+  value       = module.tpu.is_tpu ? module.tpu.tpu_chips_per_node : null
+}

--- a/modules/internal/tpu-definition/README.md
+++ b/modules/internal/tpu-definition/README.md
@@ -1,0 +1,85 @@
+## Description
+
+This is an internal helper module designed to encapsulate and centralize all hardware-specific logic for Google Cloud TPUs. It is intended to be called by parent modules like `gke-node-pool` to determine if a node pool is TPU-based and to retrieve its specific attributes.
+
+This module's primary responsibilities are:
+
+* Reliably detect if a node pool is for TPUs by checking its `placement_policy`.
+* Determine the correct GKE `tpu-accelerator` label based on the machine type family.
+* Determine the `number of chips per node` based on the specific machine type.
+* Generate the standard **Kubernetes taint** that should be applied to TPU nodes.
+
+This follows the same design pattern as the `gpu-definition` internal module, promoting a clean separation of concerns within the gke-node-pool module.
+
+## Usage
+
+This module is not intended for direct use in a blueprint. It should be called from a parent module like `gke-node-pool`.
+
+```yaml
+module "tpu" {
+  source = "../../internal/tpu-definition"
+
+  # Pass the parent module's variables to this module
+  machine_type     = var.machine_type
+  placement_policy = var.placement_policy
+}
+
+# Example of consuming the module's outputs in the parent module
+locals {
+  # The tpu_taint is then used in the node_config's dynamic "taint" block
+  tpu_taint = module.tpu.tpu_taint
+}
+```
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2025 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+No modules.
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine type of the node pool. | `string` | n/a | yes |
+| <a name="input_placement_policy"></a> [placement\_policy](#input\_placement\_policy) | The placement policy for the node pool. | <pre>object({<br/>    type         = string<br/>    name         = optional(string)<br/>    tpu_topology = optional(string)<br/>  })</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_is_tpu"></a> [is\_tpu](#output\_is\_tpu) | Boolean value indicating if the node pool is for TPUs. |
+| <a name="output_tpu_accelerator_type"></a> [tpu\_accelerator\_type](#output\_tpu\_accelerator\_type) | The label value for the TPU accelerator type (e.g., 'tpu-v6e-slice'). |
+| <a name="output_tpu_chips_per_node"></a> [tpu\_chips\_per\_node](#output\_tpu\_chips\_per\_node) | The number of TPU chips on each node in the pool. |
+| <a name="output_tpu_taint"></a> [tpu\_taint](#output\_tpu\_taint) | A list containing the standard TPU taint object if the node pool is for TPUs. |
+| <a name="output_tpu_topology"></a> [tpu\_topology](#output\_tpu\_topology) | The topology of the TPU slice (e.g., '4x4'). |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/internal/tpu-definition/main.tf
+++ b/modules/internal/tpu-definition/main.tf
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+locals {
+  # Safely check for the existence of a TPU topology.
+  is_tpu = try(var.placement_policy.tpu_topology, null) != null && try(var.placement_policy.tpu_topology, "") != ""
+
+  tpu_taint = local.is_tpu ? [{
+    key    = "google.com/tpu"
+    value  = "present"
+    effect = "NO_SCHEDULE"
+  }] : []
+
+  # Exhaustive map of machine prefixes to GKE accelerator labels.
+  tpu_accelerator_map = {
+    "ct4p"  = "tpu-v4-podslice"      # TPU v4
+    "ct5lp" = "tpu-v5-lite-podslice" # TPU v5e
+    "ct5p"  = "tpu-v5p-slice"        # TPU v5p
+    "ct6e"  = "tpu-v6e-slice"        # TPU v6e
+  }
+
+  # Map specific GCE machine types to the number of TPU chips per node (VM).
+  # Based on public Google Cloud TPU documentation.
+  tpu_chip_count_map = {
+    # v4 - ct4p
+    "ct4p-hightpu-4t" = 4
+
+    # v5e - ct5lp
+    "ct5lp-hightpu-1t" = 1
+    "ct5lp-hightpu-4t" = 4
+    "ct5lp-hightpu-8t" = 8
+
+    # v5p - ct5p
+    "ct5p-hightpu-1t" = 1
+    "ct5p-hightpu-2t" = 2
+    "ct5p-hightpu-4t" = 4
+
+    # v6e - ct6e
+    "ct6e-standard-1t" = 1
+    "ct6e-standard-4t" = 4
+    "ct6e-standard-8t" = 8
+  }
+
+  # Robustly extract the machine family prefix (e.g., "ct6e").
+  tpu_machine_family   = local.is_tpu ? element(split("-", var.machine_type), 0) : ""
+  tpu_accelerator_type = local.is_tpu ? lookup(local.tpu_accelerator_map, local.tpu_machine_family, null) : null
+  tpu_chips_per_node   = local.is_tpu ? lookup(local.tpu_chip_count_map, var.machine_type, null) : null
+}
+
+terraform {
+  required_version = ">= 1.3"
+}

--- a/modules/internal/tpu-definition/outputs.tf
+++ b/modules/internal/tpu-definition/outputs.tf
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+output "is_tpu" {
+  description = "Boolean value indicating if the node pool is for TPUs."
+  value       = local.is_tpu
+}
+
+output "tpu_accelerator_type" {
+  description = "The label value for the TPU accelerator type (e.g., 'tpu-v6e-slice')."
+  value       = local.tpu_accelerator_type
+}
+
+output "tpu_topology" {
+  description = "The topology of the TPU slice (e.g., '4x4')."
+  value       = local.is_tpu ? var.placement_policy.tpu_topology : null
+}
+
+output "tpu_chips_per_node" {
+  description = "The number of TPU chips on each node in the pool."
+  value       = local.tpu_chips_per_node
+}
+
+output "tpu_taint" {
+  description = "A list containing the standard TPU taint object if the node pool is for TPUs."
+  value       = local.tpu_taint
+}

--- a/modules/internal/tpu-definition/variables.tf
+++ b/modules/internal/tpu-definition/variables.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+variable "machine_type" {
+  description = "The machine type of the node pool."
+  type        = string
+}
+
+variable "placement_policy" {
+  description = "The placement policy for the node pool."
+  type = object({
+    type         = string
+    name         = optional(string)
+    tpu_topology = optional(string)
+  })
+}


### PR DESCRIPTION
This PR introduces two major enhancements for Cloud TPU users: it makes the core GKE modules "TPU-aware" for automated job creation and adds a new blueprint for TPU v6e with GCS integration.
1. *Automated TPU Job Configuration*:
*Problem*: Deploying TPU jobs previously required manual manifest editing for resource requests, tolerations, and GKE Warden selectors.
Solution: The gke-node-pool and gke-job-template modules have been refactored. A new internal tpu-definition module centralizes TPU logic, allowing the gke-job-template to automatically generate complete and correct manifests for TPU workloads via the use: directive, eliminating all manual steps.
2. *New GCS + TPU v6e Blueprint*:
A new `gke-tpu-v6-gcs.yaml` blueprint has been added.
This production-ready example demonstrates best practices for TPU workloads, including dedicated service accounts (Workload Identity) and performance-tuned *GCS FUSE mounts* for training data and checkpoints, all provisioned automatically.

> NOTE: There was a change in output name made as a part of PR #4607 . Refer [CP](https://github.com/GoogleCloudPlatform/cluster-toolkit/commit/de0d5174997e71b25105acf80ff54863fa3ecfd8#diff-20a095d8890c746c2ada945e8e3050106113d491dd597e08537b4222f4e085a5L114-L117). This resulted in name mismatch of `node_count` variable in `gke-job-template` module. To solve the issue, we needed to pass the `node_count` variable explicitly from the blueprint itself.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
