### PR TITLE
Simplify condition for github workflow multi-approvers job

### DIFF
--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -15,15 +15,6 @@
 name: 'multi-approvers'
 
 on:
-  pull_request:
-    types:
-    - 'opened'
-    - 'edited'
-    - 'reopened'
-    - 'synchronize'
-    - 'ready_for_review'
-    - 'review_requested'
-    - 'review_request_removed'
   pull_request_review:
     types:
     - 'submitted'
@@ -40,7 +31,7 @@ concurrency:
 
 jobs:
   multi-approvers:
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_review' && (github.event.review.state == 'approved' ||  github.event.action == 'dismissed')
+    if: github.event_name == 'pull_request_review' && (github.event.review.state == 'approved' ||  github.event.action == 'dismissed')
     uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
     with:
       org-members-path: 'GoogleCloudPlatform/cluster-toolkit/develop/cluster-toolkit-writers.json'


### PR DESCRIPTION
The previous update does not fix the issue that multi-approvers(pull_request) job does not re-run upon approval.

**Note**: Removing the PR triggers doesn't impact the approval workflow

**Reason for change**: The multi-approvers condition should run when an approval is either submitted or dismissed. The PR state should not directly affect. Note that approvals get dismissed when a new commit is added to a PR. So, that case is not missed with this change.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
