### PR TITLE
Update recommended `FI_UNIVERSE_SIZE` setting for startup script

### DIFF
--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -103,7 +103,7 @@ locals {
         export FI_OFI_RXM_USE_RNDV_WRITE=0
         export FI_VERBS_INLINE_SIZE=39
         export I_MPI_FABRICS="shm:ofi"
-        export FI_UNIVERSE_SIZE=3072
+        export FI_UNIVERSE_SIZE=1024
         export I_MPI_ADJUST_ALLTOALL=1
         export I_MPI_ADJUST_IALLTOALL=1
         export I_MPI_ADJUST_BCAST=4


### PR DESCRIPTION
This change makes libfabric to behave consistently, regardless whether it is dynamic or static built.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
