### PR TITLE
feat: Add default partition GPU check to A* SLURM daily tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-default-partition.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-default-partition.yml
@@ -1,0 +1,36 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - custom_vars.gpu_partition is defined
+
+- name: Get default partition configuration
+  ansible.builtin.shell: "scontrol show config | grep '^DefaultPartition'"
+  register: default_partition_config
+  retries: 10
+  delay: 12
+  until: default_partition_config.stdout | length > 0
+  changed_when: false
+
+- name: Extract default partition name
+  set_fact:
+    default_partition: "{{ (default_partition_config.stdout.split('='))[1] | trim }}"
+
+- name: Assert default partition is the GPU partition
+  ansible.builtin.assert:
+    that:
+    - default_partition == custom_vars.gpu_partition
+    msg: "The default partition is '{{ default_partition }}', but expected '{{ custom_vars.gpu_partition }}'."

--- a/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm-cluster.yml
@@ -27,6 +27,7 @@ network: default
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
 - test-validation/test-enroot.yml
 - test-validation/test-gpus-slurm.yml
 custom_vars:

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
@@ -30,6 +30,7 @@ sub_network: "{{ deployment_name }}-sub-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
 - test-validation/test-enroot.yml
 - test-validation/test-gpus-slurm.yml
 - test-validation/test-nccl.yml

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
@@ -28,6 +28,7 @@ network: "{{ test_name }}-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
 - test-validation/test-enroot.yml
 - test-validation/test-gpus-slurm.yml
 post_destroy_tasks:

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm-flex.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm-flex.yml
@@ -28,6 +28,7 @@ network: "{{ test_name }}-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
 - test-validation/test-enroot.yml
 - test-validation/test-gpus-slurm.yml
 post_destroy_tasks:

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
@@ -28,6 +28,7 @@ network: "{{ test_name }}-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
 - test-validation/test-enroot.yml
 - test-validation/test-gpus-slurm.yml
 post_destroy_tasks:


### PR DESCRIPTION
Add Default Partition GPU Check to SLURM Daily Tests
This PR introduces a new validation test to ensure that the default SLURM partition is correctly configured to be the GPU-enabled partition in various high-GPU-density cluster configurations.

📝 Summary of Changes
New Validation Playbook: Adds tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-default-partition.yml.

This playbook asserts that a custom_vars.gpu_partition variable is defined.
It uses the sinfo command to retrieve the current default partition (identified by a *).
It then asserts that the detected default partition name matches the expected GPU partition name provided via custom_vars.

Integration with Daily Tests: The new validation test is integrated into the post_deploy_tests for the following SLURM GPU configurations:

ml-a3-highgpu-slurm-cluster.yml
ml-a3-megagpu-slurm-ubuntu.yml
ml-a3-ultragpu-slurm.yml
ml-a4-highgpu-slurm-flex.yml
ml-a4-highgpu-slurm.yml

🎯 Rationale:
Without this validation, our example blueprints might end up with CPU-only default partition, leading to failed or misconfigured runs. This check guarantees the expected default behavior for GPU-focused deployments.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
