### PR TITLE
Adding validations for naming resources

### DIFF
--- a/modules/compute/gke-node-pool/variables.tf
+++ b/modules/compute/gke-node-pool/variables.tf
@@ -37,6 +37,15 @@ variable "name" {
     EOD
   type        = string
   default     = null
+
+  validation {
+    # Check if the variable is null OR if it matches the GCP resource naming regex.
+    condition     = var.name == null || can(regex("^[a-z]([-a-z0-9]{0,34}[a-z0-9])?$", var.name))
+    error_message = <<-EOD
+    If provided, the node pool name must be between 1 and 36 characters, start with a lowercase letter, end with an alphanumeric, and contain only lowercase letters, numbers, and hyphens.
+    Underscores are not allowed. A shorter length is enforced to accommodate a suffix when creating multiple node pools.
+    EOD
+  }
 }
 
 variable "internal_ghpc_module_id" {

--- a/modules/compute/resource-policy/variables.tf
+++ b/modules/compute/resource-policy/variables.tf
@@ -27,6 +27,15 @@ variable "region" {
 variable "name" {
   description = "The resource policy's name."
   type        = string
+
+  validation {
+    # Check if the variable matches the GCP resource naming regex.
+    condition     = can(regex("^[a-z]([-a-z0-9]{0,52}[a-z0-9])?$", var.name))
+    error_message = <<-EOD
+    The resource policy name must be between 1 and 54 characters, start with a lowercase letter, end with an alphanumeric, and contain only lowercase letters, numbers, and hyphens.
+    Underscores are not allowed. A shorter length is enforced to accommodate a random suffix.
+    EOD
+  }
 }
 
 variable "group_placement_max_distance" {


### PR DESCRIPTION
This change includes addition of **validation in variables for naming** node-pool and resource-policy resources. This is to validate the namings are as per the **GCP naming conventions** and avoid validation errors towards the end of resource provisioning.

Without these validations, the user would get the GCP validation error towards the end of cluster deployment when node pool is being spun up. Adding these validations enable checks to kick in at the terraform plan stage itself before applying resources on GCP, thereby **pre-validating errors before resources are being provisioned**.

Tested the scenarios:
* Validation in plan stage in case of invalid names.
* Successful provisioning in case of valid names.