### PR TITLE
Add Managed Lustre support in gke-a4x blueprint

### DIFF
--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -64,7 +64,7 @@ vars:
   # # Please refer https://cloud.google.com/managed-lustre/docs/locations
 
   # # Managed-Lustre instance name. This should be unique for each deployment.
-  # lustre_instance_id: gke-lustre-instance-a4x1
+  # lustre_instance_id: $(vars.deployment_name)
 
   # # The values of size_gib and per_unit_storage_throughput are co-related
   # # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
@@ -259,8 +259,6 @@ deployment_groups:
   #     remote_mount: lustrefs
   #     size_gib: $(vars.lustre_size_gib)
   #     per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
-  #     zone: us-central1-a
-
 
   # - id: lustre-pv
   #   source: modules/file-system/gke-persistent-volume


### PR DESCRIPTION
Enabled the Lustre CSI driver by default in gke-a4x blueprint and added commented out code with instructions to support managed lustre.

Manual testing steps performed:

1. Deployed the GKE A4X cluster with Managed-Lustre enabled.
2. Checked if the PVC is bound to the PV: kubectl get pvc
3. Mounted the PVC in a pod, which will mount the Managed-Lustre file system.
4. Checked if the pod is running and the volume is mounted: kubectl get pod
5. Wait for the pod to be in the 'Running' state
6. Exec into the pod: kubectl exec -it -- /bin/sh
7. Inside the pod, checked the mount:
   df -h /mnt/lustre
   mount | grep lustre
8. Managed-Lustre file system was mounted at /mnt/lustre and was able to read/write data to this path from within the container.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
