### PR TITLE
fix: Multi-Approvers Workflow

### DIFF
--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -15,6 +15,15 @@
 name: 'multi-approvers'
 
 on:
+  pull_request:
+    types:
+    - 'opened'
+    - 'edited'
+    - 'reopened'
+    - 'synchronize'
+    - 'ready_for_review'
+    - 'review_requested'
+    - 'review_request_removed'
   pull_request_review:
     types:
     - 'submitted'
@@ -31,7 +40,6 @@ concurrency:
 
 jobs:
   multi-approvers:
-    if: github.event_name == 'pull_request_review' && (github.event.review.state == 'approved' ||  github.event.action == 'dismissed')
     uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
     with:
       org-members-path: 'GoogleCloudPlatform/cluster-toolkit/develop/cluster-toolkit-writers.json'


### PR DESCRIPTION
This PR re-introduces the hook to trigger multi-approver workflow when a new PR is opened and returns to the old workflow as it was before the 13th of October 2025.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
