### PR TITLE
Pin the GKE version for GKE A3 High blueprint

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -89,6 +89,7 @@ deployment_groups:
       k8s_network_names:
         gvnic_prefix: vpc
         gvnic_start_index: 1
+      version_prefix: 1.33.5-gke.1308000
     outputs: [instructions]
 
   - id: a3_highgpu_pool

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-high.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-high.yml
@@ -1,4 +1,4 @@
-# Copyright 2025 "Google LLC"
+# Copyright 2025 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,6 +23,16 @@
   ansible.builtin.shell: |
     gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
+- name: Get GKE cluster version
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    gcloud container clusters describe {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --format="value(currentMasterVersion)"
+  register: gke_version_info
+
+- name: Print GKE cluster version
+  ansible.builtin.debug:
+    msg: "GKE Cluster Version: {{ gke_version_info.stdout }}"
+
 - name: Download NCCL test file
   delegate_to: localhost
   ansible.builtin.shell: |
@@ -33,7 +43,7 @@
 
 - name: Display NCCL test file
   debug:
-    msg: "{{nccl_test_file_contents.stdout}}"
+    msg: "{{ nccl_test_file_contents.stdout }}"
 
 - name: Create NCCL config map and deploy NCCL test pods
   delegate_to: localhost
@@ -58,7 +68,7 @@
 
 - name: Print the NCCL test logs
   debug:
-    msg: "{{nccl_test_logs.stdout}}"
+    msg: "{{ nccl_test_logs.stdout }}"
 
 - name: Ensure average bus bandwidth is >= 25 GB/s
   delegate_to: localhost
@@ -70,5 +80,4 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete pod --all -v=9
-    kubectl delete service --all -v=9
+    kubectl delete -f {{ workspace }}/examples/nccl-test.yaml


### PR DESCRIPTION
This PR introduces two changes
1>  to fetch and print the GKE version before running the NCCL test on a GKE cluster of A3-High machine
2> Temporarily pn the GKE version for A3 High GPU to 1.33.5-gke.1308000

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
