### PR TITLE
Adding correct node configurations for A4x compute nodes

### DIFF
--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -597,6 +597,12 @@ deployment_groups:
       instance_image_custom: true
       on_host_maintenance: TERMINATE
       reservation_name: $(vars.a4x_reservation_name)
+      advanced_machine_features:
+        threads_per_core: null # Use platform default value
+      node_conf:
+        CoresPerSocket: 70
+        SocketsPerBoard: 2
+        ThreadsPerCore: 1
       additional_networks:
         $(concat(
           [{


### PR DESCRIPTION
error: Toolkit configures only one CPU socket for A4X in slurm
fix: similar to other A* blueprints specifying correct node configurations in the nodesset.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
