### PR TITLE
Fix(test): Use sinfo instead of scontrol for default partition check

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-default-partition.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-default-partition.yml
@@ -18,16 +18,16 @@
     - custom_vars.gpu_partition is defined
 
 - name: Get default partition configuration
-  ansible.builtin.shell: "scontrol show config | grep '^DefaultPartition'"
-  register: default_partition_config
+  ansible.builtin.shell: sinfo --noheader  --all --format "%P" | grep "\*"
+  register: sinfo_default_partition_output
   retries: 10
   delay: 12
-  until: default_partition_config.stdout | length > 0
+  until: sinfo_default_partition_output.stdout | length > 0
   changed_when: false
 
 - name: Extract default partition name
   set_fact:
-    default_partition: "{{ (default_partition_config.stdout.split('='))[1] | trim }}"
+    default_partition: "{{ sinfo_default_partition_output.stdout_lines | first | replace('*', '') }}"
 
 - name: Assert default partition is the GPU partition
   ansible.builtin.assert:


### PR DESCRIPTION
The test-default-partition integration test was failing because the scontrol show config command was unreliable.

This PR switches to using sinfo to query the live daemon state for the default partition (marked with *).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
