### PR TITLE
Add storage.objectAdmin role in node pool SA

### DIFF
--- a/community/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
@@ -89,7 +89,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
+++ b/community/examples/gke-tpu-v6/gke-tpu-v6.yaml
@@ -108,7 +108,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -52,7 +52,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -85,7 +85,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -129,7 +129,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -163,7 +163,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
@@ -105,7 +105,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
@@ -97,7 +97,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-g4/gke-g4.yaml
+++ b/examples/gke-g4/gke-g4.yaml
@@ -98,7 +98,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -97,7 +97,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -46,7 +46,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -96,7 +96,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/examples/hpc-gke.yaml
+++ b/examples/hpc-gke.yaml
@@ -47,7 +47,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account

--- a/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
@@ -51,7 +51,7 @@ deployment_groups:
       - monitoring.metricWriter
       - monitoring.viewer
       - stackdriver.resourceMetadata.writer
-      - storage.objectViewer
+      - storage.objectAdmin
       - artifactregistry.reader
 
   - id: workload_service_account


### PR DESCRIPTION
The node pool service account needs storage.objectAdmin for GKE workloads that use host networking.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
