### PR TITLE
Fix: Resolve deployment name clash for a3-megagpu and a3-ultragpu tests

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
   gpu_zones: "[europe-west4-a,europe-west4-b,europe-west4-c]"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm.yaml"
-network: "{{ test_name }}"
+network: "{{ deployment_name }}"
 
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/cloud-build/daily-tests/tests/htc-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/htc-slurm.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
 
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/htc-slurm.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
@@ -16,8 +16,8 @@
 
 # region, zone must be defined in build file with --extra-vars flag!
 test_name: a3m-slurm
-deployment_name: a3m-{{ build[0:3] }}{{ build[-3:] }}-slurm
-slurm_cluster_name: "a3m{{ build[0:3] }}{{ build[-3:] }}"
+deployment_name: a3m-{{ build }}-slurm
+slurm_cluster_name: "a3m{{ build }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-login-*"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
@@ -16,7 +16,7 @@
 
 # region, zone must be defined in build file with --extra-vars flag!
 test_name: a3u-jbvms
-deployment_name: a3u-{{ build[0:3] }}{{ build[-3:] }}-jbvms
+deployment_name: a3u-{{ build }}-jbvms
 hostname_prefix: "{{ deployment_name }}-beowulf"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
@@ -16,8 +16,8 @@
 
 # region, zone must be defined in build file with --extra-vars flag!
 test_name: a3u-slurm
-deployment_name: a3u-{{ build[0:3] }}{{ build[-3:] }}-slurm
-slurm_cluster_name: "a3u{{ build[0:3] }}{{ build[-3:] }}"
+deployment_name: a3u-{{ build }}-slurm
+slurm_cluster_name: "a3u{{ build }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm-flex.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm-flex.yml
@@ -16,15 +16,15 @@
 
 # region, zone must be defined in build file with --extra-vars flag!
 test_name: a4h-slurm-flex
-deployment_name: a4h-slurm-flex-{{ build }}
-slurm_cluster_name: "a4hf{{ build[0:4] }}"
+deployment_name: a4h-{{ build }}-slurm-flex
+slurm_cluster_name: "a4hf{{ build }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 region: us-central1
 zone: us-central1-b
-network: "{{ test_name }}-net-0"
+network: "{{ deployment_name }}-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
@@ -47,5 +47,5 @@ cli_deployment_vars:
   slurm_cluster_name: "{{ slurm_cluster_name }}"
   disk_size_gb: 200
   a4h_cluster_size: 2
-  base_network_name: "{{ test_name }}"
+  base_network_name: "{{ deployment_name }}"
   a4h_dws_flex_enabled: true

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-slurm.yml
@@ -16,15 +16,15 @@
 
 # region, zone must be defined in build file with --extra-vars flag!
 test_name: a4h-slurm
-deployment_name: a4h-slurm-{{ build }}
-slurm_cluster_name: "a4h{{ build[0:4] }}"
+deployment_name: a4h-{{ build }}-slurm
+slurm_cluster_name: "a4h{{ build }}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 region: us-central1
 zone: us-central1-b
-network: "{{ test_name }}-net-0"
+network: "{{ deployment_name }}-net-0"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml
@@ -49,4 +49,4 @@ cli_deployment_vars:
   disk_size_gb: 200
   a4h_cluster_size: 2
   a4h_reservation_name: nvidia-b200-db38b25a-c93d-4a7e-a3c5-ba4135be357e
-  base_network_name: "{{ test_name }}"
+  base_network_name: "{{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 test_name: ml-gke-e2e
-deployment_name: ml-gke-e2e-{{ build }}
+deployment_name: ml-gke-{{ build }}-e2e
 region: asia-southeast1
 zone: asia-southeast1-b  # for remote node
 workspace: /workspace

--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -16,7 +16,7 @@
 
 test_name: ml-slurm-v6
 deployment_name: ml-slurm-v6-{{ build }}
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer


### PR DESCRIPTION
This PR resolves a deployment name clash that was occurring in the daily tests for a3-megagpu and a3-ultragpu. The following files have been updated with new, unique deployment names:

- tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
- tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml 
- tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
