### PR TITLE
docs: Fix broken link for GKE Inference Gateway in examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,7 +50,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [gke-a3-ultragpu.yaml](#gke-a3-ultragpuyaml-) ![core-badge]
   * [gke-a3-megagpu](#gke-a3-megagpuyaml-) ![core-badge]
   * [gke-a3-highgpu](#gke-a3-highgpuyaml-) ![core-badge]
-  * [gke-a3-highgpu-inference-gateway.yaml](#gke-a3-highgpu-inference-gatewayyaml--) ![core-badge]
+  * [gke-a3-highgpu-inference-gateway.yaml](#gke-a3-highgpu-inference-gatewayyaml-) ![core-badge]
   * [gke-consumption-options](#gke-consumption-options-) ![core-badge]
   * [htc-slurm.yaml](#htc-slurmyaml-) ![community-badge]
   * [htc-htcondor.yaml](#htc-htcondoryaml--) ![community-badge] ![experimental-badge]


### PR DESCRIPTION
This PR fixes a broken markdown link in `examples/README.md`.
The link for `gke-a3-highgpu-inference-gateway.yaml` incorrectly had two trailing dashes (`--`) in its anchor, causing it to not resolve correctly. This change removes one of the dashes, making the link functional.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

- [X]  Fork your PR branch from the Toolkit "develop" branch (not main)
- [X] Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
- [X] Confirm that "make tests" passes all tests
- [X] Add or modify unit tests to cover code changes
- [X] Ensure that unit test coverage remains above 80%
- [X] Update all applicable documentation
- [X] Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
