### PR TITLE
fix: Correct test build path for a3-megagpu in Cloud Build

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-mega-slurm-ubuntu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml"
 
 - id: ml-a3-megagpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner


### PR DESCRIPTION
This PR fixes an incorrect path in the Cloud Build configuration for the A3 MegaGPU tests.
The `check_for_running_build` step was erroneously pointing to `tools/cloud-build/daily-tests/builds/ml-a3-mega-slurm-ubuntu.yaml`. This has been corrected to `tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml`.
This ensures the build check script references the correct YAML definition.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
