### PR TITLE
Resolving Network name clash

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hcls.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls.yml
@@ -22,7 +22,7 @@ slurm_cluster_name: "hclsv6{{ build[0:4] }}"
 zone: europe-west1-c
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hcls-blueprint.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 cli_deployment_vars:

--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
   gpu_zones: "[europe-west4-a,europe-west4-b,europe-west4-c]"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm.yaml"
-network: "{{ test_name }}"
+network: "{{ deployment_name }}"
 
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/cloud-build/daily-tests/tests/htc-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/htc-slurm.yml
@@ -26,7 +26,7 @@ cli_deployment_vars:
 
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/community/examples/htc-slurm.yaml"
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, a*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -16,7 +16,7 @@
 
 test_name: ml-slurm-v6
 deployment_name: ml-slurm-v6-{{ build }}
-network: "{{ test_name }}-net"
+network: "{{ deployment_name }}-net"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer


### PR DESCRIPTION
This PR addresses a network name collision in the daily tests by using the deployment_name variable instead of test_name for network naming consistency.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
