### PR TITLE
Fix: root module input variable not set error when using gke-job-template

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -62,6 +62,8 @@ locals {
 }
 
 module "tpu" {
+  count = module.tpu.is_tpu ? 1 : 0
+
   source = "../../internal/tpu-definition"
 
   machine_type     = var.machine_type
@@ -113,7 +115,7 @@ resource "google_container_node_pool" "node_pool" {
     content {
       type         = var.placement_policy.type
       policy_name  = var.placement_policy.name
-      tpu_topology = module.tpu.is_tpu ? var.placement_policy.tpu_topology : null
+      tpu_topology = module.tpu.is_tpu ? module.tpu[0].tpu_topology : null
     }
   }
 
@@ -167,7 +169,7 @@ resource "google_container_node_pool" "node_pool" {
     }
 
     dynamic "taint" {
-      for_each = concat(var.taints, local.gpu_taint, module.tpu.tpu_taint)
+      for_each = concat(var.taints, local.gpu_taint, module.tpu.is_tpu ? module.tpu[0].tpu_taint : [])
       content {
         key    = taint.value.key
         value  = taint.value.value

--- a/modules/compute/gke-node-pool/outputs.tf
+++ b/modules/compute/gke-node-pool/outputs.tf
@@ -138,15 +138,15 @@ output "instance_templates" {
 
 output "tpu_accelerator_type" {
   description = "The label value for the TPU accelerator type (e.g., 'tpu-v6e-slice')."
-  value       = module.tpu.is_tpu ? module.tpu.tpu_accelerator_type : null
+  value       = module.tpu.is_tpu ? module.tpu[0].tpu_accelerator_type : null
 }
 
 output "tpu_topology" {
   description = "The topology of the TPU slice (e.g., '4x4')."
-  value       = module.tpu.is_tpu ? module.tpu.tpu_topology : null
+  value       = module.tpu.is_tpu ? module.tpu[0].tpu_topology : null
 }
 
 output "tpu_chips_per_node" {
   description = "The number of TPU chips on each node in the pool."
-  value       = module.tpu.is_tpu ? module.tpu.tpu_chips_per_node : null
+  value       = module.tpu.is_tpu ? module.tpu[0].tpu_chips_per_node : null
 }


### PR DESCRIPTION
**Error observed**:
Error: No value for required variable

  on variables.tf line 82:
  82: variable "tpu_chips_per_node_h4d-pool" {

The root module input variable "tpu_chips_per_node_h4d-pool" is not set, and
has no default value. Use a -var or -var-file command line argument to
provide a value for this variable.


**Explanation of the Fix**:
1.  **The Fix:** To solve the error, the `tpu` module is made conditional. It now only gets created if the machine type is actually a TPU. This is done by adding `count = module.tpu.is_tpu ? 1 : 0`.

2.  **Terraform's Behavior:** When you use `count` on a module or resource in Terraform, it is no longer a single object but a *list* of objects.
    *   If `is_tpu` is `true`, `count` is 1, and `module.tpu` becomes a list with one element.
    *   If `is_tpu` is `false`, `count` is 0, and `module.tpu` is an empty list.

3.  **The Syntax Change:** To access the outputs of a module that is now a list, you have to refer to it by its index in the list. Since there will only ever be one instance of it, we use `[0]`.

So, the change from `module.tpu.tpu_chips_per_node` to `module.tpu[0].tpu_chips_per_node` was required to correctly access the output of the `tpu` module after I made its creation conditional.

The reference to `module.tpu[0].tpu_chips_per_node` is updated because `count` argument is added to the `tpu` module in `modules/compute/gke-node-pool/main.tf`.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
