### PR TITLE
Enable Spot VM testing for a3-ultragpu instances

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -209,7 +209,7 @@
     - name: Wait until Slurm key exists
       ansible.builtin.wait_for:
         path: /etc/slurm/slurm.key
-        timeout: 600 # Waits for up to 10 minutes for the file to appear
+        timeout: 600  # Waits for up to 10 minutes for the file to appear
       when: key_type == 'slurm'
 
     - name: Count Slurm nodes
@@ -223,6 +223,10 @@
       retries: 60
       delay: 15
 
+    - name: Add instance labels for spot instances
+      ansible.builtin.include_tasks: tasks/add-instance-labels.yml
+      when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+
     - name: Run Integration tests for Cluster Toolkit
       ansible.builtin.include_tasks: "{{ test }}"
       vars:
@@ -231,6 +235,19 @@
       loop: "{{ post_deploy_tests }}"
       loop_control:
         loop_var: test
+
+    rescue:
+    - name: Display test failure message
+      ansible.builtin.debug:
+        msg: "A task within the integration tests failed. Conditional preemption check will run for spot instances."
+
+    - name: Check for recent preemptions for spot instances
+      ansible.builtin.include_tasks: test-validation/test-preemption.yml
+      when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+
+    - name: Propagate original failure after rescue tasks
+      ansible.builtin.fail:
+        msg: "Integration tests failed. Rescue tasks were executed."
 
     ## Always cleanup, even on failure
     always:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/add-instance-labels.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/add-instance-labels.yml
@@ -1,0 +1,54 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Check if instance_labels are provided and are a dictionary
+  ansible.builtin.assert:
+    that:
+    - custom_vars.instance_labels is defined
+    - custom_vars.instance_labels is mapping
+    - custom_vars.instance_labels | length > 0
+    fail_msg: "custom_vars.instance_labels must be a non-empty dictionary."
+
+# Creates label string of the form "key1=value1,key2=value2" to add to the instances created during the test.
+# Also, transforms key and value to lowercase to be compliant with the gcloud command.
+- name: Prepare label string
+  ansible.builtin.set_fact:
+    labels_string: "{{ keys | zip(values) | map('join', '=') | join(',') }}"
+  vars:
+    items: "{{ custom_vars.instance_labels.items() }}"
+    keys: "{{ items | map(attribute=0) | map('string') | map('lower') }}"
+    values: "{{ items | map(attribute=1) | map('string') | map('lower') }}"
+
+- name: Gather instance information
+  ansible.builtin.import_tasks: tasks/get_instance_ids.yml
+
+- name: Parse instance list
+  ansible.builtin.set_fact:
+    gce_instances_list: "{{ instances.stdout | default('[]') | from_json }}"
+
+- name: Report if no instances found
+  ansible.builtin.debug:
+    msg: "No instances found with label ghpc_deployment={{ deployment_name }} in project {{ project }}."
+  when: gce_instances_list | length == 0
+
+- name: Add spot label to each node
+  ansible.builtin.command: >-
+    gcloud compute instances update {{ item.name }}
+      --project={{ project }}
+      --zone={{ item.zone | basename }}
+      --update-labels={{ labels_string }}
+  loop: "{{ gce_instances_list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  when: gce_instances_list | length > 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-preemption.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-preemption.yml
@@ -1,0 +1,58 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Populate instance list if empty or undefined
+  when: gce_instances_list | default([]) | length == 0
+  block:
+  - name: Gather instance information
+    ansible.builtin.import_tasks: tasks/get_instance_ids.yml
+
+  - name: Parse instance list
+    ansible.builtin.set_fact:
+      gce_instances_list: "{{ instances.stdout | default('[]') | from_json }}"
+
+- name: Check for Preemption Events
+  when: gce_instances_list | length > 0
+  block:
+  # Creating a filter string of the form "resource.labels.instance_id=id1 OR resource.labels.instance_id=id2"
+  - name: Build instance ID filter string
+    ansible.builtin.set_fact:
+      instance_id_filter: "{{ gce_instances_list | map(attribute='id') | map('regex_replace', '^(.*)$', 'resource.labels.instance_id=\"\\1\"') | join(' OR ') }}"
+
+  - name: Query Cloud Audit Logs for any preemption events for these nodes
+    ansible.builtin.shell: |
+      gcloud logging read '
+        resource.type="gce_instance"
+        AND protoPayload.methodName="compute.instances.preempted"
+        AND log_id("cloudaudit.googleapis.com/system_event")
+        AND ({{ instance_id_filter }})
+      ' --project={{ project }} --freshness=4h --format="json"
+    register: preemption_logs
+
+  - name: Display Instance Names being checked
+    ansible.builtin.debug:
+      msg: "Instance Names being checked for preemption in {{ deployment_name }}: {{ gce_instances_list | map(attribute='name') | list }}"
+
+  # Displays preempted nodes if any, else, gives message that no preemption events found
+  - name: Report preemption status
+    vars:
+      preemption_logs_parsed: "{{ preemption_logs.stdout | from_json }}"
+    ansible.builtin.debug:
+      msg: >-
+        {% if preemption_logs_parsed | length > 0 %}
+        Preemption Events Found in the last 4 hours: {{ preemption_logs_parsed }}
+        {% else %}
+        No preemption events found for the checked instances in {{ deployment_name }} in the last 4 hours.
+        {% endif %}

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -1,0 +1,72 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.custom-image
+- m.cloud-storage-bucket
+- m.pre-existing-network-storage
+- m.filestore
+- m.gpu-rdma-vpc
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.startup-script
+- m.vpc
+- slurm6
+
+timeout: 14400s  # 4hr
+steps:
+# While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml"
+
+- id: ml-a3-ultragpu-onspot-slurm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "NUM_NODES=4"
+  - "IMAGE_PROJECT=ubuntu-os-accelerator-images"
+  - "IMAGE_NAME=ubuntu-accelerator-2204-amd64-with-nvidia-570-v20250722"
+  - "MACHINE_TYPE=a3-ultragpu-8g"
+  - "INSTANCE_PREFIX=a3usp"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/a3uoptions.txt"
+  args:
+  - -c
+  - |
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
+    cd /workspace && make
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
+    BLUEPRINT="/workspace/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
+    sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
+    sed -i -e '/reason:/d' $${BLUEPRINT}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="region=$${REGION} zone=$${ZONE}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
@@ -1,0 +1,53 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined in build file with --extra-vars flag!
+test_name: a3u-onspot-slurm
+deployment_name: a3u-onspot-slurm-{{ build }}
+slurm_cluster_name: "a3usp{{ build[0:5] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+network: "{{ test_name }}-net-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
+- test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
+post_destroy_tasks:
+- post-destroy-tasks/delete-image.yml
+custom_vars:
+  gpu_count: 8
+  gpu_partition: a3ultra
+  test_persistenced: true
+  partitions:
+  - a3ultra
+  mounts:
+  - /home
+  - /gcs
+  instance_labels:
+    a3ultra_onspot: true
+  enable_spot: true
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+  disk_size_gb: 200
+  a3u_cluster_size: 2
+  base_network_name: "{{ test_name }}"
+  a3u_enable_spot_vm: true

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+BUILD_ID_SHORT="${BUILD_ID:0:6}"
+PROVISIONING_MODEL="SPOT"
+TERMINATION_ACTION="DELETE"
+FULL_INSTANCE_PREFIX="${INSTANCE_PREFIX}-${BUILD_ID_SHORT}-"
+
+generate_instance_names() {
+	local prefix=$1
+	local num=$2
+	for i in $(seq -w 01 "$num"); do
+		echo "${prefix}${i}"
+	done
+}
+
+cleanup_instances() {
+	local project=$1
+	local zone=$2
+	local prefix=$3
+
+	local instance_list_output
+	if ! instance_list_output=$(gcloud compute instances list --project="${project}" --zones="${zone}" \
+		--filter="name ~ ^${prefix}" --format='value(name)'); then
+		echo "ERROR: Failed to list instances from gcloud: ${instance_list_output}" >&2
+	elif [[ -n "${instance_list_output}" ]]; then
+		local INSTANCES_TO_DELETE_ARRAY=()
+		readarray -t INSTANCES_TO_DELETE_ARRAY <<<"${instance_list_output}"
+		if ! DELETE_OUTPUT=$(gcloud compute instances delete "${INSTANCES_TO_DELETE_ARRAY[@]}" \
+			--project="${project}" \
+			--zone="${zone}" \
+			--quiet \
+			--delete-disks=all 2>&1); then
+			echo "ERROR IN DELETING RESOURCE: ${DELETE_OUTPUT}" >&2
+		fi
+	fi
+}
+
+if ! GCS_CONTENT=$(gcloud storage cat "${OPTIONS_GCS_PATH}"); then
+	echo "ERROR: Failed to read ${OPTIONS_GCS_PATH}." >&2
+	exit 1
+fi
+
+declare -a ZONES_ARRAY=()
+while IFS= read -r line; do
+	if [[ -n "${line}" ]]; then
+		ZONES_ARRAY+=("${line}")
+	fi
+done <<<"${GCS_CONTENT}"
+
+if [[ "${#ZONES_ARRAY[@]}" -eq 0 ]]; then
+	echo "ERROR: No valid zones found in ${OPTIONS_GCS_PATH}" >&2
+	exit 1
+fi
+
+SELECTED_ZONE=""
+SUCCESS=false
+
+# Loop through all zones to find capacity
+for ZONE in "${ZONES_ARRAY[@]}"; do
+	readarray -t INSTANCE_NAMES_ARRAY < <(generate_instance_names "${FULL_INSTANCE_PREFIX}" "${NUM_NODES}")
+
+	declare -a GCLOUD_CMD
+	COMMON_FLAGS=(
+		--project="${PROJECT_ID}"
+		--zone="${ZONE}"
+		--machine-type="${MACHINE_TYPE}"
+		--image-project="${IMAGE_PROJECT}"
+		--provisioning-model="${PROVISIONING_MODEL}"
+		--instance-termination-action="${TERMINATION_ACTION}"
+		--quiet
+	)
+
+	if [[ "${MACHINE_TYPE}" == "a3-ultragpu-8g" ]]; then
+		if [[ -z "${IMAGE_NAME}" ]]; then
+			echo "ERROR: IMAGE_NAME must be set for a3-ultragpu-8g" >&2
+			exit 1
+		fi
+		GCLOUD_CMD=(
+			gcloud compute instances create "${INSTANCE_NAMES_ARRAY[@]}"
+			"${COMMON_FLAGS[@]}"
+			--image="${IMAGE_NAME}"
+		)
+	else
+		if [[ -z "${IMAGE_FAMILY}" ]]; then
+			echo "ERROR: IMAGE_FAMILY must be set for ${MACHINE_TYPE}" >&2
+			exit 1
+		fi
+		GCLOUD_CMD=(
+			gcloud compute instances create "${INSTANCE_NAMES_ARRAY[@]}"
+			"${COMMON_FLAGS[@]}"
+			--image-family="${IMAGE_FAMILY}"
+			--no-address
+		)
+	fi
+	if CREATE_OUTPUT=$("${GCLOUD_CMD[@]}" 2>&1); then
+		cleanup_instances "${PROJECT_ID}" "${ZONE}" "${FULL_INSTANCE_PREFIX}"
+		SELECTED_ZONE="${ZONE}"
+		SUCCESS=true
+		break
+	elif [[ "${CREATE_OUTPUT}" != *"INSUFFICIENT_CAPACITY"* &&
+		"${CREATE_OUTPUT}" != *"ZONE_RESOURCE_POOL_EXHAUSTED"* ]]; then
+		echo "ERROR: Unexpected error ${CREATE_OUTPUT}" >&2
+	fi
+	cleanup_instances "${PROJECT_ID}" "${ZONE}" "${FULL_INSTANCE_PREFIX}"
+done
+
+if [[ "${SUCCESS}" == "true" ]]; then
+	echo "Deploying in ZONE: ${SELECTED_ZONE}"
+	export ZONE="${SELECTED_ZONE}"
+else
+	echo "--- DEPLOYMENT FAILED(Couldn't find a zone to deploy) ---" >&2
+	exit 1
+fi


### PR DESCRIPTION
This pull request introduces the capability to run tests for a3-ultragpu instances on Spot VMs. The key changes include:

- A new build ml-a3-ultragpu-onspot-slurm.yaml and test ml-a3-ultragpu-onspot-slurm.yml are added to execute tests on Spot VMs.
- The slurm-integration-test.yml is modified to execute add-instance-labels.yml and include a rescue block that checks for preemption events if testing on a spot instance.
- A new Ansible task, add-instance-labels.yml, is introduced to apply labels to all VM instances created during a test run, which helps in tracking metrics.
- A new validation playbook, test-preemption.yml, is added to query Cloud Audit Logs for any preemption events for the instances under test.
- The find_available_zone.sh script is added to find an available zone with capacity for the requested machine type.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
