### PR TITLE
Adding Robust destroy in cluster toolkit

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
@@ -27,6 +28,14 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zclconf/go-cty/cty"
+	"golang.org/x/oauth2/google"
+	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+var (
+	robustDestroy bool
 )
 
 func init() {
@@ -34,6 +43,7 @@ func init() {
 		addGroupSelectionFlags(
 			addAutoApproveFlag(
 				addArtifactsDirFlag(destroyCmd))))
+	destroyCmd.Flags().BoolVar(&robustDestroy, "robust", false, "Perform a robust destroy, including firewall rule cleanup.")
 }
 
 var (
@@ -48,6 +58,12 @@ var (
 	}
 )
 
+var (
+	destroyGroupsFunc         = destroyGroups
+	cleanupFirewallRulesFunc  = cleanupFirewallRules
+	destroyTerraformGroupFunc = destroyTerraformGroup
+)
+
 func runDestroyCmd(cmd *cobra.Command, args []string) {
 	deplRoot := args[0]
 	artifactsDir := getArtifactsDir(deplRoot)
@@ -60,14 +76,66 @@ func runDestroyCmd(cmd *cobra.Command, args []string) {
 	checkErr(validateGroupSelectionFlags(bp), ctx)
 	checkErr(shell.ValidateDeploymentDirectory(bp.Groups, deplRoot), ctx)
 
+	destroyRunner(deplRoot, artifactsDir, bp, ctx)
+}
+
+func destroyRunner(deplRoot string, artifactsDir string, bp config.Blueprint, ctx *config.YamlCtx) {
+	maxRetries := 1
+	if robustDestroy {
+		maxRetries = 3
+	}
+
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		logging.Info("Destroy attempt %d of %d", attempt, maxRetries)
+
+		destroyFailed, packerManifests := destroyGroupsFunc(deplRoot, artifactsDir, bp, ctx)
+
+		if !destroyFailed {
+			logging.Info("Successfully destroyed all selected groups.")
+			modulewriter.WritePackerDestroyInstructions(os.Stdout, packerManifests)
+			return // Exit runDestroyCmd successfully
+		}
+
+		if attempt == maxRetries {
+			logging.Fatal("Destruction of %q failed after %d attempts", deplRoot, maxRetries)
+		}
+		logging.Info("Retrying destroy...")
+	}
+}
+
+func groupHasNetworkModule(group config.Group) bool {
+	for _, module := range group.Modules {
+		if strings.HasPrefix(module.Source, "modules/network/") || strings.HasPrefix(module.Source, "community/modules/network/") {
+			return true
+		}
+	}
+	return false
+}
+
+func destroyGroups(deplRoot string, artifactsDir string, bp config.Blueprint, ctx *config.YamlCtx) (bool, []string) {
 	// destroy in reverse order of creation!
 	packerManifests := []string{}
+	destroyFailed := false
 	for i := len(bp.Groups) - 1; i >= 0; i-- {
 		group := bp.Groups[i]
 		if !isGroupSelected(group.Name) {
 			logging.Info("skipping group %q", group.Name)
 			continue
 		}
+
+		if robustDestroy && groupHasNetworkModule(group) {
+			projectID, deploymentName, err := getProjectAndDeploymentVars(bp.Vars)
+			if err != nil {
+				logging.Error("Skipping firewall cleanup: could not get required variables. %v", err)
+				destroyFailed = true
+				break
+			} else if err := cleanupFirewallRulesFunc(projectID, deploymentName); err != nil {
+				logging.Error("Failed to cleanup firewall rules for group %s: %v", group.Name, err)
+				destroyFailed = true
+				break
+			}
+		}
+
 		groupDir := filepath.Join(deplRoot, string(group.Name))
 
 		if err := shell.ImportInputs(groupDir, artifactsDir, bp); err != nil {
@@ -83,21 +151,47 @@ func runDestroyCmd(cmd *cobra.Command, args []string) {
 			moduleDir := filepath.Join(groupDir, string(group.Modules[0].ID))
 			packerManifests = append(packerManifests, filepath.Join(moduleDir, "packer-manifest.json"))
 		case config.TerraformKind:
-			err = destroyTerraformGroup(groupDir)
+			err = destroyTerraformGroupFunc(groupDir)
 		default:
 			err = fmt.Errorf("group %q is an unsupported kind %q", groupDir, group.Kind().String())
 		}
 
 		if err != nil {
 			logging.Error("failed to destroy group %q:\n%s", group.Name, renderError(err, *ctx))
+			destroyFailed = true
 			if i == 0 || !destroyChoice(bp.Groups[i-1].Name) {
-				logging.Fatal("destruction of %q failed", deplRoot)
+				break // Stop processing groups for this attempt
 			}
 		}
-
 	}
+	return destroyFailed, packerManifests
+}
 
-	modulewriter.WritePackerDestroyInstructions(os.Stdout, packerManifests)
+func getStringVar(vars config.Dict, key string) (string, error) {
+	val := vars.Get(key)
+	if val.IsNull() {
+		return "", fmt.Errorf("%s not found or is null in blueprint vars", key)
+	}
+	if val.Type() != cty.String {
+		return "", fmt.Errorf("%s is not a string, got type %s", key, val.Type().FriendlyName())
+	}
+	strVal := val.AsString()
+	if strVal == "" {
+		return "", fmt.Errorf("%s is empty in blueprint vars", key)
+	}
+	return strVal, nil
+}
+
+func getProjectAndDeploymentVars(vars config.Dict) (string, string, error) {
+	projectID, err := getStringVar(vars, "project_id")
+	if err != nil {
+		return "", "", err
+	}
+	deploymentName, err := getStringVar(vars, "deployment_name")
+	if err != nil {
+		return "", "", err
+	}
+	return projectID, deploymentName, nil
 }
 
 func destroyTerraformGroup(groupDir string) error {
@@ -109,6 +203,134 @@ func destroyTerraformGroup(groupDir string) error {
 	// Always output text when destroying the cluster
 	// The current implementation outputs JSON only for the "deploy" command
 	return shell.Destroy(tf, getApplyBehavior(), shell.TextOutput)
+}
+
+func confirmAction(prompt string) bool {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		fmt.Print(prompt)
+		in, err := reader.ReadString('\n')
+		if err != nil {
+			logging.Error("failed to read user input: %v", err)
+			return false // Default to no on error
+		}
+		switch strings.ToLower(strings.TrimSpace(in)) {
+		case "y":
+			return true
+		case "n":
+			return false
+		default:
+			fmt.Println("Please enter 'y' or 'n'.")
+			continue
+		}
+	}
+}
+
+func cleanupFirewallRules(projectID string, deploymentName string) error {
+	logging.Info("Cleaning up firewall rules for project %s, deployment %s", projectID, deploymentName)
+
+	ctx := context.Background()
+	creds, err := google.FindDefaultCredentials(ctx, compute.ComputeScope)
+	if err != nil {
+		return fmt.Errorf("failed to find default credentials: %v", err)
+	}
+
+	computeService, err := compute.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return fmt.Errorf("failed to create compute service: %v", err)
+	}
+
+	// NOTE: This is a partial solution. This implementation only
+	// uses a regular expression 'contains' filter on the deployment name to find networks (e.g. name eq ".*deployment_name.*" ).
+	// This will fail to find networks that have a custom name that does not
+	// contain the deployment name.
+	// TODO: Implement a more robust solution that parses the Terraform plan
+	// to get the exact network names.
+	filter := fmt.Sprintf("name eq \".*%s.*\"", deploymentName)
+	logging.Info("Using wildcard network filter: %s", filter)
+	networks, err := computeService.Networks.List(projectID).Filter(filter).Do()
+	if err != nil {
+		return fmt.Errorf("failed to list networks with wildcard filter: %v", err)
+	}
+
+	if len(networks.Items) == 0 {
+		logging.Info("No matching networks found for project %s.", projectID)
+		return nil
+	}
+
+	firewallsToDelete, err := listAssociatedFirewallRules(projectID, computeService, networks.Items)
+	if err != nil {
+		return err
+	}
+
+	if len(firewallsToDelete) == 0 {
+		logging.Info("No firewall rules found to delete for the identified networks.")
+		return nil
+	}
+
+	return confirmAndDeleteFirewallRules(projectID, deploymentName, &computeServiceWrapper{computeService}, firewallsToDelete)
+}
+
+type computeServiceWrapper struct {
+	*compute.Service
+}
+
+func (w *computeServiceWrapper) FirewallsDelete(projectID string, firewall string) (*compute.Operation, error) {
+	return w.Firewalls.Delete(projectID, firewall).Do()
+}
+
+// listAssociatedFirewallRules lists firewall rules associated with a given set of networks.
+func listAssociatedFirewallRules(projectID string, computeService *compute.Service, networks []*compute.Network) ([]*compute.Firewall, error) {
+	var firewallsToDelete []*compute.Firewall
+	for _, network := range networks {
+		fwList, err := computeService.Firewalls.List(projectID).Filter(fmt.Sprintf("network=\"%s\"", network.SelfLink)).Do()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list firewall rules for network %s: %v", network.Name, err)
+		}
+		firewallsToDelete = append(firewallsToDelete, fwList.Items...)
+	}
+	return firewallsToDelete, nil
+}
+
+// confirmAndDeleteFirewallRules confirms with the user and then deletes the specified firewall rules.
+func confirmAndDeleteFirewallRules(projectID string, deploymentName string, computeService firewallDeleter, firewallsToDelete []*compute.Firewall) error {
+	var firewallNames []string
+	for _, fw := range firewallsToDelete {
+		firewallNames = append(firewallNames, fw.Name)
+	}
+	logging.Info("Found firewall rules to delete: %v", firewallNames)
+
+	if !flagAutoApprove {
+		prompt := fmt.Sprintf("Do you want to delete these %d firewall rules associated with deployment %s? [y/n]: ", len(firewallNames), deploymentName)
+		if !confirmAction(prompt) {
+			logging.Info("Skipping firewall rule deletion.")
+			return nil
+		}
+	}
+
+	logging.Info("Successfully submitted deletion requests for firewall rules.")
+	// Delete firewall rules
+	var deletionErrors []string
+	for _, fwName := range firewallNames {
+		logging.Info("Deleting firewall rule %s...", fwName)
+		_, err := computeService.FirewallsDelete(projectID, fwName)
+		if err != nil {
+			// Log non-critical errors and continue trying to delete other rules
+			msg := fmt.Sprintf("Failed to delete firewall rule %s: %v", fwName, err)
+			logging.Error("error deleting firewall rule: %s", msg)
+			deletionErrors = append(deletionErrors, msg)
+		}
+	}
+
+	if len(deletionErrors) > 0 {
+		return fmt.Errorf("encountered errors while deleting firewall rules:\n%s", strings.Join(deletionErrors, "\n"))
+	}
+
+	return nil
+}
+
+type firewallDeleter interface {
+	FirewallsDelete(projectID string, firewall string) (*compute.Operation, error)
 }
 
 func destroyChoice(nextGroup config.GroupName) bool {

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -1,0 +1,380 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zclconf/go-cty/cty"
+	compute "google.golang.org/api/compute/v1"
+)
+
+func TestDestroyGroupsUnsupportedKind(t *testing.T) {
+	// Mock dependencies if necessary
+	// For this test, we primarily care about the group.Kind() switch.
+
+	bp := config.Blueprint{
+		Groups: []config.Group{
+			{
+				Name:    "unsupported-group",
+				Modules: []config.Module{},
+			},
+		},
+	}
+	ctx := &config.YamlCtx{}
+
+	destroyFailed, _ := destroyGroups("", "", bp, ctx)
+
+	if !destroyFailed {
+		t.Errorf("destroyGroups() failed to report destruction failure for unsupported kind.")
+	}
+}
+
+type mockFirewallDeleter struct {
+	deleteErr error
+}
+
+func (m *mockFirewallDeleter) FirewallsDelete(projectID string, firewall string) (*compute.Operation, error) {
+	return nil, m.deleteErr
+}
+
+func TestConfirmAndDeleteFirewallRulesWithError(t *testing.T) {
+	// Bypass the interactive prompt for this test
+	originalFlagAutoApprove := flagAutoApprove
+	flagAutoApprove = true
+	defer func() { flagAutoApprove = originalFlagAutoApprove }()
+
+	// Create a mock compute service that returns an error on delete
+	mockService := &mockFirewallDeleter{
+		deleteErr: fmt.Errorf("mock delete error"),
+	}
+
+	firewallsToDelete := []*compute.Firewall{
+		{Name: "fw-1"},
+		{Name: "fw-2"},
+	}
+
+	err := confirmAndDeleteFirewallRules("test-project", "test-deployment", mockService, firewallsToDelete)
+
+	if err == nil {
+		t.Errorf("confirmAndDeleteFirewallRules() did not return an error when it should have.")
+	}
+
+	// In a real-world scenario, you would also capture and check the log output.
+	// For this test, we are primarily concerned with the error propagation.
+}
+
+func TestRunDestroyCmd(t *testing.T) {
+	testCases := []struct {
+		name          string
+		robust        bool
+		autoApprove   bool
+		destroyFailed bool
+		expectFatal   bool
+	}{
+		{
+			name:          "robust and auto-approve",
+			robust:        true,
+			autoApprove:   true,
+			destroyFailed: false,
+			expectFatal:   false,
+		},
+		{
+			name:          "robust and no auto-approve",
+			robust:        true,
+			autoApprove:   false,
+			destroyFailed: false,
+			expectFatal:   false,
+		},
+		{
+			name:          "no robust and auto-approve",
+			robust:        false,
+			autoApprove:   true,
+			destroyFailed: false,
+			expectFatal:   false,
+		},
+		{
+			name:          "no robust and no auto-approve",
+			robust:        false,
+			autoApprove:   false,
+			destroyFailed: false,
+			expectFatal:   false,
+		},
+		{
+			name:          "robust and destroy failed",
+			robust:        true,
+			autoApprove:   true,
+			destroyFailed: true,
+			expectFatal:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock destroyGroups to control its behavior
+			destroyGroupsFunc = func(_ string, _ string, _ config.Blueprint, _ *config.YamlCtx) (bool, []string) {
+				return tc.destroyFailed, []string{}
+			}
+
+			// Set the flags
+			robustDestroy = tc.robust
+			flagAutoApprove = tc.autoApprove
+
+			// Create a dummy deployment directory
+			deplRoot, err := os.MkdirTemp("", "test-depl")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(deplRoot)
+
+			// Create a dummy artifacts directory
+			artifactsDir := filepath.Join(deplRoot, ".ghpc", "artifacts")
+			if err := os.MkdirAll(artifactsDir, 0755); err != nil {
+				t.Fatalf("Failed to create artifacts dir: %v", err)
+			}
+
+			// Create a dummy blueprint file
+			bpFile := filepath.Join(artifactsDir, "expanded_blueprint.yaml")
+			if err := os.WriteFile(bpFile, []byte(""), 0644); err != nil {
+				t.Fatalf("Failed to write dummy blueprint file: %v", err)
+			}
+
+			// Capture logging output
+			_, w, _ := os.Pipe()
+			originalStderr := os.Stderr
+			os.Stderr = w
+			defer func() {
+				os.Stderr = originalStderr
+			}()
+
+			// Use a deferred function to check for fatal errors
+			defer func() {
+				if r := recover(); r != nil {
+					if !tc.expectFatal {
+						t.Errorf("runDestroyCmd() panicked unexpectedly: %v", r)
+					}
+				} else {
+					if tc.expectFatal {
+						t.Errorf("runDestroyCmd() did not panic when it should have.")
+					}
+				}
+			}()
+
+			// Override the exit function to prevent the test from exiting
+			originalExit := logging.Exit
+			defer func() { logging.Exit = originalExit }()
+			logging.Exit = func(code int) {
+				panic(fmt.Sprintf("exit %d", code))
+			}
+
+			destroyRunner(deplRoot, artifactsDir, config.Blueprint{}, &config.YamlCtx{})
+		})
+	}
+}
+
+func TestGroupHasNetworkModule(t *testing.T) {
+	testCases := []struct {
+		name  string
+		group config.Group
+		want  bool
+	}{
+		{
+			name: "official network module",
+			group: config.Group{
+				Modules: []config.Module{{Source: "modules/network/vpc"}},
+			},
+			want: true,
+		},
+		{
+			name: "community network module",
+			group: config.Group{
+				Modules: []config.Module{{Source: "community/modules/network/vpc"}},
+			},
+			want: true,
+		},
+		{
+			name: "no network module",
+			group: config.Group{
+				Modules: []config.Module{{Source: "modules/compute/vm"}},
+			},
+			want: false,
+		},
+		{
+			name: "unrelated module",
+			group: config.Group{
+				Modules: []config.Module{{Source: "modules/other/module"}},
+			},
+			want: false,
+		},
+		{
+			name:  "empty group",
+			group: config.Group{},
+			want:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := groupHasNetworkModule(tc.group); got != tc.want {
+				t.Errorf("groupHasNetworkModule() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDestroyGroupsRobust(t *testing.T) {
+	// a group that will trigger the cleanup logic
+	networkGroup := config.Group{
+		Name: "network-group",
+		Modules: []config.Module{
+			{Source: "modules/network/vpc", Kind: config.TerraformKind},
+		},
+	}
+
+	// a group that will not
+	computeGroup := config.Group{
+		Name: "compute-group",
+		Modules: []config.Module{
+			{Source: "modules/compute/vm-instance", Kind: config.TerraformKind},
+		},
+	}
+
+	// blueprint with valid vars for cleanup
+	bpWithVars := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{
+			"project_id":      cty.StringVal("test-project"),
+			"deployment_name": cty.StringVal("test-deployment"),
+		}),
+	}
+
+	// blueprint with missing vars
+	bpWithoutVars := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{}),
+	}
+
+	// Restore original state after tests
+	originalRobustDestroy := robustDestroy
+	originalCleanupFunc := cleanupFirewallRulesFunc
+	originalDestroyTerraformGroupFunc := destroyTerraformGroupFunc
+	defer func() {
+		robustDestroy = originalRobustDestroy
+		cleanupFirewallRulesFunc = originalCleanupFunc
+		destroyTerraformGroupFunc = originalDestroyTerraformGroupFunc
+	}()
+
+	testCases := []struct {
+		name              string
+		bp                config.Blueprint
+		group             config.Group
+		robust            bool
+		cleanupErr        error // The error for the mocked cleanupFunc to return
+		expectCleanupCall bool
+		expectFail        bool
+	}{
+		{
+			name:              "robust flag off",
+			bp:                bpWithVars,
+			group:             networkGroup,
+			robust:            false,
+			cleanupErr:        nil,
+			expectCleanupCall: false,
+			expectFail:        false,
+		},
+		{
+			name:              "not a network group",
+			bp:                bpWithVars,
+			group:             computeGroup,
+			robust:            true,
+			cleanupErr:        nil,
+			expectCleanupCall: false,
+			expectFail:        false,
+		},
+		{
+			name:              "get vars fails",
+			bp:                bpWithoutVars,
+			group:             networkGroup,
+			robust:            true,
+			cleanupErr:        nil,
+			expectCleanupCall: false,
+			expectFail:        true,
+		},
+		{
+			name:              "cleanup fails",
+			bp:                bpWithVars,
+			group:             networkGroup,
+			robust:            true,
+			cleanupErr:        fmt.Errorf("mock cleanup error"),
+			expectCleanupCall: true,
+			expectFail:        true,
+		},
+		{
+			name:              "cleanup succeeds",
+			bp:                bpWithVars,
+			group:             networkGroup,
+			robust:            true,
+			cleanupErr:        nil,
+			expectCleanupCall: true,
+			expectFail:        false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			robustDestroy = tc.robust
+			cleanupCalled := false
+			cleanupFirewallRulesFunc = func(projectID, deploymentName string) error {
+				cleanupCalled = true
+				if projectID != "test-project" || deploymentName != "test-deployment" {
+					t.Errorf("cleanup function called with wrong args: got %s, %s", projectID, deploymentName)
+				}
+				return tc.cleanupErr
+			}
+
+			destroyTerraformGroupFunc = func(groupDir string) error {
+				return nil // Do nothing
+			}
+
+			// The blueprint for the test run
+			bp := tc.bp
+			bp.Groups = []config.Group{tc.group}
+
+			// We only care about the failure flag, not the packer manifests
+			destroyFailed, _ := destroyGroups("", "", bp, &config.YamlCtx{})
+
+			if cleanupCalled != tc.expectCleanupCall {
+				t.Errorf("cleanupFirewallRules call was %v, expected %v", cleanupCalled, tc.expectCleanupCall)
+			}
+
+			if destroyFailed != tc.expectFail {
+				t.Errorf("destroyGroups failed = %v, want %v", destroyFailed, tc.expectFail)
+			}
+		})
+	}
+}
+
+func TestFilterString(t *testing.T) {
+	deploymentName := "test-deployment"
+	expectedFilter := `name eq ".*test-deployment.*"`
+	actualFilter := fmt.Sprintf(`name eq ".*%s.*"`, deploymentName)
+
+	if actualFilter != expectedFilter {
+		t.Errorf("Filter string mismatch: got %q, want %q", actualFilter, expectedFilter)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -126,7 +126,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/net v0.47.0 // indirect
-	golang.org/x/oauth2 v0.30.0 // indirect
+	golang.org/x/oauth2 v0.30.0
 	golang.org/x/sys v0.38.0
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/grpc v1.74.2 // indirect

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -24,6 +24,8 @@ var (
 	infolog  *log.Logger
 	errorlog *log.Logger
 	fatallog *log.Logger
+	// Exit is a function that exits the program. It is overridden in tests.
+	Exit = os.Exit
 )
 
 func init() {
@@ -48,5 +50,5 @@ func Error(f string, a ...any) {
 func Fatal(f string, a ...any) {
 	msg := fmt.Sprintf(f, a...)
 	fatallog.Println(msg)
-	os.Exit(1)
+	Exit(1)
 }


### PR DESCRIPTION
## Summary of Changes

The `gcluster destroy` command has been enhanced with a `--robust` flag to improve the reliability of resource cleanup, particularly for firewall rules.

The `--robust` flag introduces these key features:

1.  **Targeted Firewall Cleanup:** Firewall rule cleanup is performed *only* for deployment groups that contain a network module (specifically, a module with `source: "modules/network/vpc"`). The cleanup for a group happens just *before* that specific group's resources are destroyed. This ensures firewalls are removed at the most appropriate time to avoid "resource in use" errors. The cleanup now uses the Google Cloud Go SDK instead of external `gcloud` calls.
2.  **Automatic Retry Mechanism:** The entire destroy process for all selected groups is retried if any failure occurs.
    *   **Retry Count:** The command will make up to **3 attempts** to destroy the deployment successfully.
    *   **Purpose:** This helps overcome transient issues or dependencies between resources that might not be immediately resolved in the cloud backend.

### User Interaction

-   **Firewall Deletion Confirmation:** When `--robust` is used and firewall rules are found for a group, the user is prompted to confirm their deletion [y/n], unless `--auto-approve` is also specified.
-   **Automated Mode:** The `--auto-approve` flag suppresses all prompts, including firewall deletion confirmations, for automated workflows.

## How to Use

### Standard Robust Destroy (Interactive)

This will prompt you for confirmation before deleting firewall rules.

```bash
./gcluster destroy <DEPLOYMENT_DIRECTORY> --robust
```

### Fully Automated Robust Destroy

This will automatically approve and delete all resources, including firewall rules, without any user prompts.

```bash
./gcluster destroy <DEPLOYMENT_DIRECTORY> --robust --auto-approve
```

### Standard Destroy

The original destroy functionality remains unchanged. The robust logic is **only** triggered when the `--robust` flag is present.

```bash
# Standard interactive destroy
./gcluster destroy <DEPLOYMENT_DIRECTORY>

# Standard automated destroy
./gcluster destroy <DEPLOYMENT_DIRECTORY> --auto-approve
```

## How to Test

1.  **Deploy a Cluster:** First, create a sample deployment if you don't have one already.
    ```bash
    ./gcluster deploy examples/hpc-slurm.yaml
    ```

2.  **Build the Tool:** Ensure you have the latest version of the `gcluster` binary with these changes.
    ```bash
    make gcluster
    ```

3.  **Run Robust Destroy:** Execute the destroy command with the `--robust` flag on your deployment directory.
    ```bash
    ./gcluster destroy <YOUR_DEPLOYMENT_DIRECTORY> --robust
    ```

4.  **Verify the Prompt:** The tool should list the firewall rules it intends to delete and wait for your input.
    -   Enter `y` to confirm and watch the process continue.
    -   (Optional) Re-deploy and run again, this time entering `n` to verify that the firewall cleanup is skipped.

5.  **Verify Automated Destroy:** (Optional) If you want to test the non-interactive mode, re-deploy the cluster and run:
    ```bash
    ./gcluster destroy <YOUR_DEPLOYMENT_DIRECTORY> --robust --auto-approve
    ```
    The command should complete the entire destruction process without any prompts



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
