### PR TITLE
Deprecate a3u-gcs blueprint as its no longer maintained

### DIFF
--- a/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/README.md
+++ b/examples/hypercompute_clusters/a3u-slurm-ubuntu-gcs/README.md
@@ -1,6 +1,6 @@
 >[!WARNING]
 >
->![deprecated-badge] This blueprint is deprecated and is no longer maintained. The blueprint will be removed by Feb 15, 2026
+>![deprecated-badge] This blueprint is not maintained any longer. The blueprint will be removed by Feb 15, 2026
 >
 >We recommend using the [A3 Ultra Slurm Blueprint](../../machine-learning/a3-ultragpu-8g) instead.
 


### PR DESCRIPTION
Readme after changes

<img width="1470" height="300" alt="Screenshot 2025-11-23 at 1 43 27 PM" src="https://github.com/user-attachments/assets/8123f01e-7f6e-4173-b88e-e10fb3bd4a40" />

