### PR TITLE
Add force_conflicts flag when applying manifests using kubectl

### DIFF
--- a/modules/management/kubectl-apply/kubectl/README.md
+++ b/modules/management/kubectl-apply/kubectl/README.md
@@ -43,6 +43,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_content"></a> [content](#input\_content) | The YAML body to apply to gke cluster. | `string` | `null` | no |
+| <a name="input_force_conflicts"></a> [force\_conflicts](#input\_force\_conflicts) | The force\_conflicts boolean, when true, compels kubectl apply (in server-side apply mode) to forcefully take ownership and override any resource fields managed by a different entity. For more information, see [Using Server-Side Apply in a controller](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller) | `bool` | `false` | no |
 | <a name="input_server_side_apply"></a> [server\_side\_apply](#input\_server\_side\_apply) | Allow using kubectl server-side apply method. | `bool` | `false` | no |
 | <a name="input_source_path"></a> [source\_path](#input\_source\_path) | The source for manifest(s) to apply to gke cluster. Acceptable sources are a local yaml or template (.tftpl) file path, a directory (ends with '/') containing yaml or template files, and a url for a yaml file. | `string` | `null` | no |
 | <a name="input_template_vars"></a> [template\_vars](#input\_template\_vars) | The values to populate template file(s) with. | `any` | `null` | no |

--- a/modules/management/kubectl-apply/kubectl/main.tf
+++ b/modules/management/kubectl-apply/kubectl/main.tf
@@ -81,4 +81,12 @@ resource "kubectl_manifest" "apply_doc" {
   yaml_body         = each.value
   server_side_apply = var.server_side_apply
   wait_for_rollout  = var.wait_for_rollout
+  force_conflicts   = var.force_conflicts
+
+  lifecycle {
+    precondition {
+      condition     = !var.force_conflicts || var.server_side_apply
+      error_message = "The 'force_conflicts' variable can only be set to true when 'server_side_apply' is also true."
+    }
+  }
 }

--- a/modules/management/kubectl-apply/kubectl/variables.tf
+++ b/modules/management/kubectl-apply/kubectl/variables.tf
@@ -43,3 +43,9 @@ variable "wait_for_rollout" {
   type        = bool
   default     = true
 }
+
+variable "force_conflicts" {
+  description = "The force_conflicts boolean, when true, compels kubectl apply (in server-side apply mode) to forcefully take ownership and override any resource fields managed by a different entity. For more information, see [Using Server-Side Apply in a controller](https://kubernetes.io/docs/reference/using-api/server-side-apply/#using-server-side-apply-in-a-controller)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
**Info**: Add force_conflicts bool var to kubectl manifest resource
When multiple resources are created on Kubernetes using server-side kubectl apply, it can happen that there are conflicts.

**Error observed**: 
```
Error: kubeflow-mpijobs-admin failed to run apply: Apply failed with 1 conflict: conflict with "clusterrole-aggregation-controller": .rules

Please review the fields above--they currently have other managers. Here
are the ways you can resolve this warning:

* If you intend to manage all of these fields, please re-run the apply
  command with the `--force-conflicts` flag.

* If you do not intend to manage all of the fields, please edit your
  manifest to remove references to the fields that should keep their
  current managers.

* You may co-own fields by updating your manifest to match the existing
  value; in this case, you'll become the manager if the other manager(s)
  stop managing the field (remove it from their configuration).

See https://kubernetes.io/docs/reference/using-api/server-side-apply/#conflicts
```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
