### PR TITLE
Changing timezone for integration tests to IST

### DIFF
--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -30,6 +30,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_retry_count"></a> [retry\_count](#input\_retry\_count) | Number of times to retry a failed build | `number` | `1` | no |
 | <a name="input_schedule"></a> [schedule](#input\_schedule) | Describes the schedule on which the job will be executed. | `string` | n/a | yes |
+| <a name="input_time_zone"></a> [time\_zone](#input\_time\_zone) | Specifies the time zone to be used in interpreting schedule. | `string` | `"Asia/Kolkata"` | no |
 | <a name="input_trigger"></a> [trigger](#input\_trigger) | View of google\_cloudbuild\_trigger resource | <pre>object({<br/>    name    = string<br/>    id      = string<br/>    project = string<br/>  })</pre> | n/a | yes |
 
 ## Outputs

--- a/tools/cloud-build/provision/trigger-schedule/main.tf
+++ b/tools/cloud-build/provision/trigger-schedule/main.tf
@@ -15,7 +15,7 @@
 resource "google_cloud_scheduler_job" "schedule" {
   name      = "${var.trigger.name}-schedule"
   schedule  = var.schedule
-  time_zone = "America/Los_Angeles"
+  time_zone = var.time_zone
 
   attempt_deadline = "180s"
   retry_config {

--- a/tools/cloud-build/provision/trigger-schedule/variables.tf
+++ b/tools/cloud-build/provision/trigger-schedule/variables.tf
@@ -26,6 +26,12 @@ variable "schedule" {
   type        = string
 }
 
+variable "time_zone" {
+  description = "Specifies the time zone to be used in interpreting schedule."
+  type        = string
+  default     = "Asia/Kolkata"
+}
+
 variable "retry_count" {
   description = "Number of times to retry a failed build"
   type        = number


### PR DESCRIPTION
Currently our integration tests run in PST timezone. This change modifies the schedule timezone to IST keeping the time window for the test run same. This is to streamline the tests to run nightly.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
