### PR TITLE
feat: Add support for Anywhere Cache in cloud-storage-bucket

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1275,6 +1275,11 @@ credentials for the created cluster_ and _submit a job calling `nvidia_smi`_.
 
 This blueprint shows how to use different storage options with GKE in the toolkit.
 
+> [!NOTE]
+> This blueprint also demonstrates support for Anywhere Cache. Anywhere Cache is a fully managed service
+that caches Cloud Storage data in Google Cloud.
+For more information, see [Anywhere Cache documentation](https://cloud.google.com/storage/docs/anywhere-cache).
+
 The blueprint contains the following:
 
 * A K8s Job that uses a Filestore and a GCS bucket as shared file systems between pods.

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -75,7 +75,7 @@ deployment_groups:
       master_authorized_networks:
       - display_name: deployment-machine
         cidr_block: $(vars.authorized_cidr)
-    outputs: [instructions]
+    outputs: [instructions, k8s_service_account_name]
 
   - id: debug_pool
     source: modules/compute/gke-node-pool
@@ -93,6 +93,11 @@ deployment_groups:
       local_mount: /data
       random_suffix: true
       force_destroy: true
+      anywhere_cache:
+        zones: [$(vars.zone)]
+        ttl: "86400s"
+        admission_policy: "admit-on-first-miss"
+    outputs: [gcs_bucket_name]
 
   - id: data-bucket-pv
     source: modules/file-system/gke-persistent-volume

--- a/modules/file-system/cloud-storage-bucket/README.md
+++ b/modules/file-system/cloud-storage-bucket/README.md
@@ -128,6 +128,7 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [google-beta_google_storage_anywhere_cache.cache_instances](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_storage_anywhere_cache) | resource |
 | [google-beta_google_storage_bucket.bucket](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
@@ -136,6 +137,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_anywhere_cache"></a> [anywhere\_cache](#input\_anywhere\_cache) | Anywhere Cache configurations.<br/>When you create a cache for a bucket, the cache must be created in a zone within the location of your bucket.<br/>For example, if your bucket is located in the us-east1 region, you can create a cache in us-east1-b but not us-central1-c.<br/>If your bucket is located in the ASIA dual-region, you can create a cache in any zones that make up the asia-east1 and asia-southeast1 regions.<br/>This validation only works for single regions. | <pre>object({<br/>    zones            = list(string)<br/>    ttl              = optional(string, "86400s")<br/>    admission_policy = optional(string, "admit-on-first-miss")<br/>  })</pre> | `null` | no |
+| <a name="input_anywhere_cache_create_timeout"></a> [anywhere\_cache\_create\_timeout](#input\_anywhere\_cache\_create\_timeout) | Timeout for Anywhere Cache creation operations. Can be set to a duration like '1h' or '30m'.<br/>The maximum documented creation time is 48 hours. Please refer to the official documentation for more details on timeouts:<br/>https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_anywhere_cache#timeouts | `string` | `"240m"` | no |
 | <a name="input_autoclass"></a> [autoclass](#input\_autoclass) | Configure bucket autoclass setup<br/><br/>The autoclass config supports automatic transitions of objects in the bucket to appropriate storage classes based on each object's access pattern.<br/><br/>The terminal storage class defines that objects in the bucket eventually transition to if they are not read for a certain length of time. <br/>Supported values include: 'NEARLINE', 'ARCHIVE' (Default 'NEARLINE')<br/><br/>See Cloud documentation for more details:<br/><br/>https://cloud.google.com/storage/docs/autoclass | <pre>object({<br/>    enabled                = optional(bool, false)<br/>    terminal_storage_class = optional(string, null)<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment; used as part of name of the GCS bucket. | `string` | n/a | yes |
 | <a name="input_enable_hierarchical_namespace"></a> [enable\_hierarchical\_namespace](#input\_enable\_hierarchical\_namespace) | If true, enables hierarchical namespace for the bucket. This option must be configured during the initial creation of the bucket. | `bool` | `false` | no |
@@ -162,6 +165,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_anywhere_cache_ids"></a> [anywhere\_cache\_ids](#output\_anywhere\_cache\_ids) | The IDs of the created Anywhere Cache instances. |
 | <a name="output_client_install_runner"></a> [client\_install\_runner](#output\_client\_install\_runner) | Runner that performs client installation needed to use gcs fuse. |
 | <a name="output_gcs_bucket_name"></a> [gcs\_bucket\_name](#output\_gcs\_bucket\_name) | Bucket name. |
 | <a name="output_gcs_bucket_path"></a> [gcs\_bucket\_path](#output\_gcs\_bucket\_path) | The gsutil bucket path with format of `gs://<bucket-name>`. |

--- a/modules/file-system/cloud-storage-bucket/outputs.tf
+++ b/modules/file-system/cloud-storage-bucket/outputs.tf
@@ -67,3 +67,10 @@ output "gcs_bucket_name" {
   description = "Bucket name."
   value       = google_storage_bucket.bucket.name
 }
+
+output "anywhere_cache_ids" {
+  description = "The IDs of the created Anywhere Cache instances."
+  value = [
+    for instance in google_storage_anywhere_cache.cache_instances : instance.id
+  ]
+}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-anywhere-cache.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-anywhere-cache.yml
@@ -1,0 +1,59 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+- name: Get outputs from primary group
+  delegate_to: localhost
+  ansible.builtin.command:
+    cmd: terraform output -json
+    chdir: "{{ workspace }}/{{ deployment_name }}/primary"
+  register: outputs
+  changed_when: false
+
+- name: Set necessary facts
+  delegate_to: localhost
+  ansible.builtin.set_fact:
+    bucket_name: "{{ (outputs.stdout | from_json)['gcs_bucket_name_data-bucket']['value'] }}"
+    k8s_service_account_name: "{{ (outputs.stdout | from_json)['k8s_service_account_name_gke_cluster']['value'] }}"
+    cache_zone: "{{ (lookup('file', blueprint_yaml) | from_yaml)['vars']['zone'] }}"
+
+- name: Get GKE cluster credentials
+  delegate_to: localhost
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region={{ region }} --project {{ custom_vars.project }} --verbosity=debug
+  changed_when: false
+
+- name: Create test file
+  delegate_to: localhost
+  ansible.builtin.copy:
+    content: "hello world"
+    dest: "/tmp/testfile.txt"
+
+- name: Upload test file to GCS bucket
+  delegate_to: localhost
+  ansible.builtin.command: gcloud storage cp /tmp/testfile.txt gs://{{ bucket_name }}/testfile.txt
+  changed_when: false
+
+- name: Read file from GCS bucket
+  delegate_to: localhost
+  ansible.builtin.command: "kubectl run gcs-reader-{{ build }} --image=google/cloud-sdk:slim --rm -i --restart=Never --overrides='{\"spec\":{\"serviceAccountName\": \"{{ k8s_service_account_name }}\"}}' -- /bin/bash -c \"gcloud storage cat gs://{{ bucket_name }}/testfile.txt > /dev/null\""
+  changed_when: false
+
+- name: Wait for cache creation
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    gcloud alpha storage operations list gs://{{ bucket_name }} --format=json | jq -e '.[] | select(.metadata.commonMetadata.type == "create-anywhere-cache" and .done == true and (has("error") | not))'
+  register: cache_operation
+  until: cache_operation.rc == 0
+  retries: 6
+  delay: 10
+  changed_when: false

--- a/tools/cloud-build/daily-tests/tests/gke-storage.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-storage.yml
@@ -14,13 +14,18 @@
 ---
 test_name: storage-gke
 deployment_name: gke-storage-{{ build }}
+region: us-central1
 zone: us-central1-a  # for remote node
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/storage-gke.yaml"
 network: "{{ test_name }}-net"
 remote_node: "{{ deployment_name }}-0"
-post_deploy_tests: []
+post_deploy_tests:
+- test-validation/test-anywhere-cache.yml
 cli_deployment_vars:
+  region: "{{ region }}"
   network_name: "{{ network }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
+custom_vars:
+  project: "{{ project }}"


### PR DESCRIPTION
This PR introduces support for Google Cloud Storage Anywhere Cache to the cloud-storage-bucket module. This feature allows GCS buckets to be cached at specified Google Cloud zones, significantly improving read performance for frequently accessed data.

Key Features:
   * A new anywhere_cache input variable has been added to the cloud-storage-bucket module.
   * You can define a list of zones to create multiple cache instances.
   * A single ttl (Time To Live) and admission_policy can be set for all cache instances, simplifying the configuration.

Example Usage:
  To enable Anywhere Cache for a bucket with caches in example-zone-a and example-zone-b, use the following configuration:

    anywhere_cache:
      zones: ["example-zone-a", "example-zone-b"]
      ttl: "86400s"
      admission_policy: "admit-on-first-miss"

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
