### PR TITLE
Update the nccl-tcpxo-installer, nri-device-injector, and nccl-test for a3-megagpu-8g machines

### DIFF
--- a/modules/compute/gke-node-pool/gpu_direct.tf
+++ b/modules/compute/gke-node-pool/gpu_direct.tf
@@ -43,8 +43,8 @@ locals {
     "a3-megagpu-8g" = {
       # Manifest to be installed for enabling TCPXO on a3-megagpu-8g machines
       gpu_direct_manifests = [
-        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/39308db7574925ea3c14f9113fcf87f70a6fcc26/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.8-1 for tcpxo
-        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/39308db7574925ea3c14f9113fcf87f70a6fcc26/nri_device_injector/nri-device-injector.yaml", # nri_plugin
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.8-1 for tcpxo
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/nri_device_injector/nri-device-injector.yaml", # nri_plugin
       ]
       updated_workload_path   = replace(local.workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
       rxdm_version            = "v1.0.14" # matching nccl-tcpxo-installer version v1.0.8-1

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
@@ -27,7 +27,7 @@
   delegate_to: localhost
   ansible.builtin.shell: |
     wget -O {{ workspace }}/examples/nccl-test.yaml \
-      https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/39308db7574925ea3c14f9113fcf87f70a6fcc26/gpudirect-tcpxo/nccl-test-latest.yaml
+      https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/gpudirect-tcpxo/nccl-test-latest.yaml
     cat {{ workspace }}/examples/nccl-test.yaml
   register: nccl_test_file_contents
 


### PR DESCRIPTION
**Bug**: The init-container code in nri-device-injector started failing in the integration test. 
**Fix**: Commit that fixed the nri-device-injector issue: https://github.com/GoogleCloudPlatform/container-engine-accelerators/commit/f5731f38056c7c5d7e333b4d314a7061d6a096a9.

**Change**: Update the **gpudirect-tcpxo/nccl-tcpxo-installer** and **nri_device_injector/nri-device-injector** files used in a3-megagpu-8g set up.
Also, update the nccl test file used in the gke a3-megagpu-8g integration test.
Commit linked to Release 119 is used - https://github.com/GoogleCloudPlatform/container-engine-accelerators/pull/544/commits/bd4a7491672b48dfec28f3679b679a614f6cbbc7

