### PR TITLE
Update rxdm_version info for a3-megagpu-8g machines

### DIFF
--- a/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job.yaml
+++ b/modules/compute/gke-node-pool/gpu-direct-workload/sample-tcpxo-workload-job.yaml
@@ -26,7 +26,7 @@ spec:
       subdomain: nccl-host-1
       containers:
       - name: nccl-test
-        image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.8-1
+        image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.14
         imagePullPolicy: Always
         command:
         - /bin/sh

--- a/modules/compute/gke-node-pool/gpu_direct.tf
+++ b/modules/compute/gke-node-pool/gpu_direct.tf
@@ -43,11 +43,11 @@ locals {
     "a3-megagpu-8g" = {
       # Manifest to be installed for enabling TCPXO on a3-megagpu-8g machines
       gpu_direct_manifests = [
-        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.8-1 for tcpxo
+        "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/gpudirect-tcpxo/nccl-tcpxo-installer.yaml",    # nccl_plugin v1.0.14 for tcpxo
         "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/bd4a7491672b48dfec28f3679b679a614f6cbbc7/nri_device_injector/nri-device-injector.yaml", # nri_plugin
       ]
       updated_workload_path   = replace(local.workload_path_tcpxo, ".yaml", "-tcpxo.yaml")
-      rxdm_version            = "v1.0.14" # matching nccl-tcpxo-installer version v1.0.8-1
+      rxdm_version            = "v1.0.20" # matching nccl-tcpxo-installer version v1.0.14
       min_additional_networks = 8
       major_minor_version_acceptable_map = {
         "1.28" = "1.28.9-gke.1250000"


### PR DESCRIPTION
Update rxdm_version info for a3-megagpu-8g machines.
This changes is a followup to the changes introduced in the PR #4902.

Also, updated the nccl-plugin-gpudirecttcpx-dev version in the tcpxo sample workload.