### PR TITLE
pin mypy version in precommit dep. to last stable version i.e 1.18.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ install-dev-deps: warn-terraform-version warn-packer-version check-pre-commit ch
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	pip install -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
 	pip install -r community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements-dev.txt
-	pip install mypy
+	pip install mypy==1.18.2
 
 
 clean:


### PR DESCRIPTION
pin mypy version in precommit dep. to last stable version i.e 1.18.2

New version of mypy was release on Nov 28, 2025. Makefile pulls the latest version i.e 1.19.0. Pre-commits checks in PT started failing with error logs:
```
mypy-check...............................................................Failed
- hook id: mypy-check
- exit code: 1

community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py:602: error: Module has no attribute "mock"  [attr-defined]
community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py:640: error: Module has no attribute "mock"  [attr-defined]
Found 2 errors in 1 file (checked 20 source files)
```

This PR pins the mypy version to the last stable version

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
