### PR TITLE
Update release channel for TPU 7x

### DIFF
--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -116,7 +116,7 @@ deployment_groups:
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: "1.34."
-      release_channel: STABLE
+      release_channel: RAPID
     outputs: [instructions]
 
   - id: workload_policy


### PR DESCRIPTION
The latest version in STABLE release channel is 1.33.5-gke.1162000. But for TPU 7x , the GKE version supported is 1.34.1-gke.1829001 or later. Therefore, this PR changes the release channel from STABLE to RAPID.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
