### PR TITLE
Set update on creation fail to true in PSA

### DIFF
--- a/community/modules/network/private-service-access/main.tf
+++ b/community/modules/network/private-service-access/main.tf
@@ -46,7 +46,7 @@ resource "google_service_networking_connection" "private_vpc_connection" {
   service                 = var.service_name
   reserved_peering_ranges = [google_compute_global_address.private_ip_alloc.name]
   deletion_policy         = var.deletion_policy
-  update_on_creation_fail = var.deletion_policy == "ABANDON" ? true : null
+  update_on_creation_fail = true
 }
 
 # Google Cloud NetApp Volumes need enablement of custom_route import and export


### PR DESCRIPTION
Netapp volume integration test is failing, testing out the `update_on_creation_fail` argument set to true irrespective of deletion policy

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
