### PR TITLE
Enable spot VM Testing for GKE: a3ultra

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -181,6 +181,10 @@
       vars:
         timeout_seconds: "{{ startup_timeout_seconds }}"
 
+    - name: Add instance labels for spot instances
+      ansible.builtin.include_tasks: tasks/add-instance-labels.yml
+      when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+
     - name: Run Integration tests for Cluster Toolkit
       ansible.builtin.include_tasks: "{{ test }}"
       vars:
@@ -190,6 +194,19 @@
       loop: "{{ post_deploy_tests }}"
       loop_control:
         loop_var: test
+
+    rescue:
+    - name: Display test failure message
+      ansible.builtin.debug:
+        msg: "A task within the integration tests failed. Conditional preemption check will run for spot instances."
+
+    - name: Check for recent preemptions for spot instances
+      ansible.builtin.include_tasks: test-validation/test-preemption.yml
+      when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+
+    - name: Propagate original failure after rescue tasks
+      ansible.builtin.fail:
+        msg: "Integration tests failed. Rescue tasks were executed."
 
     always:
     - name: Cleanup firewall and infrastructure

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -1,0 +1,88 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.gke-job-template
+- gke
+- m.gke-cluster
+- m.gke-node-pool
+- m.service-account
+- m.gpu-rdma-vpc
+- m.kubectl-apply
+- m.vpc
+- m.cloud-storage-bucket
+- m.gke-persistent-volume
+- m.pre-existing-network-storage
+
+timeout: 14400s  # 4hr
+steps:
+# While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml"
+
+- id: gke-a3-ultragpu-onspot
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "NUM_NODES=4"
+  - "MACHINE_TYPE=a3-ultragpu-8g"
+  - "INSTANCE_PREFIX=a3uspgke"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/a3uoptions.txt"
+  args:
+  - -c
+  - |
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
+    cd /workspace && make
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT=$${BUILD_ID:0:6}
+    EXAMPLE_BP=examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+
+    # adding vm to act as remote node
+    echo '  - id: remote-node'                           >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
+    echo '    use: [gke-a3-ultra-net-0]'                 >> $${EXAMPLE_BP}
+    echo '    settings:'                                 >> $${EXAMPLE_BP}
+    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
+    echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
+    echo ''
+    echo '  - id: job_template_hostname'                       >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/gke-job-template'        >> $${EXAMPLE_BP}
+    echo '    use: [a3-ultragpu-pool]'                         >> $${EXAMPLE_BP}
+    echo '    settings:'                                       >> $${EXAMPLE_BP}
+    echo '      image: nvidia/cuda:11.0.3-runtime-ubuntu20.04' >> $${EXAMPLE_BP}
+    echo '      command:'                                      >> $${EXAMPLE_BP}
+    echo '      - nvidia-smi'                                  >> $${EXAMPLE_BP}
+    echo '      node_count: 1'                                 >> $${EXAMPLE_BP}
+    echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
+    # Setting placement policy as compact for nccl test to run on spot VMs, adding spot variable as true and removing reservation from blueprint.
+    sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: true' $${EXAMPLE_BP}
+    sed -i '/reservation/d' $${EXAMPLE_BP}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined
+# in build file with --extra-vars flag!
+test_name: gke-a3u-spot
+deployment_name: gke-a3u-spot-{{ build }}
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml"
+network: "{{ deployment_name }}-net-0"
+remote_node: "{{ deployment_name }}-remote-node-0"
+static_node_count: 2
+instance_type: a3-ultra
+accelerator_type: nvidia-h200-141gb
+num_gpus: 16
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  static_node_count: "{{ static_node_count }}"
+  authorized_cidr: "{{ build_ip.stdout }}/32"
+  gcp_public_cidrs_access_enabled: true
+custom_vars:
+  project: "{{ project }}"
+  instance_labels:
+    a3ultra_onspot: true
+  enable_spot: true
+post_deploy_tests:
+- test-validation/test-gke-job.yml
+- test-validation/test-gke-a3-ultra.yml
+- test-validation/test-gke-kueue-config.yml


### PR DESCRIPTION
This PR introduces the capability to use Spot VMs for GKE clusters with A3 ultra GPUs and adds a new daily test to validate this configuration.

The main changes are:

- A new Cloud Build configuration(tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml) is added to run a daily test for the Spot VM configuration.
- A new test configuration file(tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml) defines the necessary variables and post-deployment tests to validate the GKE cluster with A3 ultra GPUs on Spot VMs.
- The base-integration-test.yml Ansible playbook is updated to conditionally add instance labels for Spot VMs. A rescue block is also added to the playbook. If an integration test fails on a Spot VM, a task now runs to check for recent preemptions, aiding in debugging failures related to the ephemeral nature of Spot VMs

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
