### PR TITLE
Remove hardcoded boot image for test VMs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -42,8 +42,6 @@ steps:
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
   - "PROJECT_ID=$PROJECT_ID"
   - "NUM_NODES=4"
-  - "IMAGE_PROJECT=ubuntu-os-accelerator-images"
-  - "IMAGE_NAME=ubuntu-accelerator-2204-amd64-with-nvidia-570-v20250722"
   - "MACHINE_TYPE=a3-ultragpu-8g"
   - "INSTANCE_PREFIX=a3usp"
   - "BUILD_ID=$BUILD_ID"

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -73,38 +73,16 @@ for ZONE in "${ZONES_ARRAY[@]}"; do
 	readarray -t INSTANCE_NAMES_ARRAY < <(generate_instance_names "${FULL_INSTANCE_PREFIX}" "${NUM_NODES}")
 
 	declare -a GCLOUD_CMD
-	COMMON_FLAGS=(
+	GCLOUD_CMD=(
+		gcloud compute instances create "${INSTANCE_NAMES_ARRAY[@]}"
 		--project="${PROJECT_ID}"
 		--zone="${ZONE}"
 		--machine-type="${MACHINE_TYPE}"
-		--image-project="${IMAGE_PROJECT}"
 		--provisioning-model="${PROVISIONING_MODEL}"
 		--instance-termination-action="${TERMINATION_ACTION}"
+		--no-address
 		--quiet
 	)
-
-	if [[ "${MACHINE_TYPE}" == "a3-ultragpu-8g" ]]; then
-		if [[ -z "${IMAGE_NAME}" ]]; then
-			echo "ERROR: IMAGE_NAME must be set for a3-ultragpu-8g" >&2
-			exit 1
-		fi
-		GCLOUD_CMD=(
-			gcloud compute instances create "${INSTANCE_NAMES_ARRAY[@]}"
-			"${COMMON_FLAGS[@]}"
-			--image="${IMAGE_NAME}"
-		)
-	else
-		if [[ -z "${IMAGE_FAMILY}" ]]; then
-			echo "ERROR: IMAGE_FAMILY must be set for ${MACHINE_TYPE}" >&2
-			exit 1
-		fi
-		GCLOUD_CMD=(
-			gcloud compute instances create "${INSTANCE_NAMES_ARRAY[@]}"
-			"${COMMON_FLAGS[@]}"
-			--image-family="${IMAGE_FAMILY}"
-			--no-address
-		)
-	fi
 	if CREATE_OUTPUT=$("${GCLOUD_CMD[@]}" 2>&1); then
 		cleanup_instances "${PROJECT_ID}" "${ZONE}" "${FULL_INSTANCE_PREFIX}"
 		SELECTED_ZONE="${ZONE}"


### PR DESCRIPTION
This pull request removes the hardcoded boot image for the a3-ultragpu-8g machine type in the daily Slurm integration test using spot VMs. The find_available_zone.sh script has been updated to reflect this change.

Previously, IMAGE_PROJECT and IMAGE_NAME were fixed in the test configuration. This change removes these hardcoded values since they are unnecessary while finding if a zone has available capacity for a specific machine type. 


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
