### PR TITLE
Updating the required average-bus-bw for A4X NCCL test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a4x.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a4x.yml
@@ -116,16 +116,16 @@
   debug:
     msg: "{{nccl_test_logs.stdout}}"
 
-- name: Ensure average bus bandwidth is >= 100 GB/s
+- name: Ensure average bus bandwidth is >= 200 GB/s
   delegate_to: localhost
   ansible.builtin.shell: |
     grep -o '# Avg bus bandwidth    : [0-9\.]*' pod_logs.txt | cut -d ':' -f 2 | awk '{$1=$1;print}'
   register: avg_bus_bandwidth
-  failed_when: avg_bus_bandwidth.stdout | float < 100
+  failed_when: avg_bus_bandwidth.stdout | float < 200
 
 - name: "SUCCESS: Bandwidth validation passed. Cleaning up resources."
   ansible.builtin.debug:
-    msg: "Average bus bandwidth is >= 100 GB/s. Test passed. Cleaning up JobSet."
+    msg: "Average bus bandwidth is >= 200 GB/s. Test passed. Cleaning up JobSet."
 
 - name: Clean up
   delegate_to: localhost


### PR DESCRIPTION
This PR updates the minimum required value of "average bus bandwidth" output of the NCCL test run as a part of A4X integration test. The integration test runs the NCCL on following cluster configurations:
1. Number of nodes: 2
2. Topology: gce-topology-subblock
3. Test executed: all_gather_perf
4. Message size: 1KB to 8GB with increment factor of 2

Verified multiple test runs with above configuration and the value of parameter was consistently above 200 GB/s 

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
