### PR TITLE
Register job_completion output in test-gke-job.yml 

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-job.yml
@@ -40,6 +40,10 @@
       kubectl wait --for=condition=complete "job/${JOB_NAME}" --timeout=10m
     args:
       executable: /bin/bash
+    register: job_completion
+    until: job_completion.rc == 0
+    retries: 5
+    delay: 10
   rescue:
   - name: "FAILURE: Job did not complete. Capturing debug info."
     ansible.builtin.debug:


### PR DESCRIPTION
This pull request resolves a bug where the log output for job completion displays "VARIABLE IS NOT DEFINED!" due to a missing variable registration in the `test-gke-job.yml` file. By properly registering the required variable, this change ensures more accurate analysis and debugging in the build logs, providing the expected job_completion output.

1. Logs when the variable is not registered.
```
TASK [Print job_completion debug output] ***************************************
 ok: [35.186.79.103] => {
job_completion.stdout_lines": "VARIABLE IS NOT DEFINED!"
}
```
2. Logs when the variable is registered.
```
TASK [Print job_completion debug output] ***************************************
ok: [35.186.40.16] => {
"job_completion.stdout_lines": [
"job.batch/my-job-099d condition met"
 ]
}
```
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
