### PR TITLE
Conditionally run preemption check in rescue blocks

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -196,13 +196,15 @@
         loop_var: test
 
     rescue:
-    - name: Display test failure message
-      ansible.builtin.debug:
-        msg: "A task within the integration tests failed. Conditional preemption check will run for spot instances."
-
-    - name: Check for recent preemptions for spot instances
-      ansible.builtin.include_tasks: test-validation/test-preemption.yml
+    - name: Conditionally check for spot preemptions after a failure
       when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+      block:
+      - name: Display test failure message
+        ansible.builtin.debug:
+          msg: "A task within the integration tests failed. Spot VMs are enabled, so running preemption checks."
+
+      - name: Check for recent preemptions
+        ansible.builtin.include_tasks: test-validation/test-preemption.yml
 
     - name: Propagate original failure after rescue tasks
       ansible.builtin.fail:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -237,13 +237,15 @@
         loop_var: test
 
     rescue:
-    - name: Display test failure message
-      ansible.builtin.debug:
-        msg: "A task within the integration tests failed. Conditional preemption check will run for spot instances."
-
-    - name: Check for recent preemptions for spot instances
-      ansible.builtin.include_tasks: test-validation/test-preemption.yml
+    - name: Conditionally check for spot preemptions after a failure
       when: custom_vars is defined and custom_vars.enable_spot | default(false) | bool
+      block:
+      - name: Display test failure message
+        ansible.builtin.debug:
+          msg: "A task within the integration tests failed. Spot VMs are enabled, so running preemption checks."
+
+      - name: Check for recent preemptions
+        ansible.builtin.include_tasks: test-validation/test-preemption.yml
 
     - name: Propagate original failure after rescue tasks
       ansible.builtin.fail:


### PR DESCRIPTION
This pull request modifies the rescue block in the base-integration-test.yml and slurm-integration-test.yml playbooks.

The changes ensure that the preemption check tasks are executed only when Spot VMs are enabled (custom_vars.enable_spot is true). Previously, a debug message would always be displayed on task failure, regardless of whether Spot VMs were in use. This has been corrected by moving the conditional logic to wrap the entire rescue operation, including the logging message and the preemption check.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
