### PR TITLE
Remove all references to ubuntu20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The Cluster Toolkit officially supports the following VM images:
 
 * HPC Rocky Linux 8
 * Debian 11
-* Ubuntu 20.04 LTS
+* Ubuntu 22.04 LTS
 
 For more information on these and other images, see
 [docs/vm-images.md](docs/vm-images.md).

--- a/community/examples/hpc-slurm-ubuntu2204.yaml
+++ b/community/examples/hpc-slurm-ubuntu2204.yaml
@@ -14,7 +14,7 @@
 
 ---
 
-blueprint_name: hpc-slurm-ubuntu2004-v6
+blueprint_name: hpc-slurm-ubuntu2204-v6
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -6,7 +6,7 @@
 * [Cluster Toolkit Supported Images](#cluster-toolkit-supported-images)
   * [HPC Rocky Linux 8](#hpc-rocky-linux-8)
   * [Debian 11](#debian-11)
-  * [Ubuntu 20.04 LTS](#ubuntu-2004-lts)
+  * [Ubuntu 22.04 LTS](#ubuntu-2204-lts)
   * [Windows](#windows)
   * [Other Images](#other-images)
   * [Slurm on GCP](#slurm-on-gcp)
@@ -75,7 +75,7 @@ blueprint:
         project: debian-cloud
 
       instance_image:
-        family: ubuntu-2004-lts
+        family: ubuntu-2204-lts
         project: ubuntu-os-cloud
 ```
 
@@ -114,9 +114,9 @@ HPC Rocky Linux 8 is the primary supported VM image for HPC workloads on Google 
 The Cluster Toolkit officially supports Debian 11 based VM images in the majority of
 our modules, with a couple of exceptions.
 
-### Ubuntu 20.04 LTS
+### Ubuntu 22.04 LTS
 
-The Cluster Toolkit officially supports Ubuntu 20.04 LTS based VM images in the
+The Cluster Toolkit officially supports Ubuntu 22.04 LTS based VM images in the
 majority of our modules, with a couple of exceptions.
 
 ### Windows
@@ -131,7 +131,7 @@ description of our support for Windows images.
   <th>Deployment Type/Scheduler</th>
   <th>Feature</th>
   <th></th>
-  <th>Debian 11</th><th>Rocky Linux 8</th><th>Ubuntu 20.04</th>
+  <th>Debian 11</th><th>Rocky Linux 8</th><th>Ubuntu 22.04</th>
 </tr>
 <tr>
   <td></td><td></td><td></td><td></td><td></td><td></td>
@@ -173,7 +173,7 @@ description of our support for Windows images.
   <td></td>
   <td>✓</td>
   <td><a href="../examples/hpc-slurm.yaml">✓</a></td>
-  <td><a href="../community/examples/hpc-slurm-ubuntu2004.yaml">✓</a></td>
+  <td><a href="../community/examples/hpc-slurm-ubuntu2204.yaml">✓</a></td>
 </tr>
 <tr>
   <th>Startup script</th>
@@ -190,7 +190,7 @@ description of our support for Windows images.
   <th></th>
   <td><a href="../tools/validate_configs/os_compatibility_tests/vm-crd.yaml">✓</a></td>
   <td></td>
-  <td><sup><b>*</b></sup></td>
+  <td><a href="../tools/validate_configs/os_compatibility_tests/vm-crd.yaml">✓</a></td>
 </tr>
 <tr>
   <th>Lustre</th>
@@ -222,8 +222,6 @@ description of our support for Windows images.
   <td></td>
 </tr>
 </table>
-
-<sup><b>*</b></sup> Chrome Remote desktop does not support Ubuntu 20.04, but it does support Ubuntu 22.04.
 
 ### Other Images
 
@@ -284,7 +282,7 @@ These instructions apply to the following modules:
 [batch-job]: ../modules/scheduler/batch-job-template
 [batch-login]: ../modules/scheduler/batch-login-node
 [htcondor-setup]: ../community/modules/scheduler/htcondor-setup
-[hpc-slurm-ubuntu2004.yaml]: ../community/examples/hpc-slurm-ubuntu2004.yaml
+[hpc-slurm-ubuntu2204.yaml]: ../community/examples/hpc-slurm-ubuntu2204.yaml
 
 [htc-htcondor.yaml]: ../community/examples/htc-htcondor.yaml
 [vm-startup.yaml]: ../tools/validate_configs/os_compatibility_tests/vm-startup.yaml

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [ps-slurm.yaml](#ps-slurmyaml--) ![core-badge] ![experimental-badge]
   * [cae-slurm.yaml](#cae-slurmyaml-) ![core-badge]
   * [hpc-build-slurm-image.yaml](#hpc-build-slurm-imageyaml--) ![community-badge] ![experimental-badge]
-  * [hpc-slurm-ubuntu2004.yaml](#hpc-slurm-ubuntu2004yaml--) ![community-badge]
+  * [hpc-slurm-ubuntu2204.yaml](#hpc-slurm-ubuntu2204yaml--) ![community-badge]
   * [hpc-amd-slurm.yaml](#hpc-amd-slurmyaml-) ![community-badge]
   * [hpc-slurm-sharedvpc.yaml](#hpc-slurm-sharedvpcyaml--) ![community-badge] ![experimental-badge]
   * [client-google-cloud-storage.yaml](#client-google-cloud-storageyaml--) ![community-badge] ![experimental-badge]
@@ -872,9 +872,9 @@ The blueprint contains 3 groups:
 
 [hpc-build-slurm-image.yaml]: ../community/examples/hpc-build-slurm-image.yaml
 
-### [hpc-slurm-ubuntu2004.yaml] ![community-badge]
+### [hpc-slurm-ubuntu2204.yaml] ![community-badge]
 
-Similar to the [hpc-slurm.yaml] example, but using Ubuntu 20.04 instead of CentOS 7.
+Similar to the [hpc-slurm.yaml] example, but using Ubuntu 22.04 instead of CentOS 7.
 [Other operating systems] are supported by SchedMD for the the Slurm on GCP project and images are listed [here](https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/docs/images.md#published-image-family). Only the examples listed in this page been tested by the Cluster Toolkit team.
 
 The cluster will support 2 partitions named `debug` and `compute`.
@@ -885,9 +885,9 @@ partition runs on compute optimized nodes of type `cs-standard-60`. The
 `compute` partition may require additional quota before using.
 
 [Other operating systems]: https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/docs/images.md#supported-operating-systems
-[hpc-slurm-ubuntu2004.yaml]: ../community/examples/hpc-slurm-ubuntu2004.yaml
+[hpc-slurm-ubuntu2204.yaml]: ../community/examples/hpc-slurm-ubuntu2204.yaml
 
-#### Quota Requirements for hpc-slurm-ubuntu2004.yaml
+#### Quota Requirements for hpc-slurm-ubuntu2204.yaml
 
 For this example the following is needed in the selected region:
 

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -10,7 +10,7 @@ Toolkit, see the extended [Network Storage documentation](../../../docs/network_
 ### Supported Operating Systems
 
 A Managed Lustre instance can be used with Slurm cluster or compute
-VM running Ubuntu 20.04, 22.04 or Rocky Linux 8 (including the HPC flavor).
+VM running Ubuntu 22.04 or Rocky Linux 8 (including the HPC flavor).
 
 ### Managed Lustre Access
 

--- a/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
@@ -16,7 +16,7 @@
 # Install Managed Lustre client modules
 # Based on these instructions: https://cloud.google.com/managed-lustre/docs/connect-from-compute-engine
 
-# The client modules currently only support Rocky 8, and Ubuntu 20.04/22.04
+# The client modules currently only support Rocky 8, and Ubuntu 22.04
 
 set -e
 
@@ -40,7 +40,7 @@ fi
 . /etc/os-release
 DIST="NA"
 if [[ $NAME == *"Ubuntu"* ]]; then
-	if [[ $VERSION_ID == "20.04" || $VERSION_ID == "22.04" ]]; then
+	if [[ $VERSION_ID == "22.04" ]]; then
 		DIST="Ubuntu"
 	fi
 elif [[ $NAME == *"Rocky"* ]]; then

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -75,8 +75,7 @@ The following is an example of using `pre-existing-network-storage` with the
 ```
 
 This is similar to the `lustre` filesystem, with the exception that it connects
-with a managed Lustre instance hosted by GCP.  Currently only Rocky 8 and
-Ubuntu 20.04 and Ubuntu 22.04 are supported.
+with a managed Lustre instance hosted by GCP.  Currently only Rocky 8 and Ubuntu 22.04 are supported.
 
 The following is an example of using `pre-existing-network-storage` with the `daos`
 filesystem. In order to use existing `parallelstore` instance, `fs_type` needs to be

--- a/modules/file-system/pre-existing-network-storage/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-managed-lustre-client.sh
@@ -16,7 +16,7 @@
 # Install Managed Lustre client modules
 # Based on these instructions: https://cloud.google.com/managed-lustre/docs/connect-from-compute-engine
 
-# The client modules currently only support Rocky 8, and Ubuntu 20.04/22.04
+# The client modules currently only support Rocky 8, and Ubuntu 22.04
 
 set -e
 
@@ -40,7 +40,7 @@ fi
 . /etc/os-release
 DIST="NA"
 if [[ $NAME == *"Ubuntu"* ]]; then
-	if [[ $VERSION_ID == "20.04" || $VERSION_ID == "22.04" ]]; then
+	if [[ $VERSION_ID == "22.04" ]]; then
 		DIST="Ubuntu"
 	fi
 elif [[ $NAME == *"Rocky"* ]]; then

--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -44,21 +44,6 @@ deployment_groups:
           set -ex
           echo \$(ansible --version)
 
-  - id: startup-script-u20
-    # this source line is deliberate; it is the last to support Ubuntu 20.04
-    # Ubuntu 20.04 coverage may be removed when the a3-highgpu-8g solution is
-    # refactored to use Ubuntu 22.04 or later
-    source: github.com/GoogleCloudPlatform/cluster-toolkit//modules/scripts/startup-script?ref=v1.51.1&depth=1
-    settings:
-      install_ansible: true
-      runners:
-      - type: shell
-        destination: startup.sh
-        content: |
-          #!/bin/bash
-          set -ex
-          echo \$(ansible --version)
-
   - id: workstation-ubuntu-2204
     source: modules/compute/vm-instance
     use:

--- a/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/lustre-slurm.yaml
@@ -70,7 +70,7 @@ deployment_groups:
   # Slurm VMs #
   #############
 
-  # # Ubuntu 20.04 LTS
+  # # Ubuntu 22.04 LTS
   # - id: ubuntu_nodeset
   #   source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
   #   use: [network]

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml
@@ -28,7 +28,7 @@ cli_deployment_vars:
 
 zone: us-west4-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004.yaml"
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2204.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml
@@ -14,14 +14,14 @@
 
 ---
 
-test_name: hpc-slurm-v6-ubuntu2004
+test_name: hpc-slurm-v6-ubuntu2204
 deployment_name: "ubun-v6-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.
 slurm_cluster_name: "ubunv6{{ build[0:4] }}"
 zone: us-west4-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2004.yaml"
+blueprint_yaml: "{{ workspace }}/community/examples/hpc-slurm-ubuntu2204.yaml"
 network: "{{ test_name }}-net"
 # Note: Pattern matching in gcloud only supports 1 wildcard, centv5*-login-* won't work.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"

--- a/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
@@ -22,7 +22,7 @@ vars:
   region: us-central1
   zone: us-central1-a
   # instance_image:
-  #   family: ubuntu-2004-lts
+  #   family: ubuntu-2204-lts
   #   project: ubuntu-os-cloud
   # instance_image:
   #   family: centos-7

--- a/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
@@ -22,7 +22,7 @@ vars:
   region: us-central1
   zone: us-central1-a
   # instance_image:
-  #   family: ubuntu-2004-lts
+  #   family: ubuntu-2204-lts
   #   project: ubuntu-os-cloud
   # instance_image:
   #   family: centos-7

--- a/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
@@ -22,7 +22,7 @@ vars:
   region: us-central1
   zone: us-central1-a
   instance_image:
-    family: ubuntu-2004-lts
+    family: ubuntu-2204-lts
     project: ubuntu-os-cloud
   # instance_image:
   #   family: debian-11

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -55,7 +55,7 @@ deployment_groups:
     - homefs
     settings:
       instance_image:
-        family: ubuntu-2004-lts
+        family: ubuntu-2204-lts
         project: ubuntu-os-cloud
       name_prefix: workstation-ubuntu
       instance_count: 1

--- a/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
@@ -115,7 +115,7 @@ deployment_groups:
       name_prefix: ubuntu
       instance_count: 1
       instance_image:
-        family: ubuntu-2004-lts
+        family: ubuntu-2204-lts
         project: ubuntu-os-cloud
   - id: wait-ubuntu
     source: community/modules/scripts/wait-for-startup

--- a/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
@@ -23,7 +23,7 @@ vars:
   zone: us-central1-a
   machine_type: n1-standard-2
   # instance_image:
-  #   family: ubuntu-2004-lts
+  #   family: ubuntu-2204-lts
   #   project: ubuntu-os-cloud
   # instance_image:
   #   family: centos-7

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -81,7 +81,7 @@ deployment_groups:
     settings:
       machine_type: e2-standard-4
       instance_image:
-        family: ubuntu-2004-lts
+        family: ubuntu-2204-lts
         project: ubuntu-os-cloud
 
   - id: wait

--- a/tools/validate_configs/test_configs/vm.yaml
+++ b/tools/validate_configs/test_configs/vm.yaml
@@ -39,10 +39,10 @@ deployment_groups:
       machine_type: n2-standard-2
       instance_image:
         project: ubuntu-os-cloud
-        family: ubuntu-2004-lts
+        family: ubuntu-2204-lts
         # The following can be uncommented to test that changing an image definition triggers recreation.
         # Create this image by running:
-        # gcloud compute images create myubuntu-1 --source-image-family ubuntu-2004-lts \
+        # gcloud compute images create myubuntu-1 --source-image-family ubuntu-2204-lts \
         #        --source-image-project=ubuntu-os-cloud --family myubuntu --project <project_id>
         # project: $(vars.project_id)
         # family: myubuntu


### PR DESCRIPTION
Ubuntu 20.04 reached EOL on May 31st, 2025. 
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
