### PR TITLE
Adding NCCL test for  GKE A3 UltraGPU with Spot VMs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot-nccl.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot-nccl.yaml
@@ -1,0 +1,88 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.gke-job-template
+- gke
+- m.gke-cluster
+- m.gke-node-pool
+- m.service-account
+- m.gpu-rdma-vpc
+- m.kubectl-apply
+- m.vpc
+- m.cloud-storage-bucket
+- m.gke-persistent-volume
+- m.pre-existing-network-storage
+
+timeout: 14400s  # 4hr
+steps:
+# While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot-nccl.yaml"
+
+- id: gke-a3-ultragpu-onspot-nccl
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "NUM_NODES=4"
+  - "MACHINE_TYPE=a3-ultragpu-8g"
+  - "INSTANCE_PREFIX=a3usp-gke-nccl"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/a3uoptions.txt"
+  args:
+  - -c
+  - |
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
+    cd /workspace && make
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT=$${BUILD_ID:0:6}
+    EXAMPLE_BP=examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+
+    # adding vm to act as remote node
+    echo '  - id: remote-node'                           >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
+    echo '    use: [gke-a3-ultra-net-0]'                 >> $${EXAMPLE_BP}
+    echo '    settings:'                                 >> $${EXAMPLE_BP}
+    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
+    echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
+    echo ''
+    echo '  - id: job_template_hostname'                       >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/gke-job-template'        >> $${EXAMPLE_BP}
+    echo '    use: [a3-ultragpu-pool]'                         >> $${EXAMPLE_BP}
+    echo '    settings:'                                       >> $${EXAMPLE_BP}
+    echo '      image: nvidia/cuda:11.0.3-runtime-ubuntu20.04' >> $${EXAMPLE_BP}
+    echo '      command:'                                      >> $${EXAMPLE_BP}
+    echo '      - nvidia-smi'                                  >> $${EXAMPLE_BP}
+    echo '      node_count: 1'                                 >> $${EXAMPLE_BP}
+    echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
+    # Setting placement policy as compact for nccl test to run on spot VMs, adding spot variable as true and removing reservation from blueprint.
+    sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: true' $${EXAMPLE_BP}
+    sed -i '/reservation/d' $${EXAMPLE_BP}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot-nccl.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot-nccl.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot-nccl.yml
@@ -1,0 +1,41 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone must be defined
+# in build file with --extra-vars flag!
+test_name: gke-a3usp-nc
+deployment_name: gke-a3usp-nc-{{ build }}
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml"
+network: "{{ deployment_name }}-net-0"
+remote_node: "{{ deployment_name }}-remote-node-0"
+static_node_count: 2
+instance_type: a3-ultra
+accelerator_type: nvidia-h200-141gb
+num_gpus: 16
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  static_node_count: "{{ static_node_count }}"
+  authorized_cidr: "{{ build_ip.stdout }}/32"
+  gcp_public_cidrs_access_enabled: true
+custom_vars:
+  project: "{{ project }}"
+  instance_labels:
+    a3ultra_onspot: true
+  enable_spot: true
+post_deploy_tests:
+- test-validation/test-gke-a3-ultra.yml


### PR DESCRIPTION
This PR introduces a new integration test to validate NCCL performance on GKE clusters that use A3 UltraGPU instances with Spot VMs.

The key changes include:

- Introduced a new Cloud Build configuration file (gke-a3-ultragpu-onspot-nccl.yaml) to orchestrate integration tests for GKE A3 UltraGPU clusters. The GKE cluster is configured to utilize spot VMs and a compact placement policy.
- Added a new file (gke-a3-ultragpu-onspot-nccl.yml) that defines specific parameters for the GKE A3 UltraGPU NCCL test.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
