### PR TITLE
Fixes precommit by cleaning up space 

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -32,6 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
     - uses: actions/setup-python@v5
       with:
         # internal Python tests require Python 3.12
@@ -61,6 +69,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
     - uses: actions/setup-python@v5
       with:
         # the slurm-files Python requirements.txt requires updating


### PR DESCRIPTION
Delete pre-installed softwares which are not required in the Github runner VM.

1. Android
2. Dot-net
3. Haskel
4. Large-packages: Includes GUI related tools, browsers etc.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
