### PR TITLE
Integrate Kueue support for GKE TPU v6 and v7x blueprints

### DIFF
--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -131,6 +131,27 @@ The process is nearly identical to the basic deployment.
 
 3. After deployment, the blueprint will output instructions for running a fio benchmark job. This job serves as a validation test to confirm that the GCS mounts are working correctly for both reading and writing. Follow the printed instructions to run the test.
 
+## Advanced Scheduling with Kueue
+
+This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native system for managing quotas and job queuing. This is enabled by default in the advanced blueprint (`gke-tpu-7x-advanced.yaml`).
+
+### Usage
+
+1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
+2. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
+
+    A sample job file is provided: `kueue-job-sample.yaml`.
+
+    ```sh
+    kubectl create -f ~/cluster-toolkit/examples/gke-tpu-7x/kueue-job-sample.yaml
+    ```
+
+3. **Validation:** Check the status of your workload.
+
+    ```sh
+    kubectl get workloads
+    ```
+
 ## Run the sample job
 
 The `tpu-7x-job.yaml` file creates a Pod resource in Kubernetes. The workload installs JAX and a specific `libtpu` library, and then returns the number of TPU chips it can detect.

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -49,6 +49,9 @@ vars:
   # The name of the compute engine reservation of TPU 7x nodes
   reservation:
 
+  # Kueue configuration
+  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -285,6 +288,12 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [gke-tpu-7x-cluster]
     settings:
+      kueue:
+        install: true
+        config_path: $(vars.kueue_configuration_path)
+        config_template_vars:
+          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-7x-pool.tpu_chips_per_node)
+          accelerator_type: $(gke-tpu-7x-pool.tpu_accelerator_type)
       jobset:
         install: true
 

--- a/examples/gke-tpu-7x/kueue-configuration.yaml.tftpl
+++ b/examples/gke-tpu-7x/kueue-configuration.yaml.tftpl
@@ -1,0 +1,43 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "tpu-flavor"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: ${accelerator_type}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["google.com/tpu"]
+    flavors:
+    - name: "tpu-flavor"
+      resources:
+      - name: "google.com/tpu"
+        nominalQuota: ${tpu_quota}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "default"
+  name: "user-queue"
+spec:
+  clusterQueue: "cluster-queue"

--- a/examples/gke-tpu-7x/kueue-job-sample.yaml
+++ b/examples/gke-tpu-7x/kueue-job-sample.yaml
@@ -1,0 +1,48 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: tpu-7x-job-kueue-sample
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+  - name: tpu-worker
+    replicas: 1
+    template:
+      spec:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 0
+        template:
+          spec:
+            nodeSelector:
+              cloud.google.com/gke-tpu-accelerator: tpu7x
+              cloud.google.com/gke-tpu-topology: 2x2x1 # 4 chips
+            containers:
+            - name: tpu-job
+              image: ubuntu:22.04
+              command:
+              - bash
+              - -c
+              - |
+                echo "Kueue has admitted this job!"
+                echo "Running TPU workload..."
+                sleep 60
+                echo "Job complete."
+              resources:
+                limits:
+                  google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips

--- a/examples/gke-tpu-v6/README.md
+++ b/examples/gke-tpu-v6/README.md
@@ -115,6 +115,27 @@ The process is nearly identical to the basic deployment.
 
 1. After deployment, the blueprint will output instructions for running a fio benchmark job. This job serves as a validation test to confirm that the GCS mounts are working correctly for both reading and writing. Follow the printed instructions to run the test.
 
+## Advanced Scheduling with Kueue
+
+This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native system for managing quotas and job queuing. This is enabled by default in the advanced blueprint (`gke-tpu-v6-advanced.yaml`).
+
+### Usage
+
+1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
+2. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
+
+    A sample job file is provided: `kueue-job-sample.yaml`.
+
+    ```sh
+    kubectl create -f ~/cluster-toolkit/examples/gke-tpu-v6/kueue-job-sample.yaml
+    ```
+
+3. **Validation:** Check the status of your workload.
+
+    ```sh
+    kubectl get workloads
+    ```
+
 ## Run the sample job
 
 The [tpu-multislice.yaml](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/gke-tpu-v6/tpu-multislice.yaml) file creates a service and a job resource in kubernetes. It is based on https://cloud.google.com/kubernetes-engine/docs/how-to/tpus#tpu-chips-node-pool. The  workload returns the number of TPU chips across all of the nodes in a multi-host TPU slice.

--- a/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
+++ b/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
@@ -53,6 +53,9 @@ vars:
   v6e_node_pool_disk_size_gb: 100
   version_prefix: "1.33."
 
+  # Kueue configuration
+  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -285,6 +288,12 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [gke-tpu-v6-cluster]
     settings:
+      kueue:
+        install: true
+        config_path: $(vars.kueue_configuration_path)
+        config_template_vars:
+          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-v6-pool.tpu_chips_per_node)
+          accelerator_type: $(gke-tpu-v6-pool.tpu_accelerator_type)
       jobset:
         install: true
 

--- a/examples/gke-tpu-v6/kueue-configuration.yaml.tftpl
+++ b/examples/gke-tpu-v6/kueue-configuration.yaml.tftpl
@@ -1,0 +1,43 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "tpu-flavor"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-tpu-accelerator: ${accelerator_type}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {}
+  resourceGroups:
+  - coveredResources: ["google.com/tpu"]
+    flavors:
+    - name: "tpu-flavor"
+      resources:
+      - name: "google.com/tpu"
+        nominalQuota: ${tpu_quota}
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "default"
+  name: "user-queue"
+spec:
+  clusterQueue: "cluster-queue"

--- a/examples/gke-tpu-v6/kueue-job-sample.yaml
+++ b/examples/gke-tpu-v6/kueue-job-sample.yaml
@@ -1,0 +1,48 @@
+# Copyright 2025 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  name: tpu-v6e-job-kueue-sample
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+spec:
+  replicatedJobs:
+  - name: tpu-worker
+    replicas: 1
+    template:
+      spec:
+        parallelism: 4
+        completions: 4
+        backoffLimit: 0
+        template:
+          spec:
+            nodeSelector:
+              cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+              cloud.google.com/gke-tpu-topology: 4x4 # 4x4 = 16 chips
+            containers:
+            - name: tpu-job
+              image: ubuntu:22.04
+              command:
+              - bash
+              - -c
+              - |
+                echo "Kueue has admitted this job!"
+                echo "Running TPU workload..."
+                sleep 60
+                echo "Job complete."
+              resources:
+                limits:
+                  google.com/tpu: "4" # 4 chips per pod * 4 pods = 16 chips


### PR DESCRIPTION
This PR introduces optional Kueue support to the GKE TPU v6 (`examples/gke-tpu-v6`) and GKE TPU 7x
(`examples/gke-tpu-7x`) blueprints. This integration enables advanced, Kubernetes-native job queuing
and quota management, which is essential for multi-tenant AI/ML clusters and for managing resources
in environments with limited TPU availability.

### Key Changes:

   1. **New Configuration Templates**:
       * Added `kueue-configuration.yaml.tftpl` for both v6 and 7x.
       * Configures a `ClusterQueue specifically for `google.com/tpu` resources.
       * Uses a dynamic `ResourceFlavor` that targets nodes via the `cloud.google.com/gke-tpu-accelerator`
         label, ensuring compatibility with specific hardware generations.

   2. **Blueprint Updates**:
       * Modified `gke-tpu-v6-advanced.yaml` and `gke-tpu-7x-advanced.yaml` to include the kueue
         installation block within the `workload-manager-install` module.
       * Dynamic Quota Calculation: The `tpu_quota` for the queue is automatically calculated based on
         the deployment's static capacity (`num_slices `* `static_node_count` * `chips_per_node`). This
         ensures the logical queue limit matches the physical cluster size by default.

   3. Sample Workloads:
       * Added `kueue-job-sample.yaml` for both blueprints.
       * These samples demonstrate how to submit a distributed JobSet to the configured Kueue queue.
       * Configured with correct default topologies (4x4 for v6e, 2x2x1 for 7x) and resource limits to
         run out-of-the-box on standard deployments.

   4. Documentation:
       * Updated `README.md` for both examples with a new *"Advanced Scheduling with Kueue"* section,
         detailing setup instructions and job submission steps.

### Testing:

   * **Deployment**: Validated successful deployment of both TPU v6e and TPU 7x clusters using the updated
     advanced blueprints.
   * **Verification**: Confirmed that ClusterQueue and LocalQueue resources were correctly created and
     healthy.
   * **Job Submission**: Submitted the sample kueue-job-sample.yaml on both clusters. Verified that jobs
     were successfully:
       * Admitted by Kueue (Admitted: True in workload status).
       * Scheduled onto TPU nodes.
       * Completed successfully (verified via Pod logs and status).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
