### PR TITLE
Updated terraform triggers for a3mega and a4high, and updated time for daily test runs

### DIFF
--- a/tools/cloud-build/provision/list-tests.tf
+++ b/tools/cloud-build/provision/list-tests.tf
@@ -14,5 +14,5 @@
 # limitations under the License.
 
 data "external" "list_tests_midnight" {
-  program = ["./list_tests.py", "30", "300"] # 00:30 - 05:00
+  program = ["./list_tests.py", "30", "390"] # 00:30 - 06:30
 }

--- a/tools/cloud-build/provision/list_tests.py
+++ b/tools/cloud-build/provision/list_tests.py
@@ -52,10 +52,26 @@ ORDER_SEED = b"What a wonderful phrase"
  # Test that shouldn't be scheduled too close to each other
 TEMPORAL_CONSTAINTS = [
     # (set_of_tests, min_distance)
-    (("ml-a4-highgpu-slurm", "gke-a4"), 2*60),
-    (("ml-a3-ultragpu-onspot-slurm", "ml-a3-ultragpu-onspot-jbvms", "gke-a3-ultragpu-onspot"), 1*60),
-    (("ml-a3-megagpu-slurm-ubuntu", "gke-a3-megagpu"), 1*60),
-    (("ml-a3-highgpu-slurm", "gke-a3-highgpu"), 1*60),
+    ((
+        "ml-a4-highgpu-slurm",
+        "ml-a4-highgpu-onspot-slurm",
+        "gke-a4"
+    ), 2*60),
+    ((
+        "ml-a3-ultragpu-onspot-slurm", 
+        "ml-a3-ultragpu-onspot-jbvms", 
+        "gke-a3-ultragpu-onspot"
+    ), 2*60),
+    ((
+        "ml-a3-megagpu-slurm-ubuntu",
+        "gke-a3-megagpu",
+        "ml-a3-megagpu-onspot-slurm-ubuntu",
+        "gke-a3-megagpu-onspot"
+    ), 1*60),
+    ((
+        "ml-a3-highgpu-slurm", 
+        "gke-a3-highgpu"
+    ), 1*60),
 ]
 # TODO:
 # * Consider defining constraints (e.g. reservations used) as a tags within tests yamls


### PR DESCRIPTION
This PR updates the temporal constraints for nightly integration tests to include on-spot VM test configurations for A3 mega and A4 high GPU clusters.

Specifically, it:
*   Adds `ml-a4-highgpu-onspot-slurm` to the `a4-highgpu` test group.
*   Adds `ml-a3-megagpu-onspot-slurm-ubuntu` and `gke-a3-megagpu-onspot` to the `a3-megagpu` test group.
*   Increased time between 2 a3ultra tests to 2 hours
*   Extends the time window for the midnight test scheduler by one and a half hour.

These changes prevent resource contention between on-demand and on-spot test variations and provide more time for the nightly tests to complete.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
