### PR TITLE
Add integration test for A3 high-GPU with spot VMs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -1,0 +1,75 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- slurm6
+- m.filestore
+- m.multivpc
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.service-account
+- m.startup-script
+- m.vpc
+- m.custom-image
+timeout: 14400s  # 4hr
+steps:
+# While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml"
+
+- id: ml-a3-highgpu-onspot-slurm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "MACHINE_TYPE=a3-highgpu-8g"
+  - "NUM_NODES=4"
+  - "INSTANCE_PREFIX=a3hsp"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/a3hoptions.txt"
+  args:
+  - -c
+  - |
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
+    cd /workspace && make
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
+      --extra-vars="region=$${REGION} zone=$${ZONE}"\
+      --extra-vars="tcpx_kernel_login=$${TCPX_KERNEL_LOGIN} tcpx_kernel_password=$${TCPX_KERNEL_PASSWORD} keyserver_ubuntu_key=$${KEYSERVER_UBUNTU_KEY} "\
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-highgpu-onspot-slurm.yml"
+  secretEnv: ['TCPX_KERNEL_LOGIN', 'TCPX_KERNEL_PASSWORD', 'KEYSERVER_UBUNTU_KEY']
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_ID}/secrets/tcpx-kernel-ppa-login/versions/latest
+    env: 'TCPX_KERNEL_LOGIN'
+  - versionName: projects/${PROJECT_ID}/secrets/tcpx-kernel-ppa-password/versions/latest
+    env: 'TCPX_KERNEL_PASSWORD'
+  - versionName: projects/${PROJECT_ID}/secrets/keyserver-ubuntu-key/versions/latest
+    env: 'KEYSERVER_UBUNTU_KEY'

--- a/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-onspot-slurm.yml
@@ -1,0 +1,57 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# region, zone, nfs_ip, remote_mount_homefs, must be defined in build file
+# with --extra-vars flag!
+test_name: a3h-onspot-slurm
+deployment_name: a3h-onspot-{{ build }}
+slurm_cluster_name: "a3hsp{{ build[0:5] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml"
+login_node: "{{ slurm_cluster_name }}-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+network: "{{ deployment_name }}-net-0"
+nccl_test_path: "examples/machine-learning/a3-highgpu-8g/nccl-tests"
+sub_network: "{{ deployment_name }}-sub-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
+- test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
+- test-validation/test-nccl.yml
+post_destroy_tasks:
+- post-destroy-tasks/delete-image.yml
+custom_vars:
+  gpu_partition: a3
+  gpu_count: 8
+  partitions:
+  - a3
+  mounts:
+  - /home
+  instance_labels:
+    a3high_onspot: true
+  enable_spot: true
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  tcpx_kernel_login: "{{ tcpx_kernel_login }}"
+  tcpx_kernel_password: "{{ tcpx_kernel_password }}"
+  keyserver_ubuntu_key: "{{ keyserver_ubuntu_key }}"
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+  a3_static_cluster_size: 2
+  a3_partition_name: "a3"
+  a3_enable_spot_vm: true


### PR DESCRIPTION
This PR adds a new integration test to the daily test suite for validating the deployment and functionality of a Slurm cluster on `a3-highgpu-8g` machine types using spot VMs.

This includes:
*   A new Cloud Build configuration (`ml-a3-highgpu-onspot-slurm.yaml`) to trigger the test.
*   A new test definition file (`ml-a3-highgpu-onspot-slurm.yml`) that defines the blueprint, variables, and post-deployment validation steps.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
