### PR TITLE
Remove-auto-trigger-slurm-gcp-v6-simple-job-completion

### DIFF
--- a/tools/cloud-build/provision/pr-tests.tf
+++ b/tools/cloud-build/provision/pr-tests.tf
@@ -13,13 +13,8 @@
 # limitations under the License.
 
 locals {
-  auto_approved_pr_tests = [
-    "slurm-gcp-v6-simple-job-completion"
-  ]
+  auto_approved_pr_tests = []
 
-  no_auto_trigger_tests = [
-    "slurm-gcp-v6-simple-job-completion"
-  ]
 }
 
 
@@ -37,7 +32,7 @@ resource "google_cloudbuild_trigger" "pr_test" {
     owner = "GoogleCloudPlatform"
     name  = "cluster-toolkit"
     pull_request {
-      branch          = contains(local.no_auto_trigger_tests, each.key) ? "no-auto-trigger" : ".*"
+      branch          = ".*"
       comment_control = "COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY"
     }
   }


### PR DESCRIPTION
Because the auto_approved_pr_tests locals list contains "slurm-gcp-v6-simple-job-completion", that job is treated as auto-approved, so it gets triggered without requiring manual approval.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
