### PR TITLE
Update the terraform google provider version in the gke-a4x blueprint

### DIFF
--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -77,7 +77,7 @@ vars:
 terraform_providers:
   google:
     source: hashicorp/google
-    version: 7.2.0
+    version: 7.13.0
     configuration:
       project: $(vars.project_id)
       region: $(vars.region)
@@ -86,7 +86,7 @@ terraform_providers:
 
   google-beta:
     source: hashicorp/google-beta
-    version: 7.2.0
+    version: 7.13.0
     configuration:
       project: $(vars.project_id)
       region: $(vars.region)


### PR DESCRIPTION
The terraform google and google-beta provider versions in the gke-a4x blueprint need to be updated from 7.2.0 to the latest 7.13.0 to set the maintenance exclusion end_time_behavior argument.

Ref PR: #4992 