### PR TITLE
Revert gke-a4x bp changes for maintenance_exclusions

### DIFF
--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -218,12 +218,12 @@ deployment_groups:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
       version_prefix: $(vars.version_prefix)
-      release_channel: REGULAR
+      release_channel: RAPID
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
+        start_time: "2025-04-01T00:00:00Z"
+        end_time: "2026-04-10T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
-        exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       additional_networks:
         $(concat(
           [{


### PR DESCRIPTION
gke-a4x blueprint has additional dependency. So, reverting the maintenance_exclusions edit in this hotfix release.