### PR TITLE
Update maintenance_exclusions in the dws flex start example with A3U machines on GKE

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
@@ -145,12 +145,12 @@ deployment_groups:
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: "1.32."
-      release_channel: RAPID
+      release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2024-12-01T00:00:00Z"
-        end_time: "2025-12-22T00:00:00Z"
+        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
+        exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]
 
   - id: a3-ultragpu-pool


### PR DESCRIPTION
As part of the hotfix-v1.75.1 maintenance_updates, need to update this DWS Flex Start example as well.