### PR TITLE
Update release_channel and exclusion_end_time_behavior in gke-a4x

### DIFF
--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -199,12 +199,12 @@ deployment_groups:
       - cidr_block: $(vars.authorized_cidr)  # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
       version_prefix: $(vars.version_prefix)
-      release_channel: RAPID
+      release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-04-01T00:00:00Z"
-        end_time: "2026-04-10T00:00:00Z"
+        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
+        exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       additional_networks:
         $(concat(
           [{


### PR DESCRIPTION
Updated the release_channel and exclusion_end_time_behavior settings in GKE A4X blueprint. Earlier there was an issue with the specific terraform providers listed in the blueprint. Now it's working after removing the specific providers.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
