### PR TITLE
Add slurm cluster name validation comment

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
@@ -27,7 +27,7 @@ vars:
   tcpx_kernel_password: # use value supplied by Google Cloud staff
   keyserver_ubuntu_key: # use value supplied by Google Cloud staff
   a3_reservation_name: # supply a3-highgpu-8g reservation name
-  slurm_cluster_name: # supply name for slurm cluster
+  slurm_cluster_name: # supply name for slurm cluster (lowercase alphanumeric, max 10 characters, must start with a letter)
   a3_static_cluster_size: # supply a3-highgpu-8g reservation size
   a3_partition_name: # supply partition name
   disk_size_gb: 200

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
@@ -30,7 +30,7 @@ vars:
   enable_nvidia_persistenced: true
   disk_size_gb: 200
   final_image_family: slurm-a3mega
-  slurm_cluster_name: a3mega
+  slurm_cluster_name: a3mega # (lowercase alphanumeric, max 10 characters, must start with a letter)
   a3mega_cluster_size: 2 # supply cluster size
   a3mega_reservation_name: "" # supply reservation name
   # Additional provisioning models (pick only one), can be used to substitute `a3mega_reservation_name`:


### PR DESCRIPTION
### Summary
Adds inline comment to deployment files to inform users of the `slurm_cluster_name` validation requirements before they encounter validation errors.

