### PR TITLE
Enable h4d-vm test to run on Spot VMs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -34,18 +34,32 @@ steps:
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "NUM_NODES=4"
+  - "MACHINE_TYPE=h4d-highmem-192-lssd"
+  - "INSTANCE_PREFIX=h4dsp"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/h4doptions.txt"
   args:
   - -c
   - |
-    set -x -e
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
     cd /workspace && make
-    BUILD_ID_FULL=$BUILD_ID
-    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    REGION=us-central1
-    ZONE=us-central1-a
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT=$${BUILD_ID:0:6}
     BLUEPRINT="/workspace/examples/h4d-vm.yaml"
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
+    sed -i '/  - id: h4d-vms/,/  - id: wait-for-vms/ { /    settings:/a \
+          provisioning_model: "SPOT"
+    }' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/tests/h4d-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/h4d-vm.yml
@@ -19,8 +19,6 @@ test_name: h4d-jbvms
 deployment_name: h4d-jbvms-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/h4d-vm.yaml"
-region: us-central1
-zone: us-central1-a
 network: "{{ test_name }}-net"
 remote_node: "{{ deployment_name }}-0"
 post_deploy_tests:
@@ -29,6 +27,9 @@ post_deploy_tests:
 custom_vars:
   mounts:
   - /home
+  instance_labels:
+    h4d_onspot: true
+  enable_spot: true
 cli_deployment_vars:
   region: "{{ region }}"
   zone: "{{ zone }}"


### PR DESCRIPTION
This pull request enables usage of spot VMs to run tests on h4d machines 

The changes involve two files:
* `tools/cloud-build/daily-tests/builds/h4d-vm.yaml`: This file is updated to include a "SPOT" provisioning model. 
* `tools/cloud-build/daily-tests/tests/h4d-vm.yml`: This file is modified to add instance labels for enabling and identifying Spot VM usage.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
