### PR TITLE
feat(kueue): Add wait: true to Kueue installation

### DIFF
--- a/examples/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu.yaml
@@ -107,5 +107,6 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        wait: true
       jobset:
         install: true

--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -173,6 +173,7 @@ deployment_groups:
           cronjob_schedule: $(vars.health_check_schedule)
       kueue:
         install: true
+        wait: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a3_megagpu_pool.static_gpu_count)

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -310,6 +310,7 @@ deployment_groups:
           cronjob_schedule: $(vars.health_check_schedule)
       kueue:
         install: true
+        wait: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a3-ultragpu-pool.static_gpu_count)

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -326,6 +326,7 @@ deployment_groups:
           cronjob_schedule: $(vars.health_check_schedule)
       kueue:
         install: true
+        wait: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a4-pool.static_gpu_count)


### PR DESCRIPTION
This pull request introduces a change to the Kueue installation process. By adding the `wait: true` parameter to the `kueue` settings, we ensure that the deployment process pauses until the Kueue installation is fully complete before proceeding. This helps prevent potential race conditions and ensures that all dependent components can reliably interact with a fully functional Kueue service upon startup.

This change affects the following blueprints:
* `gke-a3-highgpu.yaml`
* `gke-a3-megagpu/gke-a3-megagpu.yaml`
* `gke-a3-ultragpu/gke-a3-ultragpu.yaml`
* `gke-a4/gke-a4.yaml`

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
