### PR TITLE
Adding G4 configuration

### DIFF
--- a/modules/internal/gpu-definition/main.tf
+++ b/modules/internal/gpu-definition/main.tf
@@ -73,6 +73,10 @@ locals {
     "g2-standard-32"        = { type = "nvidia-l4", count = 1 },
     "g2-standard-48"        = { type = "nvidia-l4", count = 4 },
     "g2-standard-96"        = { type = "nvidia-l4", count = 8 },
+    "g4-standard-48"        = { type = "nvidia-rtx-pro-6000", count = 1 },
+    "g4-standard-96"        = { type = "nvidia-rtx-pro-6000", count = 2 },
+    "g4-standard-192"       = { type = "nvidia-rtx-pro-6000", count = 4 },
+    "g4-standard-384"       = { type = "nvidia-rtx-pro-6000", count = 8 },
   }
   generated_guest_accelerator = try([local.accelerator_machines[var.machine_type]], [])
 


### PR DESCRIPTION

This change updates the accelerator_machines map in modules/internal/gpu-definition/main.tf to include the new G4 series machine types ([ source](https://github.com/GoogleCloudPlatform/cluster-toolkit/compare/develop...LAVEEN:cluster-toolkit:g4addconfig?content_ref=modules+internal+gpu+definition+main+tf)). These machines are powered by the NVIDIA RTX PRO 6000 GPU.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
