### PR TITLE
Enable TPU v6e daily tests to run on Spot VMs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -35,13 +35,29 @@ steps:
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "MACHINE_TYPE=tpu"
+  - "TPU_RUNTIME_VERSION=v2-alpha-tpuv6e"
+  - "ACCELERATOR_TYPE=v6e-16"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "NUM_NODES=2"
+  - "INSTANCE_PREFIX=v6esp"
+  - "BUILD_ID=$BUILD_ID"
+  - "OPTIONS_GCS_PATH=gs://hpc-ctk1357/tpuv6eoptions.txt"
   args:
   - -c
   - |
-    set -x -e
+    set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
     cd /workspace && make
-    BUILD_ID_FULL=$BUILD_ID
-    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
+
     EXAMPLE_BP=examples/gke-tpu-v6/gke-tpu-v6.yaml
     # adding vm to act as remote node
     echo '  - id: remote-node'                                                            >> $${EXAMPLE_BP}
@@ -64,6 +80,9 @@ steps:
     echo '      node_count: 1'                                                             >> $${EXAMPLE_BP}
     echo '    outputs: [instructions]'                                                     >> $${EXAMPLE_BP}
 
+    sed -i -e '/reservation_affinity:/,+3c\      spot: true' $${EXAMPLE_BP}
+    sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
@@ -18,11 +18,8 @@ deployment_name: gke-tpu-v6e-{{ build }}
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-tpu-v6/gke-tpu-v6.yaml"
 network: "{{ deployment_name }}-net-0"
-region: us-central2
-zone: us-central2-b
 remote_node: "{{ deployment_name }}-remote-node-0"
 machine_type: ct6e-standard-4t
-extended_reservation: cloudtpu-20251024020500-953082093
 num_slices: 1
 tpu_topology: 2x2
 static_node_count: 1
@@ -34,9 +31,11 @@ cli_deployment_vars:
   tpu_topology: "{{ tpu_topology }}"
   static_node_count: "{{ static_node_count }}"
   authorized_cidr: "{{ build_ip.stdout }}/32"
-  reservation: "{{ extended_reservation }}"
 custom_vars:
   project: "{{ project }}"
   expected_tpu_count: 4
+  instance_labels:
+    tpuv6e_onspot: true
+  enable_spot: true
 post_deploy_tests:
 - test-validation/test-gke-tpu.yml


### PR DESCRIPTION
This PR updates the GKE TPU v6e daily test pipeline to support running on Spot VMs and enables dynamic zone selection.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
