### PR TITLE
Adding re-try for add ssh key step in test infra

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -146,6 +146,15 @@
         - --ttl
         - 2h
         - "--key-file=/builder/home/.ssh/id_rsa.pub"
+      retries: 5
+      delay: 10
+      until: key_created.rc == 0
+      ignore_errors: yes
+
+    - name: Fail if SSH key add failed after retries
+      ansible.builtin.fail:
+        msg: "Failed to add SSH key to OS Login after multiple retries: {{ key_created.stderr }}"
+      when: key_created.rc != 0
 
     - name: Add Login node as host
       ansible.builtin.add_host:


### PR DESCRIPTION
**What**: This change adds resiliency to a step in base ansible playbook responsible for adding ssh keys to os-login.

**Why**: There was a transient issue encountered during integration test stating: "Multiple concurrent mutations" error on the gcloud compute os-login ssh-keys add command executed via "Add SSH Keys to OS-Login" step. This happens when multiple processes try to modify the OS Login profile of the same user (in this case, the Cloud Build service account) at the same time. Hence, adding re-tries and a better failure handling of this step in playbook thereby removing transient error during test run.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
