### PR TITLE
Modifying fetching method of slurm state job

### DIFF
--- a/tools/python-integration-tests/slurm_simple_job_completion.py
+++ b/tools/python-integration-tests/slurm_simple_job_completion.py
@@ -33,7 +33,7 @@ class SlurmSimpleJobCompletionTest(test.SlurmTest):
         for job_id in job_ids:
             state = self.job_state(job_id)
             self.assertIn("COMPLETED", state, f"Job {job_id} did not complete successfully. Final state is {state}.")
-            print(f"JobID {job_id} finished successfully.")
+            log.info(f"JobID {job_id} finished successfully.")
 
     def wait_until_squeue_is_empty(self):
         while True:


### PR DESCRIPTION
**What is the change**
This change modifies the way the slurm job status is fetched in the slurm_simple_job_completion.py script. This script is used in multiple integration tests to trigger jobs on slurm cluster and validate jobs completed successfully.

**Why is it needed**
There were transient test failures because the job status could not be fetched. This is because the command used within the job_state function to fetch the job status returned an empty list of jobs (json.loads(stdout)["jobs"] is empty). The script expected to find details for a specific job_id, but none were found. This transient issue that can happen if the job completes and is purged from the slurm controller's active memory before the test has a chance to check its final state.

**Fix done**
Fixing this issue by using sacct instead of scontrol.
scontrol queries the state of jobs that are currently active or recently completed in the Slurm controller's memory. If a job finishes and is quickly purged, scontrol will find no record of it, leading to the IndexError (race condition).
sacct queries the slurm accounting database, which stores a historical record of all jobs. It is specifically designed to get the final status, exit code, and resource usage of jobs that have already finished.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
