### PR TITLE
vpc module version update

### DIFF
--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -175,7 +175,7 @@ limitations under the License.
 |------|--------|---------|
 | <a name="module_cloud_router"></a> [cloud\_router](#module\_cloud\_router) | terraform-google-modules/cloud-router/google | ~> 7.3 |
 | <a name="module_nat_ip_addresses"></a> [nat\_ip\_addresses](#module\_nat\_ip\_addresses) | terraform-google-modules/address/google | ~> 4.1 |
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 12.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 13.0 |
 
 ## Resources
 

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -180,7 +180,7 @@ resource "terraform_data" "network_profile_firewall_validation" {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   depends_on = [terraform_data.network_profile_firewall_validation]
 


### PR DESCRIPTION
Earlier, GCP ignored these BGP fields in LEGACY mode and VPC creation succeeded, but now GCP strictly validates them and throws an error, this is fixed in VPC module v13 by setting these fields only when STANDARD mode is used.

Advanced BGP fields are set only when mode = STANDARD
They are omitted when mode = LEGACY

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
