### PR TITLE
feat: add validation for BLOCK_SIZE

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
@@ -230,3 +230,9 @@ def test_gen_cloud_gres_conf_lines(mock_slurm_version, cfg, gputype, gpucount, w
     # mock nodelist to be smaller
     lkp.nodelist = mock.Mock(return_value="m22-turbo-[0-4]")  # type: ignore[method-assign]
     assert conf.gen_cloud_gres_conf_lines(lkp) == want
+
+
+def test_block_size_is_power_of_two():
+    """Verify that BLOCK_SIZE is a power of two."""
+    block_size = conf.BLOCK_SIZE
+    assert block_size > 0 and (block_size & (block_size - 1) == 0)


### PR DESCRIPTION
Added a test to ensure that the value of BLOCK_SIZE used in the file @community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py is always a power of 2.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
