### PR TITLE
Switch to using gcsfuse profile feature in aiml gcs-bucket mounts in slurm cluster blueprints

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -359,6 +359,8 @@ deployment_groups:
   # (Optional) The following creates a GCS bucket that will be mounted
   # using gcsfuse. If you prefer to use a pre-existing bucket, use the
   # modules/file-system/pre-existing-network-storage module.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
   - id: gcs_bucket
     source: modules/file-system/cloud-storage-bucket
     settings:
@@ -378,6 +380,8 @@ deployment_groups:
   # local-ssd for and enables parallel downloads.  For more information on
   # these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_checkpoints
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -399,6 +403,10 @@ deployment_groups:
   # file-cache-max-size-mb=<DATASET_SIZE>,\
   # file-cache-cache-file-for-range-read=true,\
   # to the mount_options.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_training_data
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -413,6 +421,8 @@ deployment_groups:
   # (Optional) Create a mount-point optimized for model serving.
   # For more information on these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_model_serving
     source: modules/file-system/pre-existing-network-storage
     settings:

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -363,6 +363,8 @@ deployment_groups:
   # (Optional) The following creates a GCS bucket that will be mounted
   # using gcsfuse. If you prefer to use a pre-existing bucket, use the
   # modules/file-system/pre-existing-network-storage module.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
   - id: gcs_bucket
     source: modules/file-system/cloud-storage-bucket
     settings:
@@ -382,6 +384,8 @@ deployment_groups:
   # local-ssd for and enables parallel downloads.  For more information on
   # these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_checkpoints
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -403,6 +407,10 @@ deployment_groups:
   # file-cache-max-size-mb=<DATASET_SIZE>,\
   # file-cache-cache-file-for-range-read=true,\
   # to the mount_options.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_training_data
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -417,6 +425,8 @@ deployment_groups:
   # (Optional) Create a mount-point optimized for model serving.
   # For more information on these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_model_serving
     source: modules/file-system/pre-existing-network-storage
     settings:

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -374,6 +374,8 @@ deployment_groups:
   # (Optional) The following creates a GCS bucket that will be mounted
   # using gcsfuse. If you prefer to use a pre-existing bucket, use the
   # modules/file-system/pre-existing-network-storage module.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
   - id: gcs_bucket
     source: modules/file-system/cloud-storage-bucket
     settings:
@@ -393,6 +395,8 @@ deployment_groups:
   # local-ssd for and enables parallel downloads.  For more information on
   # these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_checkpoints
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -414,6 +418,10 @@ deployment_groups:
   # file-cache-max-size-mb=<DATASET_SIZE>,\
   # file-cache-cache-file-for-range-read=true,\
   # to the mount_options.
+  # For more information on these flags, see
+  # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_training_data
     source: modules/file-system/pre-existing-network-storage
     settings:
@@ -428,6 +436,8 @@ deployment_groups:
   # (Optional) Create a mount-point optimized for model serving.
   # For more information on these flags, see
   # https://github.com/GoogleCloudPlatform/gcsfuse/tree/master/samples/gcsfuse_config
+  # and
+  # https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations
   - id: gcs_model_serving
     source: modules/file-system/pre-existing-network-storage
     settings:


### PR DESCRIPTION
### Description

- This PR uses GCSFuse `profile` parameter to replace the more fine-grained cache and config control parameters in the slurm cluster blueprints for A3-ultra, A4x-high, and A4-high node types for all the aiml workload bucket mount options. This makes the mount options in blueprints shorter and easier to maintain, as GCSFuse automatically sets the optimal value for the parameter based on the profile value ([details](https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/profile-based-configurations)).
- This also replaces `-` with `_` in the gcsfuse mount_options in the changed blueprints, as these mount-options are copied directly to /etc/fstab file for mount, and it's required to use `_` instead of `-` in gcsfuse mount-options in such a case ([persistent mounting documentation](https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/mount-bucket#persistent-mount))
- Manual testing done
  - Launched and tested the gcsfuse mounts in a slurm cluster for machine-type `a3-ultragpu-8g`, and it reflected in the flags applied correctly on a compute node.
  - Launched and tested the gcsfuse mount in a slurm cluster for machine-type `a4-highgpu-8g`, and it reflected in the mount logs and the file operations correctly in the mounted directories on the compute node.
  - Testing pending on A4X

**Note**: Found couple of unrelated issues.
1. Got error `Mounting failed as local mount: /gcs-checkpoints was already in use in fstab` seems to indicate that the srun command causes the mounts to be added to /etc/fstab again, which fails as expected. Not sure if this is a bug or is expected.
2. During `mv` operations in the gcsfuse mounts in the slurm compute node, I got errors `mv: preserving times for '/gcs/sample_1GB_renamed.txt': Operation not permitted` and `mv: preserving permissions for ‘/gcs/sample_1GB_renamed.txt’: Operation not permitted` which are expected errors because gcsfuse mount isn't fully POSIX-compliant and doesn't support file permissions changes, or preserving/propagation system times other than the modification time. But these errors showed up here because mv command tries to do both these operations and they fail. The `mv` command itself completes with exit-code 0 as expected.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main) - DONE
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development) - Not sure what do here.
* Confirm that "make tests" passes all tests - DONE
* Add or modify unit tests to cover code changes - NOT APPLICABLE
* Ensure that unit test coverage remains above 80% - NOT APPLICABLE
* Update all applicable documentation - NOT APPLICABLE
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing) - DONE
