### PR TITLE
fix: allow overriding MIN_NODES in find_available_zone.sh

### DIFF
--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -17,7 +17,7 @@ BUILD_ID_SHORT="${BUILD_ID:0:6}"
 PROVISIONING_MODEL="SPOT"
 TERMINATION_ACTION="DELETE"
 FULL_INSTANCE_PREFIX="${INSTANCE_PREFIX}-${BUILD_ID_SHORT}-"
-MIN_NODES=2 # Define minimum number of nodes required
+MIN_NODES="${MIN_NODES:-2}" # Define minimum number of nodes required
 
 generate_instance_names() {
 	local prefix=$1


### PR DESCRIPTION
This PR updates the tools/cloud-build/find_available_zone.sh script to allow the MIN_NODES variable to be overridden via an environment variable

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
