### PR TITLE
Add filestore integration to TPU v6e as a storage support

### DIFF
--- a/examples/gke-tpu-v6/README.md
+++ b/examples/gke-tpu-v6/README.md
@@ -143,7 +143,7 @@ The [tpu-multislice.yaml](https://github.com/GoogleCloudPlatform/cluster-toolkit
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials gke-tpu-v6 --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials gke-tpu-v6 --region=REGION --project=PROJECT_ID
     ```
 
     Replace the `REGION` and `PROJECT_ID` with the ones used in the blueprint.
@@ -288,7 +288,7 @@ After making these changes, run the `gcluster deploy` command as usual.
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project=PROJECT_ID
     ```
 
     Replace the `DEPLOYMENT_NAME`,`REGION` and `PROJECT_ID` with the ones used in the blueprint.
@@ -331,7 +331,7 @@ The blueprint includes a sample job (`shared-fs-job`) that demonstrates how two 
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project=PROJECT_ID
     ```
 
     Replace the `DEPLOYMENT_NAME`,`REGION` and `PROJECT_ID` with the ones used in the blueprint.

--- a/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
+++ b/examples/gke-tpu-v6/gke-tpu-v6-advanced.yaml
@@ -494,16 +494,17 @@ deployment_groups:
   #       SHARED_DIR=/mnt/v6e-filestore
   #       mkdir -p $SHARED_DIR
   #       cd $SHARED_DIR
-
+  #
   #       # Simulate some work and write to a shared file
   #       cmd="date +%s"
   #       TIMESTAMP=`$cmd`
   #       echo "Pod ${HOSTNAME} writing data at $$TIMESTAMP" >> shared_output.txt
+  #       sleep 5
   #       echo "Displaying content of shared_output.txt:"
   #       echo "---"
   #       cat shared_output.txt # Read the content to show it's shared
   #       echo "---"
-  #       sleep 120
+  #       sleep 20
   #       echo "Pod ${HOSTNAME} finished."
   #     node_count: 2
   #   outputs: [instructions]


### PR DESCRIPTION
This updates the TPU v6e example to document and test Filestore: README additions and a sample shared-fs job. It also enables filestore CSI driver in the advanced blueprint and adds commented modules/PV/job templates for provisioning and validating a shared Filestore mount.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
