### PR TITLE
Add filestore as a storage support option for TPU 7x

### DIFF
--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -296,7 +296,7 @@ Once deployed, the `Lustre` filesystem is available to the cluster as a `Persist
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project=PROJECT_ID
     ```
 
    Replace the `DEPLOYMENT_NAME`,`REGION` and `PROJECT_ID` with the ones used in the blueprint.
@@ -367,7 +367,7 @@ After making these changes, run the `gcluster deploy` command as usual.
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project=PROJECT_ID
     ```
 
    Replace the `DEPLOYMENT_NAME`,`REGION` and `PROJECT_ID` with the ones used in the blueprint.
@@ -409,7 +409,7 @@ The blueprint includes a sample job (`shared-fs-job`) that demonstrates how two 
 1. Connect to your cluster:
 
     ```sh
-    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project_id=PROJECT_ID
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region=REGION --project=PROJECT_ID
     ```
 
     Replace the `DEPLOYMENT_NAME`,`REGION` and `PROJECT_ID` with the ones used in the blueprint.

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -457,42 +457,43 @@ deployment_groups:
   #   outputs: [instructions]
 
   # # --- FILESTORE ADDITIONS ---
-  - id: filestore
-    source: modules/file-system/filestore
-    use: [gke-tpu-7x-net-0]
-    settings: {local_mount: /mnt/7x-filestore}
+  # - id: filestore
+  #   source: modules/file-system/filestore
+  #   use: [gke-tpu-7x-net-0]
+  #   settings: {local_mount: /mnt/7x-filestore}
 
-  - id: shared-filestore-pv
-    source: modules/file-system/gke-persistent-volume
-    use: [gke-tpu-7x-cluster, filestore]
+  # - id: shared-filestore-pv
+  #   source: modules/file-system/gke-persistent-volume
+  #   use: [gke-tpu-7x-cluster, filestore]
 
-  # Shared Filestore Job
-  - id: shared-fs-job
-    source: modules/compute/gke-job-template
-    use:
-    - gke-tpu-7x-cluster
-    - gke-tpu-7x-pool
-    - shared-filestore-pv
-    settings:
-      image: alpine/git:latest
-      command:
-      - sh
-      - -c
-      - |
-        echo "Pod ${HOSTNAME} is starting..."
-        SHARED_DIR=/mnt/7x-filestore
-        mkdir -p $SHARED_DIR
-        cd $SHARED_DIR
+  # # Shared Filestore Job
+  # - id: shared-fs-job
+  #   source: modules/compute/gke-job-template
+  #   use:
+  #   - gke-tpu-7x-cluster
+  #   - gke-tpu-7x-pool
+  #   - shared-filestore-pv
+  #   settings:
+  #     image: alpine/git:latest
+  #     command:
+  #     - sh
+  #     - -c
+  #     - |
+  #       echo "Pod ${HOSTNAME} is starting..."
+  #       SHARED_DIR=/mnt/7x-filestore
+  #       mkdir -p $SHARED_DIR
+  #       cd $SHARED_DIR
 
-        # Simulate some work and write to a shared file
-        cmd="date +%s"
-        TIMESTAMP=`$cmd`
-        echo "Pod ${HOSTNAME} writing data at $$TIMESTAMP" >> shared_output.txt
-        echo "Displaying content of shared_output.txt:"
-        echo "---"
-        cat shared_output.txt # Read the content to show it's shared
-        echo "---"
-        sleep 120
-        echo "Pod ${HOSTNAME} finished."
-      node_count: 2
-    outputs: [instructions]
+  #       # Simulate some work and write to a shared file
+  #       cmd="date +%s"
+  #       TIMESTAMP=`$cmd`
+  #       echo "Pod ${HOSTNAME} writing data at $$TIMESTAMP" >> shared_output.txt
+  #       sleep 5
+  #       echo "Displaying content of shared_output.txt:"
+  #       echo "---"
+  #       cat shared_output.txt # Read the content to show it's shared
+  #       echo "---"
+  #       sleep 20
+  #       echo "Pod ${HOSTNAME} finished."
+  #     node_count: 2
+  #   outputs: [instructions]


### PR DESCRIPTION
This updates the TPU 7x example to document and test Filestore: README additions and a sample shared-fs job. It also enables filestore CSI driver in the advanced blueprint and adds commented modules/PV/job templates for provisioning and validating a shared Filestore mount.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
