### PR TITLE
rdma vpc & firewall module version update

### DIFF
--- a/modules/network/firewall-rules/README.md
+++ b/modules/network/firewall-rules/README.md
@@ -83,7 +83,7 @@ limitations under the License.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_firewall_rule"></a> [firewall\_rule](#module\_firewall\_rule) | terraform-google-modules/network/google//modules/firewall-rules | ~> 12.0 |
+| <a name="module_firewall_rule"></a> [firewall\_rule](#module\_firewall\_rule) | terraform-google-modules/network/google//modules/firewall-rules | ~> 13.0 |
 
 ## Resources
 

--- a/modules/network/firewall-rules/main.tf
+++ b/modules/network/firewall-rules/main.tf
@@ -51,7 +51,7 @@ resource "terraform_data" "pga_check" {
 
 module "firewall_rule" {
   source       = "terraform-google-modules/network/google//modules/firewall-rules"
-  version      = "~> 12.0"
+  version      = "~> 13.0"
   project_id   = local.effective_project_id
   network_name = local.effective_network_name
 

--- a/modules/network/gpu-rdma-vpc/README.md
+++ b/modules/network/gpu-rdma-vpc/README.md
@@ -103,7 +103,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 12.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 13.0 |
 
 ## Resources
 

--- a/modules/network/gpu-rdma-vpc/main.tf
+++ b/modules/network/gpu-rdma-vpc/main.tf
@@ -63,7 +63,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-google-modules/network/google"
-  version = "~> 12.0"
+  version = "~> 13.0"
 
   network_name                           = local.network_name
   project_id                             = var.project_id


### PR DESCRIPTION
Earlier, GCP ignored these BGP fields in LEGACY mode and VPC creation succeeded, but now GCP strictly validates them and throws an error, this is fixed in VPC module v13 by setting these fields only when STANDARD mode is used.

Advanced BGP fields are set only when mode = STANDARD
They are omitted when mode = LEGACY

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
