### PR TITLE
Add precondition checks to disallow setting conflicting consumption options

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -391,8 +391,16 @@ resource "google_container_node_pool" "node_pool" {
       error_message = "enable_flex_start only works with reservation_affinity consume_reservation_type NO_RESERVATION."
     }
     precondition {
-      condition     = var.enable_flex_start == true ? (var.spot == false) : true
+      condition     = !(var.enable_flex_start && var.spot)
       error_message = "Both enable_flex_start and spot consumption option cannot be set to true at the same time."
+    }
+    precondition {
+      condition     = !(var.enable_queued_provisioning && var.spot)
+      error_message = "Both enable_queued_provisioning and spot consumption option cannot be set to true at the same time."
+    }
+    precondition {
+      condition     = var.spot == true ? (var.reservation_affinity.consume_reservation_type == "NO_RESERVATION") : true
+      error_message = "Spot consumption option only works with reservation_affinity consume_reservation_type NO_RESERVATION."
     }
   }
 }


### PR DESCRIPTION
Problem: The blueprint validator did not prevent a user from configuring a GKE node pool with a few conflicting consumption options. While these combinations are syntactically valid in the blueprint, it results in a `badRequest` error from the GKE API during terraform apply. This lead to wasted time deploying and debugging, as the failure occurs late in the terraform apply process. 

Solution : In this PR, we added precondition checks to prevent conflicting combinations during the blueprint check/generate phase itself for the following:

- Both `spot: true` and `enable_queued_provisioning: true` options cannot be set at the same time. 
- If Spot consumption option is enabled (`spot: true`), then reservation should not be set.

Tested these changes locally.

