### PR TITLE
Enable nccl test in A3Ultra post_deploy_tests

### DIFF
--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
@@ -23,7 +23,7 @@ blueprint_yaml: "{{ workspace }}/examples/machine-learning/a3-ultragpu-8g/a3ultr
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 network: "{{ test_name }}-net-0"
-nccl_test_path: "examples/machine-learning/a3-ultragpus-8g/nccl-tests"
+nccl_test_path: "examples/machine-learning/a3-ultragpu-8g/nccl-tests"
 post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-partitions.yml


### PR DESCRIPTION
Enable the NCCL validation test into the automated daily post-deployment test suite for A3Ultra GPU instances.