### PR TITLE
Fix: Update gcluster help message to use correct product name

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,8 +46,7 @@ var (
 	rootCmd    = &cobra.Command{
 		Use:   "gcluster",
 		Short: "A blueprint and deployment engine for HPC clusters in GCP.",
-		Long: `gHPC provides a flexible and simple to use interface to accelerate
-HPC deployments on the Google Cloud Platform.`,
+		Long:  `Google Cloud Cluster Toolkit is an open source tool that makes it easy to create and manage repeatable AI/ML and HPC clusters on Google Cloud.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := cmd.Help(); err != nil {
 				logging.Fatal("cmd.Help function failed: %s", err)


### PR DESCRIPTION
The help message in the gcluster root command was using the outdated term "gHPC". This commit updates the long description to use the correct product name "Google Cloud Cluster Toolkit" and clarifies its purpose for AI/ML and HPC clusters.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
