### PR TITLE
Modifying timeout for managed lustre module

### DIFF
--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -35,6 +35,7 @@ locals {
   mount_options    = var.mount_options
   instance_id      = var.name != null ? var.name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
   destination_path = "/"
+  lustre_timeout   = contains([125, 250], var.per_unit_storage_throughput) ? "2h" : "1h"
 
   install_managed_lustre_client_runner = {
     "type"        = "shell"
@@ -75,9 +76,9 @@ resource "google_lustre_instance" "lustre_instance" {
   gke_support_enabled = var.gke_support_enabled
 
   timeouts {
-    create = contains([125, 250], var.per_unit_storage_throughput) ? "2h" : "1h"
-    update = contains([125, 250], var.per_unit_storage_throughput) ? "2h" : "1h"
-    delete = contains([125, 250], var.per_unit_storage_throughput) ? "2h" : "1h"
+    create = local.lustre_timeout
+    update = local.lustre_timeout
+    delete = local.lustre_timeout
   }
 
   depends_on = [var.private_vpc_connection_peering, data.google_storage_bucket.lustre_import_bucket]


### PR DESCRIPTION
It was observed during testing of all the Managed Lustre tiers that certain tiers of managed lustre take more than 1hr to deploy. Hence, this change makes the timeout conditional based on the tier of Managed Lustre instead of a hardcoded 1hr value.
Details:
Tiers: 125 MBps per TiB and 250 MBps per TiB take more than 1hr to deploy.
Tiers: 500 MBps per TiB and 1000 MBps per TiB take less than 1hr to deploy.

This change configures the timeout based on the tier provided as input.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
