### PR TITLE
Update integration test destory command with --robust flag

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -123,7 +123,7 @@
       register: gcluster_destroy
       changed_when: gcluster_destroy.changed
       ignore_errors: true
-      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --auto-approve
+      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --robust --auto-approve
       args:
         chdir: "{{ workspace }}"
       environment:
@@ -184,7 +184,7 @@
       register: gcluster_destroy
       changed_when: gcluster_destroy.changed
       ignore_errors: true
-      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --auto-approve
+      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --robust --auto-approve
       args:
         chdir: "{{ workspace }}"
       environment:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
@@ -38,7 +38,7 @@
       register: gcluster_destroy
       changed_when: gcluster_destroy.changed
       ignore_errors: true
-      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --auto-approve
+      ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --robust --auto-approve
       args:
         chdir: "{{ workspace }}"
       environment:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_gcluster_failure.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_gcluster_failure.yml
@@ -37,7 +37,7 @@
     register: gcluster_destroy
     changed_when: gcluster_destroy.changed
     run_once: true
-    ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --auto-approve
+    ansible.builtin.command: ./gcluster destroy {{ deployment_name }} --robust --auto-approve
     # Temporarily add retry due to K8S deletion issue.
     until: gcluster_destroy.rc == 0
     retries: 1


### PR DESCRIPTION
With the `--robust` flag support with the `gcluster destroy` command, the destroy commands linked to integration tests can also be updated to improve failures due to destroy failures.