### PR TITLE
Add gIB versions v1.1.1 and v1.1.0 for arm64

### DIFF
--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -331,7 +331,7 @@ deployment_groups:
         path: $(vars.gib_installer_path)
         template_vars:
           image: "us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64"
-          version: v1.0.7
+          version: v1.1.0
           accelerator_count: 4
           node_affinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -27,7 +27,7 @@ locals {
   # For details refer the official change log https://github.com/kubernetes-sigs/jobset/releases
   jobset_supported_versions    = ["0.10.1", "0.10.0", "0.9.1", "0.9.0"]
   gib_supported_versions_x86   = ["v1.0.2", "v1.0.3", "v1.0.5", "v1.0.6", "v1.1.0"]
-  gib_supported_versions_arm64 = ["v1.0.7"]
+  gib_supported_versions_arm64 = ["v1.1.1", "v1.1.0", "v1.0.7"]
   gib_supported_versions = var.target_architecture == "arm64" ? (
     local.gib_supported_versions_arm64
     ) : (


### PR DESCRIPTION
Update kubectl-apply module to include latest gIB versions for ARM64

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
