### PR TITLE
Update wait flag to overcome destruction failure with kueue

### DIFF
--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -326,7 +326,8 @@ deployment_groups:
           cronjob_schedule: $(vars.health_check_schedule)
       kueue:
         install: true
-        wait: false
+        wait: false # Set to false to overcome an intermittent destruction failure
+                    # where 'helm uninstall' can time out.
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a4-pool.static_gpu_count)


### PR DESCRIPTION
The GKE A4 integration test passes its functional validation but fails during the infrastructure destruction phase due to a timeout while uninstalling the Kueue workload manager. This is an intermittent failure.