### PR TITLE
feat: add regional quota availability validator

### DIFF
--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -19,13 +19,11 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
-	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
-	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
@@ -243,80 +241,6 @@ func testZoneInRegion(bp config.Blueprint, inputs config.Dict) error {
 		return err
 	}
 	return TestZoneInRegion(m["project_id"], m["zone"], m["region"])
-}
-
-// TestIAMPolicyBindingExists checks for a specific IAM binding, resolving project numbers automatically.
-func TestIAMPolicyBindingExists(hostProjectID string, serviceProjectID string, role string) error {
-	ctx := context.Background()
-	s, err := cloudresourcemanager.NewService(ctx)
-	if err != nil {
-		return handleClientError(err)
-	}
-
-	// 1. Resolve Service Project Number to construct the member string
-	// This makes it generic so you don't need to hardcode the project number.
-	project, err := s.Projects.Get(serviceProjectID).Do()
-	if err != nil {
-		return fmt.Errorf("failed to get service project %s: %v", serviceProjectID, handleClientError(err))
-	}
-	member := fmt.Sprintf("serviceAccount:%d-compute@developer.gserviceaccount.com", project.ProjectNumber)
-
-	// 2. Fetch IAM policy for the Host Project
-	policy, err := s.Projects.GetIamPolicy(hostProjectID, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
-	if err != nil {
-		return fmt.Errorf("failed to get IAM policy for host project %s: %v", hostProjectID, handleClientError(err))
-	}
-
-	// 3. Verify the binding exists
-	for _, binding := range policy.Bindings {
-		if binding.Role == role {
-			for _, m := range binding.Members {
-				if m == member {
-					return nil // Success: Binding confirmed
-				}
-			}
-		}
-	}
-
-	return fmt.Errorf("IAM binding for role %q and member %q not found in project %q", role, member, hostProjectID)
-}
-
-// testIAMPolicyBindingExists extracts inputs and only runs if a shared reservation is detected
-func testIAMPolicyBindingExists(bp config.Blueprint, inputs config.Dict) error {
-	m, err := inputsAsStrings(inputs)
-	if err != nil {
-		return err
-	}
-
-	resName := m["reservation_name"]
-
-	// Handle conditional execution: Only run if it's a shared reservation path.
-	// Shared reservation format: "projects/<project-id>/reservations/<name>"
-	// Normal reservation format: "reservation-name"
-	if !strings.HasPrefix(resName, "projects/") {
-		fmt.Printf("skipping IAM binding check: %q is not a shared reservation path", resName)
-		return nil // Success: Skip validation for local reservations
-	}
-
-	// 1. Extract Host Project ID from the shared reservation path
-	re := regexp.MustCompile(`^projects/([^/]+)/`)
-	matches := re.FindStringSubmatch(resName)
-	if len(matches) <= 1 {
-		fmt.Printf("skipping IAM binding check: could not parse project ID from %q", resName)
-		return nil
-	}
-	hostProjectID := matches[1]
-
-	// 2. Extract other required fields
-	serviceProjectID := m["service_project_id"]
-	role := m["role"]
-
-	if serviceProjectID == "" || role == "" {
-		return fmt.Errorf("validator %s requires 'service_project_id' and 'role'", "test_iam_policy_binding_exists")
-	}
-
-	// 3. Invoke core validation logic
-	return TestIAMPolicyBindingExists(hostProjectID, serviceProjectID, role)
 }
 
 // getFloat64 safely converts a cty.Value to a float64, handling marks and strings

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -54,7 +54,6 @@ const (
 	testZoneInRegionName              = "test_zone_in_region"
 	testModuleNotUsedName             = "test_module_not_used"
 	testDeploymentVariableNotUsedName = "test_deployment_variable_not_used"
-	testIAMPolicyBindingExistsName    = "test_iam_policy_binding_exists"
 	testQuotaAvailabilityName         = "test_quota_availability"
 )
 
@@ -67,7 +66,6 @@ func implementations() map[string]func(config.Blueprint, config.Dict) error {
 		testZoneInRegionName:              testZoneInRegion,
 		testModuleNotUsedName:             testModuleNotUsed,
 		testDeploymentVariableNotUsedName: testDeploymentVariableNotUsed,
-		testIAMPolicyBindingExistsName:    testIAMPolicyBindingExists,
 		testQuotaAvailabilityName:         testQuotaAvailability,
 	}
 }

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -26,7 +26,7 @@ run_test() {
 	exampleFile=$(basename "$example")
 	DEPLOYMENT=$(echo "${exampleFile%.yaml}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
 	PROJECT="invalid-project"
-	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_iam_policy_binding_exists,test_quota_availability"
+	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability"
 	GHPC_PATH="${cwd}/ghpc"
 	BP_PATH="${cwd}/${example}"
 	# Cover the three possible starting sequences for local sources: ./ ../ /


### PR DESCRIPTION
Description
This PR introduces the test_quota_availability validator to the Cluster Toolkit. This validator proactively checks if a target Google Cloud project and region have sufficient quotas for requested resources before Terraform begins provisioning infrastructure.

Why is this needed?
Large HPC deployments often fail mid-way through a 10-20 minute Terraform run because the project lacks enough vCPU, GPU, or Persistent Disk quota. This validator eliminates this "fail-late" scenario by verifying requirements during the gcluster create phase.

Key Functionalities
1. Resource Aggregation: It automatically scans all modules in a blueprint to sum up the total requested counts for CPUs, GPUs, and Persistent Disks.
2. GCP API Integration: It queries the compute.v1 API to retrieve real-time regional quota limits and current usage.
3. Intelligent Logic:
Compares (Current Usage+Blueprint Request) against the project limit
Supports overrides via validator inputs for specific machine types or cluster sizes
Provides high-precision error messages that show the exact Requested, Available, Limit, and Usage values.

How to use
Add the validator to the validators section of your blueprint:

validators:
  - validator: test_quota_availability
    inputs:
      project_id: $(vars.project_id)
      region: $(vars.region)
      a3mega_cluster_size: $(vars.a3mega_cluster_size)
      machine_type: $(vars.machine_type)
      disk_size_gb: $(vars.disk_size_gb)

Testing Scenarios Covered
The validator has been verified against the following cases:

1. Insufficient CPU Quota: Correctly identifies when total vCPUs exceed regional limits.
2. Insufficient GPU Quota: Specifically maps accelerator types (e.g., A100 80GB) to their respective quota metrics.
3. Massive Disk Requests: Flags scenarios where requested persistent disk space exceeds the project's standard 100 TiB limit.
4. Error Handling: Confirms failure if an invalid project ID or region is provided.
5. Data Types: Handles both numeric and string-quoted variables from HCL/YAML without panicking.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
