### PR TITLE
handling resource policy creation

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -52,9 +52,23 @@ steps:
       echo "ERROR: ZONE not found" >&2
       exit 1
     fi
+    REGION="$${ZONE%-*}"
+    echo "Using ZONE=$${ZONE} and REGION=$${REGION}"
+
+    # Check for and create the resource policy if it doesn't exist
+    POLICY_NAME="a2-highgpu-compact"
+    if ! gcloud compute resource-policies describe $${POLICY_NAME} --region=$${REGION} --project=$${PROJECT_ID} > /dev/null 2>&1; then
+      echo "Resource policy $${POLICY_NAME} not found in region $${REGION}. Creating it..."
+      gcloud compute resource-policies create group-placement $${POLICY_NAME} \
+        --collocation=collocated \
+        --region=$${REGION} \
+        --project=$${PROJECT_ID}
+      echo "Resource policy $${POLICY_NAME} created."
+    else
+      echo "Resource policy $${POLICY_NAME} already exists in region $${REGION}."
+    fi
     set -x
     cd /workspace && make
-    REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
 


### PR DESCRIPTION
1. Added a section after the REGION variable is determined.
2. Check for Policy: It uses gcloud compute resource-policies describe a2-highgpu-compact --region=$${REGION} --project=$${PROJECT_ID}. The output is redirected to /dev/null and we check the exit code. If the policy doesn't exist, this command fails.
3. Create if Not Found: If the describe command fails (indicated by !), it runs gcloud compute resource-policies create group-placement a2-highgpu-compact ... to create the missing policy in the dynamically determined $REGION.
4. Informative Output: Added echo statements to indicate whether the policy was found or created.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
