### PR TITLE
Update terraform version in test_runner image to 1.12.2

### DIFF
--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -29,7 +29,9 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     dnsutils && \
     # install terraform and packer
     apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main" && \
-    apt-get -y update && apt-get install -y unzip python3-pip python3-netaddr terraform packer jq && \
+    apt-get -y update && \
+    # Pin Terraform version to 1.12.2
+    apt-get install -y unzip python3-pip python3-netaddr terraform=1.12.2 packer jq && \
     # install gcloud
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
       | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
@@ -38,7 +40,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add -  && \
     apt-get -y update && apt-get -y install google-cloud-sdk && \
     apt-get -y install kubectl && \
     # following is required to execute kubectl commands
-    apt-get -y install google-cloud-cli-gke-gcloud-auth-plugin && \ 
+    apt-get -y install google-cloud-cli-gke-gcloud-auth-plugin && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     # install ansible and python dependencies
     pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
Pin Terraform version in test-runner image

The test-runner Docker image used for integration tests was previously pulling the latest Terraform version. This change pins the version to 1.12.2 to ensure a stable and predictable test environment.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
