### PR TITLE
Fix transient aperture device error in A3M slurm yaml

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -452,11 +452,6 @@ deployment_groups:
             "data-root": "$(vars.localssd_mountpoint)/docker"
           }
       runners:
-      - type: shell
-        destination: enable_fabric_manager.sh
-        content: |
-          #!/bin/bash
-          systemctl enable nvidia-fabricmanager
       - type: ansible-local
         destination: slurm_aperture.yml
         content: |


### PR DESCRIPTION
This PR addresses transient "Aperture devices not found" errors on A3-Mega nodes.
The hardware that manages these devices boots at the same time as the compute node. If the node finishes booting first, it looks for the devices before they are ready, leading to a "not found" error.

A move to udev rules was made to automate mounting, but the system's "readiness check" was too rigid—it would fail instantly if the device was even a second late. 

These changes improves the reliability of Aperture device initialization:
- Implements Polling in ExecCondition: Replaces the static directory check with a 60-second polling loop (30×2s) to wait for device readiness.
