### PR TITLE
TPU v6e DWS flex integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-tpu-flex-autoscaling.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-tpu-flex-autoscaling.yml
@@ -1,0 +1,159 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Assert variables are defined
+  ansible.builtin.assert:
+    that:
+    - custom_vars.project is defined
+
+- name: Get cluster credentials for kubectl
+  delegate_to: localhost
+  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
+
+# --- Flex Start Specific Checks (Pre-Job) ---
+
+- name: Verify Initial Node Count (Should be 0 for Flex)
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    kubectl get nodes -l cloud.google.com/gke-tpu-accelerator={{ custom_vars.tpu_accelerator_type | default('tpu-v6e-slice') }} --no-headers | wc -l
+  register: initial_node_count
+  failed_when: initial_node_count.stdout | int != 0
+
+- name: Identify Job File
+  delegate_to: localhost
+  ansible.builtin.shell: ls {{ workspace }}/{{ deployment_name }}/primary/my-job*.yaml | head -n 1
+  register: job_file_result
+  changed_when: False
+
+- name: Register Job Variables
+  ansible.builtin.set_fact:
+    job_file_path: "{{ job_file_result.stdout }}"
+    job_name: "{{ job_file_result.stdout | basename | splitext | first }}"
+
+- name: Execute the job
+  delegate_to: localhost
+  ansible.builtin.command: kubectl create -f {{ job_file_path }}
+  changed_when: False
+
+# --- Flex Start Specific Checks (Scale Up) ---
+
+- name: Block to wait for job completion, verify scaling, and capture failures
+  block:
+  # Check for TriggeredScaleUp event (This confirms Flex/Autoscaling kicked in)
+  - name: Wait for TriggeredScaleUp event
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get events --sort-by='.lastTimestamp' | grep "TriggeredScaleUp" | grep -E "gke-tpu|instanceGroups"
+    register: scale_up_event
+    retries: 30 # Wait up to ~5 minutes (30 * 10s)
+    delay: 10
+    until: scale_up_event.rc == 0
+
+  - name: Wait for nodes to become Ready
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get nodes -l cloud.google.com/gke-tpu-accelerator={{ custom_vars.tpu_accelerator_type | default('tpu-v6e-slice') }} --no-headers | grep "Ready" | wc -l
+    register: ready_node_count
+    retries: 60 # Wait up to 10 minutes for nodes to boot
+    delay: 10
+    until: ready_node_count.stdout | int == (custom_vars.expected_node_count | default(4) | int)
+
+  - name: Verify Flex Start label on Nodes
+    delegate_to: localhost
+    ansible.builtin.shell: |
+       kubectl get nodes -l cloud.google.com/gke-flex-start=true --no-headers | wc -l
+    register: labeled_node_count
+    failed_when: labeled_node_count.stdout | int == 0
+
+  - name: Wait for job to complete
+    delegate_to: localhost
+    ansible.builtin.command: kubectl wait --for=condition=complete "job/{{ job_name }}" --timeout=20m
+    register: job_wait_result
+
+  - name: Verify Expected Pods Completed
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get pods --selector=job-name={{ job_name }} --field-selector=status.phase=Succeeded --no-headers | wc -l
+    register: succeeded_pod_count
+    failed_when: succeeded_pod_count.stdout | int != (custom_vars.expected_node_count | default(4) | int)
+
+  - name: Get job logs
+    delegate_to: localhost
+    # Using label selector to get logs from all pods in the job
+    ansible.builtin.shell: |
+      kubectl logs -l job-name={{ job_name }} --all-containers --prefix --tail=30
+    register: job_logs
+    changed_when: false
+    no_log: true
+
+  - name: Print job output
+    ansible.builtin.debug:
+      msg: "Job Output (Last 30 lines per container): {{ job_logs.stdout if (job_logs.stdout is defined and job_logs.stdout | length > 0) else 'No logs found' }}"
+
+  - name: Wait for nodes to scale down to 0
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get nodes -l cloud.google.com/gke-tpu-accelerator={{ custom_vars.tpu_accelerator_type | default('tpu-v6e-slice') }} --no-headers | wc -l
+    register: final_node_count
+    retries: 120
+    delay: 10 # Wait up to 20 minutes for scale down
+    until: final_node_count.stdout | int == 0
+
+  rescue:
+  - name: "FAILURE: Job did not complete or verification failed. Capturing debug info."
+    ansible.builtin.debug:
+      msg: "The Job failed to complete within the expected time or failed verification. See debug output below."
+
+  - name: Get all pods status on failure
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get pods -o wide
+    register: pods_on_failure
+    changed_when: false
+
+  - name: Print all pods status on failure
+    ansible.builtin.debug:
+      msg: "{{ pods_on_failure.stdout_lines }}"
+
+  - name: Describe the job on failure
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl describe job {{ job_name }}
+    register: job_describe_on_failure
+    changed_when: false
+
+  - name: Print job description on failure
+    ansible.builtin.debug:
+      msg: "{{ job_describe_on_failure.stdout_lines }}"
+
+  - name: Get events on failure
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get events --sort-by='.lastTimestamp'
+    register: events_on_failure
+    changed_when: false
+
+  - name: Print events on failure
+    ansible.builtin.debug:
+      msg: "{{ events_on_failure.stdout_lines }}"
+
+  - name: Fail the playbook
+    ansible.builtin.fail:
+      msg: "GKE DWS Flex Job validation failed."
+
+  always:
+  - name: Clean up
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl delete job {{ job_name }}

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.vpc
+- m.service-account
+- m.gke-cluster
+- m.gke-node-pool
+- m.kubectl-apply
+- m.cloud-storage-bucket
+- m.gke-job-template
+- m.gke-persistent-volume
+- m.pre-existing-network-storage
+- gke
+
+timeout: 7200s
+
+steps:
+# While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml"
+
+- id: gke-tpu-v6e-flex
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  - "PROJECT_ID=$PROJECT_ID"
+  - "BUILD_ID=$BUILD_ID"
+  args:
+  - -c
+  - |
+    set -e -u -o pipefail
+    set -x
+    cd /workspace && make
+    ZONE=asia-northeast1-b
+    REGION=asia-northeast1
+    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
+
+    # We use the DWS Flex example blueprint
+    EXAMPLE_BP=examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+
+    echo ''
+    echo '  - id: remote-node'                                                            >> $${EXAMPLE_BP}
+    echo '    source: modules/compute/vm-instance'                                        >> $${EXAMPLE_BP}
+    echo '    use: [gke-tpu-v6-net-0]'                                                    >> $${EXAMPLE_BP}
+    echo '    settings:'                                                                  >> $${EXAMPLE_BP}
+    echo '      machine_type: n2-standard-2'                                              >> $${EXAMPLE_BP}
+    echo '      name_prefix: remote-node'                                                 >> $${EXAMPLE_BP}
+    echo '      add_deployment_name_before_prefix: true'                                  >> $${EXAMPLE_BP}
+
+    # IMPORTANT: Ensure auto_repair is FALSE for Flex, and remove conflicting spot/reservation settings if any
+    # The base blueprint might have defaults we want to override via sed if CLI vars aren't enough or to be safe
+    # But cli_deployment_vars in the test definition should handle most overrides.
+
+    # Run the test
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml"

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml
@@ -1,0 +1,51 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+test_name: gke-tpu-v6e-flex
+deployment_name: gk-t-v6-flx-{{ build }}
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml"
+network: "{{ deployment_name }}-net-0"
+remote_node: "{{ deployment_name }}-remote-node-0"
+machine_type: ct6e-standard-4t
+region: asia-northeast1
+zone: asia-northeast1-b
+num_slices: 1
+tpu_topology: 4x4
+enable_flex_start: true
+autoscaling_min_node_count: 0
+autoscaling_max_node_count: 4
+
+cli_deployment_vars:
+  project_id: "{{ project }}"
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  num_slices: "{{ num_slices }}"
+  machine_type: "{{ machine_type }}"
+  tpu_topology: "{{ tpu_topology }}"
+  enable_flex_start: "{{ enable_flex_start }}"
+  autoscaling_min_node_count: "{{ autoscaling_min_node_count }}"
+  autoscaling_max_node_count: "{{ autoscaling_max_node_count }}"
+  authorized_cidr: "{{ build_ip.stdout }}/32"
+  system_node_pool_disk_size_gb: 200
+  v6e_node_pool_disk_size_gb: 100
+
+custom_vars:
+  project: "{{ project }}"
+  expected_node_count: 4
+  tpu_accelerator_type: tpu-v6e-slice
+
+post_deploy_tests:
+- test-validation/test-gke-tpu-flex-autoscaling.yml


### PR DESCRIPTION
### Overview
  This PR introduces a new integration test for GKE TPU v6e utilizing the DWS Flex Start (Dynamic Workload
  Scheduling) consumption model. 

### Key Changes

  1. TPU v6e Flex Integration Test
   * Cloud Build Orchestration: Added tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml to manage the
     end-to-end lifecycle in CI/CD.
   * Test Configuration: Created tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml with optimized settings
     for TPU v6e topologies.
   * Robust Validation: Implemented test-validation/test-gke-tpu-flex-autoscaling.yml which specifically validates
     the Flex Start lifecycle:
       * Verifies the cluster starts with 0 TPU nodes.
       * Detects the TriggeredScaleUp event with robust regex matching.
       * Ensures nodes are correctly labeled with cloud.google.com/gke-flex-start=true.
       * Captures logs from all job containers before scale-down occurs.
       * Verifies the cluster successfully scales back to 0 nodes after completion.

### Verification Results

  Cloud Build
  Successfully validated via:

``` gcloud builds submit --config tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml ```

  Local Execution
  Successfully verified the full validation suite running from a local Cloud Workstation.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
