### PR TITLE
fixing precommit - staticcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -142,10 +142,10 @@ repos:
 #   rev: v1.0.0-rc.1
 #   hooks:
 #   - id: go-critic
-- repo: https://github.com/Bahjat/pre-commit-golang
-  rev: v1.0.3
+- repo: https://github.com/golangci/golangci-lint
+  rev: v1.63.4
   hooks:
-  - id: go-static-check
+  - id: golangci-lint
 - repo: https://github.com/adrienverge/yamllint
   rev: v1.34.0
   hooks:


### PR DESCRIPTION
Why staticcheck Failed?
According to the error logs provided, the existing go-static-check hook failed because of a compiler version mismatch. Specifically, the Cluster Toolkit module now requires Go 1.24.6, but the staticcheck binary used in the pre-commit environment was built with Go 1.24.4.

Error logs:
go staticcheck...........................................................Failed
- hook id: go-static-check
- exit code: 1
-: module requires at least go1.24.6, but Staticcheck was built with go1.24.4 (compile)
-: module requires at least go1.24.6, but Staticcheck was built with go1.24.4 (compile)

This mismatch prevents the linter from correctly compiling and analyzing the source code, as it cannot satisfy the newer Go version requirements of the module.

Advantages of Switching to golangci-lint (v1.63.4)

The move to golangci-lint resolves this bottleneck while offering several improvements:

1. Version Compatibility: By updating to golangci-lint v1.63.4, the project ensures compatibility with the latest Go toolchains and modules.
2. Aggregation: golangci-lint acts as a linter aggregator. It can run many linters in parallel (including staticcheck and govet) more efficiently than running them as individual pre-commit hooks.
3. Improved Enforcement: It provides a unified way to manage multiple code quality checks, ensuring that the new code introduced in PR-5140 meets the project's standards without being blocked by toolchain versioning conflicts.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
