### PR TITLE
Update minimum google terraform provider version for gke-cluster module to 7.13

### DIFF
--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -110,16 +110,16 @@ limitations under the License.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.13 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.13 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.36 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 7.2 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.2 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 7.13 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.13 |
 
 ## Modules
 

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.2"
+      version = ">= 7.13"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.2"
+      version = ">= 7.13"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
The `end_time_behavior` variable in the `exclusion_options` setting within `maintenance_exclusion` was introduced in the terraform-provider-google version [7.12.0](https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#7120-november-18-2025).