### PR TITLE
Image updates and re enabling bandwidth tier in hpc-enterprise-slurm

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -26,7 +26,7 @@ vars:
   slurm_image:
     # Visit https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/docs/images.md#published-image-family
     # for a list of valid family options with Slurm
-    family: slurm-gcp-6-11-hpc-rocky-linux-8
+    family: slurm-gcp-6-12-hpc-rocky-linux-8
     project: schedmd-slurm-public
   # If image above is changed to use custom image, then setting below must be set to true
   instance_image_custom: false
@@ -138,6 +138,7 @@ deployment_groups:
     settings:
       node_count_dynamic_max: 20
       machine_type: c2-standard-60  # this is the default
+      bandwidth_tier: tier_1_enabled
       instance_image: $(vars.slurm_image)
       disk_type: pd-ssd
       disk_size_gb: 100

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -24,8 +24,9 @@ validators:
 
 vars:
   sys_net_range: 172.16.0.0/16
-  source_image_family: ubuntu-accelerator-2204-amd64-with-nvidia-570
-  source_image_project_id: [ubuntu-os-accelerator-images]
+  base_image:
+    project: ubuntu-os-accelerator-images
+    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260108
   a3mega_partition_name: a3mega
   local_mount_homefs: /home
   instance_image:
@@ -345,8 +346,8 @@ deployment_groups:
       # building this image does not require a GPU-enabled VM but must *not* be
       # run on a N-series VM otherwise, the "open" drivers will not install
       machine_type: c2-standard-8
-      source_image_family: $(vars.source_image_family)
-      source_image_project_id: $(vars.source_image_project_id)
+      source_image: $(vars.base_image.image)
+      source_image_project_id: [$(vars.base_image.project)]
       image_family: $(vars.final_image_family)
       disk_size: $(vars.disk_size_gb)
       omit_external_ip: false


### PR DESCRIPTION
### DESCRIPTION

This PR updates default image configurations and enables high-bandwidth networking for specific Slurm blueprints to improve stability and performance.

Changes:
1. examples/hpc-enterprise-slurm.yaml

   - Updated the Slurm image family from slurm-gcp-6-11-hpc-rocky-linux-8 to slurm-gcp-6-12-hpc-rocky-linux-8.
   - Re-enabled `bandwidth_tier` to  `tier_enabled_1` bandwidth for compute nodes to leverage enhanced network performance.
2. examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml

   - Shifted from using a floating source_image_family to pinning a specific base image version.
   - Updated the Packer slurm-image module to reference the new pinned base_image variables.
