### PR TITLE
Shift more tests to exclusively run on Spot VMs

### DIFF
--- a/tools/cloud-build/provision/list_tests.py
+++ b/tools/cloud-build/provision/list_tests.py
@@ -38,11 +38,16 @@ import itertools
 # OFE-deployment test is configured to only run as a PR trigger and does
 # not run on a nightly basis. Refer tools/cloud-build/provision/pr-ofe-test.tf
 # for the configuration.
+# Other tests mentioned here are being replaced with equivalent OnSPot tests
 TO_SKIP = frozenset([
-    "ofe-deployment", 
-    "ml-a3-ultragpu-slurm", 
-    "gke-a3-ultragpu", 
-    "ml-a3-ultragpu-jbvms"
+    "gke-a3-megagpu",
+    "gke-a3-ultragpu",
+    "gke-a4",
+    "ml-a3-megagpu-slurm-ubuntu",
+    "ml-a3-ultragpu-jbvms",
+    "ml-a3-ultragpu-slurm",
+    "ml-a4-highgpu-slurm",
+    "ofe-deployment",
 ])
 
 # Seed for deterministic order of tests, change to other value to shuffle tests
@@ -53,10 +58,6 @@ ORDER_SEED = b"What a wonderful phrase"
 TEMPORAL_CONSTAINTS = [
     # (set_of_tests, min_distance)
     ((
-        "ml-a4-highgpu-slurm",
-        "gke-a4"
-    ), 2*60),
-    ((
         "ml-a4-highgpu-onspot-slurm",
         "gke-a4-onspot"
     ), 2*60),
@@ -66,8 +67,6 @@ TEMPORAL_CONSTAINTS = [
         "gke-a3-ultragpu-onspot"
     ), 2*60),
     ((
-        "ml-a3-megagpu-slurm-ubuntu",
-        "gke-a3-megagpu",
         "ml-a3-megagpu-onspot-slurm-ubuntu",
         "gke-a3-megagpu-onspot"
     ), 1*60),


### PR DESCRIPTION
This PR disables some DAILY Tests running on reservation in favor of exclusively running these tests on Spot Capacity.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
