### PR TITLE
external PR auto-label

### DIFF
--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -1,0 +1,59 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Label External PRs
+
+on:
+  pull_request_target:
+    branches:
+    - develop
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  check-user-and-label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check user and add label if external
+      uses: actions/github-script@v7
+      with:
+        script: |
+            const author = context.payload.pull_request.user.login;
+
+            const file = await github.rest.repos.getContent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: "cluster-toolkit-writers.json"
+            });
+
+            const content = Buffer.from(file.data.content, "base64").toString();
+            const writers = JSON.parse(content);
+            const internalUsers = writers.map(w => w.login);
+
+            if (!internalUsers.includes(author)) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ["external"]
+              });
+            }


### PR DESCRIPTION
This PR enables adding of "external" label automatically to all PRs raised by individuals not part of the cluster-toolkit-writers.json file.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
