### PR TITLE
Fix frictions identified in gke-h4d example

### DIFF
--- a/examples/gke-h4d/README.md
+++ b/examples/gke-h4d/README.md
@@ -5,55 +5,7 @@ This blueprint uses GKE to provision a Kubernetes cluster and a H4D node pool, a
 > **_NOTE:_** The required GKE version for H4D support is >= 1.32.3-gke.1170000.
 
 ## Steps to deploy the H4D blueprint
-
-1. Install Cluster Toolkit
-    1. Install [dependencies](https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies).
-    1. Set up [Cluster Toolkit](https://cloud.google.com/cluster-toolkit/docs/setup/configure-environment).
-1. Switch to the Cluster Toolkit directory
-
-   ```sh
-   cd cluster-toolkit
-   ```
-
-1. Get the IP address for your host machine
-
-   ```sh
-   curl ifconfig.me
-   ```
-
-1. Update the vars block of the `gke-h4d-deployment.yaml` file.
-    1. `project_id`: ID of the project where you are deploying the cluster.
-    1. `deployment_name`: Name of the deployment.
-    1. `region`: Compute region used for the deployment.
-    1. `zone`: Compute zone used for the deployment.
-    1. `static_node_count`: Number of nodes to create.
-    1. `authorized_cidr`: update the IP address in `<your-ip-address>/32`.
-    1. `reservation`: The name of the compute engine reservation in the form of <reservation-name>. To target a BLOCK_NAME, the name of the extended reservation can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>.
-
-1. Build the Cluster Toolkit binary
-
-   ```sh
-   make
-   ```
-
-1. Provision the GKE cluster
-
-   ```sh
-   ./gcluster deploy -d examples/gke-h4d/gke-h4d-deployment.yaml examples/gke-h4d/gke-h4d.yaml
-   ```
-
-   These four options are displayed:
-
-   ```sh
-   (D)isplay full proposed changes,
-   (A)pply proposed changes,
-   (S)top and exit,
-   (C)ontinue without applying
-   ```
-
-   Type `a` and hit enter to create the cluster.
-
-1. Additionally, this example blueprint provisions a filestore and connects it to the GKE Cluster via Persistent Volume (PV). An example job template is included in the blueprint which runs a parallel job that reads and writes data to this shared storage. A command similar to `kubectl create -f <file-path>` is displayed in the deployment outputs which can be used to trigger the sample job.
+Refer to [Run high performance computing (HPC) workloads with H4D](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/run-hpc-workloads#cluster-toolkit) for instructions on creating the GKE-H4D cluster.
 
 ## Run a test using the MPI Operator
 The MPI Operator is installed on the cluster during the deployment. To run a test using the MPI Operator on the GKE H4D cluster, refer to https://github.com/GoogleCloudPlatform/kubernetes-engine-samples/tree/main/hpc/mpi.

--- a/examples/gke-h4d/gke-h4d-deployment.yaml
+++ b/examples/gke-h4d/gke-h4d-deployment.yaml
@@ -16,28 +16,28 @@ terraform_backend_defaults:
   type: gcs
   configuration:
     # The GCS bucket used for storing terraform state
-    bucket: BUCKET_NAME
+    bucket:
 
 vars:
   # Your GCP Project ID
-  project_id: PROJECT_ID
+  project_id:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: DEPLOYMENT_NAME
+  deployment_name:
 
   # The GCP Region used for this deployment.
-  region: COMPUTE_REGION
+  region:
 
   # The GCP Zone used for this deployment.
-  zone: COMPUTE_ZONE
+  zone:
 
   # The number of nodes to be created
-  static_node_count: NODE_COUNT
+  static_node_count:
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: IP_ADDRESS/SUFFIX
+  authorized_cidr:
 
   # The name of the compute engine reservation in the form of
   # <reservation-name>

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -181,7 +181,7 @@ deployment_groups:
       jobset:
         install: true
       apply_manifests:
-      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.6.0/deploy/v2beta1/mpi-operator.yaml"
+      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.7.0/deploy/v2beta1/mpi-operator.yaml"
         server_side_apply: true
 
   # Filestore


### PR DESCRIPTION
### Fixes
1. The [Run high performance computing (HPC) workloads with H4D](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/run-hpc-workloads) cloud doc includes Cluster Toolkit deployment instructions. Updated README with this information.

2. Updated the deployment file to follow the best practice of keeping inputs empty.

3. Update the MPI Operator version from [v0.6.0](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/gke-h4d/gke-h4d.yaml#L213) to the latest version [v0.7.0](https://github.com/kubeflow/mpi-operator/tree/release-0.7?tab=readme-ov-file).