### PR TITLE
effective binary usage for h4d build file

### DIFF
--- a/tools/cloud-build/provision/daily-tests.tf
+++ b/tools/cloud-build/provision/daily-tests.tf
@@ -34,7 +34,7 @@ resource "google_cloudbuild_trigger" "daily_test" {
   # Specify it explicitly to reduce discreppancy.
   ignored_files  = []
   included_files = []
-  substitutions = {}
+  substitutions  = {}
 }
 
 module "daily_test_schedule" {


### PR DESCRIPTION
Use binary zip bundle for Daily Tests, Else(that is for PR and local runs) use the make command, also secrets are handled.