### PR TITLE
Fix the babysit files limitation with pagination logic

### DIFF
--- a/tools/cloud-build/babysit/runner.py
+++ b/tools/cloud-build/babysit/runner.py
@@ -42,9 +42,14 @@ def get_pr(pr_num: int) -> dict:
     return resp.json()
 
 def get_pr_files(pr_num: int) -> list[str]:
-    resp = requests.get(f"https://api.github.com/repos/GoogleCloudPlatform/hpc-toolkit/pulls/{pr_num}/files")
-    resp.raise_for_status()
-    return [f['filename'] for f in resp.json()]
+    files = []
+    url = f"https://api.github.com/repos/GoogleCloudPlatform/hpc-toolkit/pulls/{pr_num}/files?per_page=100"
+    while url:
+        resp = requests.get(url)
+        resp.raise_for_status()
+        files.extend(resp.json())
+        url = resp.links.get("next", {}).get("url")
+    return [f['filename'] for f in files]
 
 def get_changed_files_tags(files: Collection[str]) -> set[str]:
     tags = set()


### PR DESCRIPTION
The babysit tool was failing to find test selectors for PR 5190 because the _get_pr_files_ function lacked pagination logic when querying the GitHub API. By default, the API only returns the first 30 files, and since the module changes in the PR were positioned later in the list, the tool didn't see them and couldn't generate the necessary m.schedmd-slurm-gcp-v6-login tags.

This PR updates tools/cloud-build/babysit/runner.py to support pagination, which ensures that all changed files are retrieved and correctly mapped to their respective test tags.
