### PR TITLE
Update CAE Example README.md to reflect correct blueprint location

### DIFF
--- a/examples/cae/README.md
+++ b/examples/cae/README.md
@@ -113,7 +113,7 @@ storage intact and b) you can build software before you deploy your cluster.
    Call the following gcluster command to deploy the cae-slurm blueprint.
 
    ```bash
-   ./gcluster deploy cae-slurm
+   ./gcluster deploy cae-slurm-v6
    ```
 
    The next `gcluster` prompt will ask you to **display**, **apply**, **stop**, or
@@ -178,7 +178,7 @@ commands to destroy the deployment in this reverse order. You will be prompted
 to confirm the deletion of each stage.
 
 ```bash
-./gcluster destroy cae-slurm
+./gcluster destroy cae-slurm-v6
 ```
 
 > [!WARNING]


### PR DESCRIPTION
Update the CAE Example README.md's blueprint location to correctly move it from community/examples/ to examples/cae.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
