### PR TITLE
Update and pin terraform version to 1.12.2

### DIFF
--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -91,7 +91,7 @@ jobs:
         check-latest: true
     - uses: hashicorp/setup-terraform@v3
       with:
-        terraform_version: latest
+        terraform_version: "1.12.2"
         terraform_wrapper: false
     - run: make install-dev-deps
     - uses: terraform-linters/setup-tflint@v4

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # PREAMBLE
 MIN_PACKER_VERSION=1.7.9 # for building images
-MIN_TERRAFORM_VERSION=1.5.7 # for deploying modules
+MIN_TERRAFORM_VERSION=1.12.2 # for deploying modules
 MIN_GOLANG_VERSION=1.24 # for building gcluster
 
 .PHONY: install install-user tests format install-dev-deps \

--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |

--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
 
-  required_version = ">= 0.12.31"
+  required_version = "= 1.12.2"
 }
 
 provider "google" {

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/README.md
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.87.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.2 |

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/README.md
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/community/front-end/ofe/tf/README.md
+++ b/community/front-end/ofe/tf/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/community/front-end/ofe/tf/network/README.md
+++ b/community/front-end/ofe/tf/network/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
 
 ## Providers

--- a/community/front-end/ofe/tf/network/versions.tf
+++ b/community/front-end/ofe/tf/network/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/front-end/ofe/tf/versions.tf
+++ b/community/front-end/ofe/tf/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/gke-nodeset/README.md
+++ b/community/modules/compute/gke-nodeset/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 
 ## Providers

--- a/community/modules/compute/gke-nodeset/versions.tf
+++ b/community/modules/compute/gke-nodeset/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/gke-partition/README.md
+++ b/community/modules/compute/gke-partition/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 
 ## Providers

--- a/community/modules/compute/gke-partition/versions.tf
+++ b/community/modules/compute/gke-partition/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -197,7 +197,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.1"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/mig/README.md
+++ b/community/modules/compute/mig/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 
 ## Providers

--- a/community/modules/compute/mig/versions.tf
+++ b/community/modules/compute/mig/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/notebook/README.md
+++ b/community/modules/compute/notebook/README.md
@@ -68,7 +68,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.34 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/compute/notebook/versions.tf
+++ b/community/modules/compute/notebook/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -61,7 +61,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.81.0"
   }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
@@ -38,7 +38,7 @@ be accessed as `tpu` partition.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.81.0"

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -165,7 +165,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.4"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
@@ -64,7 +64,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.81.0"

--- a/community/modules/container/artifact-registry/README.md
+++ b/community/modules/container/artifact-registry/README.md
@@ -103,7 +103,7 @@ Note: only Docker registries have been tested so far. Placeholders do exist for 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/container/artifact-registry/versions.tf
+++ b/community/modules/container/artifact-registry/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/bigquery-dataset/README.md
+++ b/community/modules/database/bigquery-dataset/README.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/bigquery-dataset/versions.tf
+++ b/community/modules/database/bigquery-dataset/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/bigquery-table/README.md
+++ b/community/modules/database/bigquery-table/README.md
@@ -44,7 +44,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/bigquery-table/versions.tf
+++ b/community/modules/database/bigquery-table/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.81.0"
   }
 
-  required_version = ">= 0.13.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -84,7 +84,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.14 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/file-system/weka-client/README.md
+++ b/community/modules/file-system/weka-client/README.md
@@ -150,7 +150,7 @@ weka local rm -f --all
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/file-system/weka-client/versions.tf
+++ b/community/modules/file-system/weka-client/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/files/fsi-montecarlo-on-batch/README.md
+++ b/community/modules/files/fsi-montecarlo-on-batch/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/community/modules/files/fsi-montecarlo-on-batch/versions.tf
+++ b/community/modules/files/fsi-montecarlo-on-batch/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/internal/slurm-gcp/instance/README.md
+++ b/community/modules/internal/slurm-gcp/instance/README.md
@@ -46,7 +46,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.43 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 

--- a/community/modules/internal/slurm-gcp/instance/versions.tf
+++ b/community/modules/internal/slurm-gcp/instance/versions.tf
@@ -16,7 +16,7 @@
  */
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/internal/slurm-gcp/instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/instance_template/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
 
 ## Providers

--- a/community/modules/internal/slurm-gcp/instance_template/versions.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/versions.tf
@@ -14,7 +14,7 @@
 
 
 terraform {
-  required_version = "~> 1.0"
+  required_version = "= 1.12.2"
 
   required_providers {
     local = {

--- a/community/modules/internal/slurm-gcp/internal_instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.88 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 

--- a/community/modules/internal/slurm-gcp/internal_instance_template/versions.tf
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">=0.13.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/internal/slurm-gcp/login/README.md
+++ b/community/modules/internal/slurm-gcp/login/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 
 ## Providers

--- a/community/modules/internal/slurm-gcp/login/versions.tf
+++ b/community/modules/internal/slurm-gcp/login/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/internal/slurm-gcp/nodeset_tpu/README.md
+++ b/community/modules/internal/slurm-gcp/nodeset_tpu/README.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.53 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 

--- a/community/modules/internal/slurm-gcp/nodeset_tpu/versions.tf
+++ b/community/modules/internal/slurm-gcp/nodeset_tpu/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/management/dependencies-installer/README.md
+++ b/community/modules/management/dependencies-installer/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 

--- a/community/modules/management/dependencies-installer/helm_install/README.md
+++ b/community/modules/management/dependencies-installer/helm_install/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 
 ## Providers

--- a/community/modules/management/dependencies-installer/helm_install/versions.tf
+++ b/community/modules/management/dependencies-installer/helm_install/versions.tf
@@ -20,5 +20,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/management/dependencies-installer/kubernetes_manifest/README.md
+++ b/community/modules/management/dependencies-installer/kubernetes_manifest/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers

--- a/community/modules/management/dependencies-installer/kubernetes_manifest/versions.tf
+++ b/community/modules/management/dependencies-installer/kubernetes_manifest/versions.tf
@@ -20,5 +20,5 @@ terraform {
       version = "~> 2.23"
     }
   }
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/management/dependencies-installer/versions.tf
+++ b/community/modules/management/dependencies-installer/versions.tf
@@ -26,5 +26,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/project/service-enablement/README.md
+++ b/community/modules/project/service-enablement/README.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/pubsub/bigquery-sub/README.md
+++ b/community/modules/pubsub/bigquery-sub/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/pubsub/bigquery-sub/versions.tf
+++ b/community/modules/pubsub/bigquery-sub/versions.tf
@@ -31,5 +31,5 @@ terraform {
   provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.81.0"
   }
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/pubsub/topic/README.md
+++ b/community/modules/pubsub/topic/README.md
@@ -39,7 +39,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/pubsub/topic/versions.tf
+++ b/community/modules/pubsub/topic/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/remote-desktop/chrome-remote-desktop/README.md
+++ b/community/modules/remote-desktop/chrome-remote-desktop/README.md
@@ -53,7 +53,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -105,7 +105,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.81.0"
   }
 
-  required_version = ">= 1.1"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -91,7 +91,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.81.0"
   }
 
-  required_version = ">= 1.1.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-pool-secrets/README.md
+++ b/community/modules/scheduler/htcondor-pool-secrets/README.md
@@ -118,7 +118,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.81.0"
   }
 
-  required_version = ">= 1.3.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-service-accounts/README.md
+++ b/community/modules/scheduler/htcondor-service-accounts/README.md
@@ -90,7 +90,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/htcondor-service-accounts/versions.tf
+++ b/community/modules/scheduler/htcondor-service-accounts/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-setup/README.md
+++ b/community/modules/scheduler/htcondor-setup/README.md
@@ -80,7 +80,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/htcondor-setup/versions.tf
+++ b/community/modules/scheduler/htcondor-setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -261,7 +261,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0.0 |
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     null = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/README.md
@@ -42,7 +42,7 @@ No outputs.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     null = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 1.3"
+  required_version = "= 1.12.2"
   required_providers {
     archive = {
       source  = "hashicorp/archive"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -59,7 +59,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.81.0"

--- a/community/modules/scheduler/slinky/README.md
+++ b/community/modules/scheduler/slinky/README.md
@@ -114,7 +114,7 @@ squeue
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.16 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 

--- a/community/modules/scheduler/slinky/versions.tf
+++ b/community/modules/scheduler/slinky/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     helm = {

--- a/community/modules/scripts/gcloud/README.md
+++ b/community/modules/scripts/gcloud/README.md
@@ -45,7 +45,7 @@ deployment_groups:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scripts/gcloud/versions.tf
+++ b/community/modules/scripts/gcloud/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = ">= 3.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -116,7 +116,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scripts/htcondor-install/versions.tf
+++ b/community/modules/scripts/htcondor-install/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scripts/ramble-execute/README.md
+++ b/community/modules/scripts/ramble-execute/README.md
@@ -64,7 +64,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 
 ## Providers

--- a/community/modules/scripts/ramble-execute/versions.tf
+++ b/community/modules/scripts/ramble-execute/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = "= 1.12.2"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/community/modules/scripts/ramble-setup/README.md
+++ b/community/modules/scripts/ramble-setup/README.md
@@ -71,7 +71,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 

--- a/community/modules/scripts/ramble-setup/versions.tf
+++ b/community/modules/scripts/ramble-setup/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/scripts/spack-execute/README.md
+++ b/community/modules/scripts/spack-execute/README.md
@@ -91,7 +91,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 
 ## Providers

--- a/community/modules/scripts/spack-execute/versions.tf
+++ b/community/modules/scripts/spack-execute/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = "= 1.12.2"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/community/modules/scripts/spack-setup/README.md
+++ b/community/modules/scripts/spack-setup/README.md
@@ -325,7 +325,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 

--- a/community/modules/scripts/spack-setup/versions.tf
+++ b/community/modules/scripts/spack-setup/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/scripts/wait-for-startup/README.md
+++ b/community/modules/scripts/wait-for-startup/README.md
@@ -50,7 +50,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/community/modules/scripts/windows-startup-script/README.md
+++ b/community/modules/scripts/windows-startup-script/README.md
@@ -76,7 +76,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -19,5 +19,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/compute/gke-job-template/README.md
+++ b/modules/compute/gke-job-template/README.md
@@ -73,7 +73,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/compute/gke-job-template/versions.tf
+++ b/modules/compute/gke-job-template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     random = {

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -278,7 +278,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/compute/resource-policy/README.md
+++ b/modules/compute/resource-policy/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.29.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/compute/resource-policy/versions.tf
+++ b/modules/compute/resource-policy/versions.tf
@@ -30,5 +30,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:resource-policy/v1.81.0"
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -168,7 +168,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -37,5 +37,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.81.0"
   }
 
-  required_version = ">= 1.3.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/cloud-storage-bucket/README.md
+++ b/modules/file-system/cloud-storage-bucket/README.md
@@ -107,7 +107,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.9.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/modules/file-system/cloud-storage-bucket/versions.tf
@@ -35,5 +35,5 @@ terraform {
   provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.81.0"
   }
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -190,7 +190,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.81.0"
   }
 
-  required_version = ">= 1.3.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -151,7 +151,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
 

--- a/modules/file-system/gke-persistent-volume/versions.tf
+++ b/modules/file-system/gke-persistent-volume/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.0"
+  required_version = "= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/file-system/gke-storage/README.md
+++ b/modules/file-system/gke-storage/README.md
@@ -97,7 +97,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/file-system/gke-storage/versions.tf
+++ b/modules/file-system/gke-storage/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.81.0"

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -233,7 +233,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.27.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/managed-lustre/versions.tf
+++ b/modules/file-system/managed-lustre/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.81.0"
   }
 
-  required_version = ">= 1.3.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/netapp-storage-pool/README.md
+++ b/modules/file-system/netapp-storage-pool/README.md
@@ -141,7 +141,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/netapp-storage-pool/versions.tf
+++ b/modules/file-system/netapp-storage-pool/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.81.0"
   }
 
-  required_version = ">= 1.5.7"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -149,7 +149,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
 
 ## Providers

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -28,5 +28,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.81.0"
   }
 
-  required_version = ">= 1.5.7"
+  required_version = "= 1.12.2"
 }

--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -146,7 +146,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/file-system/parallelstore/versions.tf
+++ b/modules/file-system/parallelstore/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -155,7 +155,7 @@ the network storage doc for a complete list of supported modules.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/file-system/pre-existing-network-storage/versions.tf
+++ b/modules/file-system/pre-existing-network-storage/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/internal/gpu-definition/README.md
+++ b/modules/internal/gpu-definition/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/gpu-definition/main.tf
+++ b/modules/internal/gpu-definition/main.tf
@@ -98,5 +98,5 @@ output "machine_type_guest_accelerator" {
 }
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/internal/instance_validations/README.md
+++ b/modules/internal/instance_validations/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/instance_validations/versions.tf
+++ b/modules/internal/instance_validations/versions.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.15.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/internal/network-attachment/README.md
+++ b/modules/internal/network-attachment/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0.0 |
 
 ## Providers

--- a/modules/internal/network-attachment/main.tf
+++ b/modules/internal/network-attachment/main.tf
@@ -59,7 +59,7 @@ output "self_link" {
 }
 
 terraform {
-  required_version = ">= 0.15.0"
+  required_version = "= 1.12.2"
 
   required_providers {
     google-beta = {

--- a/modules/internal/tpu-definition/README.md
+++ b/modules/internal/tpu-definition/README.md
@@ -52,7 +52,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/tpu-definition/main.tf
+++ b/modules/internal/tpu-definition/main.tf
@@ -65,5 +65,5 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/internal/vpc_peering/README.md
+++ b/modules/internal/vpc_peering/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/internal/vpc_peering/main.tf
+++ b/modules/internal/vpc_peering/main.tf
@@ -69,7 +69,7 @@ output "peering_name" {
 }
 
 terraform {
-  required_version = ">= 0.15.0"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -185,7 +185,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.0 |

--- a/modules/management/kubectl-apply/helm_install/README.md
+++ b/modules/management/kubectl-apply/helm_install/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 
 ## Providers

--- a/modules/management/kubectl-apply/helm_install/versions.tf
+++ b/modules/management/kubectl-apply/helm_install/versions.tf
@@ -20,5 +20,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/management/kubectl-apply/kubectl/README.md
+++ b/modules/management/kubectl-apply/kubectl/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
 
 ## Providers

--- a/modules/management/kubectl-apply/kubectl/versions.tf
+++ b/modules/management/kubectl-apply/kubectl/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/management/kubectl-apply/versions.tf
+++ b/modules/management/kubectl-apply/versions.tf
@@ -38,5 +38,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:kubectl-apply/v1.81.0"
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/monitoring/dashboard/README.md
+++ b/modules/monitoring/dashboard/README.md
@@ -48,7 +48,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/firewall-rules/README.md
+++ b/modules/network/firewall-rules/README.md
@@ -69,7 +69,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/firewall-rules/versions.tf
+++ b/modules/network/firewall-rules/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.81.0"
   }
 
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/gpu-rdma-vpc/README.md
+++ b/modules/network/gpu-rdma-vpc/README.md
@@ -93,7 +93,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/network/gpu-rdma-vpc/versions.tf
+++ b/modules/network/gpu-rdma-vpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 0.15.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/multivpc/README.md
+++ b/modules/network/multivpc/README.md
@@ -76,7 +76,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/network/multivpc/versions.tf
+++ b/modules/network/multivpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 1.4.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/pre-existing-subnetwork/README.md
+++ b/modules/network/pre-existing-subnetwork/README.md
@@ -55,7 +55,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/pre-existing-subnetwork/versions.tf
+++ b/modules/network/pre-existing-subnetwork/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.81.0"
   }
 
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/pre-existing-vpc/README.md
+++ b/modules/network/pre-existing-vpc/README.md
@@ -67,7 +67,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.81.0"
   }
 
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/private-service-access/README.md
+++ b/modules/network/private-service-access/README.md
@@ -75,7 +75,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.40 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/network/private-service-access/versions.tf
+++ b/modules/network/private-service-access/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.81.0"
   }
 
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 }

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -161,7 +161,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/network/vpc/versions.tf
+++ b/modules/network/vpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = ">= 0.15.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/project/service-account/README.md
+++ b/modules/project/service-account/README.md
@@ -66,7 +66,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 
 ## Providers
 

--- a/modules/project/service-account/versions.tf
+++ b/modules/project/service-account/versions.tf
@@ -18,5 +18,5 @@ terraform {
   required_providers {
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -121,7 +121,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/modules/scheduler/batch-job-template/versions.tf
+++ b/modules/scheduler/batch-job-template/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = ">= 4.0"
     }
   }
-  required_version = ">= 1.1"
+  required_version = "= 1.12.2"
 }

--- a/modules/scheduler/batch-login-node/README.md
+++ b/modules/scheduler/batch-login-node/README.md
@@ -76,7 +76,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.81.0"
   }
 
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -109,7 +109,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.13 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.13 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.36 |

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/scheduler/pre-existing-gke-cluster/README.md
+++ b/modules/scheduler/pre-existing-gke-cluster/README.md
@@ -75,7 +75,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 
 ## Providers

--- a/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -26,5 +26,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.81.0"
   }
 
-  required_version = ">= 1.3"
+  required_version = "= 1.12.2"
 }

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -289,7 +289,7 @@ limitations under the License.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.81.0"
   }
 
-  required_version = ">= 1.5"
+  required_version = "= 1.12.2"
 }

--- a/pkg/modulereader/modules/test_role/test_module/versions.tf
+++ b/pkg/modulereader/modules/test_role/test_module/versions.tf
@@ -21,5 +21,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -414,7 +414,7 @@ func (s *zeroSuite) TestWriteVersions(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(string(b), Equals, license+`
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     elephant = {

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -207,7 +207,7 @@ func writeVersions(providers map[string]config.TerraformProvider, dst string) er
 	body := f.Body()
 	body.AppendNewline()
 	tfb := body.AppendNewBlock("terraform", []string{}).Body()
-	tfb.SetAttributeValue("required_version", cty.StringVal(">= 1.2"))
+	tfb.SetAttributeValue("required_version", cty.StringVal("= 1.12.2"))
 	tfb.AppendNewline()
 
 	pb := tfb.AppendNewBlock("required_providers", []string{}).Body()

--- a/pkg/sourcereader/modules/network/vpc/main.tf
+++ b/pkg/sourcereader/modules/network/vpc/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.14.0"
+  required_version = "= 1.12.2"
 }
 
 locals {

--- a/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
+++ b/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
         python3-pip
 
 # Install Terraform
-ARG TERRAFORM_VERSION=1.5.2
+ARG TERRAFORM_VERSION=1.12.2
 RUN wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -O terraform.zip && \
     unzip terraform.zip && \
     mv terraform /usr/local/bin/ && \

--- a/tools/cloud-build/images/cluster-toolkit-dockerfile/README.md
+++ b/tools/cloud-build/images/cluster-toolkit-dockerfile/README.md
@@ -13,7 +13,7 @@ To build and use this Dockerfile, you'll need:
 ## Build Arguments
 The following build arguments can be used to customize the build process:
 * **`BASE_IMAGE`**: The base image to use for the build. Defaults to `gcr.io/google.com/cloudsdktool/google-cloud-cli:stable`.
-* **`TERRAFORM_VERSION`**: The version of Terraform to install. Defaults to `1.5.2`.
+* **`TERRAFORM_VERSION`**: The version of Terraform to install. Defaults to `1.12.2`.
 * **`PACKER_VERSION`**: The version of Packer to install. Defaults to `1.8.6`.
 * **`GO_VERSION`**: The version of Go to install. Defaults to `1.23.0`.
 * **`CLUSTER_TOOLKIT_REF`**: The [Cluster Toolkit repository's](https://github.com/GoogleCloudPlatform/cluster-toolkit/releases) branch or tag from which to build Cluster Toolkit.  Defaults to the `main` branch, which is the latest official release.

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -19,7 +19,7 @@ When prompted for project, use integration test project.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 
 ## Providers

--- a/tools/cloud-build/provision/trigger-schedule/versions.tf
+++ b/tools/cloud-build/provision/trigger-schedule/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/cloud-build/provision/versions.tf
+++ b/tools/cloud-build/provision/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = ">= 1.2"
+  required_version = "= 1.12.2"
 
   required_providers {
     google = {


### PR DESCRIPTION
Upgrade Terraform version to 1.12.2

This change updates the cluster toolkit to use Terraform version 1.12.2 consistently.

**Reasons for Upgrade:**

*   Standardizing on a more recent stable version of Terraform.
*   Leveraging potential bug fixes and new features in Terraform 1.12.2.
*   Ensuring compatibility with newer provider features.

**Changes Made:**

*   Pinned Terraform version to `= 1.12.2` in all `versions.tf` and few other files.

**Troubleshooting & Fixes:**

During pre-commit checks, errors like "Could not retrieve the list of available versions for provider..." were encountered. This was due to existing `.terraform.lock.hcl` files locking provider versions that were not compatible with Terraform 1.12.2 or causing resolution conflicts.

To resolve this, all `.terraform.lock.hcl` files within the Cluster Toolkit directory were removed using:
`find . -name ".terraform.lock.hcl" -delete`

This forces Terraform to re-resolve provider dependencies compatible with version 1.12.2 upon the next `terraform init`, generating new lock files.

**Impact:**

*   All deployments and tests will now use Terraform v1.12.2.
*   Developers will need to ensure their local environment matches this version.
*   New `.terraform.lock.hcl` files will be generated by `terraform init` reflecting dependencies compatible with TF 1.12.2.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
