### PR TITLE
Install Kueue in TPU base bps of v6e and 7x

### DIFF
--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -49,7 +49,7 @@ vars:
   # The name of the compute engine reservation of TPU 7x nodes
   reservation:
 
-# Kueue configuration
+  # Kueue configuration
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -49,6 +49,9 @@ vars:
   # The name of the compute engine reservation of TPU 7x nodes
   reservation:
 
+  # Kueue configuration
+  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
 
 deployment_groups:
 - group: primary
@@ -155,5 +158,11 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [gke-tpu-7x-cluster]
     settings:
+      kueue:
+        install: true
+        config_path: $(vars.kueue_configuration_path)
+        config_template_vars:
+          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-7x-pool.tpu_chips_per_node)
+          accelerator_type: $(gke-tpu-7x-pool.tpu_accelerator_type)
       jobset:
         install: true

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -53,7 +53,7 @@ vars:
   v6e_node_pool_disk_size_gb: 100
   version_prefix: "1.33."
 
- # Kueue configuration
+  # Kueue configuration
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -52,6 +52,9 @@ vars:
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
 
+  # Kueue configuration
+  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
 
 deployment_groups:
 - group: primary
@@ -202,5 +205,11 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [gke-tpu-v6e-cluster]
     settings:
+      kueue:
+        install: true
+        config_path: $(vars.kueue_configuration_path)
+        config_template_vars:
+          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-v6e-pool.tpu_chips_per_node)
+          accelerator_type: $(gke-tpu-v6e-pool.tpu_accelerator_type)
       jobset:
         install: true


### PR DESCRIPTION
Install Kueue in TPU base bps of v6e and 7x. At this time, the Kueue is installed in the advanced blueprints. We want to install Kueue on all out blueprints.