### PR TITLE
Update gke-a3m readme with additional consumption options

### DIFF
--- a/examples/gke-a3-megagpu/README.md
+++ b/examples/gke-a3-megagpu/README.md
@@ -1,3 +1,7 @@
 Refer to [Deploy an A3 Mega GKE cluster for ML training](https://cloud.google.com/cluster-toolkit/docs/deploy/deploy-a3-mega-gke-cluster) for instructions on creating the GKE-A3M cluster.
 
 Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A3M cluster.
+
+### Additional Consumption Options
+The Cluster Toolkit supports alternative consumption options such as Spot VMs or Dynamic Workload Scheduler (DWS) Flex-start.
+Refer to step 5 of [Create a cluster using Cluster Toolkit](https://docs.cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for general instructions on other consumption options. Similar configuration settings can be used for GKE-A3M cluster as well.


### PR DESCRIPTION
This PR makes changes to gke-a3m README.md to include reference to other consumption options such as Spot and Flex-start. This is a part of the friction encountered for  gke-a3mega.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
