### PR TITLE
predeploy-execution-order

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -52,6 +52,12 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
+  - name: Run Pre Deploy Tasks
+    ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
+    loop: "{{ pre_deploy_tasks | default([]) }}"
+    loop_control:
+      loop_var: pre_deploy_task
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -59,12 +65,6 @@
 
   - name: Create Infrastructure and test
     block:
-
-    - name: Run Pre Deploy Tasks
-      ansible.builtin.include_tasks: "{{ pre_deploy_task }}"
-      loop: "{{ pre_deploy_tasks | default([]) }}"
-      loop_control:
-        loop_var: pre_deploy_task
 
     - name: Create Cluster with gcluster
       register: deployment


### PR DESCRIPTION
The failure [slurm-gcp-v6-static](https://pantheon.corp.google.com/cloud-build/builds;region=global/06c4566d-410d-4eec-9a84-7fb50d75ada5?project=hpc-toolkit-dev)  by task execution order.
 Now pre-deploy runs before gcluster deploy, so the reservation exists before validation.
 


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
