### PR TITLE
Implement static namespace injection and GCS locking for integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -52,33 +52,9 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
-  ## Define Lock Variables
-  - name: Define Base Lock Variables
-    ansible.builtin.set_fact:
-      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
-      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
-
-  - name: Define Derived Lock Paths
-    ansible.builtin.set_fact:
-      static_network_name: "{{ static_test_name }}-net"
-      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
-      local_lock_file: "/tmp/{{ static_test_name }}.lock"
-
-  ## Create cluster
-  - name: Create Local Empty Lock File
-    ansible.builtin.file:
-      path: "{{ local_lock_file }}"
-      state: touch
-
-  - name: Acquire Test Namespace Lock
-    ansible.builtin.shell: |
-      gsutil cp -n "{{ local_lock_file }}" "{{ lock_file_path }}"
-    register: lock_acquired
-    changed_when: lock_acquired.rc == 0
-    retries: 30  # Retry for 30 minutes
-    delay: 60    # Wait 60 seconds between retries
-    until: lock_acquired.rc == 0
-    delegate_to: localhost
+  ## Define Lock Variables and Acquire
+  - name: Set up Test Namespace Lock
+    ansible.builtin.include_tasks: tasks/setup_lock.yml
 
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -251,13 +227,8 @@
         msg: "Integration tests failed. Rescue tasks were executed."
 
     always:
-    - name: Release Network Lock
-      ansible.builtin.shell: |
-        gsutil rm "{{ lock_file_path }}"
-      register: lock_released
-      changed_when: lock_released.rc == 0
-      delegate_to: localhost
-      ignore_errors: true # Continue even if lock file doesn't exist for some reason
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
 
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -52,7 +52,34 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
+  ## Define Lock Variables
+  - name: Define Base Lock Variables
+    ansible.builtin.set_fact:
+      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+  - name: Define Derived Lock Paths
+    ansible.builtin.set_fact:
+      static_network_name: "{{ static_test_name }}-net"
+      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+      local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
   ## Create cluster
+  - name: Create Local Empty Lock File
+    ansible.builtin.file:
+      path: "{{ local_lock_file }}"
+      state: touch
+
+  - name: Acquire Test Namespace Lock
+    ansible.builtin.shell: |
+      gsutil cp -n "{{ local_lock_file }}" "{{ lock_file_path }}"
+    register: lock_acquired
+    changed_when: lock_acquired.rc == 0
+    retries: 30  # Retry for 30 minutes
+    delay: 60    # Wait 60 seconds between retries
+    until: lock_acquired.rc == 0
+    delegate_to: localhost
+
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
       file: tasks/create_deployment_directory.yml
@@ -120,7 +147,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={{ network }}
+        - --network={{ static_network_name }}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
@@ -224,6 +251,14 @@
         msg: "Integration tests failed. Rescue tasks were executed."
 
     always:
+    - name: Release Network Lock
+      ansible.builtin.shell: |
+        gsutil rm "{{ lock_file_path }}"
+      register: lock_released
+      changed_when: lock_released.rc == 0
+      delegate_to: localhost
+      ignore_errors: true # Continue even if lock file doesn't exist for some reason
+
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:
         file: tasks/rescue_gcluster_failure.yml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -52,7 +52,19 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
-  ## Define Lock Variables and Acquire
+  ## Define Lock Variables
+  - name: Define Base Lock Variables
+    ansible.builtin.set_fact:
+      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+  - name: Define Derived Lock Paths
+    ansible.builtin.set_fact:
+      static_network_name: "{{ static_test_name }}-net"
+      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+      local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
+  ## Acquire Lock
   - name: Set up Test Namespace Lock
     ansible.builtin.include_tasks: tasks/setup_lock.yml
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -38,6 +38,10 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
+  ## Define Lock Variables and Acquire
+  - name: Set up Test Namespace Lock
+    ansible.builtin.include_tasks: tasks/setup_lock.yml
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -142,6 +146,10 @@
       ansible.builtin.fail:
         msg: "Failed while setting up test infrastructure"
 
+    always:
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
+
 - name: Run Integration Tests
   hosts: remote_host
   gather_facts: false  # must wait until host is reachable
@@ -167,6 +175,8 @@
       loop_control:
         loop_var: test
     always:
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
     - name: Delete Firewall Rule
       delegate_to: localhost
       register: fw_deleted

--- a/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml
@@ -38,7 +38,19 @@
       dig TXT +short o-o.myaddr.l.google.com @ns1.google.com | \
           awk -F'"' '{print $2}'
 
-  ## Define Lock Variables and Acquire
+  ## Define Lock Variables
+  - name: Define Base Lock Variables
+    ansible.builtin.set_fact:
+      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+  - name: Define Derived Lock Paths
+    ansible.builtin.set_fact:
+      static_network_name: "{{ static_test_name }}-net"
+      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+      local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
+  ## Acquire Lock
   - name: Set up Test Namespace Lock
     ansible.builtin.include_tasks: tasks/setup_lock.yml
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
@@ -20,6 +20,9 @@
   vars:
     delete_image: true
   tasks:
+  - name: Set up Test Namespace Lock
+    ansible.builtin.include_tasks: tasks/setup_lock.yml
+
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
       file: tasks/create_deployment_directory.yml
@@ -34,6 +37,9 @@
       environment:
         TF_IN_AUTOMATION: "TRUE"
     always:
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
+
     - name: Destroy deployment
       register: gcluster_destroy
       changed_when: gcluster_destroy.changed

--- a/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml
@@ -20,6 +20,19 @@
   vars:
     delete_image: true
   tasks:
+  ## Define Lock Variables
+  - name: Define Base Lock Variables
+    ansible.builtin.set_fact:
+      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+  - name: Define Derived Lock Paths
+    ansible.builtin.set_fact:
+      static_network_name: "{{ static_test_name }}-net"
+      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+      local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
+  ## Acquire Lock
   - name: Set up Test Namespace Lock
     ansible.builtin.include_tasks: tasks/setup_lock.yml
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import yaml
+import sys
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: inject_static_names.py <blueprint_yaml_path> <static_test_name>")
+        sys.exit(1)
+
+    blueprint_path = sys.argv[1]
+    static_test_name = sys.argv[2]
+
+    with open(blueprint_path, "r") as f:
+        data = yaml.safe_load(f)
+
+    net_count = 0
+
+    if "deployment_groups" in data:
+        for group in data["deployment_groups"]:
+            if "modules" in group:
+                for mod in group["modules"]:
+                    src = mod.get("source", "")
+                    mod_id = mod.get("id", "unknown")
+
+                    if src.startswith("modules/network/"):
+                        if "settings" not in mod:
+                            mod["settings"] = {}
+                        
+                        # First network matches Ansible firewall exact name, others get suffixes
+                        if net_count == 0:
+                            net_name = f"{static_test_name}-net"
+                            sub_name = f"{static_test_name}-subnet"
+                        else:
+                            net_name = f"{static_test_name}-n{net_count}"
+                            sub_name = f"{static_test_name}-n{net_count}-sub"
+
+                        mod["settings"]["network_name"] = net_name
+                        mod["settings"]["subnetwork_name"] = sub_name
+                        net_count += 1
+                        
+                    elif src in ["modules/file-system/filestore", "modules/file-system/managed-lustre"]:
+                        if "settings" not in mod:
+                            mod["settings"] = {}
+                        mod["settings"]["name"] = f"{static_test_name}-{mod_id}"
+
+    with open(blueprint_path, "w") as f:
+        yaml.dump(data, f, sort_keys=False)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
@@ -26,35 +26,47 @@ def main():
     with open(blueprint_path, "r") as f:
         data = yaml.safe_load(f)
 
+    if not data:
+        return
+
     net_count = 0
+    storage_count = 0
 
-    if "deployment_groups" in data:
-        for group in data["deployment_groups"]:
-            if "modules" in group:
-                for idx, mod in enumerate(group["modules"]):
-                    src = mod.get("source", "")
-                    mod_id = mod.get("id", f"unknown-mod-{idx}")
+    for group in data.get("deployment_groups") or []:
+        for mod in group.get("modules") or []:
+            if not isinstance(mod, dict):
+                continue
+            
+            src = mod.get("source", "")
 
-                    if src.startswith("modules/network/"):
-                        if "settings" not in mod:
-                            mod["settings"] = {}
-                        
-                        # First network matches Ansible firewall exact name, others get suffixes
-                        if net_count == 0:
-                            net_name = f"{static_test_name}-net"
-                            sub_name = f"{static_test_name}-subnet"
-                        else:
-                            net_name = f"{static_test_name}-n{net_count}"
-                            sub_name = f"{static_test_name}-n{net_count}-sub"
+            if src.startswith("modules/network/"):
+                if "settings" not in mod:
+                    mod["settings"] = {}
+                
+                # First network matches Ansible firewall exact name, others get suffixes
+                if net_count == 0:
+                    net_name = f"{static_test_name}-net"[:63]
+                    sub_name = f"{static_test_name}-subnet"[:63]
+                else:
+                    net_name = f"{static_test_name}-n{net_count}"[:63]
+                    sub_name = f"{static_test_name}-n{net_count}-sub"[:63]
 
-                        mod["settings"]["network_name"] = net_name
-                        mod["settings"]["subnetwork_name"] = sub_name
-                        net_count += 1
-                        
-                    elif src in ["modules/file-system/filestore", "modules/file-system/managed-lustre"]:
-                        if "settings" not in mod:
-                            mod["settings"] = {}
-                        mod["settings"]["name"] = f"{static_test_name}-{mod_id}"
+                mod["settings"]["network_name"] = net_name
+                mod["settings"]["subnetwork_name"] = sub_name
+                net_count += 1
+                
+            elif src in ["modules/file-system/filestore", "modules/file-system/managed-lustre"]:
+                if "settings" not in mod:
+                    mod["settings"] = {}
+
+                mod_id = mod.get("id")
+                if mod_id:
+                    sanitized_id = mod_id.replace("_", "-")
+                    name = f"{static_test_name}-{sanitized_id}"[:63]
+                else:
+                    name = f"{static_test_name}-storage-{storage_count}"[:63]
+                    storage_count += 1
+                mod["settings"]["name"] = name
 
     with open(blueprint_path, "w") as f:
         yaml.dump(data, f, sort_keys=False)

--- a/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
@@ -39,7 +39,7 @@ def main():
             
             src = mod.get("source", "")
 
-            if src in ["modules/network/vpc", "modules/network/pre-existing-vpc"]:
+            if src in ["modules/network/vpc"]:
                 if "settings" not in mod:
                     mod["settings"] = {}
                 
@@ -53,6 +53,13 @@ def main():
 
                 mod["settings"]["network_name"] = net_name
                 mod["settings"]["subnetwork_name"] = sub_name
+                
+                # Ensure secondary ranges lists track the statically assigned subnet_name, 
+                # as otherwise GKE gets confused if the subnets defined in yaml don't match exactly.
+                if "secondary_ranges_list" in mod["settings"]:
+                    for smod in mod["settings"]["secondary_ranges_list"]:
+                        smod["subnetwork_name"] = sub_name
+
                 net_count += 1
                 
             elif src == "modules/network/multivpc":
@@ -62,9 +69,9 @@ def main():
                 # multivpc creates multiple networks, pass prefix
                 # To prevent collisions, we suffix it with current count
                 if net_count == 0:
-                    net_name_prefix = f"{static_test_name}-net"[:63]
+                    net_name_prefix = f"{static_test_name}-net"[:54]
                 else:
-                    net_name_prefix = f"{static_test_name}-n{net_count}"[:63]
+                    net_name_prefix = f"{static_test_name}-n{net_count}"[:54]
                     
                 mod["settings"]["network_name_prefix"] = net_name_prefix
                 net_count += mod.get("settings", {}).get("network_count", 4)
@@ -74,11 +81,17 @@ def main():
                     mod["settings"] = {}
                 
                 if net_count == 0:
-                    net_name = f"{static_test_name}-net"[:63]
+                    net_name = f"{static_test_name}-net"[:56]
+                    sub_name = f"{static_test_name}-sub"[:63]
                 else:
-                    net_name = f"{static_test_name}-n{net_count}"[:63]
+                    net_name = f"{static_test_name}-n{net_count}"[:56]
+                    sub_name = f"{static_test_name}-n{net_count}-sub"[:63]
                     
                 mod["settings"]["network_name"] = net_name
+                
+                if "subnetworks_template" in mod["settings"] and isinstance(mod["settings"]["subnetworks_template"], dict):
+                    mod["settings"]["subnetworks_template"]["name_prefix"] = sub_name
+                    
                 net_count += 1
                 
             elif src in ["modules/file-system/filestore", "modules/file-system/managed-lustre"]:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
@@ -31,9 +31,9 @@ def main():
     if "deployment_groups" in data:
         for group in data["deployment_groups"]:
             if "modules" in group:
-                for mod in group["modules"]:
+                for idx, mod in enumerate(group["modules"]):
                     src = mod.get("source", "")
-                    mod_id = mod.get("id", "unknown")
+                    mod_id = mod.get("id", f"unknown-mod-{idx}")
 
                     if src.startswith("modules/network/"):
                         if "settings" not in mod:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py
@@ -39,7 +39,7 @@ def main():
             
             src = mod.get("source", "")
 
-            if src.startswith("modules/network/"):
+            if src in ["modules/network/vpc", "modules/network/pre-existing-vpc"]:
                 if "settings" not in mod:
                     mod["settings"] = {}
                 
@@ -53,6 +53,32 @@ def main():
 
                 mod["settings"]["network_name"] = net_name
                 mod["settings"]["subnetwork_name"] = sub_name
+                net_count += 1
+                
+            elif src == "modules/network/multivpc":
+                if "settings" not in mod:
+                    mod["settings"] = {}
+                
+                # multivpc creates multiple networks, pass prefix
+                # To prevent collisions, we suffix it with current count
+                if net_count == 0:
+                    net_name_prefix = f"{static_test_name}-net"[:63]
+                else:
+                    net_name_prefix = f"{static_test_name}-n{net_count}"[:63]
+                    
+                mod["settings"]["network_name_prefix"] = net_name_prefix
+                net_count += mod.get("settings", {}).get("network_count", 4)
+                
+            elif src == "modules/network/gpu-rdma-vpc":
+                if "settings" not in mod:
+                    mod["settings"] = {}
+                
+                if net_count == 0:
+                    net_name = f"{static_test_name}-net"[:63]
+                else:
+                    net_name = f"{static_test_name}-n{net_count}"[:63]
+                    
+                mod["settings"]["network_name"] = net_name
                 net_count += 1
                 
             elif src in ["modules/file-system/filestore", "modules/file-system/managed-lustre"]:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -58,6 +58,10 @@
     loop_control:
       loop_var: pre_deploy_task
 
+  ## Define Lock Variables and Acquire
+  - name: Set up Test Namespace Lock
+    ansible.builtin.include_tasks: tasks/setup_lock.yml
+
   ## Create cluster
   - name: Create Deployment Directory
     ansible.builtin.include_tasks:
@@ -207,6 +211,10 @@
       ansible.builtin.fail:
         msg: "Failed while setting up test infrastructure"
 
+    always:
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
+
 - name: Run Integration Tests
   hosts: remote_host
   gather_facts: false  # must wait until host is reachable
@@ -355,6 +363,9 @@
     - name: Print Slurm slurmsync.log
       ansible.builtin.debug:
         var: slurmsync_output.stdout_lines
+
+    - name: Release Test Namespace Lock
+      ansible.builtin.include_tasks: tasks/release_lock.yml
 
     - name: Cleanup firewall and infrastructure
       ansible.builtin.include_tasks:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -58,7 +58,19 @@
     loop_control:
       loop_var: pre_deploy_task
 
-  ## Define Lock Variables and Acquire
+  ## Define Lock Variables
+  - name: Define Base Lock Variables
+    ansible.builtin.set_fact:
+      static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+      gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+  - name: Define Derived Lock Paths
+    ansible.builtin.set_fact:
+      static_network_name: "{{ static_test_name }}-net"
+      lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+      local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
+  ## Acquire Lock
   - name: Set up Test Namespace Lock
     ansible.builtin.include_tasks: tasks/setup_lock.yml
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -30,16 +30,32 @@
     deployment_vars_str: "--vars \"\\\"{{ cli_deployment_vars.items() | map('join', '=') | join('\\\"\" --vars \"\\\"') }}\\\"\""
   when: cli_deployment_vars is defined and cli_deployment_vars is mapping
 
+- name: Create Temporary Injected Blueprint
+  ansible.builtin.copy:
+    src: "{{ blueprint_yaml }}"
+    dest: "{{ workspace }}/.injected-{{ deployment_name }}.yaml"
+    remote_src: yes
+
+- name: Inject Static Module Overrides (Network & Storage)
+  ansible.builtin.command: |
+    {{ workspace }}/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py "{{ workspace }}/.injected-{{ deployment_name }}.yaml" "{{ static_test_name }}"
+
 - name: Create Blueprint
   ansible.builtin.command: |
-      ./gcluster create -l ERROR "{{ blueprint_yaml }}" \
+      ./gcluster create -l ERROR "{{ workspace }}/.injected-{{ deployment_name }}.yaml" \
       --backend-config bucket={{ state_bucket }} \
       --vars project_id={{ project }} \
       --vars deployment_name={{ deployment_name }} \
+      --vars static_test_name={{ static_test_name }} \
       {{ deployment_vars_str if deployment_vars_str is defined else '' }}
   args:
     creates: "{{ workspace }}/{{ deployment_name }}"
     chdir: "{{ workspace }}"
+
+- name: Cleanup Temporary Injected Blueprint
+  ansible.builtin.file:
+    path: "{{ workspace }}/.injected-{{ deployment_name }}.yaml"
+    state: absent
 
 - name: Compress Blueprint
   ansible.builtin.command:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -40,6 +40,10 @@
   ansible.builtin.command: |
     {{ workspace }}/tools/cloud-build/daily-tests/ansible_playbooks/scripts/inject_static_names.py "{{ workspace }}/.injected-{{ deployment_name }}.yaml" "{{ static_test_name }}"
 
+- name: Display Injected Blueprint
+  ansible.builtin.command: |
+    cat "{{ workspace }}/.injected-{{ deployment_name }}.yaml"
+
 - name: Create Blueprint
   ansible.builtin.command: |
       ./gcluster create -l ERROR "{{ workspace }}/.injected-{{ deployment_name }}.yaml" \

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -46,7 +46,6 @@
       --backend-config bucket={{ state_bucket }} \
       --vars project_id={{ project }} \
       --vars deployment_name={{ deployment_name }} \
-      --vars static_test_name={{ static_test_name }} \
       {{ deployment_vars_str if deployment_vars_str is defined else '' }}
   args:
     creates: "{{ workspace }}/{{ deployment_name }}"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/release_lock.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/release_lock.yml
@@ -1,0 +1,22 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Release Network Lock
+  ansible.builtin.shell: |
+    gsutil rm "{{ lock_file_path }}"
+  register: lock_released
+  changed_when: lock_released.rc == 0
+  delegate_to: localhost
+  ignore_errors: true # Continue even if lock file doesn't exist for some reason

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/release_lock.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/release_lock.yml
@@ -15,7 +15,7 @@
 ---
 - name: Release Network Lock
   ansible.builtin.shell: |
-    gsutil rm "{{ lock_file_path }}"
+    gsutil rm "{{ hostvars['localhost']['lock_file_path'] }}"
   register: lock_released
   changed_when: lock_released.rc == 0
   delegate_to: localhost

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/setup_lock.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/setup_lock.yml
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 ---
-- name: Define Base Lock Variables
-  ansible.builtin.set_fact:
-    static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
-    gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
-
-- name: Define Derived Lock Paths
-  ansible.builtin.set_fact:
-    static_network_name: "{{ static_test_name }}-net"
-    lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
-    local_lock_file: "/tmp/{{ static_test_name }}.lock"
 
 - name: Create Local Empty Lock File
   ansible.builtin.file:
@@ -31,21 +21,21 @@
 
 - name: Verify Lock Bucket Exists (Fail Fast)
   ansible.builtin.shell: |
-    gsutil ls "{{ gcs_lock_bucket }}"
+    gsutil ls "{{ hostvars['localhost']['gcs_lock_bucket'] }}"
   register: bucket_check
   delegate_to: localhost
   failed_when: bucket_check.rc != 0
 
 - name: "Check and Break Stale Locks (TTL: 4 hours)"
   ansible.builtin.shell: |
-    CREATE_TIME=$(gsutil stat "{{ lock_file_path }}" 2>/dev/null | grep "Creation time:" | awk -F': ' '{print $2}') || true
+    CREATE_TIME=$(gsutil stat "{{ hostvars['localhost']['lock_file_path'] }}" 2>/dev/null | grep "Creation time:" | awk -F': ' '{print $2}') || true
     if [ -n "$CREATE_TIME" ]; then
       CREATE_EPOCH=$(date -d "$CREATE_TIME" +%s 2>/dev/null || date -j -f "%a, %d %b %Y %H:%M:%S %Z" "$CREATE_TIME" +%s)
       NOW_EPOCH=$(date +%s)
       AGE_SECONDS=$((NOW_EPOCH - CREATE_EPOCH))
       if [ "$AGE_SECONDS" -gt 14400 ]; then
         echo "Lock is older than 4 hours ($AGE_SECONDS seconds). Breaking stale lock."
-        gsutil rm "{{ lock_file_path }}"
+        gsutil rm "{{ hostvars['localhost']['lock_file_path'] }}"
       fi
     fi
   delegate_to: localhost
@@ -53,7 +43,7 @@
 
 - name: Acquire Test Namespace Lock
   ansible.builtin.shell: |
-    timeout 60s gsutil cp -n "{{ local_lock_file }}" "{{ lock_file_path }}"
+    timeout 60s gsutil cp -n "{{ hostvars['localhost']['local_lock_file'] }}" "{{ hostvars['localhost']['lock_file_path'] }}"
   register: lock_acquired
   changed_when: lock_acquired.rc == 0
   retries: 30  # Retry for 30 minutes

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/setup_lock.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/setup_lock.yml
@@ -1,0 +1,62 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Define Base Lock Variables
+  ansible.builtin.set_fact:
+    static_test_name: "{{ test_prefix | default('') }}{{ test_name }}"
+    gcs_lock_bucket: "gs://{{ project }}-hpc-toolkit-locks"
+
+- name: Define Derived Lock Paths
+  ansible.builtin.set_fact:
+    static_network_name: "{{ static_test_name }}-net"
+    lock_file_path: "{{ gcs_lock_bucket }}/locks/{{ static_test_name }}.lock"
+    local_lock_file: "/tmp/{{ static_test_name }}.lock"
+
+- name: Create Local Empty Lock File
+  ansible.builtin.file:
+    path: "{{ local_lock_file }}"
+    state: touch
+
+- name: Verify Lock Bucket Exists (Fail Fast)
+  ansible.builtin.shell: |
+    gsutil ls "{{ gcs_lock_bucket }}"
+  register: bucket_check
+  delegate_to: localhost
+  failed_when: bucket_check.rc != 0
+
+- name: "Check and Break Stale Locks (TTL: 4 hours)"
+  ansible.builtin.shell: |
+    CREATE_TIME=$(gsutil stat "{{ lock_file_path }}" 2>/dev/null | grep "Creation time:" | awk -F': ' '{print $2}') || true
+    if [ -n "$CREATE_TIME" ]; then
+      CREATE_EPOCH=$(date -d "$CREATE_TIME" +%s 2>/dev/null || date -j -f "%a, %d %b %Y %H:%M:%S %Z" "$CREATE_TIME" +%s)
+      NOW_EPOCH=$(date +%s)
+      AGE_SECONDS=$((NOW_EPOCH - CREATE_EPOCH))
+      if [ "$AGE_SECONDS" -gt 14400 ]; then
+        echo "Lock is older than 4 hours ($AGE_SECONDS seconds). Breaking stale lock."
+        gsutil rm "{{ lock_file_path }}"
+      fi
+    fi
+  delegate_to: localhost
+  changed_when: false
+
+- name: Acquire Test Namespace Lock
+  ansible.builtin.shell: |
+    timeout 60s gsutil cp -n "{{ local_lock_file }}" "{{ lock_file_path }}"
+  register: lock_acquired
+  changed_when: lock_acquired.rc == 0
+  retries: 30  # Retry for 30 minutes
+  delay: 60    # Wait 60 seconds between retries
+  until: lock_acquired.rc == 0
+  delegate_to: localhost

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -53,6 +53,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ansible-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -77,5 +77,6 @@ steps:
     echo '      timeout: 10800'                                   >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml"

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -52,6 +52,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=ubuntu" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -53,6 +53,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=default" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -54,6 +54,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/cloud-batch.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -97,6 +97,7 @@ steps:
       /^[ ]*settings:$/a \      spot: true
     }' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue-onspot.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue.yaml
@@ -63,6 +63,7 @@ steps:
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a2-highgpu-kueue.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -93,6 +93,7 @@ steps:
             type: COMPACT
     }' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-highgpu-onspot.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -75,6 +75,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -93,6 +93,7 @@ steps:
       --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-megagpu-onspot.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -90,6 +90,7 @@ steps:
     sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: true' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -75,6 +75,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -94,6 +94,7 @@ steps:
     sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: true' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -79,6 +79,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -94,6 +94,7 @@ steps:
     sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: true' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-a4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4.yaml
@@ -80,6 +80,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -86,6 +86,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -73,6 +73,7 @@ steps:
     echo '      node_count: 1'                                 >> $${EXAMPLE_BP}
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-g4.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -84,6 +84,7 @@ steps:
     sed -i '/placement_policy:/,+1d' $${EXAMPLE_BP}
     cat $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d-onspot.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -79,6 +79,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -78,6 +78,7 @@ steps:
     echo '        - name: sample-reservation-01'                  >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -67,6 +67,7 @@ steps:
     IP=$(curl ifconfig.me)
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -70,6 +70,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -67,6 +67,7 @@ steps:
     echo '      zone: us-central1-a'               >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -91,6 +91,7 @@ steps:
     sed -i -e '/reservation_affinity:/,+3c\      spot: true' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -80,6 +80,7 @@ steps:
 
     # Run the test
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -94,6 +94,7 @@ steps:
     sed -i -e '/reservation_affinity:/,+3c\      spot: true' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml"

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -69,6 +69,7 @@ steps:
     echo '    settings: {name: ubuntu, image_type: UBUNTU_CONTAINERD}' >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -72,6 +72,7 @@ steps:
           provisioning_model: "SPOT"
     }' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -68,6 +68,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -55,6 +55,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-build-slurm-image.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -59,6 +59,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -57,6 +57,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/htc-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -60,6 +60,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -71,6 +71,7 @@ steps:
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE}"\

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -60,6 +60,7 @@ steps:
     REGION=us-west1
     ZONE=us-west1-a
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -77,6 +77,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-megagpu-onspot-slurm-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -64,6 +64,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -65,6 +65,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \
       --extra-vars="instance_image_family=$${CUSTOM_IMAGE_FAMILY}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -59,6 +59,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -70,6 +70,7 @@ steps:
     # Removing reservation and automatic restart from blueprint for spot VMs to work.
     sed -i -e '/reservation/d' -e '/automatic_restart/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -77,6 +77,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -64,6 +64,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -65,6 +65,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \
       --extra-vars="instance_image_family=$${CUSTOM_IMAGE_FAMILY}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -77,6 +77,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a4-highgpu-onspot-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-slurm.yaml
@@ -65,6 +65,7 @@ steps:
     sed -i -e 's/\breservation_name\b/future_reservation/g' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -73,6 +73,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-g4-onspot-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -72,6 +72,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -72,6 +72,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -71,6 +71,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-h4d-onspot-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -60,6 +60,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -57,6 +57,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -55,6 +55,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -50,6 +50,7 @@ steps:
     git init . # ofe deploymemt requires some git repo to figure out top level directory
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/ofe-deployment-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ofe-deployment.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -59,6 +59,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -55,6 +55,7 @@ steps:
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -52,6 +52,7 @@ steps:
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -66,6 +66,7 @@ steps:
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/slinky.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -56,6 +56,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -56,6 +56,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -57,6 +57,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -57,6 +57,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -54,6 +54,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-static.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -72,6 +72,7 @@ steps:
     sed -i 's/^[ ]*preemptible: false/      preemptible: true/' $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -56,6 +56,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -63,6 +63,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:3}
 
     ansible-playbook -v tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -60,6 +60,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']


### PR DESCRIPTION
### Objective
Resolve resource exhaustion issues (such as VPC peering limits and subnet conflicts) during concurrent integration test runs by enforcing isolated, predictable static namespaces and distributed locking.

### Problem Statement
Currently, Integration Tests generate pseudo-random hashes via `gcluster` for network and storage modules during dynamic deployments. When 60+ daily and PR tests run simultaneously, they overwhelm the central project's quotas by spinning up hundreds of isolated VPCs. Attempting to use static names natively in blueprints directly would result in concurrent tests colliding over the same exact VPC or Filestore name.

### Solution & Architecture
This PR introduces **Static Namespace Injection** paired with **GCS-Based Global Test Locks** to safely multiplex and isolate overlapping test runs without corrupting our example blueprints.

**1. GCS Distributed Locking (`gsutil cp -n`)**
We now utilize atomic GCS copy operations as a global lock server. Before any integration test is allowed to execute `gcluster create`, Ansible establishes a lock for that specific `test_name` (e.g., `gs://<project_id>-hpc-toolkit-locks/locks/daily-slurm-gke.lock`).
* If a PR test and a Daily test run the exact same blueprint, their unique `_TEST_PREFIX` ensures they deploy onto different VPCs.
* If two overlapping runs attempt to use the exact same prefix+test name, the second runner will properly wait for the lock to release, avoiding a collision.

**2. In-Flight Dynamic Settings Injection (`inject_static_names.py`)**
Rather than asking users to hardcode static names inside all of our `examples/` folder (which would break the user experience), this PR introduces a Python pre-processor to the Ansible deployer pipeline. 
Right before executing `gcluster create`, Ansible copies the target blueprint into a temporary `.injected.yaml` file. The Python script parses the topology and intelligently forces `settings.network_name`, `settings.subnetwork_name`, and `settings.name` (for Lustre/Filestore) into the deployment groups. It handles multi-NIC architecture gracefully by assigning `-net`, `-n1`, `-n2`, etc.

**3. Cloud Build Propagation**
Updated all 72 `tools/cloud-build/daily-tests/builds/*.yaml` files to explicitly forward `_TEST_PREFIX` down into the Ansible runtime environment as an extra variable, correctly differentiating `daily-` vs `pr-` namespaces.

### Verification Performed
* Ran a local highly-concurrent Python simulation across 189 simultaneous simulated tests mimicking PRs and Daily crons entirely.
* Confirmed a `100%` success rate of GCS test locks holding and deferring overlapping jobs.
* Confirmed advanced blueprint corner cases (multi-NIC topologies, multi-deployment groups, and blueprints natively lacking `settings:` blocks) are all parsed correctly by the injection script.
* Pre-commit (yamllint, python formatters) passed successfully.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
