### PR TITLE
Update slurm_cluster_name regex

### DIFF
--- a/community/modules/compute/gke-nodeset/variables.tf
+++ b/community/modules/compute/gke-nodeset/variables.tf
@@ -27,8 +27,8 @@ variable "slurm_cluster_name" {
   description = "Cluster name, used in slurm controller"
 
   validation {
-    condition     = var.slurm_cluster_name != null && can(regex("^[a-z]([-a-z0-9]{0,20})$", var.slurm_cluster_name))
-    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,20})$'."
+    condition     = var.slurm_cluster_name != null && can(regex("^[a-z]([-a-z0-9]{0,19})$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   }
 }
 

--- a/community/modules/internal/slurm-gcp/instance_template/variables.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/variables.tf
@@ -383,8 +383,8 @@ variable "slurm_cluster_name" {
   description = "Cluster name, used for resource naming."
 
   validation {
-    condition     = can(regex("^[a-z]([-a-z0-9]{0,20})$", var.slurm_cluster_name))
-    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,20})$'."
+    condition     = can(regex("^[a-z]([-a-z0-9]{0,19})$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
@@ -62,8 +62,8 @@ variable "slurm_cluster_name" {
   description = "The cluster name, used for resource naming and slurm accounting."
 
   validation {
-    condition     = can(regex("^[a-z]([-a-z0-9]{0,20})$", var.slurm_cluster_name))
-    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,20})$'."
+    condition     = can(regex("^[a-z]([-a-z0-9]{0,19})$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -37,8 +37,8 @@ variable "slurm_cluster_name" {
   default     = null
 
   validation {
-    condition     = var.slurm_cluster_name == null || can(regex("^[a-z]([-a-z0-9]{0,20})$", var.slurm_cluster_name))
-    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,20})$'."
+    condition     = var.slurm_cluster_name == null || can(regex("^[a-z]([-a-z0-9]{0,19})$", var.slurm_cluster_name))
+    error_message = "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   }
 }
 

--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
@@ -27,7 +27,7 @@ vars:
   tcpx_kernel_password: # use value supplied by Google Cloud staff
   keyserver_ubuntu_key: # use value supplied by Google Cloud staff
   a3_reservation_name: # supply a3-highgpu-8g reservation name
-  slurm_cluster_name: # supply name for slurm cluster (lowercase alphanumeric, max 10 characters, must start with a letter)
+  slurm_cluster_name: # supply name for slurm cluster (lowercase letters, numbers, and hyphens, max 20 characters, must start with a letter)
   a3_static_cluster_size: # supply a3-highgpu-8g reservation size
   a3_partition_name: # supply partition name
   disk_size_gb: 200

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
@@ -30,7 +30,7 @@ vars:
   enable_nvidia_persistenced: true
   disk_size_gb: 200
   final_image_family: slurm-a3mega
-  slurm_cluster_name: # supply name for slurm cluster (lowercase alphanumeric, max 10 characters, must start with a letter)
+  slurm_cluster_name: # supply name for slurm cluster (lowercase letters, numbers, and hyphens, max 20 characters, must start with a letter)
   a3mega_cluster_size:  # supply cluster size
   a3mega_reservation_name: # supply reservation name
   # Additional provisioning models (pick only one), can be used to substitute `a3mega_reservation_name`:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -618,7 +618,7 @@ func (err InputValueError) Error() string {
 
 var matchLabelNameExp *regexp.Regexp = regexp.MustCompile(`^[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}$`)
 var matchLabelValueExp *regexp.Regexp = regexp.MustCompile(`^[\p{Ll}\p{Lo}\p{N}_-]{0,63}$`)
-var matchSlurmClusterNameExp *regexp.Regexp = regexp.MustCompile(`^[a-z](?:[a-z0-9]{0,9})$`)
+var matchSlurmClusterNameExp *regexp.Regexp = regexp.MustCompile(`^[a-z][-a-z0-9]{0,19}$`)
 
 // isValidLabelName checks if a string is a valid name for a GCP label.
 // For more information on valid label names, see the docs at:

--- a/pkg/config/errors.go
+++ b/pkg/config/errors.go
@@ -166,7 +166,7 @@ const (
 	errMsgValueNotString       = string("value was not of type string")
 	errMsgValueEmptyString     = string("value is an empty string")
 	errMsgLabelValueReqs       = string("value can only contain lowercase letters, numeric characters, underscores and dashes, and must be between 0 and 63 characters long")
-	errMsgSlurmClusterNameReqs = string("must start with a lowercase letter, contain only lowercase letters and numbers, and be between 1 and 10 characters long")
+	errMsgSlurmClusterNameReqs = string("must start with a lowercase letter, contain only lowercase letters, numbers and hyphens, and be between 1 and 20 characters long")
 	ErrMsgResourceInZone       = "%s %q is not available in zone %q in project %q"
 	ErrMsgResourceInAnyZone    = "%s %q is not available in any requested zones [%s] in project %q"
 )


### PR DESCRIPTION
### Summary

Update slurm_cluster_name regex to match in upfront and TF Validations and address a bug in TF validations as it took 21 instead of 20 chars max.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
