### PR TITLE
Fix SELinux issue in hpc-build-slurm-image blueprint

### DIFF
--- a/community/examples/hpc-build-slurm-image.yaml
+++ b/community/examples/hpc-build-slurm-image.yaml
@@ -46,12 +46,11 @@ deployment_groups:
         content: |
           #!/bin/bash
           set -e -o pipefail
-          # Slurm build on Rocky8 will upgrade to python38 as part of build
-          # This is not compatible with ansible-local runner
-          dnf install -y python38
-          alternatives --set python3 /usr/bin/python3.8
+          # Slurm build on Rocky8 will upgrade to python3.12 as part of build
+          dnf install -y python3.12 python3.12-pip
+          alternatives --set python3 /usr/bin/python3.12
           python3 -m pip install pip --upgrade
-          python3 -m pip install ansible==6.7.0
+          python3 -m pip install ansible==8.7.0
           python3 -m pip install selinux
           export PATH=/usr/local/bin:$PATH
           ansible --version


### PR DESCRIPTION
This PR fixes a deployment failure in `hpc-build-slurm-image.yaml` where startup script fails to disable SELinux because `selinux` module is not found in the Python3 environment for Rocky Linux 8 image.

**Changes:**
- **Upgraded Ansible to 8.7.0:** Provides `ansible-core 2.15`. Slurm 25.11.2 requires `ansible-core >= 2.15`.
- **Upgraded Python to 3.12:** Required to support Ansible 8.7.0.

Part of this fix was delivered in [slurm-gcp PR](https://github.com/GoogleCloudPlatform/slurm-gcp/pull/329).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
