### PR TITLE
pin staticcheck to v0.6.1 to restore WEEKLY-build-dependency-check

### DIFF
--- a/tools/cloud-build/dependency-checks/Dockerfile.precommit
+++ b/tools/cloud-build/dependency-checks/Dockerfile.precommit
@@ -26,4 +26,4 @@ RUN go install github.com/terraform-docs/terraform-docs@latest      && \
     go install github.com/google/addlicense@latest                  && \
     go install mvdan.cc/sh/v3/cmd/shfmt@latest                      && \
     go install golang.org/x/tools/cmd/goimports@latest              && \
-    go install honnef.co/go/tools/cmd/staticcheck@latest
+    go install honnef.co/go/tools/cmd/staticcheck@v0.6.1


### PR DESCRIPTION
## Description

This PR pins `staticcheck` to `v0.6.1` within `precommit` Dockerfile to resolve the ongoing failures in the `WEEKLY-build-dependency-check` Cloud Build job.

**Root Cause Analysis:**
The `WEEKLY-build-dependency-check` job has been failing because it uses unpinned linter installations (`@latest`). Recently, `staticcheck` released `v0.7.0`, which introduced a hard requirement for Go 1.25.0+. However, our Cloud Build environment (`golang:bullseye`) currently provides Go 1.24.6, causing the installation step to fail and halting the build.

**Reasoning**
Upgrading the core language version from Go 1.24 to 1.25 across the entire Cluster Toolkit to satisfy a linter requirement introduces risk without our standard, full-lifecycle validation testing. 

## Testing Performed
- Verified the build step locally.
- Confirmed `pre-commit` functions correctly with the pinned version.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
