### PR TITLE
update nccl tests for a4-h and a4x-h

### DIFF
--- a/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -58,7 +58,8 @@ EOF
 fi
 
 # Install ramble and make world read/writeable.
-sudo git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git -C "${SOFTWARE_INSTALL}"/ramble checkout 2a020babedd68be15448f3893d2a245fcaa8bd73
 sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 
 # Create python environment for ramble, and install requirements
@@ -76,6 +77,8 @@ ramble workspace create -a -d "${TEST_DIR}"
 cat <<EOF >"${TEST_DIR}"/configs/ramble.yaml
 # Ramble Configuration for NCCL Tests
 ramble:
+  config:
+    overwrite_inventories: true
   modifiers:
   - name: pyxis-enroot
   - name: nccl-gib

--- a/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -58,7 +58,8 @@ EOF
 fi
 
 # Install ramble and make world read/writeable.
-sudo git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git -C "${SOFTWARE_INSTALL}"/ramble checkout 2a020babedd68be15448f3893d2a245fcaa8bd73
 sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 
 # Create python environment for ramble, and install requirements
@@ -76,6 +77,8 @@ ramble workspace create -a -d "${TEST_DIR}"
 cat <<EOF >"${TEST_DIR}"/configs/ramble.yaml
 # Ramble Configuration for NCCL Tests
 ramble:
+  config:
+    overwrite_inventories: true
   modifiers:
   - name: pyxis-enroot
   - name: nccl-gib


### PR DESCRIPTION
update NCCL tests for a4-highgpu-8g and a4x-highgpu-4g to pin ramble version and set `overwrite_inventories` to `true`.  NCCL tests fail to successfully run without these changes. 



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
