### PR TITLE
Add Time to live labels in A* slurm Integration tests

### DIFF
--- a/tools/add_ttl_label.sh
+++ b/tools/add_ttl_label.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# tools/add_ttl_label.sh
+# Scoped script to add a TTL label ONLY under the top-level 'vars:' block.
+
+if [ "$#" -ne 1 ]; then
+	echo "Usage: $0 <blueprint-file>"
+	exit 1
+fi
+
+BLUEPRINT_FILE=$1
+
+# Check if file exists
+if [ ! -f "$BLUEPRINT_FILE" ]; then
+	echo "ERROR: Blueprint file not found: $BLUEPRINT_FILE" >&2
+	exit 1
+fi
+
+# Calculate TTL (Current UTC + 4 hours)
+TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
+
+# 1. Identify the boundaries of the 'vars:' block
+VARS_START=$(grep -n "^vars:" "$BLUEPRINT_FILE" | head -1 | cut -d: -f1)
+
+if [ -z "$VARS_START" ]; then
+	echo "ERROR: 'vars:' block not found in $BLUEPRINT_FILE" >&2
+	exit 1
+fi
+
+# Find the next top-level key (line starting with non-whitespace, non-# character)
+NEXT_SECTION=$(tail -n +$((VARS_START + 1)) "$BLUEPRINT_FILE" | grep -n "^[^ #]" | head -1 | cut -d: -f1)
+
+if [ -z "$NEXT_SECTION" ]; then
+	# No next section exists, search to the end of the file
+	VARS_END=$(wc -l <"$BLUEPRINT_FILE")
+else
+	# Calculate the absolute line number for the end of the range (exclusive)
+	VARS_END=$((VARS_START + NEXT_SECTION - 1))
+fi
+
+# 2. Check the state within the identified RANGE and apply changes
+RANGE="${VARS_START},${VARS_END}"
+
+# Check if 'labels:' exists specifically within the 'vars:' block
+if ! sed -n "${RANGE}p" "$BLUEPRINT_FILE" | grep -q "^  labels:"; then
+	# Case A: No labels in vars. Add it directly after the 'vars:' line.
+	sed -i "${VARS_START}a\\  labels:\n    time-to-live: \"${TTL_LABEL}\"" "$BLUEPRINT_FILE"
+
+elif ! sed -n "${RANGE}p" "$BLUEPRINT_FILE" | grep -q "time-to-live:"; then
+	# Case B: labels: exists in vars, but time-to-live does not.
+	# Find the line number of 'labels:' within vars
+	LABELS_LINE=$(sed -n "${RANGE}p" "$BLUEPRINT_FILE" | grep -n "^  labels:" | cut -d: -f1)
+	if [ -n "$LABELS_LINE" ]; then
+		# Convert relative to absolute line number
+		LABELS_ABS=$((VARS_START + LABELS_LINE - 1))
+		sed -i "${LABELS_ABS}a\\    time-to-live: \"${TTL_LABEL}\"" "$BLUEPRINT_FILE"
+	fi
+
+else
+	# Case C: time-to-live already exists in vars. Update its value.
+	sed -i "${RANGE}s/time-to-live: \"[^\"]*\"/time-to-live: \"${TTL_LABEL}\"/" "$BLUEPRINT_FILE"
+fi
+
+echo "✓ TTL label added/updated in $BLUEPRINT_FILE"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -84,9 +84,7 @@ steps:
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi
 
-    # Calculate Time-To-Live label (Current UTC time + 4 hours)
-    TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
-    sed -i "/^vars:/a \  labels:\n    time-to-live: \"$$TTL_LABEL\"" $${BLUEPRINT}
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -62,9 +62,7 @@ steps:
 
     BLUEPRINT="/workspace/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml"
 
-    # Calculate Time-To-Live label (Current UTC time + 4 hours)
-    TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
-    sed -i "/^vars:/a \  labels:\n    time-to-live: \"$$TTL_LABEL\"" $${BLUEPRINT}\
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -86,9 +86,7 @@ steps:
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi
 
-    # Calculate Time-To-Live label (Current UTC time + 4 hours)
-    TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
-    sed -i "/^vars:/a \  labels:\n    time-to-live: \"$$TTL_LABEL\"" $${BLUEPRINT}
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -64,9 +64,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
 
-    # Calculate Time-To-Live label (Current UTC time + 4 hours)
-    TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
-    sed -i "/^vars:/a \  labels:\n    time-to-live: \"$$TTL_LABEL\"" $${BLUEPRINT}
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
         --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -74,6 +74,8 @@ steps:
       echo "INFO: Using $${VARS_FILE} as it is for SPOT provisioning."
     fi
 
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
+
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -82,6 +82,8 @@ steps:
       echo "INFO: Using $${JBVM_VARS_FILE} as it is for SPOT provisioning."
     fi
 
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
+
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -86,9 +86,8 @@ steps:
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi
 
-    # Calculate Time-To-Live label (Current UTC time + 4 hours)
-    TTL_LABEL=$(date -u -d '+4 hours' +'%Y-%m-%d_%H-%M')
-    sed -i "/^vars:/a \  labels:\n    time-to-live: \"$$TTL_LABEL\"" $${BLUEPRINT}
+
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \


### PR DESCRIPTION
### Summary

Add Time-to-live label which is current_time+4 hrs in A* Slurm integration tests.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
