### PR TITLE
[Failed] Hotfix: Update G4 NVIDIA drivers for kernel 6.17 compatibility

### DIFF
--- a/examples/ml-slurm-g4.yaml
+++ b/examples/ml-slurm-g4.yaml
@@ -102,9 +102,8 @@ deployment_groups:
             # with the NVIDIA repository version.
             - name: Remove conflicting Ubuntu NVIDIA firmware
               ansible.builtin.apt:
-                name: nvidia-firmware-590-590.48.01
+                name: nvidia-firmware-590
                 state: absent
-              ignore_errors: true
 
             # Install the package with force-overwrite to handle any remaining file conflicts
             - name: Install NVIDIA fabric and CUDA


### PR DESCRIPTION
**Hotfix**: Update G4 NVIDIA drivers for kernel 6.17 compatibility

- Update NVIDIA driver branch from 575 to 590 to support the newer 6.17.0-1008-gcp kernel in recent Ubuntu 24.04 LTS images.
- Resolve dpkg file conflicts by adding a task to remove the pre-installed Ubuntu 'nvidia-firmware-590' package.
- Use 'force-overwrite' dpkg option to ensure NVIDIA repository firmware correctly replaces conflicting system files.
- Correct package naming to 'nvidia-driver-590-open' to align with NVIDIA's current repository conventions for open kernel modules.
- Set CUDA toolkit to 12.8 for stable compatibility with the 590 branch.

**Callouts**:
* The issue being fixed here can re-occur if the image and package versions are not pinned.