### PR TITLE
Hotfix: update G4 NVIDIA drivers for kernel 6.17 compatibility

### DIFF
--- a/examples/ml-slurm-g4.yaml
+++ b/examples/ml-slurm-g4.yaml
@@ -73,11 +73,11 @@ deployment_groups:
               enable_nvidia_dcgm: false
               nvidia_packages:
               # 1. Open Kernel Driver: Installs the open-source kernel components.
-              - nvidia-kernel-open-575
-              # 2. Driver Metapackage: Pulls in the 580.xx driver version.
-              - cuda-drivers-575
-              # 3. CUDA Toolkit: Installs the 12.9.1 toolkit.
-              - cuda-toolkit-12-9
+              - nvidia-driver-590-open
+              # 2. Driver Metapackage: Pulls in the 590.xx driver version.
+              - cuda-drivers-590
+              # 3. CUDA Toolkit: Installs the 12.8 toolkit (stable for 590).
+              - cuda-toolkit-12-8
               - datacenter-gpu-manager
 
             tasks:
@@ -98,10 +98,18 @@ deployment_groups:
               ansible.builtin.apt:
                 update_cache: true
 
-            # Install the package
+            # Latest Ubuntu images pre-install a firmware package that conflicts
+            # with the NVIDIA repository version.
+            - name: Remove conflicting Ubuntu NVIDIA firmware
+              ansible.builtin.apt:
+                name: nvidia-firmware-590
+                state: absent
+
+            # Install the package with force-overwrite to handle any remaining file conflicts
             - name: Install NVIDIA fabric and CUDA
               ansible.builtin.apt:
                 name: "{{ item }}"
+                dpkg_options: 'force-overwrite'
               loop: "{{ nvidia_packages }}"
 
             # This section will optionally freeze the packages with


### PR DESCRIPTION
**Hotfix**: Update G4 NVIDIA drivers for kernel 6.17 compatibility

- Update NVIDIA driver branch from 575 to 590 to support the newer 6.17.0-1008-gcp kernel in recent Ubuntu 24.04 LTS images.
- Resolve dpkg file conflicts by adding a task to remove the pre-installed Ubuntu 'nvidia-firmware-590' package.
- Use 'force-overwrite' dpkg option to ensure NVIDIA repository firmware correctly replaces conflicting system files.
- Correct package naming to 'nvidia-driver-590-open' to align with NVIDIA's current repository conventions for open kernel modules.
- Set CUDA toolkit to 12.8 for stable compatibility with the 590 branch.


**Callouts**:
The issue being fixed here can re-occur if the image and package versions are not pinned.