### PR TITLE
Hotfix: Update the region and zone(s) to overcome Lustre instance creation issue

### DIFF
--- a/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml
@@ -18,12 +18,12 @@ deployment_name: "enter-{{ build }}"
 # Manually adding the slurm_cluster_name for use in node names, which filters
 # non-alphanumeric chars and is capped at 10 chars.
 slurm_cluster_name: "enter{{ build[0:5] }}"
-zone: europe-west4-c
+zone: us-central1-a
 cli_deployment_vars:
   network_name: "{{ network }}"
-  region: europe-west4
+  region: us-central1
   zone: "{{ zone }}"
-  gpu_zones: "[europe-west4-a,europe-west4-b,europe-west4-c]"
+  gpu_zones: "[us-central1-a, us-central1-b, us-central1-c, us-central1-f]"
   lustre_instance_id: "lustre-instance-{{build}}"
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-enterprise-slurm.yaml"


### PR DESCRIPTION
The `PR-test-hpc-enterprise-slurm` PR test has been failing with the error below:
```
Step #1 - "hpc-enterprise-slurm-v6": 2026-02-26T05:10:29Z Error: Error waiting to create Instance: Error waiting for Creating Instance: Error code 13, message: an internal error has occurred
Step #1 - "hpc-enterprise-slurm-v6": 
Step #1 - "hpc-enterprise-slurm-v6":   with module.lustre-gcp.google_lustre_instance.lustre_instance,
Step #1 - "hpc-enterprise-slurm-v6":   on modules/embedded/modules/file-system/managed-lustre/main.tf line 61, in resource "google_lustre_instance" "lustre_instance":
Step #1 - "hpc-enterprise-slurm-v6":   61: resource "google_lustre_instance" "lustre_instance" {
```
One such failed build: https://pantheon.corp.google.com/cloud-build/builds;region=global/220fe844-9432-4d57-8820-82c6d32e001a?e=13803378&mods=monitoring_api_prod&project=hpc-toolkit-dev

**Workaround**: Update the region and zone inputs.
**Callouts**: The test should be improved to make a check similar to how spot tests run for identifying an appropriate region / zone.