### PR TITLE
[Draft] Hotfix: Add env variables to overcome A3 highgpu failure

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_epilog.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_epilog.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Set context for the slurm_mux script to correctly identify and run epilog scripts.
-export SLURM_SCRIPT_CONTEXT="epilog_slurmd"
+export SLURM_SCRIPT_CONTEXT="epilog"
 if [[ -x /opt/apps/adm/slurm/slurm_epilog ]]; then
 	exec /opt/apps/adm/slurm/slurm_epilog
 fi

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_prolog.sh
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_prolog.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Set context for the slurm_mux script to correctly identify and run prolog scripts.
-export SLURM_SCRIPT_CONTEXT="prolog_slurmd"
+export SLURM_SCRIPT_CONTEXT="prolog"
 if [[ -x /opt/apps/adm/slurm/slurm_prolog ]]; then
 	exec /opt/apps/adm/slurm/slurm_prolog
 fi


### PR DESCRIPTION
The NCCL test failure with WEXITSTATUS 3 was caused by a missing environment variable in the Slurm Prolog/Epilog wrapper scripts.


  **Root Cause Analysis**
   1. TCPX Initialization: NCCL tests on A3 HighGPU nodes require the rxdm (Receive Data Path Manager) script to create Unix Domain
      Sockets in /run/tcpx-${SLURM_JOB_ID}. These sockets are then mounted into the Enroot container.
   2. Multiplexer Failure: The rxdm script is executed via a multiplexer script (slurm_mux). This multiplexer depends on the
      SLURM_SCRIPT_CONTEXT environment variable to determine which scripts to run (e.g., prolog_slurmd or epilog_slurmd).
   3. Missing Context: The wrapper scripts external_prolog.sh and external_epilog.sh were calling slurm_mux without setting
      SLURM_SCRIPT_CONTEXT. Consequently, slurm_mux skipped all scripts, including rxdm.
   4. Container Startup Failure: Because rxdm did not run, the /run/tcpx-${SLURM_JOB_ID} directory was never created on the compute
      nodes. When srun attempted to start the container, the mount operation failed because the source directory did not exist,
      leading to exit code 3.


  Fixes Applied
 Updated the following files in the schedmd-slurm-gcp-v6-controller module:
   - `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_prolog.sh`: Now exports
     SLURM_SCRIPT_CONTEXT="prolog_slurmd".
   - `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/files/external_epilog.sh`: Now exports
     SLURM_SCRIPT_CONTEXT="epilog_slurmd".


  These changes ensure that custom prologs and epilogs (including TCPX setup) are correctly identified and executed by the multiplexer.