### PR TITLE
Modifying prefix_length for PSA to accomodate sufficient IPs for peering

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -214,7 +214,7 @@ deployment_groups:
   #   source: modules/network/private-service-access
   #   use: [gke-a3-ultra-net-0]
   #   settings:
-  #     prefix_length: 24
+  #     prefix_length: 22
 
   # # Firewall to allow Managed Lustre connection
   # - id: lustre_firewall_rule

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -229,7 +229,7 @@ deployment_groups:
   #   source: modules/network/private-service-access
   #   use: [gke-a4-net-0]
   #   settings:
-  #     prefix_length: 24
+  #     prefix_length: 22
 
   # # Firewall to allow Managed Lustre connection
   # - id: lustre_firewall_rule

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -232,7 +232,7 @@ deployment_groups:
   #   source: modules/network/private-service-access
   #   use: [gke-a4x-net-0]
   #   settings:
-  #     prefix_length: 24
+  #     prefix_length: 22
 
   # # Firewall to allow Managed Lustre connection
   # - id: lustre_firewall_rule

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -60,7 +60,7 @@ deployment_groups:
     source: modules/network/private-service-access
     use: [network]
     settings:
-      prefix_length: 24
+      prefix_length: 22
 
   # Firewall to allow Managed Lustre connection
   - id: lustre_firewall_rule

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -249,7 +249,7 @@ deployment_groups:
   #   source: modules/network/private-service-access
   #   use: [gke-tpu-7x-net-0]
   #   settings:
-  #     prefix_length: 24
+  #     prefix_length: 22
 
   # # Firewall to allow Managed Lustre connection
   # - id: lustre_firewall_rule

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -249,7 +249,7 @@ deployment_groups:
   #   source: modules/network/private-service-access
   #   use: [gke-tpu-v6e-net-0]
   #   settings:
-  #     prefix_length: 24
+  #     prefix_length: 22
 
   # # Firewall to allow Managed Lustre connection
   # - id: lustre_firewall_rule

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -32,7 +32,7 @@ that the correct subnetwork has private service access.
     source: modules/network/private-service-access
     use: [network]
     settings:
-      prefix_length: 24
+      prefix_length: 22
 
   - id: lustre
     source: modules/file-system/managed-lustre


### PR DESCRIPTION
Fix: Increase PSA IP range for gke-managed-lustre

The gke-managed-lustre blueprint allocates a /24 range for PSA (prefix_length: 24). The Managed Lustre service requires a certain number of IPs within the producer network that is peered with VPC. A /24 looks to be insufficient for the internal needs of the services.

This change increases the allocated range size by modifying the `prefix_length` in the `private-service-access` module from `24` to `22`. This increases the number of IP addresses reserved for the service producer, making it more resilient to IP exhaustion within the tenant project.

Testing: The integration test associated with gke-managed-lustre blueprint is now successful with the change which was failing due to PSA IPs exhausted for service earlier. 

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
