### PR TITLE
fix: Update a3m and a3u script to resolve slurm nccl test failure

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/nccl-tests/import_pytorch_container.sh
+++ b/examples/machine-learning/a3-megagpu-8g/nccl-tests/import_pytorch_container.sh
@@ -28,8 +28,8 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
 		# Fallback to a guaranteed writable location in /tmp
 		XDG_RUNTIME_DIR="/tmp/enroot-runtime-$(id -u)"
 		export XDG_RUNTIME_DIR
-		sudo mkdir -p "$XDG_RUNTIME_DIR"
-		sudo chmod a+rw "$XDG_RUNTIME_DIR"
+		mkdir -p "$XDG_RUNTIME_DIR"
+		chmod 700 "$XDG_RUNTIME_DIR"
 	fi
 fi
 

--- a/examples/machine-learning/a3-ultragpu-8g/nccl-tests/import_pytorch_container.sh
+++ b/examples/machine-learning/a3-ultragpu-8g/nccl-tests/import_pytorch_container.sh
@@ -28,8 +28,8 @@ if [ -z "$XDG_RUNTIME_DIR" ]; then
 		# Fallback to a guaranteed writable location in /tmp
 		XDG_RUNTIME_DIR="/tmp/enroot-runtime-$(id -u)"
 		export XDG_RUNTIME_DIR
-		sudo mkdir -p "$XDG_RUNTIME_DIR"
-		sudo chmod a+rw "$XDG_RUNTIME_DIR"
+		mkdir -p "$XDG_RUNTIME_DIR"
+		chmod 700 "$XDG_RUNTIME_DIR"
 	fi
 fi
 


### PR DESCRIPTION
This PR resolves the error encountered while running NCCL test for a3 machines:
Error encountered in the NCCL tests:
`
mkdir: cannot create directory ‘/run/enroot’: Permission denied
`

Fix:
`XDG_RUNTIME_DIR` is a standard Linux environment variable defined by the XDG Base Directory Specification. It points to a directory specific to the logged-in user for storing small, temporary runtime files. Enroot uses this variable to determine where to create its workspace. If it's unset, Enroot falls back to a hardcoded system path (`/run`) which causes the crash. 
We are resolving the Permission denied error by manually setting the `XDG_RUNTIME_DIR` environment variable to a user-specific, world-writable directory in /tmp (e.g., /tmp/enroot-runtime-$(id -u)). This ensures enroot uses a safe, writable workspace instead of defaulting to the restricted, root-owned /run/enroot path


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
