### PR TITLE
ai fixer precommit

### DIFF
--- a/cmd/ai.go
+++ b/cmd/ai.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+)
+
+var aiCmd = &cobra.Command{
+	Use:   "ai",
+	Short: "AI-powered tools for Cluster Toolkit",
+	Long:  `A collection of AI-powered tools to assist with development and deployment in Cluster Toolkit.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := cmd.Help(); err != nil {
+			log.Fatalf("Error executing help command: %v", err)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(aiCmd)
+}

--- a/cmd/fix_pre_commits.go
+++ b/cmd/fix_pre_commits.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"hpc-toolkit/pkg/ai"
+	"hpc-toolkit/pkg/logging"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	maxRetries int
+	verbose    bool
+	region     string
+	model      string
+)
+
+var fixPreCommitsCmd = &cobra.Command{
+	Use:   "fix-pre-commits",
+	Short: "Automatically fix pre-commit failures using AI",
+	Long:  `Runs pre-commit hooks, identifies failures, and uses AI to generate and apply fixes.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fixer := ai.NewFixer(ai.FixerOptions{
+			MaxRetries: maxRetries,
+			Verbose:    verbose,
+			Region:     region,
+			Model:      model,
+		})
+		if err := fixer.Run(args); err != nil {
+			logging.Fatal("Failed to fix pre-commits: %v", err)
+		}
+	},
+}
+
+func init() {
+	fixPreCommitsCmd.Flags().IntVar(&maxRetries, "max-retries", 3, "Maximum number of retries per file")
+	fixPreCommitsCmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	fixPreCommitsCmd.Flags().StringVar(&region, "region", "us-central1", "Vertex AI region")
+	fixPreCommitsCmd.Flags().StringVar(&model, "model", "gemini-2.0-flash-001", "Vertex AI model")
+	aiCmd.AddCommand(fixPreCommitsCmd)
+}

--- a/docs/ai_pre_commit_usage.md
+++ b/docs/ai_pre_commit_usage.md
@@ -1,0 +1,99 @@
+# AI-Powered Pre-commit Fixer Workflow
+
+This guide details how to use the `gcluster ai fix-pre-commits` command to automatically resolve pre-commit failures in the Cluster Toolkit.
+
+## Prerequisites
+
+Before running the tool, ensure you have the following installed and configured:
+
+1. **`pre-commit`**: The core framework for managing and maintaining multi-language pre-commit hooks.
+
+   ```bash
+   pip install pre-commit
+   # Verify installation
+   pre-commit --version
+   ```
+
+2. **`gcloud` CLI**: Required for authenticating with Vertex AI.
+
+   ```bash
+   # Install Google Cloud SDK if not present
+   # Authenticate with your Google Cloud account
+   gcloud auth login
+   gcloud auth application-default login
+   ```
+
+3. **Vertex AI Access**: Ensure the project currently configured in `gcloud` has the Vertex AI API enabled.
+
+   ```bash
+   # Check current project
+   gcloud config get-value project
+   ```
+
+## Installation
+
+If you are running from source, build the `gcluster` binary:
+
+```bash
+cd cluster-toolkit
+go build -o gcluster .
+```
+
+## Usage
+
+### 1. Fix All Failures
+To run pre-commit hooks on all files and automatically fix any failures:
+
+```bash
+./gcluster ai fix-pre-commits
+```
+
+**What happens:**
+1. The tool runs `pre-commit run --all-files`.
+2. If failures are detected, it identifies the failing files and error messages.
+3. It sends the file content and error to Vertex AI (Gemini) to generate a fix.
+4. It applies the fix and re-runs the hooks to verify.
+5. It repeats this process (up to `--max-retries`) until all hooks pass.
+
+### 2. Fix Specific Files
+To limit the scope to specific files (useful for faster iteration):
+
+```bash
+./gcluster ai fix-pre-commits pkg/shell/terraform.go modules/vpc/main.tf
+```
+
+### 3. Customize Behavior
+You can adjust the retry limit using the `--max-retries` flag (default is 3):
+
+```bash
+./gcluster ai fix-pre-commits --max-retries 5 --verbose
+```
+
+**Options:**
+- `-v` or `--verbose`: Enable verbose logging to see detailed errors and AI debug info.
+- `--max-retries`: Set the maximum number of retry attempts (default: 3).
+- `--model`: Specify the Vertex AI model to use (default: `gemini-2.0-flash-001`).
+- `--region`: Specify the Vertex AI region (default: `us-central1`).
+
+### 4. Specifying a Different Model
+
+If the default model (`gemini-2.0-flash-001`) is not available in your project/region, you can specify a different one:
+
+```bash
+./gcluster ai fix-pre-commits --model gemini-1.0-pro-001 --verbose
+```
+
+### 5. Troubleshooting
+
+| Issue | Cause | Resolution |
+| :--- | :--- | :--- |
+| `pre-commit is not installed` | Missing dependency | Run `pip install pre-commit`. |
+| `failed to get access token` | Not authenticated | Run `gcloud auth login`. |
+| `Vertex AI API returned status: 403` | API disabled or no permission | Enable Vertex AI API in your GCP project or switch to a project with access. |
+| `Wait, the fix is wrong!` | AI Hallucination | The tool attempts to fix based on the error, but AI isn't perfect. Always review the `git diff` before committing! |
+
+## Best Practices
+
+- **Review Changes**: Always run `git diff` after the tool completes to ensure the fixes are correct.
+- **Commit Frequently**: Use the tool to clear logical units of work.
+- **Fallback**: If the tool gets stuck in a loop, you can always fix the issue manually and run `pre-commit run --all-files` to verify.

--- a/pkg/ai/client.go
+++ b/pkg/ai/client.go
@@ -1,0 +1,218 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+const (
+	defaultModel  = "gemini-1.5-pro"
+	defaultRegion = "us-central1"
+)
+
+type Client struct {
+	projectID string
+	region    string
+	model     string
+	verbose   bool
+}
+
+func NewClient(verbose bool, region, model string) *Client {
+	if region == "" {
+		region = defaultRegion
+	}
+	if model == "" {
+		model = "gemini-2.0-flash-001"
+	}
+	return &Client{
+		region:  region,
+		model:   model,
+		verbose: verbose,
+	}
+}
+
+func (c *Client) GenerateFix(content string, failure Failure) (string, error) {
+	if c.projectID == "" {
+		if err := c.initProjectID(); err != nil {
+			return "", err
+		}
+	}
+
+	token, err := c.getAccessToken()
+	if err != nil {
+		return "", err
+	}
+
+	prompt := fmt.Sprintf(`You are an expert software engineer.
+The following file failed pre-commit hook '%s'.
+Error message: '%s'.
+File content:
+%s
+
+Please provide the corrected file content. Do not provide any markdown formatting, just the raw code. 
+If the file is a Go file, ensure it compiles and follows gofmt.
+If the file is a Terraform file, ensure it follows terraform fmt.
+Focus your fix on line %d and its immediate context. PRESERVE all other content exactly as is.
+Return ONLY the full file content. Do NOT truncate. Do NOT use placeholders.`, failure.Hook, failure.Message, content, failure.Line)
+
+	resp, err := c.callVertexAI(token, prompt)
+	if err != nil {
+		return "", err
+	}
+
+	return cleanResponse(resp), nil
+}
+
+func (c *Client) initProjectID() error {
+	cmd := exec.Command("gcloud", "config", "get-value", "project")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to get project ID: %w", err)
+	}
+	c.projectID = strings.TrimSpace(string(output))
+	return nil
+}
+
+func (c *Client) getAccessToken() (string, error) {
+	cmd := exec.Command("gcloud", "auth", "print-access-token")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get access token: %w", err)
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+func (c *Client) callVertexAI(token, prompt string) (string, error) {
+	url := fmt.Sprintf("https://%s-aiplatform.googleapis.com/v1/projects/%s/locations/%s/publishers/google/models/%s:generateContent", c.region, c.projectID, c.region, c.model)
+
+	requestBody := map[string]interface{}{
+		"contents": []map[string]interface{}{
+			{
+				"role": "user",
+				"parts": []map[string]interface{}{
+					{"text": prompt},
+				},
+			},
+		},
+		"generationConfig": map[string]interface{}{
+			"temperature": 0.2,
+			"topP":        0.8,
+			"topK":        40,
+		},
+	}
+
+	jsonBody, err := json.Marshal(requestBody)
+	if err != nil {
+		return "", err
+	}
+
+	if c.verbose {
+		fmt.Printf("DEBUG: Calling Vertex AI URL: %s\n", url)
+		fmt.Printf("DEBUG: Project ID: %s\n", c.projectID)
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-user-project", c.projectID)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		var bodyBytes []byte
+		if resp.Body != nil {
+			bodyBytes, _ = io.ReadAll(resp.Body)
+		}
+		return "", fmt.Errorf("Vertex AI API returned status: %s. Body: %s", resp.Status, string(bodyBytes))
+	}
+
+	return parseVertexResponse(resp.Body)
+}
+
+func parseVertexResponse(body io.Reader) (string, error) {
+	var parsedResp map[string]interface{}
+	if err := json.NewDecoder(body).Decode(&parsedResp); err != nil {
+		return "", err
+	}
+
+	candidates, ok := parsedResp["candidates"].([]interface{})
+	if !ok || len(candidates) == 0 {
+		return "", fmt.Errorf("no candidates returned from AI")
+	}
+
+	candidate := candidates[0].(map[string]interface{})
+	contentParts, ok := candidate["content"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unexpected response structure")
+	}
+
+	parts, ok := contentParts["parts"].([]interface{})
+	if !ok || len(parts) == 0 {
+		return "", fmt.Errorf("no content parts returned")
+	}
+
+	textPart, ok := parts[0].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("unexpected part structure")
+	}
+
+	text, ok := textPart["text"].(string)
+	if !ok {
+		return "", fmt.Errorf("text not found in response")
+	}
+
+	return text, nil
+}
+
+func cleanResponse(text string) string {
+	if strings.Contains(text, "```") {
+		var result []string
+		lines := strings.Split(text, "\n")
+		inCodeBlock := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "```") {
+				inCodeBlock = !inCodeBlock
+				continue
+			}
+			if inCodeBlock {
+				result = append(result, line)
+			}
+		}
+		if len(result) > 0 {
+			return strings.Join(result, "\n")
+		}
+	}
+
+	return strings.TrimSpace(text)
+}

--- a/pkg/ai/fixer.go
+++ b/pkg/ai/fixer.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/logging"
+	"os"
+	"os/exec"
+)
+
+type FixerOptions struct {
+	MaxRetries int
+	Verbose    bool
+	Region     string
+	Model      string
+}
+
+type Fixer struct {
+	options FixerOptions
+	client  *Client
+}
+
+func NewFixer(options FixerOptions) *Fixer {
+	return &Fixer{
+		options: options,
+		client:  NewClient(options.Verbose, options.Region, options.Model),
+	}
+}
+
+func (f *Fixer) Run(files []string) error {
+	if _, err := exec.LookPath("pre-commit"); err != nil {
+		return fmt.Errorf("pre-commit is not installed or not in PATH. Please install it first: https://pre-commit.com")
+	}
+
+	for i := 0; i < f.options.MaxRetries; i++ {
+		logging.Info("[Attempt %d/%d] Running pre-commit hooks...", i+1, f.options.MaxRetries)
+		failures, modified, err := f.runPreCommit(files)
+		if err == nil {
+			logging.Info("All pre-commit hooks passed!")
+			return nil
+		}
+
+		if len(failures) == 0 {
+			if modified {
+				logging.Info("Some hooks modified files. Retrying...")
+				continue
+			}
+			return fmt.Errorf("pre-commit failed with unknown errors: %w", err)
+		}
+
+		logging.Info("Found %d failures. Attempting to fix...", len(failures))
+		fixedCount := 0
+		for _, failure := range failures {
+			logging.Info("Fixing %s...", failure.File)
+			if err := f.fixFailure(failure); err != nil {
+				logging.Error("Failed to fix %s: %v", failure.File, err)
+			} else {
+				fixedCount++
+			}
+		}
+
+		if fixedCount == 0 {
+			return fmt.Errorf("could not fix any failures, stopping loop")
+		}
+	}
+
+	return fmt.Errorf("max retries reached, some hooks still failing")
+}
+
+func (f *Fixer) runPreCommit(files []string) ([]Failure, bool, error) {
+	args := []string{"run"}
+	if len(files) > 0 {
+		args = append(args, "--files")
+		args = append(args, files...)
+	} else {
+		args = append(args, "--all-files")
+	}
+
+	cmd := exec.Command("pre-commit", args...)
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+
+	if f.options.Verbose {
+		logging.Info("Pre-commit output:\n%s", string(output))
+	}
+
+	if err == nil {
+		return nil, false, nil
+	}
+
+	failures, modified := ParseFailures(string(output))
+	return failures, modified, err
+}
+
+func (f *Fixer) fixFailure(failure Failure) error {
+	content, err := os.ReadFile(failure.File)
+	if err != nil {
+		return fmt.Errorf("failed to read file: %w", err)
+	}
+
+	fixedContent, err := f.client.GenerateFix(string(content), failure)
+	if err != nil {
+		return fmt.Errorf("AI generation failed: %w", err)
+	}
+
+	if err := os.WriteFile(failure.File, []byte(fixedContent), 0644); err != nil {
+		return fmt.Errorf("failed to write file: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/ai/parser.go
+++ b/pkg/ai/parser.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type Failure struct {
+	File    string
+	Line    int
+	Message string
+	Hook    string
+}
+
+func ParseFailures(output string) ([]Failure, bool) {
+	var failures []Failure
+	lines := strings.Split(output, "\n")
+	modified := false
+	commonErrorRegex := regexp.MustCompile(`^([^:\s]+):(\d+):(?:(\d+):)?\s*(.*)$`)
+
+	hookHeaderRegex := regexp.MustCompile(`^(.+?)\.+Failed$`)
+
+	currentHook := ""
+
+	for _, line := range lines {
+		if matches := hookHeaderRegex.FindStringSubmatch(line); len(matches) > 1 {
+			currentHook = strings.TrimSpace(matches[1])
+			continue
+		}
+
+		if matches := commonErrorRegex.FindStringSubmatch(line); len(matches) > 1 {
+			msg := matches[4]
+			if currentHook != "" {
+				msg = "[" + currentHook + "] " + msg
+			}
+			lineNumber := 0
+			if len(matches) > 2 {
+				_, err := fmt.Sscanf(matches[2], "%d", &lineNumber)
+				if err != nil {
+					lineNumber = 0
+				}
+			}
+			failures = append(failures, Failure{
+				File:    matches[1],
+				Line:    lineNumber,
+				Message: msg,
+				Hook:    currentHook,
+			})
+		}
+
+		if strings.Contains(line, "files were modified by this hook") {
+			modified = true
+		}
+	}
+
+	return failures, modified
+}

--- a/pkg/ai/parser_test.go
+++ b/pkg/ai/parser_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ai
+
+import (
+	"testing"
+)
+
+func TestParseFailures(t *testing.T) {
+	output := `
+Terraform fmt............................................................Failed
+- hook id: terraform_fmt
+- exit code: 3
+- files were modified by this hook
+
+modules/vpc/main.tf
+
+GolangCI Lint............................................................Failed
+- hook id: golangci-lint
+- exit code: 1
+
+pkg/shell/terraform.go:23:2: ineffectual assignment to err (ineffassign)
+pkg/shell/terraform_test.go:10:5: unknown field (typecheck)
+
+Check Yaml...............................................................Passed
+`
+
+	expected := []Failure{
+		{
+			File:    "pkg/shell/terraform.go",
+			Line:    0, // regex doesn't parse line number to int yet, but string check
+			Message: "[GolangCI Lint] ineffectual assignment to err (ineffassign)",
+			Hook:    "GolangCI Lint",
+		},
+		{
+			File:    "pkg/shell/terraform_test.go",
+			Line:    0,
+			Message: "[GolangCI Lint] unknown field (typecheck)",
+			Hook:    "GolangCI Lint",
+		},
+	}
+
+	failures, _ := ParseFailures(output)
+
+	if len(failures) != len(expected) {
+		t.Fatalf("Expected %d failures, got %d", len(expected), len(failures))
+	}
+
+	for i, f := range failures {
+		if f.File != expected[i].File {
+			t.Errorf("Failure %d: Expected File %s, got %s", i, expected[i].File, f.File)
+		}
+		if f.Message != expected[i].Message {
+			t.Errorf("Failure %d: Expected Message %s, got %s", i, expected[i].Message, f.Message)
+		}
+		if f.Hook != expected[i].Hook {
+			t.Errorf("Failure %d: Expected Hook %s, got %s", i, expected[i].Hook, f.Hook)
+		}
+	}
+
+	outputModified := `
+Terraform fmt............................................................Failed
+- hook id: terraform_fmt
+- exit code: 3
+- files were modified by this hook
+
+modules/vpc/main.tf
+`
+	_, modified := ParseFailures(outputModified)
+	if !modified {
+		t.Error("Expected modified=true, got false")
+	}
+
+	outputSuccess := `
+Terraform fmt............................................................Passed
+`
+	failuresSuccess, modifiedSuccess := ParseFailures(outputSuccess)
+	if len(failuresSuccess) != 0 {
+		t.Errorf("Expected 0 failures, got %d", len(failuresSuccess))
+	}
+	if modifiedSuccess {
+		t.Error("Expected modified=false, got true")
+	}
+}


### PR DESCRIPTION
The AI Pre-commit Fixer is a proposed tool within the cluster-toolkit (likely via gcluster) that automatically identifies, diagnoses, and resolves pre-commit failures. Instead of developers manually fixing linting errors, formatting issues, or simple logic bugs, this tool acts as an autonomous agent to clear the "pre-commit debt" before code push.