### PR TITLE
Update nccl test script to fix enroot directory issue in A3H

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/nccl-tests/import_pytorch_container.sh
+++ b/examples/machine-learning/a3-highgpu-8g/nccl-tests/import_pytorch_container.sh
@@ -13,7 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This creates a file named "nvidia+pytorch+21.10-py3.sqsh", which
+# This creates a file named "nvidia+pytorch+23.10-py3.sqsh", which
 # uses ~18 GB of disk space. This should be run on a filesystem that
 # can be seen by all worker nodes
+
+# Fix for non-interactive shells where XDG_RUNTIME_DIR is not set
+if [ -z "$XDG_RUNTIME_DIR" ]; then
+	# Try creating a user-specific directory in /run (often fails for non-root)
+	XDG_RUNTIME_DIR="/run/user/$(id -u)"
+	export XDG_RUNTIME_DIR
+
+	# Check if we can actually use it
+	if [ ! -d "$XDG_RUNTIME_DIR" ]; then
+		# Fallback to a guaranteed writable location in /tmp
+		XDG_RUNTIME_DIR="/tmp/enroot-runtime-$(id -u)"
+		export XDG_RUNTIME_DIR
+		mkdir -p "$XDG_RUNTIME_DIR"
+		chmod 700 "$XDG_RUNTIME_DIR"
+	fi
+fi
+
 enroot import docker://nvcr.io#nvidia/pytorch:23.10-py3


### PR DESCRIPTION
This PR resolves the error encountered while running NCCL test for a3h machines:
Error encountered in the NCCL tests:
`
mkdir: cannot create directory ‘/run/enroot’: Permission denied
`

Fix:
`XDG_RUNTIME_DIR` is a standard Linux environment variable defined by the XDG Base Directory Specification. It points to a directory specific to the logged-in user for storing small, temporary runtime files. Enroot uses this variable to determine where to create its workspace. If it's unset, Enroot falls back to a hardcoded system path (`/run`) which causes the crash. 
We are resolving the Permission denied error by manually setting the `XDG_RUNTIME_DIR` environment variable to a user-specific, world-writable directory in /tmp (e.g., /tmp/enroot-runtime-$(id -u)). This ensures enroot uses a safe, writable workspace instead of defaulting to the restricted, root-owned /run/enroot path

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
