### PR TITLE
Marking parallelstore deprecated for gcluster warnings

### DIFF
--- a/modules/file-system/gke-storage/README.md
+++ b/modules/file-system/gke-storage/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> The `Parallelstore` `storage_type` is deprecated and will be removed on June 30, 2026. For a
+> The `Parallelstore` `storage_type` is deprecated and will be removed on August 31, 2026. For a
 > replacement on GKE, we recommend using the
 > [GCP Managed Lustre module](../managed-lustre/README.md)
 > See the [gke-managed-lustre.yaml](../../../examples/gke-managed-lustre.yaml) blueprint for a complete example.

--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -1,5 +1,5 @@
 > [!WARNING]
-> This module is deprecated and will be removed on June 30, 2026. The
+> This module is deprecated and will be removed on August 31, 2026. The
 > recommended replacement is the
 > [GCP Managed Lustre module](../managed-lustre/README.md)
 

--- a/modules/file-system/parallelstore/metadata.yaml
+++ b/modules/file-system/parallelstore/metadata.yaml
@@ -18,7 +18,7 @@ spec:
     services:
     - parallelstore.googleapis.com
 ghpc:
-  deprecation_date: "2026-06-30"
+  deprecation_date: "2026-08-31"
   alternative_module: "modules/file-system/managed-lustre"
   validators:
   - validator: regex


### PR DESCRIPTION
The Parallelstore module is marked deprecated and its usage is already removed from all our blueprints. Now, that the gcluster deprecation warning feature is in place, we need to configure the deprecation to the module metadata. This change configures the deprecation parameters for parallelstore module.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
