### PR TITLE
feat: Cluster Toolkit Slurm HA Controllers

### DIFF
--- a/community/examples/hpc-slurm-ha.yaml
+++ b/community/examples/hpc-slurm-ha.yaml
@@ -1,0 +1,200 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hpcslurmha
+
+vars:
+  project_id: # Set Project ID
+  deployment_name: hpcslurmha
+  region: us-central1
+  zone: us-central1-a
+
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    bucket: # Set Bucket Name Here
+
+deployment_groups:
+- group: primary
+  modules:
+  # Service Accounts
+  - id: controller_sa
+    source: modules/project/service-account
+    kind: terraform
+    settings:
+      deployment_name: $(vars.deployment_name)
+      project_id: $(vars.project_id)
+      name: controller-sa
+      description: Controller Service Account
+      display_name: Controller SA
+      project_roles:
+      - compute.instanceAdmin.v1
+      - iam.serviceAccountUser
+      - storage.objectViewer
+      - logging.logWriter
+      - monitoring.metricWriter
+
+  - id: login_sa
+    source: modules/project/service-account
+    kind: terraform
+    settings:
+      deployment_name: $(vars.deployment_name)
+      project_id: $(vars.project_id)
+      name: login-sa
+      description: Login Node Service Account
+      display_name: Login SA
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - storage.objectViewer
+
+  - id: compute_sa
+    source: modules/project/service-account
+    kind: terraform
+    settings:
+      deployment_name: $(vars.deployment_name)
+      project_id: $(vars.project_id)
+      name: compute-sa
+      description: Compute Node Service Account
+      display_name: Compute SA
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - storage.objectViewer
+
+  # Network
+  - id: network
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.deployment_name)-net
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-primary-subnet
+        subnet_region: $(vars.region)
+        subnet_ip: 10.80.0.0/24
+
+  # Filestore (Shared /home)
+  - id: home_fs
+    source: modules/file-system/filestore
+    settings:
+      network_id: $(network.network_id)
+      size_gb: 1024
+      zone: $(vars.zone)
+
+  # Debug Logic (Define Login Node properties, does not create VM directly)
+  - id: debug_nodes
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    settings:
+      name_prefix: debug
+      num_instances: 1
+      machine_type: n1-standard-2
+      service_account_email: $(login_sa.service_account_email)
+      service_account_scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      enable_oslogin: true
+      subnetwork_self_link: $(network.subnetwork_self_link)
+      enable_login_public_ips: false # NO EXTERNAL IP
+
+  # Nodeset (Compute)
+  - id: compute_nodes
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    settings:
+      name: a2-nodes
+      node_count_dynamic_max: 4
+      node_count_static: 0
+      machine_type: n1-standard-2
+      service_account_email: $(compute_sa.service_account_email)
+      service_account_scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      enable_oslogin: true
+      subnetwork_self_link: $(network.subnetwork_self_link)
+      enable_placement: false
+      network_storage:
+      - server_ip: $(home_fs.network_storage.server_ip)
+        remote_mount: $(home_fs.network_storage.remote_mount)
+        local_mount: /home
+        fs_type: nfs
+        mount_options: _netdev,hard,intr
+
+  # Partition
+  - id: debug_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute_nodes]
+    settings:
+      partition_name: debug
+      is_default: true
+
+  # Filestore (Dedicated State for Controller)
+  - id: controller_fs
+    source: modules/file-system/filestore
+    settings:
+      network_id: $(network.network_id)
+      size_gb: 1024
+      zone: $(vars.zone)
+
+  # Cloud SQL (External DB)
+  - id: slurm_db
+    source: community/modules/database/slurm-cloudsql-federation
+    settings:
+      deployment_name: $(vars.deployment_name)
+      project_id: $(vars.project_id)
+      region: $(vars.region)
+      tier: db-f1-micro
+      sql_instance_name: $(vars.deployment_name)-db
+      network_id: $(network.network_id)
+      use_psc_connection: true
+      subnetwork_self_link: $(network.subnetwork_self_link)
+
+  # Controller (Custom HA Module)
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [debug_partition]
+    settings:
+      enable_backup_controller: true
+      slurm_cluster_name: hpcslurmha
+      backup_zone: us-central1-f
+      # Disable PD state disk, rely on /var/spool/slurm filestore share
+      controller_state_disk: null
+      cloudsql:
+        server_ip: $(slurm_db.cloudsql.server_ip)
+        user: $(slurm_db.cloudsql.user)
+        password: $(slurm_db.cloudsql.password)
+        db_name: $(slurm_db.cloudsql.db_name)
+      enable_controller_public_ips: false # NO EXTERNAL IP
+      machine_type: n1-standard-2
+      zone: $(vars.zone)
+      service_account_email: $(controller_sa.service_account_email)
+      service_account_scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+      enable_oslogin: true
+      subnetwork_self_link: $(network.subnetwork_self_link)
+      login_nodes: $(debug_nodes.login_nodes)
+      network_storage:
+      - server_ip: $(home_fs.network_storage.server_ip)
+        remote_mount: $(home_fs.network_storage.remote_mount)
+        local_mount: /home
+        fs_type: nfs
+        mount_options: _netdev,hard,intr
+      - server_ip: $(controller_fs.network_storage.server_ip)
+        remote_mount: $(controller_fs.network_storage.remote_mount)
+        local_mount: /var/spool/slurm
+        fs_type: nfs
+        mount_options: _netdev,hard,intr
+      login_network_storage:
+      - server_ip: $(home_fs.network_storage.server_ip)
+        remote_mount: $(home_fs.network_storage.remote_mount)
+        local_mount: /home
+        fs_type: nfs
+        mount_options: _netdev,hard,intr
+      static_ips:
+      - "10.80.0.10"
+      - "10.80.0.11"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -3,9 +3,8 @@
 This module creates a slurm controller node via the internal
 [slurm\_instance\_template] module.
 
-More information about Slurm On GCP can be found at the
-[project's GitHub page][slurm-gcp] and in the
-[Slurm on Google Cloud User Guide][slurm-ug].
+More information about Slurm On GCP can be found at the [project's GitHub
+page][slurm-gcp] and in the [Slurm on Google Cloud User Guide][slurm-ug].
 
 The [user guide][slurm-ug] provides detailed instructions on customizing and
 enhancing the Slurm on GCP cluster as well as recommendations on configuring the
@@ -34,9 +33,8 @@ This creates a controller node with the following attributes:
 
 * connected to the primary subnetwork of `network`
 * the filesystem with the ID `homefs` (defined elsewhere in the blueprint)
-  mounted
-* One partition with the ID `compute_partition` (defined elsewhere in the
-  blueprint)
+    mounted
+* One partition with the ID `compute_partition` (defined elsewhere in the blueprint)
 * machine type upgraded from the default `c2-standard-4` to `c2-standard-8`
 
 ### Live Cluster Reconfiguration
@@ -56,8 +54,67 @@ The following are examples of updates that can be made to a running cluster:
 * Resize an existing partition
 * Attach new network storage to an existing partition
 
-> **NOTE**: Changing the VM `machine_type` of a partition may not work.
-> It is better to create a new partition and delete the old one.
+> **NOTE**: Changing the VM `machine_type` of a partition may not work. It is
+> better to create a new partition and delete the old one.
+
+## High Availability (HA)
+
+The `schedmd-slurm-gcp-v6-controller` module supports High Availability (HA) for
+the Slurm controller. This feature deploys a secondary "Backup" controller that
+allows the cluster to continue operating if the primary controller fails.
+
+### Architecture
+
+* **Primary Controller**: The active Slurm controller.
+
+* **Backup Controller**: A passive standby controller that monitors the
+    primary.
+
+* **Shared State**: Both controllers share the Slurm state directory (e.g.,
+    `/var/spool/slurm`) via a network mount (Filestore or NFS) to synchronize
+    keys and runtime state.
+
+### Enabling HA
+
+To enable High Availability:
+
+1. Set `enable_backup_controller` to `true`.
+2. Set `controller_state_disk` to `null` to disable the default local state
+   disk.
+3. Ensure `StateSaveLocation` points to a shared network mount (e.g.,
+   Filestore, NFS) that is mounted on both controllers at `/var/spool/slurm`.
+
+> **CRITICAL**: The `StateSaveLocation` MUST be a shared network filesystem
+> (like Filestore or NFS) that supports simultaneous read/write access from both
+> controllers. Zonal or Regional Persistent Disks (PD) are **NOT** supported for
+> this purpose as they do not provide the necessary shared access for HA state
+> management.
+
+### Example Configuration
+
+```yaml
+- id: slurm_controller
+  source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+  use:
+  - network
+  - homefs
+  settings:
+    enable_backup_controller: true
+    backup_machine_type: c2-standard-8
+    controller_state_disk: null
+    network_storage:
+    - server_ip: $(controller_fs.network_storage.server_ip)
+      remote_mount: $(controller_fs.network_storage.remote_mount)
+      local_mount: /var/spool/slurm
+      fs_type: nfs
+      mount_options: _netdev,hard,intr
+```
+
+### Backward Compatibility
+
+The HA feature is **opt-in**. If `enable_backup_controller` is set to `false`
+(the default), the module deploys a standard single-controller cluster,
+preserving existing behavior.
 
 ## Custom Images
 
@@ -69,19 +126,21 @@ page.
 
 ## GPU Support
 
-More information on GPU support in Slurm on GCP and other Cluster Toolkit modules
-can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
+More information on GPU support in Slurm on GCP and other Cluster Toolkit
+modules can be found at [docs/gpu-support.md](../../../../docs/gpu-support.md)
 
 ## Reservation for Scheduled Maintenance
 
-A [maintenance event](https://cloud.google.com/compute/docs/instances/host-maintenance-overview#maintenanceevents) is when a compute engine stops a VM to perform a hardware or
-software update which is determined by the host maintenance policy. This can
-also affect the running jobs if the maintenance kicks in. Now, Customers can
-protect jobs from getting terminated due to maintenance using the cluster
-toolkit. You can enable creation of reservation for scheduled maintenance for
-your compute nodeset and Slurm will reserve your node for maintenance during the
-maintenance window. If you try to schedule any jobs which overlap with the
-maintenance reservation, Slurm would not schedule any job.
+A
+[maintenance event](https://cloud.google.com/compute/docs/instances/host-maintenance-overview#maintenanceevents)
+is when a compute engine stops a VM to perform a hardware or software update
+which is determined by the host maintenance policy. This can also affect the
+running jobs if the maintenance kicks in. Now, Customers can protect jobs from
+getting terminated due to maintenance using the cluster toolkit. You can enable
+creation of reservation for scheduled maintenance for your compute nodeset and
+Slurm will reserve your node for maintenance during the maintenance window. If
+you try to schedule any jobs which overlap with the maintenance reservation,
+Slurm would not schedule any job.
 
 You can specify in your blueprint like
 
@@ -146,10 +205,10 @@ together as possible. Capacity constraints at the time of VM creation may still
 force VMs to be spread across multiple racks. Google provides the `max-distance`
 flag which can used to control the maximum spreading allowed. Read more about
 `max-distance` in the
-[official docs](https://cloud.google.com/compute/docs/instances/use-compact-placement-policies
-).
+[official docs](https://cloud.google.com/compute/docs/instances/use-compact-placement-policies).
 
-You can use the `placement_max_distance` setting on the nodeset module to control the `max-distance` behavior. See the following example:
+You can use the `placement_max_distance` setting on the nodeset module to
+control the `max-distance` behavior. See the following example:
 
 ```yaml
   - id: nodeset
@@ -174,9 +233,8 @@ gcloud beta compute resource-policies list \
   --format='yaml(name,groupPlacementPolicy.maxDistance)'
 ```
 
-> [!WARNING]
-> If a zone lacks capacity, using a lower `max-distance` value (such as 1) is
-> more likely to cause VMs creation to fail.
+> [!WARNING] If a zone lacks capacity, using a lower `max-distance` value (such
+> as 1) is more likely to cause VMs creation to fail.
 
 ## TreeWidth and Node Communication
 
@@ -192,6 +250,7 @@ controller by setting TreeWidth to a value >= largest partition.
 If the largest partition was 200 nodes, configure the blueprint as follows:
 
 ```yaml
+
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     ...
@@ -221,6 +280,7 @@ For example, to limit the node resumption rate to 100 nodes per minute,
 configure the blueprint as follows:
 
 ```yaml
+
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
     ...
@@ -233,9 +293,10 @@ Adjust this value based on the capabilities of your shared filesystem and the
 expected scaling behavior of your cluster.
 
 ## Support
-The Cluster Toolkit team maintains the wrapper around the [slurm-on-gcp] terraform
-modules. For support with the underlying modules, see the instructions in the
-[slurm-gcp README][slurm-gcp-readme].
+
+The Cluster Toolkit team maintains the wrapper around the [slurm-on-gcp]
+terraform modules. For support with the underlying modules, see the instructions
+in the [slurm-gcp README][slurm-gcp-readme].
 
 [slurm-on-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp
 [slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp#slurm-on-google-cloud-platform
@@ -282,6 +343,7 @@ limitations under the License.
 | <a name="module_login"></a> [login](#module\_login) | ../../internal/slurm-gcp/login | n/a |
 | <a name="module_nodeset_cleanup"></a> [nodeset\_cleanup](#module\_nodeset\_cleanup) | ./modules/cleanup_compute | n/a |
 | <a name="module_nodeset_cleanup_tpu"></a> [nodeset\_cleanup\_tpu](#module\_nodeset\_cleanup\_tpu) | ./modules/cleanup_tpu | n/a |
+| <a name="module_slurm_backup_controller_template"></a> [slurm\_backup\_controller\_template](#module\_slurm\_backup\_controller\_template) | ../../internal/slurm-gcp/instance_template | n/a |
 | <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | ../../internal/slurm-gcp/instance_template | n/a |
 | <a name="module_slurm_files"></a> [slurm\_files](#module\_slurm\_files) | ./modules/slurm_files | n/a |
 | <a name="module_slurm_nodeset_template"></a> [slurm\_nodeset\_template](#module\_slurm\_nodeset\_template) | ../../internal/slurm-gcp/instance_template | n/a |
@@ -291,6 +353,7 @@ limitations under the License.
 
 | Name | Type |
 | ---- | ---- |
+| [google-beta_google_compute_instance_from_template.backup_controller](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_from_template) | resource |
 | [google-beta_google_compute_instance_from_template.controller](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_from_template) | resource |
 | [google_compute_disk.controller_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_secret_manager_secret.cloudsql](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
@@ -309,6 +372,8 @@ limitations under the License.
 | <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for the controller, if any. | <pre>list(object({<br/>    access_config = optional(list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    })), [])<br/>    alias_ip_range = optional(list(object({<br/>      ip_cidr_range         = string<br/>      subnetwork_range_name = string<br/>    })), [])<br/>    ipv6_access_config = optional(list(object({<br/>      network_tier = string<br/>    })), [])<br/>    network            = optional(string)<br/>    network_ip         = optional(string, "")<br/>    nic_type           = optional(string)<br/>    queue_count        = optional(number)<br/>    stack_type         = optional(string)<br/>    subnetwork         = optional(string)<br/>    subnetwork_project = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_advanced_machine_features"></a> [advanced\_machine\_features](#input\_advanced\_machine\_features) | See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#nested_advanced_machine_features | <pre>object({<br/>    enable_nested_virtualization = optional(bool)<br/>    threads_per_core             = optional(number)<br/>    turbo_mode                   = optional(string)<br/>    visible_core_count           = optional(number)<br/>    performance_monitoring_unit  = optional(string)<br/>    enable_uefi_networking       = optional(bool)<br/>  })</pre> | <pre>{<br/>  "threads_per_core": 1<br/>}</pre> | no |
 | <a name="input_allow_automatic_updates"></a> [allow\_automatic\_updates](#input\_allow\_automatic\_updates) | If false, disables automatic system package updates on the created instances.  This feature is<br/>only available on supported images (or images derived from them).  For more details, see<br/>https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates | `bool` | `true` | no |
+| <a name="input_backup_machine_type"></a> [backup\_machine\_type](#input\_backup\_machine\_type) | Machine type for the backup controller. If null, uses the same as the primary controller. | `string` | `null` | no |
+| <a name="input_backup_zone"></a> [backup\_zone](#input\_backup\_zone) | Zone for the backup controller. If null, it will be placed in the same region, potentially different zone. | `string` | `null` | no |
 | <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br/>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br/>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br/>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br/>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br/>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br/>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
 | <a name="input_bucket_dir"></a> [bucket\_dir](#input\_bucket\_dir) | Bucket directory for cluster files to be put into. If not specified, then one will be chosen based on slurm\_cluster\_name. | `string` | `null` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket.<br/>Ignored when 'create\_bucket' is true. | `string` | `null` | no |
@@ -335,6 +400,7 @@ limitations under the License.
 | <a name="input_disk_resource_manager_tags"></a> [disk\_resource\_manager\_tags](#input\_disk\_resource\_manager\_tags) | (Optional) A set of key/value resource manager tag pairs to bind to the instance disks. Keys must be in the format tagKeys/{tag\_key\_id}, and values are in the format tagValues/456. | `map(string)` | `{}` | no |
 | <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Boot disk size in GB. | `number` | `50` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Boot disk type, can be either hyperdisk-balanced, pd-ssd, pd-standard, pd-balanced, or pd-extreme. | `string` | `"pd-ssd"` | no |
+| <a name="input_enable_backup_controller"></a> [enable\_backup\_controller](#input\_enable\_backup\_controller) | Enables a secondary backup controller for High Availability. | `bool` | `false` | no |
 | <a name="input_enable_bigquery_load"></a> [enable\_bigquery\_load](#input\_enable\_bigquery\_load) | Enables loading of cluster job usage into big query.<br/><br/>NOTE: Requires Google Bigquery API. | `bool` | `false` | no |
 | <a name="input_enable_chs_gpu_health_check_epilog"></a> [enable\_chs\_gpu\_health\_check\_epilog](#input\_enable\_chs\_gpu\_health\_check\_epilog) | Enable a Cluster Health Sacnner(CHS) GPU health check that slurmd executes as an epilog script after completing a job step from a new job allocation.<br/>Compute nodes that fail GPU health check during epilog will be marked as drained. Find more details at:<br/>https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/docs/CHS-Slurm.md | `bool` | `false` | no |
 | <a name="input_enable_chs_gpu_health_check_prolog"></a> [enable\_chs\_gpu\_health\_check\_prolog](#input\_enable\_chs\_gpu\_health\_check\_prolog) | Enable a Cluster Health Sacnner(CHS) GPU health check that slurmd executes as a prolog script whenever it is asked to run a job step from a new job allocation. Compute nodes that fail GPU health check during prolog will be marked as drained. Find more details at:<br/>https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/docs/CHS-Slurm.md | `bool` | `false` | no |
@@ -366,6 +432,7 @@ limitations under the License.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to create. | `string` | `"c2-standard-4"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata, provided as a map. | `map(string)` | `{}` | no |
 | <a name="input_min_cpu_platform"></a> [min\_cpu\_platform](#input\_min\_cpu\_platform) | Specifies a minimum CPU platform. Applicable values are the friendly names of<br/>CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list:<br/>https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform | `string` | `null` | no |
+| <a name="input_munge_mount"></a> [munge\_mount](#input\_munge\_mount) | Remote munge mount for compute and login nodes to acquire the munge.key.<br/>By default, the munge mount server will be assumed to be the<br/>`var.slurm_control_host` (or `var.slurm_control_addr` if non-null) when<br/>`server_ip=null`. | <pre>object({<br/>    server_ip     = string<br/>    remote_mount  = string<br/>    fs_type       = string<br/>    mount_options = string<br/>  })</pre> | <pre>{<br/>  "fs_type": "nfs",<br/>  "mount_options": "",<br/>  "remote_mount": "/etc/munge/",<br/>  "server_ip": null<br/>}</pre> | no |
 | <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured on all instances. | <pre>list(object({<br/>    server_ip             = string,<br/>    remote_mount          = string,<br/>    local_mount           = string,<br/>    fs_type               = string,<br/>    mount_options         = string,<br/>    client_install_runner = optional(map(string))<br/>    mount_runner          = optional(map(string))<br/>  }))</pre> | `[]` | no |
 | <a name="input_nodeset"></a> [nodeset](#input\_nodeset) | Define nodesets, as a list. | <pre>list(object({<br/>    node_count_static      = optional(number, 0)<br/>    node_count_dynamic_max = optional(number, 1)<br/>    node_conf              = optional(map(string), {})<br/>    nodeset_name           = string<br/>    additional_disks = optional(list(object({<br/>      disk_name                  = optional(string)<br/>      device_name                = optional(string)<br/>      disk_size_gb               = optional(number)<br/>      disk_type                  = optional(string)<br/>      disk_labels                = optional(map(string), {})<br/>      auto_delete                = optional(bool, true)<br/>      boot                       = optional(bool, false)<br/>      disk_resource_manager_tags = optional(map(string), {})<br/>    })), [])<br/>    bandwidth_tier                      = optional(string, "platform_default")<br/>    can_ip_forward                      = optional(bool, false)<br/>    disk_auto_delete                    = optional(bool, true)<br/>    disk_labels                         = optional(map(string), {})<br/>    disk_resource_manager_tags          = optional(map(string), {})<br/>    disk_size_gb                        = optional(number)<br/>    disk_type                           = optional(string)<br/>    disk_encryption_key                 = optional(string)<br/>    disk_encryption_key_service_account = optional(string)<br/>    enable_confidential_vm              = optional(bool, false)<br/>    confidential_instance_type          = optional(string)<br/>    enable_placement                    = optional(bool, false)<br/>    placement_max_distance              = optional(number, null)<br/>    enable_oslogin                      = optional(bool, true)<br/>    enable_shielded_vm                  = optional(bool, false)<br/>    enable_maintenance_reservation      = optional(bool, false)<br/>    enable_opportunistic_maintenance    = optional(bool, false)<br/>    gpu = optional(object({<br/>      count = number<br/>      type  = string<br/>    }))<br/>    accelerator_topology = optional(string, null)<br/>    dws_flex = object({<br/>      enabled          = bool<br/>      max_run_duration = number<br/>      use_job_duration = bool<br/>      use_bulk_insert  = bool<br/>    })<br/>    labels       = optional(map(string), {})<br/>    machine_type = optional(string)<br/>    advanced_machine_features = object({<br/>      enable_nested_virtualization = optional(bool)<br/>      threads_per_core             = optional(number)<br/>      turbo_mode                   = optional(string)<br/>      visible_core_count           = optional(number)<br/>      performance_monitoring_unit  = optional(string)<br/>      enable_uefi_networking       = optional(bool)<br/>    })<br/>    maintenance_interval     = optional(string)<br/>    instance_properties_json = string<br/>    metadata                 = optional(map(string), {})<br/>    min_cpu_platform         = optional(string)<br/>    network_tier             = optional(string, "STANDARD")<br/>    network_storage = optional(list(object({<br/>      server_ip             = string<br/>      remote_mount          = string<br/>      local_mount           = string<br/>      fs_type               = string<br/>      mount_options         = string<br/>      client_install_runner = optional(map(string))<br/>      mount_runner          = optional(map(string))<br/>    })), [])<br/>    on_host_maintenance   = optional(string)<br/>    preemptible           = optional(bool, false)<br/>    region                = optional(string)<br/>    resource_manager_tags = optional(map(string), {})<br/>    service_account = optional(object({<br/>      email  = optional(string)<br/>      scopes = optional(list(string), ["https://www.googleapis.com/auth/cloud-platform"])<br/>    }))<br/>    shielded_instance_config = optional(object({<br/>      enable_integrity_monitoring = optional(bool, true)<br/>      enable_secure_boot          = optional(bool, true)<br/>      enable_vtpm                 = optional(bool, true)<br/>    }))<br/>    source_image_family  = optional(string)<br/>    source_image_project = optional(string)<br/>    source_image         = optional(string)<br/>    subnetwork_self_link = string<br/>    additional_networks = optional(list(object({<br/>      network            = string<br/>      subnetwork         = string<br/>      subnetwork_project = string<br/>      network_ip         = string<br/>      nic_type           = string<br/>      stack_type         = string<br/>      queue_count        = number<br/>      access_config = list(object({<br/>        nat_ip       = string<br/>        network_tier = string<br/>      }))<br/>      ipv6_access_config = list(object({<br/>        network_tier = string<br/>      }))<br/>      alias_ip_range = list(object({<br/>        ip_cidr_range         = string<br/>        subnetwork_range_name = string<br/>      }))<br/>    })))<br/>    access_config = optional(list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    })))<br/>    spot               = optional(bool, false)<br/>    tags               = optional(list(string), [])<br/>    termination_action = optional(string)<br/>    reservation_name   = optional(string)<br/>    future_reservation = string<br/>    startup_script = optional(list(object({<br/>      filename = string<br/>    content = string })), [])<br/><br/>    zone_target_shape = string<br/>    zone_policy_allow = set(string)<br/>    zone_policy_deny  = set(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_nodeset_dyn"></a> [nodeset\_dyn](#input\_nodeset\_dyn) | Defines dynamic nodesets, as a list. | <pre>list(object({<br/>    nodeset_name    = string<br/>    nodeset_feature = string<br/>  }))</pre> | `[]` | no |
@@ -385,6 +452,7 @@ limitations under the License.
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | Cluster name, used for resource naming and slurm accounting.<br/>If not provided it will default to the first 8 characters of the deployment name (removing any invalid characters). | `string` | `null` | no |
 | <a name="input_slurm_conf_template"></a> [slurm\_conf\_template](#input\_slurm\_conf\_template) | Slurm slurm.conf template. Content of the file in 'slurm\_conf\_tpl' is used if this is not set. | `string` | `null` | no |
 | <a name="input_slurm_conf_tpl"></a> [slurm\_conf\_tpl](#input\_slurm\_conf\_tpl) | Slurm slurm.conf template file path. This path is used only if raw content is not provided in 'slurm\_conf\_template'. | `string` | `null` | no |
+| <a name="input_slurm_key_mount"></a> [slurm\_key\_mount](#input\_slurm\_key\_mount) | Remote mount for compute and login nodes to acquire the slurm.key. | <pre>object({<br/>    server_ip     = string<br/>    remote_mount  = string<br/>    fs_type       = string<br/>    mount_options = string<br/>  })</pre> | `null` | no |
 | <a name="input_slurmdbd_conf_tpl"></a> [slurmdbd\_conf\_tpl](#input\_slurmdbd\_conf\_tpl) | Slurm slurmdbd.conf template file path. | `string` | `null` | no |
 | <a name="input_static_ips"></a> [static\_ips](#input\_static\_ips) | List of static IPs for VM instances. | `list(string)` | `[]` | no |
 | <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | Subnet to deploy to. | `string` | n/a | yes |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -54,13 +54,34 @@ locals {
 
   disable_automatic_updates_metadata = var.allow_automatic_updates ? {} : { google_disable_automatic_updates = "TRUE" }
 
+  controller_project_id = coalesce(var.controller_project_id, var.project_id)
+
+  # HA Locals
+  backup_machine_type          = coalesce(var.backup_machine_type, var.machine_type)
+  backup_zone                  = coalesce(var.backup_zone, var.zone)
+  slurm_backup_controller_name = var.enable_backup_controller ? "${local.slurm_cluster_name}-backup-controller" : ""
+
+  # Merge HA metadata
   metadata = merge(
     local.disable_automatic_updates_metadata,
     var.metadata,
-    local.universe_domain
+    local.universe_domain,
+    {
+      slurm_ha_role                = "primary"
+      slurm_backup_controller_name = local.slurm_backup_controller_name
+    }
   )
 
-  controller_project_id = coalesce(var.controller_project_id, var.project_id)
+  backup_metadata = merge(
+    local.disable_automatic_updates_metadata,
+    var.metadata,
+    local.universe_domain,
+    {
+      slurm_ha_role       = "backup"
+      slurm_cluster_name  = local.slurm_cluster_name
+      slurm_instance_role = "controller"
+    }
+  )
 }
 
 data "google_project" "controller_project" {
@@ -201,6 +222,87 @@ resource "google_compute_instance_from_template" "controller" {
           subnetwork_range_name = alias_ip_range.value.subnetwork_range_name
         }
       }
+    }
+  }
+}
+
+# BACKUP CONTROLLER TEMPLATE
+module "slurm_backup_controller_template" {
+  source = "../../internal/slurm-gcp/instance_template"
+  count  = var.enable_backup_controller ? 1 : 0
+
+  project_id          = local.controller_project_id
+  region              = var.region
+  slurm_instance_role = "controller"
+  slurm_cluster_name  = local.slurm_cluster_name
+  labels              = local.labels
+
+  disk_auto_delete           = var.disk_auto_delete
+  disk_labels                = merge(var.disk_labels, local.labels)
+  disk_size_gb               = var.disk_size_gb
+  disk_type                  = var.disk_type
+  disk_resource_manager_tags = var.disk_resource_manager_tags
+  additional_disks           = local.additional_disks
+  bandwidth_tier             = var.bandwidth_tier
+  slurm_bucket_path          = module.slurm_files.slurm_bucket_path
+  can_ip_forward             = var.can_ip_forward
+  advanced_machine_features  = var.advanced_machine_features
+  resource_manager_tags      = var.resource_manager_tags
+
+  enable_confidential_vm   = var.enable_confidential_vm
+  enable_oslogin           = var.enable_oslogin
+  enable_shielded_vm       = var.enable_shielded_vm
+  shielded_instance_config = var.shielded_instance_config
+
+  gpu = one(module.gpu.guest_accelerator)
+
+  machine_type     = local.backup_machine_type
+  metadata         = local.backup_metadata
+  min_cpu_platform = var.min_cpu_platform
+
+  on_host_maintenance = var.on_host_maintenance
+  preemptible         = var.preemptible
+  service_account     = local.service_account
+
+  source_image_family  = local.source_image_family
+  source_image_project = local.source_image_project_normalized
+  source_image         = local.source_image
+
+  subnetwork = var.subnetwork_self_link
+
+  tags = concat([local.slurm_cluster_name], var.tags)
+}
+
+# BACKUP INSTANCE
+resource "google_compute_instance_from_template" "backup_controller" {
+  provider = google-beta
+  count    = var.enable_backup_controller ? 1 : 0
+
+  name                     = local.slurm_backup_controller_name
+  project                  = local.controller_project_id
+  zone                     = local.backup_zone
+  source_instance_template = module.slurm_backup_controller_template[0].self_link
+  labels                   = module.slurm_backup_controller_template[0].labels
+
+  allow_stopping_for_update = true
+
+  network_interface {
+    dynamic "access_config" {
+      for_each = var.enable_controller_public_ips ? ["unit"] : []
+      content {
+        nat_ip       = null
+        network_tier = null
+      }
+    }
+    network_ip = length(var.static_ips) >= 2 ? var.static_ips[1] : ""
+    subnetwork = var.subnetwork_self_link
+    stack_type = var.subnetwork_stack_type
+  }
+
+  dynamic "network_interface" {
+    for_each = var.controller_network_attachment != null ? [1] : []
+    content {
+      network_attachment = var.controller_network_attachment
     }
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/metadata.yaml
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/metadata.yaml
@@ -24,9 +24,9 @@ ghpc:
   - validator: range
     inputs:
       vars: [static_ips]
-      max: 1
+      max: 2
       length_check: true # Validates the list's length instead of its elements.
-    error_message: "The Slurm modules supports 0 or 1 static IPs on controller instance."
+    error_message: "The Slurm module supports 0, 1, or 2 static IPs on controller instances."
   - validator: regex
     inputs:
       vars: [slurm_cluster_name]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -65,6 +65,8 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_accounting_storage_backup_host"></a> [accounting\_storage\_backup\_host](#input\_accounting\_storage\_backup\_host) | The backup accounting storage host. | `string` | `null` | no |
+| <a name="input_backup_controller_key_timeout"></a> [backup\_controller\_key\_timeout](#input\_backup\_controller\_key\_timeout) | The time in seconds for the backup controller to wait for the shared key to become available. | `number` | `300` | no |
 | <a name="input_bucket_dir"></a> [bucket\_dir](#input\_bucket\_dir) | Bucket directory for cluster files to be put into. | `string` | `null` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | Name of GCS bucket to use. | `string` | n/a | yes |
 | <a name="input_cgroup_conf_tpl"></a> [cgroup\_conf\_tpl](#input\_cgroup\_conf\_tpl) | Slurm cgroup.conf template file path. | `string` | `null` | no |
@@ -97,6 +99,8 @@ No modules.
 | <a name="input_output_dir"></a> [output\_dir](#input\_output\_dir) | Directory where this module will write its files to. These files include:<br/>cloud.conf; cloud\_gres.conf; config.yaml; resume.py; suspend.py; and util.py. | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID. | `string` | n/a | yes |
 | <a name="input_prolog_scripts"></a> [prolog\_scripts](#input\_prolog\_scripts) | List of scripts to be used for Prolog. Programs for the slurmd to execute<br/>whenever it is asked to run a job step from a new job allocation.<br/>See https://slurm.schedmd.com/slurm.conf.html#OPT_Prolog. | <pre>list(object({<br/>    filename = string<br/>    content  = optional(string)<br/>    source   = optional(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_slurm_backup_controller_ip"></a> [slurm\_backup\_controller\_ip](#input\_slurm\_backup\_controller\_ip) | The backup controller static IP. | `string` | `null` | no |
+| <a name="input_slurm_backup_controller_name"></a> [slurm\_backup\_controller\_name](#input\_slurm\_backup\_controller\_name) | The backup controller name. | `string` | `null` | no |
 | <a name="input_slurm_bin_dir"></a> [slurm\_bin\_dir](#input\_slurm\_bin\_dir) | Path to directory of Slurm binary commands (e.g. scontrol, sinfo). If 'null',<br/>then it will be assumed that binaries are in $PATH. | `string` | `null` | no |
 | <a name="input_slurm_cluster_name"></a> [slurm\_cluster\_name](#input\_slurm\_cluster\_name) | The cluster name, used for resource naming and slurm accounting. | `string` | n/a | yes |
 | <a name="input_slurm_conf_template"></a> [slurm\_conf\_template](#input\_slurm\_conf\_template) | Slurm slurm.conf template. Content of the file in 'slurm\_conf\_tpl' is used if this is not set. | `string` | `null` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurm.conf.tpl
@@ -34,7 +34,7 @@ MessageTimeout=60
 #              vvvvv  WARNING: DO NOT MODIFY SECTION BELOW  vvvvv              #
 ################################################################################
 
-SlurmctldHost={control_host}({control_addr})
+{slurmctld_hosts}
 
 AuthType=auth/{auth_key}
 AuthInfo=cred_expire=120
@@ -53,6 +53,7 @@ StateSaveLocation={state_save}
 # LOGGING AND ACCOUNTING
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageHost={accounting_storage_host}
+{accounting_storage_backup_host}
 ClusterName={name}
 SlurmctldLogFile={slurmlog}/slurmctld.log
 SlurmdLogFile={slurmlog}/slurmd-%n.log

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurmdbd.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurmdbd.conf.tpl
@@ -12,7 +12,7 @@ AuthType=auth/{auth_key}
 AuthAltTypes=auth/jwt
 AuthAltParameters=jwt_key={state_save}/jwt_hs256.key
 
-DbdHost={control_host}
+{dbd_host_str}
 
 LogFile={slurmlog}/slurmdbd.log
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -41,16 +41,19 @@ resource "random_uuid" "cluster_id" {
 
 locals {
   config = {
-    enable_bigquery_load  = var.enable_bigquery_load
-    cloudsql_secret       = var.cloudsql_secret
-    cluster_id            = random_uuid.cluster_id.result
-    project               = var.project_id
-    slurm_cluster_name    = var.slurm_cluster_name
-    enable_slurm_auth     = var.enable_slurm_auth
-    bucket_path           = local.bucket_path
-    enable_debug_logging  = var.enable_debug_logging
-    extra_logging_flags   = var.extra_logging_flags
-    controller_state_disk = var.controller_state_disk
+    enable_bigquery_load           = var.enable_bigquery_load
+    cloudsql_secret                = var.cloudsql_secret
+    cluster_id                     = random_uuid.cluster_id.result
+    project                        = var.project_id
+    slurm_cluster_name             = var.slurm_cluster_name
+    slurm_backup_controller_name   = var.slurm_backup_controller_name
+    slurm_backup_controller_ip     = var.slurm_backup_controller_ip
+    accounting_storage_backup_host = var.accounting_storage_backup_host
+    enable_slurm_auth              = var.enable_slurm_auth
+    bucket_path                    = local.bucket_path
+    enable_debug_logging           = var.enable_debug_logging
+    extra_logging_flags            = var.extra_logging_flags
+    controller_state_disk          = var.controller_state_disk
 
     # storage
     disable_default_mounts = var.disable_default_mounts
@@ -59,6 +62,7 @@ locals {
     # timeouts
     controller_startup_scripts_timeout = var.controller_startup_scripts_timeout
     compute_startup_scripts_timeout    = var.compute_startup_scripts_timeout
+    backup_controller_key_timeout      = var.backup_controller_key_timeout
 
     munge_mount     = local.munge_mount
     slurm_key_mount = var.slurm_key_mount
@@ -107,8 +111,8 @@ locals {
   slurm_bin_dir        = var.slurm_bin_dir != null ? abspath(var.slurm_bin_dir) : null
   slurm_log_dir        = var.slurm_log_dir != null ? abspath(var.slurm_log_dir) : null
 
-  munge_mount = var.enable_hybrid ? {
-    server_ip     = lookup(var.munge_mount, "server_ip", coalesce(var.slurm_control_addr, var.slurm_control_host))
+  munge_mount = (var.enable_hybrid || var.slurm_backup_controller_name != null) ? {
+    server_ip     = lookup(var.munge_mount, "server_ip", coalesce(var.slurm_control_addr, var.slurm_control_host, "$controller"))
     remote_mount  = lookup(var.munge_mount, "remote_mount", "/etc/munge/")
     fs_type       = lookup(var.munge_mount, "fs_type", "nfs")
     mount_options = lookup(var.munge_mount, "mount_options", "")

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -28,6 +28,8 @@ from util import dirs, slurmdirs
 import tpu
 from addict import Dict as NSDict # type: ignore
 import yaml
+import socket
+import time
 
 
 FILE_PREAMBLE = """
@@ -327,6 +329,54 @@ def install_slurm_conf(lkp: util.Lookup) -> None:
         "auth_key": "slurm" if lkp.cfg.enable_slurm_auth else "munge",
     }
 
+    # Resolve IPs for SlurmctldHost to ensure correct HA configuration (requires name(IP) format)
+    # and use multiple lines for Slurm 23.02+ syntax compliance if HA is enabled.
+    control_host = lkp.control_host
+    try:
+        control_ip = socket.gethostbyname(control_host)
+    except Exception as e:
+        log.warning(f"Failed to resolve control_host {control_host}: {e}")
+        control_ip = lkp.control_addr if lkp.control_addr else control_host
+
+    slurmctld_hosts_str = f"SlurmctldHost={control_host}({control_ip})"
+
+    backup_name = lkp.cfg.get("slurm_backup_controller_name")
+    if backup_name:
+        backup_ip = lkp.cfg.get("slurm_backup_controller_ip")
+        if not backup_ip:
+            timeout = lkp.cfg.get("controller_startup_scripts_timeout", 300)
+            snooze = 10 # seconds
+            retries = int(timeout / snooze)
+            for i in range(retries):
+                try:
+                    backup_ip = socket.gethostbyname(backup_name)
+                    log.info(f"Successfully resolved backup_controller hostname '{backup_name}' to {backup_ip}")
+                    break
+                except Exception as e:
+                    if i < retries - 1:
+                        log.warning(f"Failed to resolve backup_controller hostname '{backup_name}' (Attempt {i + 1}/{retries}): {e}. Retrying in {snooze} seconds...")
+                        time.sleep(snooze)
+                    else:
+                        log.error(f"Failed to resolve backup_controller hostname '{backup_name}' after {retries} attempts: {e}")
+                        raise
+        else:
+            log.info(f"Using static backup_controller IP {backup_ip} from config")
+
+        slurmctld_hosts_str += f"\nSlurmctldHost={backup_name}({backup_ip})"
+
+    conf_options["slurmctld_hosts"] = slurmctld_hosts_str
+
+    # Append backup controller to AccountingStorageHost
+    if lkp.cfg.accounting_storage_backup_host:
+        conf_options["accounting_storage_backup_host"] = f"AccountingStorageBackupHost={lkp.cfg.accounting_storage_backup_host}"
+    elif backup_name:
+        # If DbdBackupHost is used, then slurmdbd runs on both.
+        backup_storage_host = backup_ip if lkp.cfg.controller_network_attachment else backup_name
+        conf_options["accounting_storage_backup_host"] = f"AccountingStorageBackupHost={backup_storage_host}"
+    else:
+        conf_options["accounting_storage_backup_host"] = ""
+
+
     conf = lkp.cfg.slurm_conf_tpl.format(**conf_options)
 
     conf_file = lkp.etc_dir / "slurm.conf"
@@ -337,7 +387,7 @@ def install_slurm_conf(lkp: util.Lookup) -> None:
 def install_slurmdbd_conf(lkp: util.Lookup) -> None:
     """install slurmdbd.conf"""
     conf_options = {
-        "control_host": lkp.control_host,
+        "dbd_host_str": f"DbdHost={lkp.control_host}",
         "slurmlog": dirs.log,
         "state_save": slurmdirs.state,
         "db_name": "slurm_acct_db",
@@ -347,6 +397,14 @@ def install_slurmdbd_conf(lkp: util.Lookup) -> None:
         "db_port": "3306",
         "auth_key": "slurm" if lkp.cfg.enable_slurm_auth else "munge",
     }
+
+    # Configure DbdHost and DbdBackupHost
+    dbd_host_str = f"DbdHost={lkp.control_host}"
+    backup_name = lkp.cfg.get("slurm_backup_controller_name")
+    if backup_name:
+        dbd_host_str += f"\nDbdBackupHost={backup_name}"
+
+    conf_options["dbd_host_str"] = dbd_host_str
 
     if lkp.cfg.cloudsql_secret:
         secret_name = f"{lkp.cfg.slurm_cluster_name}-slurm-secret-cloudsql"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -221,7 +221,7 @@ def _generate_key(p: Path) -> None:
     run(f"dd if=/dev/random of={p} bs=1024 count=1")
 
 
-def setup_key(lkp: util.Lookup) -> None:
+def setup_key(lkp: util.Lookup, is_primary: bool = True) -> None:
     file_name = "munge.key"
     dir = dirs.munge
 
@@ -231,35 +231,79 @@ def setup_key(lkp: util.Lookup) -> None:
 
     dst = Path(dir / file_name)
 
-    if lkp.cfg.controller_state_disk.device_name:
-        # Copy key from persistent state disk
-        persist = slurmdirs.state / file_name
-        if not persist.exists():
-            _generate_key(persist)
+    shared_dir = Path(slurmdirs.state)
+    shared_key = shared_dir / file_name
 
-        shutil.copyfile(persist, dst)
+    if is_primary:
+        # Primary Controller Logic:
+        # 1. Restore  key from shared state if local is missing but shared exists
+        # 2. Generate local if neither exists
+        # 3. Sync local to shared
+
+        if not dst.exists():
+            if shared_key.exists():
+                log.info(f"Restoring {file_name} from {shared_key}")
+                shutil.copyfile(shared_key, dst)
+            elif lkp.cfg.controller_state_disk.device_name:
+                 # For zonal state disk (files might be directly there if mounted at slurmdirs.state)
+                 # But if slurmdirs.state IS shared_dir, we already checked shared_key.exists()
+                 # If controller_state_disk is used, slurmdirs.state IS the persistence.
+                 pass
+
+            if not dst.exists(): # Still missing
+                log.info(f"Generating {file_name}")
+                _generate_key(dst)
+
+        # Set permissions on local key
         if lkp.cfg.enable_slurm_auth:
             util.chown_slurm(dst, mode=0o400)
-            util.chown_slurm(persist, mode=0o400)
         else:
             shutil.chown(dst, user="munge", group="munge")
             os.chmod(dst, stat.S_IRUSR)
+
+        # Sync to shared location
+        if not shared_key.exists():
+            log.info(f"Syncing {file_name} to {shared_key}")
+            try:
+                shutil.copyfile(dst, shared_key)
+                if lkp.cfg.enable_slurm_auth:
+                    util.chown_slurm(shared_key, mode=0o400)
+                else:
+                    util.chown_slurm(shared_key, mode=0o600)
+            except Exception as e:
+                log.warning(f"Failed to sync key to shared storage: {e}")
+
     else:
-        if dst.exists():
-            log.info("key already exists. Skipping key generation.")
+        # Wait for key to appear in shared storage and copy to local destination
+
+        timeout = lkp.cfg.get("backup_controller_key_timeout", 300)
+        snooze = 10 # seconds
+        retries = int(timeout / snooze)
+        log.info(f"Waiting for {file_name} in {shared_dir} for up to {timeout} seconds")
+        for _ in range(retries):
+            if shared_key.exists():
+                break
+            time.sleep(snooze)
+
+        if not shared_key.exists():
+            log.error(f"Timed out waiting for {file_name} in {shared_dir}")
+            raise FileNotFoundError(f"{file_name} not found in shared storage")
+
+        log.info(f"Copying {file_name} from {shared_dir}")
+        shutil.copyfile(shared_key, dst)
+
+        if lkp.cfg.enable_slurm_auth:
+            util.chown_slurm(dst, mode=0o400)
         else:
-            _generate_key(dst)
-            if lkp.cfg.enable_slurm_auth:
-              util.chown_slurm(dst, mode=0o400)
-            else:
-              shutil.chown(dst, user="munge", group="munge")
-              os.chmod(dst, stat.S_IRUSR)
+            shutil.chown(dst, user="munge", group="munge")
+            os.chmod(dst, stat.S_IRUSR)
 
     if lkp.cfg.enable_slurm_auth:
         # Put key into shared volume for distribution
-        distributed = util.slurmdirs.key_distribution / file_name
-        shutil.copyfile(dst, distributed)
-        util.chown_slurm(distributed, mode=0o400)
+        if is_primary:
+            distributed = util.slurmdirs.key_distribution / file_name
+            shutil.copyfile(dst, distributed)
+            util.chown_slurm(distributed, mode=0o400)
         # Munge is distributed from /etc/munge.
     else:
         run("systemctl restart munge", timeout=30)
@@ -415,10 +459,13 @@ def self_report_controller_address(lkp: util.Lookup) -> None:
     with blob.open('w') as f:
         f.write(yaml.dump(data))
 
-def setup_controller():
-    """Run controller setup"""
-    log.info("Setting up controller")
+def setup_controller(is_primary: bool):
+    """Shared controller setup logic for both primary and backup."""
+    role_name = "Primary" if is_primary else "Backup"
+    log.info(f"Setting up {role_name} controller")
     lkp = util.lookup()
+
+    # Topology and configuration
     util.chown_slurm(dirs.scripts / "config.yaml", mode=0o600)
     install_custom_scripts()
     if util.slurm_version_gte(lkp.slurm_version, "25.05"):
@@ -426,15 +473,19 @@ def setup_controller():
     else:
         conf_v2411.generate_configs_slurm_v2411(lkp)
 
-
-    if lkp.cfg.controller_state_disk.device_name != None:
-        mount_save_state_disk()
-
-    setup_jwt_key()
-    setup_key(lkp)
-
     setup_sudoers()
     setup_network_storage()
+
+    # Ensure state directory permissions are correct (especially if mounted via NFS)
+    util.chown_slurm(slurmdirs.state)
+
+    # Primary-specific state disk mounting
+    if is_primary:
+        if lkp.cfg.controller_state_disk.device_name != None:
+            mount_save_state_disk()
+
+    setup_jwt_key()
+    setup_key(lkp, is_primary=is_primary)
 
     run_custom_scripts()
 
@@ -479,7 +530,7 @@ def setup_controller():
 
     log.info("Check status of cluster services")
     if not lkp.cfg.enable_slurm_auth:
-      run("systemctl status munge", timeout=30)
+        run("systemctl status munge", timeout=30)
     run("systemctl status slurmdbd", timeout=30)
     run("systemctl status slurmctld", timeout=30)
     run("systemctl status slurmrestd", timeout=30)
@@ -498,21 +549,23 @@ def setup_controller():
 
     self_report_controller_address(lkp)
 
-    log.info("Done setting up controller")
+    log.info(f"Done setting up {role_name} controller")
     pass
-
 
 def setup_login():
     """run login node setup"""
     log.info("Setting up login")
 
     lkp = lookup()
-    slurmctld_host = f"{lkp.control_host}"
-    if lkp.control_addr:
-        slurmctld_host = f"{lkp.control_host}({lkp.control_addr})"
-    sackd_options = [
-        f'--conf-server="{slurmctld_host}:{lkp.control_host_port}"',
-    ]
+    primary_control_host = lkp.control_host_addr or lkp.control_host
+    backup_control_host = lkp.cfg.get("slurm_backup_controller_ip") or lkp.cfg.get("slurm_backup_controller_name")
+
+    servers = [f"{primary_control_host}:{lkp.control_host_port}"]
+    if backup_control_host:
+        servers.append(f"{backup_control_host}:{lkp.control_host_port}")
+
+    conf_server_arg = ",".join(f'"{s}"' for s in servers)
+    sackd_options = [f"--conf-server={conf_server_arg}"]
     sysconf = f"""SACKD_OPTIONS='{" ".join(sackd_options)}'"""
     update_system_config("sackd", sysconf)
     install_custom_scripts()
@@ -522,7 +575,10 @@ def setup_login():
     if not lkp.cfg.enable_slurm_auth:
       run("systemctl restart munge", timeout=30)
     run("systemctl enable sackd", timeout=30)
-    run("systemctl restart sackd", timeout=30)
+    try:
+        run("systemctl restart sackd", timeout=30)
+    except Exception:
+        log.exception("Failed to restart sackd, ignoring failure.")
     run("systemctl enable --now slurmcmd.timer", timeout=30)
 
     run_custom_scripts()
@@ -541,12 +597,15 @@ def setup_compute():
 
     lkp = lookup()
     util.chown_slurm(dirs.scripts / "config.yaml", mode=0o600)
-    slurmctld_host = f"{lkp.control_host}"
-    if lkp.control_addr:
-        slurmctld_host = f"{lkp.control_host}({lkp.control_addr})"
-    slurmd_options = [
-        f'--conf-server="{slurmctld_host}:{lkp.control_host_port}"',
-    ]
+    primary_control_host = lkp.control_host_addr or lkp.control_host
+    backup_control_host = lkp.cfg.get("slurm_backup_controller_ip") or lkp.cfg.get("slurm_backup_controller_name")
+
+    servers = [f"{primary_control_host}:{lkp.control_host_port}"]
+    if backup_control_host:
+        servers.append(f"{backup_control_host}:{lkp.control_host_port}")
+
+    conf_server_arg = ",".join(f'"{s}"' for s in servers)
+    slurmd_options = [f"--conf-server={conf_server_arg}"]
 
     try:
         slurmd_feature = util.instance_metadata("attributes/slurmd_feature", silent=True)
@@ -650,13 +709,22 @@ def main():
     setup_cloud_ops()
     configure_dirs()
     # call the setup function for the instance type
+    role = lookup().instance_role
+    try:
+        ha_role = util.instance_metadata("attributes/slurm_ha_role", silent=True)
+        if ha_role == "backup":
+            role = "backup_controller"
+    except:
+        pass
+
     {
-        "controller": setup_controller,
+        "controller": lambda: setup_controller(is_primary=True),
+        "backup_controller": lambda: setup_controller(is_primary=False),
         "compute": setup_compute,
         "login": setup_login,
     }.get(
-        lookup().instance_role,
-        lambda: log.fatal(f"Unknown node role: {lookup().instance_role}"))()
+        role,
+        lambda: log.fatal(f"Unknown node role: {role}"))()
 
     end_motd()
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -184,6 +184,26 @@ def mount_fstab(mounts: list[NSMount], log):
                 raise e
 
 
+def wait_for_file(file_path: Path, timeout: int = 300):
+    """Wait for a file to exist and be non-empty at the given path."""
+    log.info(f"Waiting up to {timeout}s for file to exist and be ready: {file_path}")
+
+    for retry, wait in enumerate(util.backoff_delay(1.0, timeout), 1):
+        try:
+            if file_path.exists() and file_path.stat().st_size > 0:
+                with open(file_path, 'rb') as f:
+                    f.read(1)
+                log.info(f"File found and verified: {file_path}")
+                return
+        except OSError as e:
+            log.warning(f"File {file_path} exists but is not ready (try {retry}): {e}")
+
+        if wait > 0:
+            time.sleep(wait)
+
+    raise TimeoutError(f"Timeout waiting for file to be ready: {file_path}")
+
+
 def munge_mount_handler():
     if lookup().is_controller:
         return
@@ -223,8 +243,10 @@ def munge_mount_handler():
         raise err
 
     munge_key = Path(dirs.munge / "munge.key")
+    src_key = Path(mnt.local_mount / "munge.key")
+    wait_for_file(src_key)
     log.info(f"Copy munge.key from: {mnt.local_mount}")
-    shutil.copy2(Path(mnt.local_mount / "munge.key"), munge_key)
+    shutil.copy2(src_key, munge_key)
 
     log.info("Restrict permissions of munge.key")
     shutil.chown(munge_key, user="munge", group="munge")
@@ -275,8 +297,10 @@ def slurm_key_mount_handler():
 
     file_name = "slurm.key"
     dst = Path(util.slurmdirs.etc / file_name)
+    src_key = mnt.local_mount / file_name
+    wait_for_file(src_key)
     log.info(f"Copy slurm.key from: {mnt.local_mount}")
-    shutil.copy2(mnt.local_mount / file_name, dst)
+    shutil.copy2(src_key, dst)
 
     log.info("Restrict permissions of slurm.key")
     util.chown_slurm(dst, mode=0o400)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/variables.tf
@@ -67,6 +67,30 @@ variable "slurm_cluster_name" {
   }
 }
 
+variable "slurm_backup_controller_name" {
+  type        = string
+  description = "The backup controller name."
+  default     = null
+}
+
+variable "slurm_backup_controller_ip" {
+  type        = string
+  description = "The backup controller static IP."
+  default     = null
+}
+
+variable "accounting_storage_backup_host" {
+  type        = string
+  description = "The backup accounting storage host."
+  default     = null
+}
+
+variable "backup_controller_key_timeout" {
+  description = "The time in seconds for the backup controller to wait for the shared key to become available."
+  type        = number
+  default     = 300
+}
+
 variable "controller_state_disk" {
   description = <<EOD
   A disk that will be attached to the controller instance template to save state of slurm. The disk is created and used by default.

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -119,6 +119,25 @@ locals {
 
 
   nodeset_startup_scripts = { for k, v in local.nodeset_map : k => concat(local.common_scripts, v.startup_script) }
+
+  state_spool_mount = one([
+    for ns in var.network_storage : ns
+    if ns.local_mount == "/var/spool/slurm"
+  ])
+
+  auto_munge_mount = (var.enable_backup_controller && local.state_spool_mount != null) ? {
+    server_ip     = local.state_spool_mount.server_ip
+    remote_mount  = local.state_spool_mount.remote_mount
+    fs_type       = local.state_spool_mount.fs_type
+    mount_options = "defaults,soft,intr,timeo=600,retrans=2"
+  } : var.munge_mount
+
+  auto_slurm_key_mount = (var.enable_backup_controller && local.state_spool_mount != null) ? {
+    server_ip     = local.state_spool_mount.server_ip
+    remote_mount  = local.state_spool_mount.remote_mount
+    fs_type       = local.state_spool_mount.fs_type
+    mount_options = "defaults,soft,intr,timeo=600,retrans=2"
+  } : var.slurm_key_mount
 }
 
 module "daos_network_storage_scripts" {
@@ -137,6 +156,8 @@ module "slurm_files" {
 
   project_id                    = var.project_id
   slurm_cluster_name            = local.slurm_cluster_name
+  slurm_backup_controller_name  = var.enable_backup_controller ? local.slurm_backup_controller_name : null
+  slurm_backup_controller_ip    = var.enable_backup_controller && length(var.static_ips) >= 2 ? var.static_ips[1] : null
   bucket_dir                    = var.bucket_dir
   bucket_name                   = local.bucket_name
   controller_network_attachment = var.controller_network_attachment
@@ -170,7 +191,9 @@ module "slurm_files" {
   task_epilog_scripts                = var.task_epilog_scripts
   task_prolog_scripts                = var.task_prolog_scripts
 
-  disable_default_mounts = !var.enable_default_mounts
+  munge_mount            = local.auto_munge_mount
+  slurm_key_mount        = local.auto_slurm_key_mount
+  disable_default_mounts = !var.enable_default_mounts || var.enable_backup_controller
   network_storage = [
     for storage in var.network_storage : {
       server_ip     = storage.server_ip,

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -87,6 +87,28 @@ variable "bucket_dir" {
 # CONTROLLER: CLOUD # See variables_controller_instance.tf for the controller instance variables.
 #####################
 
+variable "enable_backup_controller" {
+  description = "Enables a secondary backup controller for High Availability."
+  type        = bool
+  default     = false
+  validation {
+    condition     = var.enable_backup_controller == false || (length(var.network_storage) > 0 && var.controller_state_disk == null)
+    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null and network_storage must be provided (non-empty) to share state."
+  }
+}
+
+variable "backup_machine_type" {
+  description = "Machine type for the backup controller. If null, uses the same as the primary controller."
+  type        = string
+  default     = null
+}
+
+variable "backup_zone" {
+  description = "Zone for the backup controller. If null, it will be placed in the same region, potentially different zone."
+  type        = string
+  default     = null
+}
+
 #########
 # LOGIN #
 #########

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
@@ -119,8 +119,8 @@ variable "static_ips" {
   description = "List of static IPs for VM instances."
   default     = []
   validation {
-    condition     = length(var.static_ips) <= 1
-    error_message = "The Slurm modules supports 0 or 1 static IPs on controller instance."
+    condition     = length(var.static_ips) <= 2
+    error_message = "The Slurm module supports 0, 1, or 2 static IPs on controller instances."
   }
 }
 
@@ -424,4 +424,38 @@ variable "resource_manager_tags" {
     condition     = alltrue([for value in keys(var.resource_manager_tags) : can(regex("tagKeys/[0-9]+", value))])
     error_message = "All Resource Manager tag keys should be in the format 'tagKeys/[0-9]+'"
   }
+}
+
+variable "munge_mount" {
+  description = <<-EOD
+  Remote munge mount for compute and login nodes to acquire the munge.key.
+  By default, the munge mount server will be assumed to be the
+  `var.slurm_control_host` (or `var.slurm_control_addr` if non-null) when
+  `server_ip=null`.
+  EOD
+  type = object({
+    server_ip     = string
+    remote_mount  = string
+    fs_type       = string
+    mount_options = string
+  })
+  default = {
+    server_ip     = null
+    remote_mount  = "/etc/munge/"
+    fs_type       = "nfs"
+    mount_options = ""
+  }
+}
+
+variable "slurm_key_mount" {
+  description = <<-EOD
+  Remote mount for compute and login nodes to acquire the slurm.key.
+  EOD
+  type = object({
+    server_ip     = string
+    remote_mount  = string
+    fs_type       = string
+    mount_options = string
+  })
+  default = null
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,6 +17,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [(Optional) Setting up a remote terraform state](#optional-setting-up-a-remote-terraform-state)
 * [Blueprint Descriptions](#blueprint-descriptions)
   * [hpc-slurm.yaml](#hpc-slurmyaml-) ![core-badge]
+  * [hpc-slurm-ha.yaml](#hpc-slurm-hayaml-) ![community-badge]
   * [hpc-enterprise-slurm.yaml](#hpc-enterprise-slurmyaml-) ![core-badge]
   * [hpc-slurm6-tpu.yaml](#hpc-slurm6-tpuyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm6-tpu-maxtext.yaml](#hpc-slurm6-tpu-maxtextyaml--) ![community-badge] ![experimental-badge]
@@ -219,6 +220,16 @@ For this example the following is needed in the selected region:
   needed for the `compute` partition_
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for the `compute` partition_
+
+### [hpc-slurm-ha.yaml] ![community-badge]
+
+Creates a highly available (HA) Slurm cluster. This setup includes a primary controller
+and a backup controller to ensure control plane resilience. If the primary controller
+instance fails, the Slurm services can be failed over to the backup controller, minimizing
+downtime. This blueprint configures the necessary shared storage and network settings to
+support the HA configuration.
+
+[hpc-slurm-ha.yaml]: ./hpc-slurm-ha.yaml
 
 ### [hpc-enterprise-slurm.yaml] ![core-badge]
 


### PR DESCRIPTION
## 1. Slurm HA Controller Implementation

The HA controller implementation builds upon the standard controller setup but introduces critical changes to support High Availability via a Primary/Backup model and shared state.

### Core Modifications
-   **setup.py**:
    -   **Setup Order**: `setup_network_storage()` is now called *before* `setup_key()` and `setup_jwt_key()`. This is essential because HA relies on shared network storage (Filestore/NFS) to synchronize keys between controllers.
    -   **Key Synchronization**: `setup_key()` was refactored to handle `is_primary` logic.
        -   **Primary**: Generates keys and copies them to the shared state directory (`slurmdirs.state`) i.e `/var/log/spool/slurm`.
        -   **Backup**: Waits for keys to appear in the shared directory and configures `slurmctlcld`.
    -   **Controller Setup**: refactored `setup_controller()` to handle `is_primary` logic. It configures the instances as `primary` and `backup` controllers base on the instance respective roles.
    -   **Munge Keys**: `setup_key()` now also syncs via shared state, similar to jwt keys.

-   **conf.py**:
    -   Updates to `install_slurm_conf` to generate `SlurmctldHost` entries for receiving HA heartbeat messages.
    -   Updates to `install_slurmdbd_conf` to support `DbdBackupHost`.

- **controller.tf**:
   - Updated to add backup_controller instance template,  instance and related resources blocks provided `enable_backup_controller` is true.
 

## 2. Backward Compatibility

The implementation preserves backward compatibility for single-controller deployments:
-   **Guarded by Variable**: The HA functionality is controlled by the `enable_backup_controller` Terraform variable, which defaults to `false`.
-   **Default Behavior**: When `enable_backup_controller` is false, the module behaves exactly as the standard single-controller deployment:
    -   `slurm.conf` is generated with a single controller host.
    -   Key synchronization logic is skipped in favor of local generation.
    -   No backup controller resources are created or configured.

## Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)


## Test
1. Slurm HA deployed
<img width="1406" height="192" alt="Screenshot 2026-03-07 at 12 51 41" src="https://github.com/user-attachments/assets/317e1855-d253-4034-810b-eb596c899145" />

2. Stop slurmctld on primary controller
<img width="2592" height="1066" alt="image" src="https://github.com/user-attachments/assets/9a36c024-14bd-40bc-95bc-01438ce8cc88" />

3. Observe logs on primary controller:
<img width="2592" height="1066" alt="image" src="https://github.com/user-attachments/assets/004ea622-bcb7-4fad-8636-180742e4c301" />

4. Observe logs on backup controller:
<img width="2592" height="1066" alt="image" src="https://github.com/user-attachments/assets/3a628b66-d49b-4f84-bdf3-1d2d3f56883c" />

5. shutdown primary controller
<img width="2828" height="446" alt="image" src="https://github.com/user-attachments/assets/ed283fbb-add0-4a49-bc0b-f668b8fdff76" />

6. Observe logs on backup controller:
<img width="2040" height="1268" alt="image" src="https://github.com/user-attachments/assets/c5d2c6ad-0ff9-40d3-a4bb-baac1e2945db" />

8. Check cluster status on backup controller:
    [Note jobs still running and also successful new job submission from backup controller]
<img width="2592" height="1266" alt="image" src="https://github.com/user-attachments/assets/2f52cb5e-48b4-47da-8ad1-57df74b3adf0" />

10. Restart primary controller:
<img width="2812" height="384" alt="image" src="https://github.com/user-attachments/assets/ead1ea26-e44c-451e-9b75-2647c7abe353" />

11. Observe cluster status:
<img width="2040" height="1268" alt="image" src="https://github.com/user-attachments/assets/122cb24e-6f29-4b7e-af66-9da3381bf6bb" />

12. Jobs completed successfully:
<img width="1582" height="380" alt="image" src="https://github.com/user-attachments/assets/bb12195c-dc31-48d5-acc2-c5d34709b4cd" />
