### PR TITLE
fix: guard setup_cloud_ops against empty ops agent config

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -591,10 +591,10 @@ def setup_cloud_ops() -> None:
     # Guard: skip if config is empty or missing the expected slurm receivers structure.
     # This happens when the ops agent is installed with a default empty config (comments only).
     if (
-        not file
-        or not isinstance(file, dict)
-        or not isinstance(file.get("logging"), dict)
-        or "setup" not in file.get("logging", {}).get("receivers", {})
+        not isinstance(file, dict)
+        or not isinstance(logging := file.get("logging"), dict)
+        or not isinstance(receivers := logging.get("receivers"), dict)
+        or "setup" not in receivers
     ):
         log.warning(
             "google-cloud-ops-agent config is missing expected structure, skipping cloud ops customization"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -588,6 +588,19 @@ def setup_cloud_ops() -> None:
     with open("/etc/google-cloud-ops-agent/config.yaml", "r") as f:
         file = yaml.safe_load(f)
 
+    # Guard: skip if config is empty or missing the expected slurm receivers structure.
+    # This happens when the ops agent is installed with a default empty config (comments only).
+    if (
+        not file
+        or not isinstance(file, dict)
+        or not isinstance(file.get("logging"), dict)
+        or "setup" not in file.get("logging", {}).get("receivers", {})
+    ):
+        log.warning(
+            "google-cloud-ops-agent config is missing expected structure, skipping cloud ops customization"
+        )
+        return
+
     # Update setup receiver path
     file["logging"]["receivers"]["setup"]["include_paths"] = ["/var/log/slurm/setup.log"]
 


### PR DESCRIPTION
## Description

`setup_cloud_ops()` crashes when the Google Cloud Ops Agent is active but its config file (`/etc/google-cloud-ops-agent/config.yaml`) contains only comments (the default install state on some images). `yaml.safe_load()` returns `None` for a comments-only file, and the function then immediately tries to subscript it, causing:

```
TypeError: 'NoneType' object is not subscriptable
```

On images where the ops agent config has a `logging` section but lacks the slurm-specific `receivers.setup` structure, the failure is:

```
KeyError: 'setup'
```

In both cases `setup.py` aborts entirely before node setup completes.

## Fix

Add a guard after `yaml.safe_load()` that returns early with a warning if the config is `None`, not a dict, or missing the expected `logging.receivers.setup` structure. The ops agent continues running with its default config — only the slurm-specific customization (log path injection, cluster labels) is skipped.

## Testing

Verified on freshly provisioned Slurm login nodes where the ops agent was active with a default empty config. With this fix, `setup.py` completes successfully and all downstream services come up normally.