### PR TITLE
enable execution of external prolog/epilog for A4X

### DIFF
--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -710,3 +710,4 @@ deployment_groups:
         switch_type: switch/nvidia_imex
       controller_state_disk: null
       controller_startup_script: $(controller_startup.startup_script)
+      enable_external_prolog_epilog: true


### PR DESCRIPTION
The PR adds enable_external_prolog_epilog: true flag to the a4xhigh-slurm-blueprint.yaml.

Why it should be enabled

The blueprint is already staging several critical scripts via the controller_scripts section into the /opt/apps/adm/slurm directory:

**imex_prolog / imex_epilog:** Required for NVIDIA IMEX (Interrupt Management and Execution) support.
**gpu-test:** A cluster health check to ensure GPUs are functional before/after jobs.
**sudo-oslogin:** Enables passwordless sudo for authorized users.

Without this flag, while these scripts are successfully downloaded and placed on the disk, Slurm will never execute them because the necessary "multiplexer" infrastructure and Slurm configuration changes are not applied.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
