### PR TITLE
fix: prevent munge startup race on compute node boot

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -554,6 +554,18 @@ def setup_compute():
     install_custom_scripts()
 
     setup_nss_slurm()
+
+    if not lkp.cfg.enable_slurm_auth:
+        # Prevent a race where munge.service starts at boot before munge.key is
+        # deployed, leaving munge in a failed state that blocks slurmd authentication.
+        munge_override_dir = Path("/etc/systemd/system/munge.service.d")
+        munge_override_dir.mkdir(parents=True, exist_ok=True)
+        (munge_override_dir / "require-key.conf").write_text(
+            "[Unit]\nConditionPathExists=/etc/munge/munge.key\n"
+        )
+        run("systemctl daemon-reload", timeout=30)
+        run("systemctl reset-failed munge", timeout=30, check=False)
+
     setup_network_storage()
 
     has_gpu = run("lspci | grep --ignore-case 'NVIDIA' | wc -l", shell=True).returncode

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -561,7 +561,7 @@ def setup_compute():
         munge_override_dir = Path("/etc/systemd/system/munge.service.d")
         munge_override_dir.mkdir(parents=True, exist_ok=True)
         (munge_override_dir / "require-key.conf").write_text(
-            "[Unit]\nConditionPathExists=/etc/munge/munge.key\n"
+            f"[Unit]\nConditionPathExists={dirs.munge / 'munge.key'}\n"
         )
         run("systemctl daemon-reload", timeout=30)
         run("systemctl reset-failed munge", timeout=30, check=False)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -494,6 +494,19 @@ def setup_controller():
     pass
 
 
+def prevent_munge_boot_race():
+    """Install a systemd drop-in so munge.service is skipped (not failed) at
+    boot when munge.key is absent, and clear any failed state from the current
+    boot before setup_network_storage() deploys the key."""
+    munge_override_dir = Path("/etc/systemd/system/munge.service.d")
+    munge_override_dir.mkdir(parents=True, exist_ok=True)
+    (munge_override_dir / "require-key.conf").write_text(
+        f"[Unit]\nConditionPathExists={dirs.munge / 'munge.key'}\n"
+    )
+    run("systemctl daemon-reload", timeout=30)
+    run("systemctl reset-failed munge", timeout=30, check=False)
+
+
 def setup_login():
     """run login node setup"""
     log.info("Setting up login")
@@ -508,6 +521,9 @@ def setup_login():
     sysconf = f"""SACKD_OPTIONS='{" ".join(sackd_options)}'"""
     update_system_config("sackd", sysconf)
     install_custom_scripts()
+
+    if not lkp.cfg.enable_slurm_auth:
+        prevent_munge_boot_race()
 
     setup_network_storage()
     setup_sudoers()
@@ -556,15 +572,7 @@ def setup_compute():
     setup_nss_slurm()
 
     if not lkp.cfg.enable_slurm_auth:
-        # Prevent a race where munge.service starts at boot before munge.key is
-        # deployed, leaving munge in a failed state that blocks slurmd authentication.
-        munge_override_dir = Path("/etc/systemd/system/munge.service.d")
-        munge_override_dir.mkdir(parents=True, exist_ok=True)
-        (munge_override_dir / "require-key.conf").write_text(
-            f"[Unit]\nConditionPathExists={dirs.munge / 'munge.key'}\n"
-        )
-        run("systemctl daemon-reload", timeout=30)
-        run("systemctl reset-failed munge", timeout=30, check=False)
+        prevent_munge_boot_race()
 
     setup_network_storage()
 


### PR DESCRIPTION
On compute node first boot, systemd starts `munge.service` (which is enabled in the SLURM image) before the startup script has deployed `/etc/munge/munge.key` via `setup_network_storage()`. Munge fails and enters a `failed` systemd state.

The existing `systemctl restart munge` in `setup_compute()` runs after the key is deployed, but a prior `failed` state can leave the munge socket unreliable, causing `slurmd` to be unable to authenticate with `slurmctld` even though both services appear running. This manifests as nodes stuck in `NOT_RESPONDING+POWERING_UP` with jobs hanging in `CONFIGURING`.

This fix installs a systemd drop-in for `munge.service` with `ConditionPathExists=/etc/munge/munge.key` before `setup_network_storage()` runs. This causes systemd to skip (not fail) the munge autostart when the key is absent — leaving it `inactive` rather than `failed`. A `systemctl reset-failed munge` also clears any failed state from the current boot's race before the key-deployment restart.