### PR TITLE
Ensure fully qualified URLs for reservation subblocks

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -315,6 +315,10 @@ resource "google_container_node_pool" "node_pool" {
       node_config[0].local_nvme_ssd_block_config,
     ]
     precondition {
+      condition     = !(length(compact(local.input_reservation_suffixes)) > 0 && length((var.zones != null ? var.zones : [])) == 0)
+      error_message = "var.zones must be explicitly provided when using an extended reservation block."
+    }
+    precondition {
       condition     = (var.max_pods_per_node == null) || (data.google_container_cluster.gke_cluster.networking_mode == "VPC_NATIVE")
       error_message = "max_pods_per_node does not work on `routes-based` clusters, that don't have IP Aliasing enabled."
     }
@@ -347,12 +351,12 @@ resource "google_container_node_pool" "node_pool" {
     precondition {
       condition = (
         (local.input_specific_reservations_count == 0) ||
-        ((length(local.verified_specific_reservations) == 1 || !var.is_reservation_active) &&
+        (((length(local.verified_specific_reservations) > 0 && length(local.verified_specific_reservations) == length(toset(var.zones != null ? var.zones : []))) || !var.is_reservation_active) &&
         length(local.specific_reservation_requirement_violations) == 0)
       )
       error_message = <<-EOT
       Check if your reservation is configured correctly:
-      - A reservation with the name must exist in the specified project and one of the specified zones
+      - A reservation with the name must exist in the specified project and all of the specified zones (var.zones must be explicitly provided when var.is_reservation_active is true)
 
       - Its consumption type must be "specific"
       %{for property in local.specific_reservation_requirement_violations}

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -32,7 +32,7 @@ data "google_compute_reservation" "specific_reservations" {
     {} :
     {
       for pair in flatten([
-        for zone in try(var.zones, []) : [
+        for zone in(var.zones != null ? var.zones : []) : [
           for i, reservation_name in try(local.input_reservation_names, []) : {
             key : "${local.input_reservation_projects[i]}/${zone}/${reservation_name}"
             zone : zone
@@ -90,18 +90,21 @@ locals {
 }
 
 locals {
-  # Check if reservation is valid, that is, if it exists, there should be only 1 verified specific reservation or the reservation doesn't exist
-  is_valid_reservation = length(local.verified_specific_reservations) == 1 || !var.is_reservation_active
+  # Check if reservation is valid: specific reservations must be verified in all targeted zones
+  is_valid_reservation = (length(local.verified_specific_reservations) > 0 && length(local.verified_specific_reservations) == length(toset(var.zones != null ? var.zones : []))) || !var.is_reservation_active
 
   # Build the list of reservation names when var.is_reservation_active is true
   active_reservation_values = [
-    for i, r in local.verified_specific_reservations :
-    length(local.input_reservation_suffixes[i]) > 0 ?
-    format("%s%s", r.name, local.input_reservation_suffixes[i]) :
-    "projects/${r.project}/reservations/${r.name}"
+    for r in local.verified_specific_reservations :
+    "projects/${r.project}/zones/${r.zone}/reservations/${r.name}${try(local.input_reservation_suffixes[0], "")}"
   ]
 
-  # Define a default reservation value if no specific reservations are present
-  specific_reservation_name  = length(local.input_reservation_names) > 0 ? local.input_reservation_names[0] : ""
-  default_reservation_values = ["projects/${var.project_id}/reservations/${local.specific_reservation_name}"]
+  default_reservation_values = local.input_specific_reservations_count == 0 ? [] : (
+    length(var.zones != null ? var.zones : []) > 0 ? [
+      for z in toset(var.zones != null ? var.zones : []) :
+      "projects/${local.input_reservation_projects[0]}/zones/${z}/reservations/${local.input_reservation_names[0]}${try(local.input_reservation_suffixes[0], "")}"
+      ] : [
+      "projects/${local.input_reservation_projects[0]}/reservations/${local.input_reservation_names[0]}${try(local.input_reservation_suffixes[0], "")}"
+    ]
+  )
 }


### PR DESCRIPTION
Fixes URI formatting when targeting reservation blocks/subblocks in the `gke-node-pool` module. 

When users provide a suffix in the `specific_reservations[0].name` field (e.g., `my-res/reservationBlocks/my-block`), the module previously dropped the suffix for inactive reservations, and failed to include the required `zone` in the URI for active ones. 

This PR updates `active_reservation_values` and `default_reservation_values` to properly construct the fully qualified `projects/{project}/zones/{zone}/reservations/{name}/reservationBlocks/{block}` URI whenever a suffix is detected.