### PR TITLE
feat: optional infra setup for inference gateway

### DIFF
--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -52,6 +52,8 @@ vars:
 
   auto_monitoring_scope: "NONE"
 
+  enable_inference_gateway: false
+
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -80,6 +82,17 @@ deployment_groups:
       - subnet_name: $(vars.deployment_name)-sub-0
         subnet_region: $(vars.region)
         subnet_ip: 192.168.0.0/18
+
+      # If using an Envoy-based load balancer (https://docs.cloud.google.com/load-balancing/docs/load-balancing-overview#tech-gclb),
+      # uncomment the below to create the matching required subnet.
+      # Note that using GKE Gateway $(vars.enable_inference_gateway) with an L7 load balancer is Envoy-based.
+
+      #- subnet_name: $(vars.deployment_name)-proxy-only-subnet
+      #  subnet_region: $(vars.region)
+      #  subnet_ip: 10.10.0.0/23
+      #  purpose: REGIONAL_MANAGED_PROXY
+      #  role: ACTIVE
+
       secondary_ranges_list:
       - subnetwork_name: $(vars.deployment_name)-sub-0
         ranges:
@@ -184,6 +197,7 @@ deployment_groups:
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
+      enable_inference_gateway: $(vars.enable_inference_gateway)
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"


### PR DESCRIPTION
Allow user to opt into creating the infrastructure required for inference gateway. This includes setting the GKE cluster gateway setting to standard (already exists) & creating a proxy-only subnet of the used network (new in this PR).

Tested by:
  * (1) not specifying anything in gke-a4-deployment.yaml and seeing the usual default behavior of no gateway setting and subnet.
  * (2) specifying enable_inference_gateway=true in gke-a4-deployment.yaml and seeing both gateway setting enabled and subnet created.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
