### PR TITLE
Update base image driver to 580 in a3u and a4h slurm blueprints

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -29,11 +29,11 @@ vars:
   sys_net_range: 172.16.0.0/16
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260225
   a3mega_partition_name: a3mega
   local_mount_homefs: /home
   instance_image:
-    family: $(vars.final_image_family)
+    family: $(vars.final_image_family)-u24
     project: $(vars.project_id)
   enable_login_public_ips: true
   enable_controller_public_ips: true
@@ -194,8 +194,8 @@ deployment_groups:
         content: |
           #!/bin/bash
           set -ex -o pipefail
+          # 1. Install the specific compatible versions without the virtual libnvsdm package
           add-nvidia-repositories -y
-          apt update -y
           apt install -y \
               cuda-toolkit-12-8 \
               nvidia-container-toolkit \
@@ -203,7 +203,7 @@ deployment_groups:
               datacenter-gpu-manager-4-dev=1:4.5.3-1 \
               datacenter-gpu-manager-4-core=1:4.5.3-1
 
-          # 2. Hold ALL components
+          # 2. Hold the packages to prevent accidental updates
           apt-mark hold \
               datacenter-gpu-manager-4-cuda12 \
               datacenter-gpu-manager-4-dev \
@@ -354,6 +354,14 @@ deployment_groups:
           apt-get install --assume-yes google-cloud-cli
           # Clean up the bash executable hash for subsequent steps using gsutil
           hash -r
+      - type: shell
+        destination: stop_packer_early.sh
+        content: |
+          #!/bin/bash
+          # Signal Packer to finish using the clean short hostname
+          BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
+          rm \$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null)
+          gcloud compute instances add-metadata \$(hostname -s) --metadata "startup-script-status"="done" --zone $(vars.zone)
 
 - group: slurm-build
   modules:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -29,11 +29,11 @@ vars:
   sys_net_range: 172.16.0.0/16
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260225
+    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
   a3mega_partition_name: a3mega
   local_mount_homefs: /home
   instance_image:
-    family: $(vars.final_image_family)-u24
+    family: $(vars.final_image_family)
     project: $(vars.project_id)
   enable_login_public_ips: true
   enable_controller_public_ips: true
@@ -166,20 +166,44 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
+      - type: ansible-local
+        destination: update-gvnic.yml
+        content: |
+          ---
+          - name: Install updated gVNIC driver from GitHub
+            hosts: all
+            become: true
+            vars:
+              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.4.3/gve-dkms_1.4.3_all.deb
+              package_filename: /tmp/{{ package_url | basename }}
+            tasks:
+            - name: Install driver dependencies
+              ansible.builtin.apt:
+                name:
+                - dkms
+            - name: Download gVNIC package
+              ansible.builtin.get_url:
+                url: "{{ package_url }}"
+                dest: "{{ package_filename }}"
+            - name: Install updated gVNIC
+              ansible.builtin.apt:
+                deb: "{{ package_filename }}"
+                state: present
       - type: shell
         destination: install-cuda-toolkit.sh
         content: |
           #!/bin/bash
           set -ex -o pipefail
-          # 1. Install the specific compatible versions without the virtual libnvsdm package
+          add-nvidia-repositories -y
+          apt update -y
           apt install -y \
               cuda-toolkit-12-8 \
               nvidia-container-toolkit \
-              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
-              datacenter-gpu-manager-4-core=1:4.5.3-1
+              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
+              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
+              datacenter-gpu-manager-4-core=1:4.5.2-1
 
-          # 2. Hold the packages to prevent accidental updates
+          # 2. Hold ALL components
           apt-mark hold \
               datacenter-gpu-manager-4-cuda12 \
               datacenter-gpu-manager-4-dev \
@@ -330,15 +354,6 @@ deployment_groups:
           apt-get install --assume-yes google-cloud-cli
           # Clean up the bash executable hash for subsequent steps using gsutil
           hash -r
-      - type: shell
-        destination: stop_packer_early.sh
-        content: |
-          #!/bin/bash
-          # Signal Packer to finish using the clean short hostname
-          BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
-          LOG_DEST=`curl -s -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null`
-          if [ -n "\$LOG_DEST" ]; then rm -f "\$LOG_DEST"; fi
-          gcloud compute instances add-metadata `hostname -s` --metadata "startup-script-status"="done" --zone $(vars.zone)
 
 - group: slurm-build
   modules:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -166,36 +166,12 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
-      - type: ansible-local
-        destination: update-gvnic.yml
-        content: |
-          ---
-          - name: Install updated gVNIC driver from GitHub
-            hosts: all
-            become: true
-            vars:
-              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.4.3/gve-dkms_1.4.3_all.deb
-              package_filename: /tmp/{{ package_url | basename }}
-            tasks:
-            - name: Install driver dependencies
-              ansible.builtin.apt:
-                name:
-                - dkms
-            - name: Download gVNIC package
-              ansible.builtin.get_url:
-                url: "{{ package_url }}"
-                dest: "{{ package_filename }}"
-            - name: Install updated gVNIC
-              ansible.builtin.apt:
-                deb: "{{ package_filename }}"
-                state: present
       - type: shell
         destination: install-cuda-toolkit.sh
         content: |
           #!/bin/bash
           set -ex -o pipefail
           # 1. Install the specific compatible versions without the virtual libnvsdm package
-          add-nvidia-repositories -y
           apt install -y \
               cuda-toolkit-12-8 \
               nvidia-container-toolkit \
@@ -360,8 +336,9 @@ deployment_groups:
           #!/bin/bash
           # Signal Packer to finish using the clean short hostname
           BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
-          rm \$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null)
-          gcloud compute instances add-metadata \$(hostname -s) --metadata "startup-script-status"="done" --zone $(vars.zone)
+          LOG_DEST=`curl -s -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null`
+          if [ -n "\$LOG_DEST" ]; then rm -f "\$LOG_DEST"; fi
+          gcloud compute instances add-metadata `hostname -s` --metadata "startup-script-status"="done" --zone $(vars.zone)
 
 - group: slurm-build
   modules:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -199,9 +199,9 @@ deployment_groups:
           apt install -y \
               cuda-toolkit-12-8 \
               nvidia-container-toolkit \
-              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
-              datacenter-gpu-manager-4-core=1:4.5.2-1
+              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
+              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
+              datacenter-gpu-manager-4-core=1:4.5.3-1
 
           # 2. Hold ALL components
           apt-mark hold \

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -80,13 +80,6 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
-      - type: shell
-        name: install-kernel-headers
-        destination: install_kernel_headers.sh
-        content: |
-          #!/bin/bash
-          sudo apt-get update
-          sudo apt-get install -y dkms linux-headers-\$(uname -r)
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container
         content: |

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -210,9 +210,9 @@ deployment_groups:
                 notify: Reload SystemD
 
             handlers:
-              - name: Reload SystemD
-                ansible.builtin.systemd:
-                  daemon_reload: true
+            - name: Reload SystemD
+              ansible.builtin.systemd:
+                daemon_reload: true
 
             post_tasks:
               - name: Disable NVIDIA services by default (Slurm starts them on boot)
@@ -482,6 +482,9 @@ deployment_groups:
             hosts: all
             become: true
             tasks:
+            - name: Update apt cache
+              ansible.builtin.apt:
+                update_cache: yes
             - name: Install Linux Modules Extra
               ansible.builtin.package:
                 name:
@@ -520,7 +523,7 @@ deployment_groups:
             - name: Install NCCL-GIB Plugin
               ansible.builtin.apt:
                 name: "nccl-gib=$(vars.nccl_gib_version)"
-                update_cache: no
+                update_cache: true
             - name: Freeze NCCL GIB Plugin
               ansible.builtin.dpkg_selections:
                 name: "nccl-gib"

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -210,9 +210,9 @@ deployment_groups:
                 notify: Reload SystemD
 
             handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
+              - name: Reload SystemD
+                ansible.builtin.systemd:
+                  daemon_reload: true
 
             post_tasks:
               - name: Disable NVIDIA services by default (Slurm starts them on boot)
@@ -482,9 +482,6 @@ deployment_groups:
             hosts: all
             become: true
             tasks:
-            - name: Update apt cache
-              ansible.builtin.apt:
-                update_cache: yes
             - name: Install Linux Modules Extra
               ansible.builtin.package:
                 name:
@@ -523,7 +520,7 @@ deployment_groups:
             - name: Install NCCL-GIB Plugin
               ansible.builtin.apt:
                 name: "nccl-gib=$(vars.nccl_gib_version)"
-                update_cache: true
+                update_cache: no
             - name: Freeze NCCL GIB Plugin
               ansible.builtin.dpkg_selections:
                 name: "nccl-gib"

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -80,6 +80,13 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - type: shell
+        name: install-kernel-headers
+        destination: install_kernel_headers.sh
+        content: |
+          #!/bin/bash
+          sudo apt-get update
+          sudo apt-get install -y dkms linux-headers-\$(uname -r)
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container
         content: |

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -27,7 +27,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
   image_build_machine_type: n2-standard-16
   build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
@@ -38,7 +38,7 @@ vars:
   local_ssd_mountpoint: /mnt/localssd
   instance_image:
     project: $(vars.project_id)
-    family: $(vars.deployment_name)-u22
+    family: $(vars.deployment_name)-u24
   disk_size_gb: 100
   nccl_gib_version: 1.1.0
   libnccl_version: 2.27.5-1+cuda12.9
@@ -51,6 +51,7 @@ vars:
 
   # Managed Lustre is only supported in specific regions and zones
   # Please refer https://cloud.google.com/managed-lustre/docs/locations
+
   # Managed-Lustre instance name. This should be unique for each deployment.
   lustre_instance_id: $(vars.deployment_name)-lustre
 
@@ -125,7 +126,6 @@ deployment_groups:
             "install_gcsfuse": true,
             "install_lustre": false,
             "install_managed_lustre": true,
-            "install_nvidia_repo": true,
             "install_ompi": true,
             "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
@@ -150,75 +150,79 @@ deployment_groups:
           * - nofile 1048576
           * - cpu unlimited
           * - rtprio unlimited
-      - type: shell
-        destination: install-cuda-toolkit.sh
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          add-nvidia-repositories -y
-          apt install -y \
-              cuda-toolkit-12-8 \
-              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
-              datacenter-gpu-manager-4-core=1:4.5.3-1
-
-          # 2. Hold ALL components
-          apt-mark hold \
-              datacenter-gpu-manager-4-cuda12 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
 
       - type: ansible-local
-        destination: settings_nvidia_dcgm.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: Nvidia and DGMA settings
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
+            vars:
+              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
+              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
+              nvidia_packages:
+                - cuda-toolkit-13-0
+                - datacenter-gpu-manager-4-cuda13
+                - datacenter-gpu-manager-4-dev
+                - datacenter-gpu-manager-4-core
             tasks:
-            - name: Reduce NVIDIA repository priority
-              ansible.builtin.copy:
-                dest: /etc/apt/preferences.d/cuda-repository-pin-600
-                mode: 0o0644
-                owner: root
-                group: root
-                content: |
-                  Package: *
-                  Pin: release l=NVIDIA CUDA
-                  Pin-Priority: 400
-            - name: Create nvidia-persistenced override directory
-              ansible.builtin.file:
-                path: /etc/systemd/system/nvidia-persistenced.service.d
-                state: directory
-                owner: root
-                group: root
-                mode: 0o755
-            - name: Configure nvidia-persistenced override
-              ansible.builtin.copy:
-                dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                owner: root
-                group: root
-                mode: 0o644
-                content: |
-                  [Service]
-                  ExecStart=
-                  ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-              notify: Reload SystemD
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: "{{ cuda_repo_url }}"
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install NVIDIA packages
+                ansible.builtin.apt:
+                  name: "{{ item }}"
+                  state: present
+                  allow_downgrade: yes
+                loop: "{{ nvidia_packages }}"
+
+              - name: Freeze NVIDIA packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop: "{{ nvidia_packages }}"
+
+              - name: Create nvidia-persistenced override directory
+                ansible.builtin.file:
+                  path: /etc/systemd/system/nvidia-persistenced.service.d
+                  state: directory
+                  owner: root
+                  group: root
+                  mode: 0o755
+
+              - name: Configure nvidia-persistenced override
+                ansible.builtin.copy:
+                  dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
+                  owner: root
+                  group: root
+                  mode: 0o644
+                  content: |
+                    [Service]
+                    ExecStart=
+                    ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
+                notify: Reload SystemD
+
             handlers:
             - name: Reload SystemD
               ansible.builtin.systemd:
                 daemon_reload: true
+
             post_tasks:
-            - name: Disable NVIDIA DCGM by default (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-dcgm.service
-                state: stopped
-                enabled: false
-            - name: Disable nvidia-persistenced SystemD unit (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-persistenced.service
-                state: stopped
-                enabled: false
+              - name: Disable NVIDIA services by default (Slurm starts them on boot)
+                ansible.builtin.service:
+                  name: "{{ item }}"
+                  state: stopped
+                  enabled: false
+                loop:
+                  - nvidia-dcgm.service
+                  - nvidia-persistenced.service
 
       - type: ansible-local
         destination: install_ibverbs_utils.yml
@@ -263,6 +267,7 @@ deployment_groups:
       metadata:
         user-data: |
           #cloud-config
+          create_hostname_file: true
           write_files:
           - path: /etc/apt/apt.conf.d/20auto-upgrades
             permissions: '0644'
@@ -453,6 +458,21 @@ deployment_groups:
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
+      - type: shell
+        destination: fix_enroot_env.sh
+        content: |
+          #!/bin/bash
+          # 1. Disable Ubuntu 24.04 restriction on unprivileged user namespaces
+          # Required for enroot/pyxis to work
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+            echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/90-enroot-namespaces.conf
+          fi
+
+          # 2. Ensure /etc/hostname exists (needed by enroot/pyxis)
+          if [ ! -f /etc/hostname ]; then
+            hostname > /etc/hostname
+          fi
       # Install NCCL
       - type: ansible-local
         destination: install_nccl.yml
@@ -618,7 +638,18 @@ deployment_groups:
         ThreadsPerCore: 2
       additional_networks:
         $(concat(
-          a3ultra-slurm-net-1.instance_additional_networks,
+          [{
+            network=null,
+            subnetwork=a3ultra-slurm-net-1.subnetwork_self_link,
+            subnetwork_project=vars.project_id,
+            nic_type="GVNIC",
+            queue_count=null,
+            network_ip="",
+            stack_type=null,
+            access_config=[],
+            ipv6_access_config=[],
+            alias_ip_range=[]
+          }],
           a3ultra-slurm-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -85,6 +85,13 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - type: shell
+        name: install-kernel-headers
+        destination: install_kernel_headers.sh
+        content: |
+          #!/bin/bash
+          sudo apt-get update
+          sudo apt-get install -y dkms linux-headers-\$(uname -r)
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container
         content: |

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -27,7 +27,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
   image_build_machine_type: n2-standard-16
   build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
@@ -40,7 +40,7 @@ vars:
   local_ssd_mountpoint: /mnt/localssd
   instance_image:
     project: $(vars.project_id)
-    family: $(vars.deployment_name)-u22
+    family: $(vars.deployment_name)-u24
   disk_size_gb: 100
   nccl_gib_version: 1.1.0
   libnccl_version: 2.27.5-1+cuda12.9
@@ -131,7 +131,6 @@ deployment_groups:
             "install_gcsfuse": true,
             "install_lustre": false,
             "install_managed_lustre": false,
-            "install_nvidia_repo": true,
             "install_ompi": true,
             "allow_kernel_upgrades": false,
             "monitoring_agent": "cloud-ops",
@@ -156,77 +155,74 @@ deployment_groups:
           * - nofile 1048576
           * - cpu unlimited
           * - rtprio unlimited
-      - type: shell
-        destination: install-cuda-toolkit.sh
-        content: |
-          #!/bin/bash
-          set -ex -o pipefail
-          add-nvidia-repositories -y
-          apt update -y
-          apt install -y \
-              cuda-toolkit-12-8 \
-              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
-              datacenter-gpu-manager-4-core=1:4.5.3-1
-
-          # 2. Hold ALL components
-          apt-mark hold \
-              datacenter-gpu-manager-4-cuda12 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
       - type: ansible-local
-        destination: configure_cuda_dcgm.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: CUDA and DGMA settings
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
             vars:
-              enable_nvidia_dcgm: false
+              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
+              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
+              nvidia_packages:
+                - cuda-toolkit-13-0
+                - datacenter-gpu-manager-4-cuda13
+                - datacenter-gpu-manager-4-dev
+                - datacenter-gpu-manager-4-core
             tasks:
-            - name: Reduce NVIDIA repository priority
-              ansible.builtin.copy:
-                dest: /etc/apt/preferences.d/cuda-repository-pin-600
-                mode: 0o0644
-                owner: root
-                group: root
-                content: |
-                  Package: *
-                  Pin: release l=NVIDIA CUDA
-                  Pin-Priority: 400
-            - name: Create nvidia-persistenced override directory
-              ansible.builtin.file:
-                path: /etc/systemd/system/nvidia-persistenced.service.d
-                state: directory
-                owner: root
-                group: root
-                mode: 0o755
-            - name: Configure nvidia-persistenced override
-              ansible.builtin.copy:
-                dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                owner: root
-                group: root
-                mode: 0o644
-                content: |
-                  [Service]
-                  ExecStart=
-                  ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-              notify: Reload SystemD
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: "{{ cuda_repo_url }}"
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install NVIDIA packages
+                ansible.builtin.apt:
+                  name: "{{ item }}"
+                  state: present
+                  allow_downgrade: yes
+                loop: "{{ nvidia_packages }}"
+
+              - name: Freeze NVIDIA packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop: "{{ nvidia_packages }}"
+
+              - name: Create nvidia-persistenced override directory
+                ansible.builtin.file:
+                  path: /etc/systemd/system/nvidia-persistenced.service.d
+                  state: directory
+                  mode: 0o755
+
+              - name: Configure nvidia-persistenced override
+                ansible.builtin.copy:
+                  dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
+                  mode: 0o644
+                  content: |
+                    [Service]
+                    ExecStart=
+                    ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
+                notify: Reload SystemD
+
             handlers:
             - name: Reload SystemD
               ansible.builtin.systemd:
                 daemon_reload: true
+
             post_tasks:
-            - name: Disable NVIDIA DCGM by default (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-dcgm.service
-                state: stopped
-                enabled: "{{ enable_nvidia_dcgm }}"
-            - name: Disable nvidia-persistenced SystemD unit (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-persistenced.service
-                state: stopped
-                enabled: false
+              - name: Disable NVIDIA services by default (Slurm starts them on boot)
+                ansible.builtin.service:
+                  name: "{{ item }}"
+                  state: stopped
+                  enabled: false
+                loop:
+                  - nvidia-dcgm.service
+                  - nvidia-persistenced.service
 
       - type: ansible-local
         destination: install_ibverbs_utils.yml
@@ -245,7 +241,6 @@ deployment_groups:
         destination: /etc/enroot/enroot.conf
         content: |
           ENROOT_CONFIG_PATH     ${HOME}/.enroot
-
 
 - group: image
   modules:
@@ -271,6 +266,7 @@ deployment_groups:
       metadata:
         user-data: |
           #cloud-config
+          create_hostname_file: true
           write_files:
           - path: /etc/apt/apt.conf.d/20auto-upgrades
             permissions: '0644'
@@ -472,6 +468,18 @@ deployment_groups:
       - $(gcs_training_data.mount_runner)
       - $(gcs_model_serving.client_install_runner)
       - $(gcs_model_serving.mount_runner)
+      - type: shell
+        destination: fix_enroot_env.sh
+        content: |
+          #!/bin/bash
+          # 1. Fix Ubuntu 24.04 AppArmor restriction on unprivileged user namespaces
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          fi
+          # 2. Ensure /etc/hostname exists (required by enroot-mount)
+          if [ ! -f /etc/hostname ]; then
+            hostname > /etc/hostname
+          fi
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
@@ -643,7 +651,18 @@ deployment_groups:
         ThreadsPerCore: 2
       additional_networks:
         $(concat(
-          a4high-slurm-net-1.instance_additional_networks,
+          [{
+            network=null,
+            subnetwork=a4high-slurm-net-1.subnetwork_self_link,
+            subnetwork_project=vars.project_id,
+            nic_type="GVNIC",
+            queue_count=null,
+            network_ip="",
+            stack_type=null,
+            access_config=[],
+            ipv6_access_config=[],
+            alias_ip_range=[]
+          }],
           a4high-slurm-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -85,13 +85,6 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
-      - type: shell
-        name: install-kernel-headers
-        destination: install_kernel_headers.sh
-        content: |
-          #!/bin/bash
-          sudo apt-get update
-          sudo apt-get install -y dkms linux-headers-\$(uname -r)
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container
         content: |


### PR DESCRIPTION
### Summary

This pull request updates the base image configurations for A3 Ultra, and A4 High slurm blueprints to use Ubuntu 24.04 and NVIDIA driver 580.

### Key Changes Made

- **Base Image Migration:** Updated multiple blueprints to the Ubuntu 24.04 LTS stack with NVIDIA 580 drivers to support latest GPU capabilities.
- **Resolved Enroot "Permission Denied" Errors:** Added environment fixes for Ubuntu 24.04 to disable kernel restrictions on unprivileged user namespaces and ensure /etc/hostname is created, unblocking Pyxis container jobs.
- **Automation Optimization:** Introduced stop_packer_early.sh to signal Packer completion via instance metadata due to a known bug

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
