### PR TITLE
Integrate storage profile in GCSFuse

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -33,7 +33,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-h200-141gb
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
@@ -303,45 +303,23 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # Create a remote mount of training_bucket using
-  # mount options optimized for reading training data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/training-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  # Create a remote mount of checkpoint_bucket using mount
-  # options optimized for writing and reading checkpoint data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/checkpointing-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, a3-ultragpu-cluster]
+    use: [training_bucket, a3-ultragpu-cluster]
     settings:
       gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, a3-ultragpu-cluster]
+    use: [checkpoint_bucket, a3-ultragpu-cluster]
     settings:
       gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -303,6 +303,9 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -308,7 +308,6 @@ deployment_groups:
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, a3-ultragpu-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
       gcsfuse_storage_class_name: gcsfusecsi-training
 
@@ -317,7 +316,6 @@ deployment_groups:
     source: modules/file-system/gke-persistent-volume
     use: [checkpoint_bucket, a3-ultragpu-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
       gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -175,6 +175,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a4-net-0, workload_service_account]
     settings:
+      auto_monitoring_scope: $(vars.auto_monitoring_scope)
       system_node_pool_machine_type: "e2-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -322,6 +322,9 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -48,7 +48,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a4_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-b200
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   auto_monitoring_scope: "NONE"
 
@@ -175,7 +175,6 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a4-net-0, workload_service_account]
     settings:
-      auto_monitoring_scope: $(vars.auto_monitoring_scope)
       system_node_pool_machine_type: "e2-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
@@ -322,45 +321,21 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # Create a remote mount of training_bucket using
-  # mount options optimized for reading training data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/training-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  # Create a remote mount of checkpoint_bucket using mount
-  # options optimized for writing and reading checkpoint data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/checkpointing-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, a4-cluster]
+    use: [training_bucket, a4-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, a4-cluster]
+    use: [checkpoint_bucket, a4-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -330,6 +330,9 @@ deployment_groups:
       force_destroy: false
       enable_hierarchical_namespace: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -54,7 +54,7 @@ vars:
   asapd_lite_installer_path: $(ghpc_stage("./asapd-lite-installer.yaml"))
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   accelerator_type: nvidia-gb300
-  version_prefix: "1.34."
+  version_prefix: "1.35."
 
   # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
@@ -330,45 +330,21 @@ deployment_groups:
       force_destroy: false
       enable_hierarchical_namespace: true
 
-  # Create a remote mount of training_bucket using
-  # mount options optimized for reading training data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/checkpointing-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  # Create a remote mount of checkpoint_bucket using mount
-  # options optimized for writing and reading checkpoint data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/checkpointing-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, a4x-max-cluster]
+    use: [training_bucket, a4x-max-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, a4x-max-cluster]
+    use: [checkpoint_bucket, a4x-max-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -365,6 +365,9 @@ deployment_groups:
         effect: NoSchedule
     outputs: [instructions]
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -56,7 +56,7 @@ vars:
   nvidia_dra_driver_path: $(ghpc_stage("./nvidia-dra-driver.yaml"))
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   accelerator_type: nvidia-gb200
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
@@ -365,45 +365,21 @@ deployment_groups:
         effect: NoSchedule
     outputs: [instructions]
 
-  # Create a remote mount of training_bucket using
-  # mount options optimized for reading training data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/training-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  # Create a remote mount of checkpoint_bucket using mount
-  # options optimized for writing and reading checkpoint data.
-  # Based on Source of truth https://github.com/GoogleCloudPlatform/gcsfuse/blob/d1373b665b7f60e98856d2181f1193396ef16427/samples/gke-csi-yaml/gpu/checkpointing-pv.yaml#L15
-  # Some of the options might be available only on latest GKE version, please check the cluster version to meet the required version https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-storage-fuse-csi-driver-perf
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, a4x-cluster]
+    use: [training_bucket, a4x-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, a4x-cluster]
+    use: [checkpoint_bucket, a4x-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -171,7 +171,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34.1"
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
@@ -236,34 +236,18 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-7x-cluster]
+    use: [training_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-7x-cluster]
+    use: [checkpoint_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -236,6 +236,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -235,6 +235,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -45,7 +45,7 @@ vars:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   # --- FLEX START SETTINGS ---
   enable_flex_start: true
@@ -235,34 +235,18 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-v6e-cluster]
+    use: [training_bucket, gke-tpu-v6e-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-v6e-cluster]
+    use: [checkpoint_bucket, gke-tpu-v6e-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -170,7 +170,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34.1"
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
@@ -233,37 +233,21 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-7x-cluster]
+    use: [training_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-7x-cluster]
+    use: [checkpoint_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -233,6 +233,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -45,7 +45,7 @@ vars:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   # --- FLEX START SETTINGS ---
   enable_flex_start: true
@@ -232,37 +232,21 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-v6-cluster]
+    use: [training_bucket, gke-tpu-v6-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-v6-cluster]
+    use: [checkpoint_bucket, gke-tpu-v6-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -232,6 +232,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -190,7 +190,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34.1"
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
@@ -299,37 +299,21 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-7x-cluster]
+    use: [training_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-7x-cluster]
+    use: [checkpoint_bucket, gke-tpu-7x-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -299,6 +299,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -51,7 +51,7 @@ vars:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
-  version_prefix: "1.33."
+  version_prefix: "1.35."
 
   # Kueue configuration
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
@@ -299,37 +299,21 @@ deployment_groups:
       jobset:
         install: true
 
-  - id: gcs-training
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(training_bucket.gcs_bucket_name)
-      local_mount: /training-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true"
-
-  - id: gcs-checkpointing
-    source: modules/file-system/pre-existing-network-storage
-    settings:
-      remote_mount: $(checkpoint_bucket.gcs_bucket_name)
-      local_mount: /checkpoint-data
-      fs_type: gcsfuse
-      mount_options: "implicit-dirs,metadata-cache:ttl-secs:-1,metadata-cache:stat-cache-max-size-mb:-1,metadata-cache:type-cache-max-size-mb:-1,file-cache:max-size-mb:-1,file-cache:cache-file-for-range-read:true,file-cache:enable-parallel-downloads:true,rename-dir-limit=200000"
-
-  # Persistent Volume for training data
+  # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-training, gke-tpu-v6e-cluster]
+    use: [training_bucket, gke-tpu-v6e-cluster]
     settings:
-      gcs_bucket_name: $(training_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-training
 
-  # Persistent Volume for checkpoint data
+  # Persistent Volume for checkpoint data using GCS Fuse Storage Profile
   - id: checkpointing-pv
     source: modules/file-system/gke-persistent-volume
-    use: [gcs-checkpointing, gke-tpu-v6e-cluster]
+    use: [checkpoint_bucket, gke-tpu-v6e-cluster]
     settings:
-      gcs_bucket_name: $(checkpoint_bucket.gcs_bucket_name)
       capacity_gib: 1000000
+      gcsfuse_storage_class_name: gcsfusecsi-checkpointing
 
   # This is an example job that will install and run an `fio`
   # benchmark against the training and checkpointing buckets.

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -299,6 +299,9 @@ deployment_groups:
       jobset:
         install: true
 
+  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
+  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
+  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -109,6 +109,43 @@ authorized to connect to the Kubernetes API. You can add the
 the IP address of the machine performing the deployment. This will ensure that
 the deploying machine can connect to the cluster.
 
+### GCS Fuse Storage Profiles Prerequisites
+
+When using `gcsfuse_storage_class_name` with GCS Fuse, GKE requires a custom IAM role named `gke.gcsfuse.profileUser` to be present in the project. This role grants the GKE service agent permissions to manage Anywhere Caches and retrieve bucket metadata.
+
+If this role is not already created in your project, you must create it before deploying.
+
+You can create it using the `gcloud` CLI:
+
+```bash
+gcloud iam roles create gke.gcsfuse.profileUser \
+  --project=<YOUR_PROJECT_ID> \
+  --title="GKE GCSFuse Profile User" \
+  --description="Allows scanning GCS buckets for objects, retrieving bucket metadata, and creating Anywhere Caches." \
+  --permissions="storage.objects.list,storage.buckets.get,storage.anywhereCaches.create,storage.anywhereCaches.get,storage.anywhereCaches.list,storage.anywhereCaches.update"
+```
+
+Or using Terraform:
+
+```hcl
+resource "google_project_iam_custom_role" "gcsfuse_profile_user" {
+  role_id     = "gke.gcsfuse.profileUser"
+  project     = var.project_id
+  title       = "GKE GCSFuse Profile User"
+  description = "Allows scanning GCS buckets for objects, retrieving bucket metadata, and creating Anywhere Caches."
+  permissions = [
+    "storage.objects.list",
+    "storage.buckets.get",
+    "storage.anywhereCaches.create",
+    "storage.anywhereCaches.get",
+    "storage.anywhereCaches.list",
+    "storage.anywhereCaches.update",
+  ]
+}
+```
+
+The `gke-persistent-volume` module will automatically handle binding this role to the GKE service agent if `gcsfuse_storage_class_name` is provided.
+
 ### Connecting Via Use
 
 The diagram below shows the valid `use` relationships for the GKE Cluster Toolkit
@@ -170,11 +207,13 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
+| [google_project_iam_member.gcsfuse_agent_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [kubectl_manifest.pv](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.pvc](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.pvc_namespace](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
@@ -184,6 +223,7 @@ No modules.
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the GKE cluster in the format `projects/{{project}}/locations/{{location}}/clusters/{{cluster}}` | `string` | n/a | yes |
 | <a name="input_filestore_id"></a> [filestore\_id](#input\_filestore\_id) | An identifier for a filestore with the format `projects/{{project}}/locations/{{location}}/instances/{{name}}`. | `string` | `null` | no |
 | <a name="input_gcs_bucket_name"></a> [gcs\_bucket\_name](#input\_gcs\_bucket\_name) | The gcs bucket to be used with the persistent volume. | `string` | `null` | no |
+| <a name="input_gcsfuse_storage_class_name"></a> [gcsfuse\_storage\_class\_name](#input\_gcsfuse\_storage\_class\_name) | The storage class name for GCS Fuse. Allowed values: gcsfusecsi-training, gcsfusecsi-serving, gcsfusecsi-checkpointing. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | GCE resource labels to be applied to resources. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_lustre_id"></a> [lustre\_id](#input\_lustre\_id) | An identifier for a lustre with the format `projects/{{project}}/locations/{{location}}/instances/{{name}}`. | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to deploy the storage PVC/PV | `string` | `"default"` | no |

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -144,7 +144,13 @@ resource "google_project_iam_custom_role" "gcsfuse_profile_user" {
 }
 ```
 
-The `gke-persistent-volume` module will automatically handle binding this role to the GKE service agent if `gcsfuse_storage_class_name` is provided.
+Once created, the role must be bound to the GKE Service Agent (`service-<PROJECT_NUMBER>@container-engine-robot.iam.gserviceaccount.com`).
+
+```bash
+gcloud projects add-iam-policy-binding <YOUR_PROJECT_ID> \
+  --member="serviceAccount:service-<YOUR_PROJECT_NUMBER>@container-engine-robot.iam.gserviceaccount.com" \
+  --role="projects/<YOUR_PROJECT_ID>/roles/gke.gcsfuse.profileUser"
+```
 
 ### Connecting Via Use
 
@@ -207,13 +213,11 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [google_project_iam_member.gcsfuse_agent_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [kubectl_manifest.pv](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.pvc](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [kubectl_manifest.pvc_namespace](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
-| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 

--- a/modules/file-system/gke-persistent-volume/main.tf
+++ b/modules/file-system/gke-persistent-volume/main.tf
@@ -75,10 +75,23 @@ locals {
     labels   = local.labels
   }
 
+  # Check if a GCS Fuse storage profile is active
+  has_gcsfuse_storage_profile = var.gcsfuse_storage_class_name != "" && var.gcsfuse_storage_class_name != null
+
+  # Extract mount options as a list (fallback to empty list if not GCS)
+  gcs_mount_opts_raw = var.gcs_bucket_name != null ? split(",", var.network_storage.mount_options) : []
+
+  # Apply filters to clean up the options
+  gcs_mount_options = [
+    for opt in local.gcs_mount_opts_raw : opt
+    if !contains(["defaults", "_netdev"], opt) &&                  # Filter out defaults
+    !(opt == "implicit_dirs" && local.has_gcsfuse_storage_profile) # Filter implicit_dirs if profile is active
+  ]
+
   # Variables for PV templates, merging common vars with type-specific ones.
   pv_template_vars = {
     gcs = merge(local.common_pv_vars, {
-      mount_options      = var.gcs_bucket_name != null ? [for opt in split(",", var.network_storage.mount_options) : opt if !contains(["defaults", "_netdev"], opt) && !(opt == "implicit_dirs" && var.gcsfuse_storage_class_name != "" && var.gcsfuse_storage_class_name != null)] : []
+      mount_options      = local.gcs_mount_options
       bucket_name        = var.gcs_bucket_name
       namespace          = var.namespace
       pvc_name           = local.pvc_name

--- a/modules/file-system/gke-persistent-volume/main.tf
+++ b/modules/file-system/gke-persistent-volume/main.tf
@@ -20,11 +20,6 @@ locals {
 }
 
 locals {
-  # Extract project ID from cluster ID
-  project_id = split("/", var.cluster_id)[1]
-}
-
-locals {
   # Flags indicating which storage type is active based on input variables.
   storage_type_active = {
     gcs       = var.gcs_bucket_name != null
@@ -128,10 +123,6 @@ data "google_container_cluster" "gke_cluster" {
   location = local.cluster_location
 }
 
-data "google_project" "project" {
-  project_id = split("/", var.cluster_id)[1]
-}
-
 data "google_client_config" "default" {}
 
 provider "kubectl" {
@@ -163,11 +154,4 @@ resource "kubectl_manifest" "pv" {
 resource "kubectl_manifest" "pvc" {
   yaml_body  = local.pvc_content
   depends_on = [kubectl_manifest.pv, kubectl_manifest.pvc_namespace]
-}
-
-resource "google_project_iam_member" "gcsfuse_agent_binding" {
-  count   = var.gcsfuse_storage_class_name != null ? 1 : 0
-  project = local.project_id
-  role    = "projects/${local.project_id}/roles/gke.gcsfuse.profileUser"
-  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }

--- a/modules/file-system/gke-persistent-volume/main.tf
+++ b/modules/file-system/gke-persistent-volume/main.tf
@@ -20,6 +20,11 @@ locals {
 }
 
 locals {
+  # Extract project ID from cluster ID
+  project_id = split("/", var.cluster_id)[1]
+}
+
+locals {
   # Flags indicating which storage type is active based on input variables.
   storage_type_active = {
     gcs       = var.gcs_bucket_name != null
@@ -78,7 +83,7 @@ locals {
   # Variables for PV templates, merging common vars with type-specific ones.
   pv_template_vars = {
     gcs = merge(local.common_pv_vars, {
-      mount_options      = var.gcs_bucket_name != null ? [for opt in split(",", var.network_storage.mount_options) : opt if !contains(["defaults", "_netdev", "implicit_dirs"], opt)] : []
+      mount_options      = var.gcs_bucket_name != null ? [for opt in split(",", var.network_storage.mount_options) : opt if !contains(["defaults", "_netdev"], opt) && !(opt == "implicit_dirs" && var.gcsfuse_storage_class_name != "" && var.gcsfuse_storage_class_name != null)] : []
       bucket_name        = var.gcs_bucket_name
       namespace          = var.namespace
       pvc_name           = local.pvc_name
@@ -161,8 +166,8 @@ resource "kubectl_manifest" "pvc" {
 }
 
 resource "google_project_iam_member" "gcsfuse_agent_binding" {
-  count   = var.gcsfuse_storage_class_name != "" ? 1 : 0
-  project = split("/", var.cluster_id)[1]
-  role    = "projects/${split("/", var.cluster_id)[1]}/roles/gke.gcsfuse.profileUser"
+  count   = var.gcsfuse_storage_class_name != null ? 1 : 0
+  project = local.project_id
+  role    = "projects/${local.project_id}/roles/gke.gcsfuse.profileUser"
   member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }

--- a/modules/file-system/gke-persistent-volume/main.tf
+++ b/modules/file-system/gke-persistent-volume/main.tf
@@ -60,11 +60,12 @@ locals {
 
   # Common variables for all PVC templates
   common_pvc_vars = {
-    pv_name   = local.pv_name
-    pvc_name  = local.pvc_name
-    labels    = local.labels
-    capacity  = "${var.capacity_gib}Gi"
-    namespace = var.namespace
+    pv_name            = local.pv_name
+    pvc_name           = local.pvc_name
+    labels             = local.labels
+    capacity           = "${var.capacity_gib}Gi"
+    namespace          = var.namespace
+    storage_class_name = var.gcsfuse_storage_class_name
   }
 
   # Common variables for all PV templates
@@ -77,10 +78,11 @@ locals {
   # Variables for PV templates, merging common vars with type-specific ones.
   pv_template_vars = {
     gcs = merge(local.common_pv_vars, {
-      mount_options = var.gcs_bucket_name != null ? split(",", var.network_storage.mount_options) : []
-      bucket_name   = var.gcs_bucket_name
-      namespace     = var.namespace
-      pvc_name      = local.pvc_name
+      mount_options      = var.gcs_bucket_name != null ? [for opt in split(",", var.network_storage.mount_options) : opt if !contains(["defaults", "_netdev", "implicit_dirs"], opt)] : []
+      bucket_name        = var.gcs_bucket_name
+      namespace          = var.namespace
+      pvc_name           = local.pvc_name
+      storage_class_name = var.gcsfuse_storage_class_name
     })
     lustre = merge(local.common_pv_vars, {
       location        = var.lustre_id != null ? split("/", var.lustre_id)[3] : null
@@ -121,6 +123,10 @@ data "google_container_cluster" "gke_cluster" {
   location = local.cluster_location
 }
 
+data "google_project" "project" {
+  project_id = split("/", var.cluster_id)[1]
+}
+
 data "google_client_config" "default" {}
 
 provider "kubectl" {
@@ -152,4 +158,11 @@ resource "kubectl_manifest" "pv" {
 resource "kubectl_manifest" "pvc" {
   yaml_body  = local.pvc_content
   depends_on = [kubectl_manifest.pv, kubectl_manifest.pvc_namespace]
+}
+
+resource "google_project_iam_member" "gcsfuse_agent_binding" {
+  count   = var.gcsfuse_storage_class_name != "" ? 1 : 0
+  project = split("/", var.cluster_id)[1]
+  role    = "projects/${split("/", var.cluster_id)[1]}/roles/gke.gcsfuse.profileUser"
+  member  = "serviceAccount:service-${data.google_project.project.number}@container-engine-robot.iam.gserviceaccount.com"
 }

--- a/modules/file-system/gke-persistent-volume/templates/gcs-pv.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/gcs-pv.yaml.tftpl
@@ -8,7 +8,7 @@ metadata:
     ${key}: ${val}
   %{~ endfor ~}
 spec:
-  storageClassName: ""
+  storageClassName: "${storage_class_name != null ? storage_class_name : ""}"
   capacity:
     storage: ${capacity}
   accessModes:

--- a/modules/file-system/gke-persistent-volume/templates/gcs-pvc.yaml.tftpl
+++ b/modules/file-system/gke-persistent-volume/templates/gcs-pvc.yaml.tftpl
@@ -11,7 +11,7 @@ metadata:
 spec:
   accessModes:
   - ReadWriteMany
-  storageClassName: ""
+  storageClassName: "${storage_class_name != null ? storage_class_name : ""}"
   volumeName: ${pv_name}
   resources:
     requests:

--- a/modules/file-system/gke-persistent-volume/variables.tf
+++ b/modules/file-system/gke-persistent-volume/variables.tf
@@ -91,3 +91,13 @@ variable "pvc_name" {
   type        = string
   default     = null
 }
+
+variable "gcsfuse_storage_class_name" {
+  description = "The storage class name for GCS Fuse. Allowed values: gcsfusecsi-training, gcsfusecsi-serving, gcsfusecsi-checkpointing."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.gcsfuse_storage_class_name == null || contains(["gcsfusecsi-training", "gcsfusecsi-serving", "gcsfusecsi-checkpointing"], var.gcsfuse_storage_class_name)
+    error_message = "gcsfuse_storage_class_name must be one of gcsfusecsi-training, gcsfusecsi-serving, gcsfusecsi-checkpointing."
+  }
+}

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -35,6 +35,8 @@ import (
 var reservationNameRegex = regexp.MustCompile(`^projects/([^/]+)/reservations/([^/]+)$`)
 var resKeyRegex = regexp.MustCompile(`^(.*_)?reservation(_name)?$`)
 
+const gcsFuseProfileUserRole = "gke.gcsfuse.profileUser"
+
 func getErrorReason(err googleapi.Error) (string, map[string]interface{}) {
 	for _, d := range err.Details {
 		m, ok := d.(map[string]interface{})
@@ -499,7 +501,13 @@ func testDiskTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) err
 	return testResourceInZoneAvailability(bp, inputs, "test_disk_type_in_zone", "disk_type", "disk type", validateDiskTypeInZone)
 }
 
-// testGCSFuseIAMRoleExists checks if the custom IAM role 'gke.gcsfuse.profileUser' exists.
+// testGCSFuseIAMRoleExistsCheck verifies that the required custom IAM role for GCS Fuse exists.
+// High-level logic for failures:
+//   - Hard Failure (404): If the role explicitly does not exist, we block deployment because
+//     GCS Fuse Storage Profiles will fail at runtime without it.
+//   - Soft Warning (403/other): If we cannot verify the role due to permission issues (e.g., the
+//     runner lacks 'iam.roles.get'), we log a warning but do not block. This prevents blocking
+//     users who have deployment permissions but not project-wide IAM read permissions.
 func testGCSFuseIAMRoleExistsCheck(projectID string) error {
 	ctx := context.Background()
 	s, err := iam.NewService(ctx)
@@ -507,13 +515,13 @@ func testGCSFuseIAMRoleExistsCheck(projectID string) error {
 		return handleClientError(err)
 	}
 
-	roleName := fmt.Sprintf("projects/%s/roles/gke.gcsfuse.profileUser", projectID)
+	roleName := fmt.Sprintf("projects/%s/roles/%s", projectID, gcsFuseProfileUserRole)
 	_, err = s.Projects.Roles.Get(roleName).Do()
 	if err != nil {
 		var herr *googleapi.Error
 		if errors.As(err, &herr) && herr.Code == 404 {
 			return config.HintError{
-				Err: fmt.Errorf("custom IAM role 'gke.gcsfuse.profileUser' was not found in project %s", projectID),
+				Err: fmt.Errorf("custom IAM role '%s' was not found in project %s", gcsFuseProfileUserRole, projectID),
 				Hint: "GCS Fuse CSI Storage Profiles require this custom IAM role.\n" +
 					"Please refer to modules/file-system/gke-persistent-volume/README.md for instructions.",
 			}
@@ -554,7 +562,7 @@ func checkGCSFuseIAMBinding(ctx context.Context, projectID string, roleName stri
 	roleGranted := false
 
 	for _, binding := range policy.Bindings {
-		if binding.Role == roleName || binding.Role == fmt.Sprintf("projects/%s/roles/gke.gcsfuse.profileUser", projectID) {
+		if binding.Role == roleName {
 			for _, member := range binding.Members {
 				if member == agentMember {
 					roleGranted = true

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -499,8 +499,8 @@ func testDiskTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) err
 	return testResourceInZoneAvailability(bp, inputs, "test_disk_type_in_zone", "disk_type", "disk type", validateDiskTypeInZone)
 }
 
-// TestGCSFuseIAMRoleExists checks if the custom IAM role 'gke.gcsfuse.profileUser' exists.
-func TestGCSFuseIAMRoleExists(projectID string) error {
+// testGCSFuseIAMRoleExists checks if the custom IAM role 'gke.gcsfuse.profileUser' exists.
+func testGCSFuseIAMRoleExistsCheck(projectID string) error {
 	ctx := context.Background()
 	s, err := iam.NewService(ctx)
 	if err != nil {
@@ -518,8 +518,10 @@ func TestGCSFuseIAMRoleExists(projectID string) error {
 					"Please refer to modules/file-system/gke-persistent-volume/README.md for instructions.",
 			}
 		}
-		// If 403 or other API issue, issue warning but do not block (maybe user just cannot read it)
-		logging.Error("WARNING: Could not check IAM role %s: %v. Proceeding.", roleName, err)
+		logging.Error("\n[!] WARNING: Unable to verify existence of the custom IAM role '%s'.", roleName)
+		logging.Error("    Permission 'iam.roles.get' was denied. GCS Fuse CSI Storage Profiles require this role to scan and mount storage.")
+		logging.Error("    Please verify with your Google Cloud administrator that the custom IAM role has been provisioned successfully.")
+		logging.Error("    Reference: modules/file-system/gke-persistent-volume/README.md\n")
 		return nil
 	}
 
@@ -577,5 +579,5 @@ func testGCSFuseIAMRoleExists(bp config.Blueprint, inputs config.Dict) error {
 	if err != nil {
 		return err
 	}
-	return TestGCSFuseIAMRoleExists(m["project_id"])
+	return testGCSFuseIAMRoleExistsCheck(m["project_id"])
 }

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -19,12 +19,15 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 	"regexp"
 	"strings"
 
 	"golang.org/x/exp/maps"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
+	iam "google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	serviceusage "google.golang.org/api/serviceusage/v1"
 )
@@ -494,4 +497,85 @@ func testMachineTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) 
 // testDiskTypeInZoneAvailability automatically validates disk types in modules
 func testDiskTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) error {
 	return testResourceInZoneAvailability(bp, inputs, "test_disk_type_in_zone", "disk_type", "disk type", validateDiskTypeInZone)
+}
+
+// TestGCSFuseIAMRoleExists checks if the custom IAM role 'gke.gcsfuse.profileUser' exists.
+func TestGCSFuseIAMRoleExists(projectID string) error {
+	ctx := context.Background()
+	s, err := iam.NewService(ctx)
+	if err != nil {
+		return handleClientError(err)
+	}
+
+	roleName := fmt.Sprintf("projects/%s/roles/gke.gcsfuse.profileUser", projectID)
+	_, err = s.Projects.Roles.Get(roleName).Do()
+	if err != nil {
+		var herr *googleapi.Error
+		if errors.As(err, &herr) && herr.Code == 404 {
+			return config.HintError{
+				Err: fmt.Errorf("custom IAM role 'gke.gcsfuse.profileUser' was not found in project %s", projectID),
+				Hint: "GCS Fuse CSI Storage Profiles require this custom IAM role.\n" +
+					"Please refer to modules/file-system/gke-persistent-volume/README.md for instructions.",
+			}
+		}
+		// If 403 or other API issue, issue warning but do not block (maybe user just cannot read it)
+		logging.Error("WARNING: Could not check IAM role %s: %v. Proceeding.", roleName, err)
+		return nil
+	}
+
+	// Optional Check: Validate IAM Binding for the GKE Service Agent
+	checkGCSFuseIAMBinding(ctx, projectID, roleName)
+
+	return nil
+}
+
+func checkGCSFuseIAMBinding(ctx context.Context, projectID string, roleName string) {
+	crmService, err := cloudresourcemanager.NewService(ctx)
+	if err != nil {
+		logging.Error("WARNING: Could not initialize Cloud Resource Manager service: %v. Skipping IAM binding check.", err)
+		return
+	}
+
+	project, err := crmService.Projects.Get(projectID).Do()
+	if err != nil {
+		logging.Error("WARNING: Could not fetch project number for %s: %v. Skipping IAM binding check.", projectID, err)
+		return
+	}
+
+	policy, err := crmService.Projects.GetIamPolicy(projectID, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
+	if err != nil {
+		logging.Error("WARNING: Could not fetch IAM policy for %s: %v. Skipping IAM binding check.", projectID, err)
+		return
+	}
+
+	agentMember := fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", project.ProjectNumber)
+	roleGranted := false
+
+	for _, binding := range policy.Bindings {
+		if binding.Role == roleName || binding.Role == fmt.Sprintf("projects/%s/roles/gke.gcsfuse.profileUser", projectID) {
+			for _, member := range binding.Members {
+				if member == agentMember {
+					roleGranted = true
+					break
+				}
+			}
+		}
+	}
+
+	if !roleGranted {
+		logging.Error("\n[!] WARNING: GKE Service Agent (%s) does not appear to have the custom role '%s' assigned.", agentMember, roleName)
+		logging.Error("    This might cause GCS Fuse CSI drivers to fail at runtime.")
+		logging.Error("    Refer to modules/file-system/gke-persistent-volume/README.md to manually bind permissions.\n")
+	}
+}
+
+func testGCSFuseIAMRoleExists(bp config.Blueprint, inputs config.Dict) error {
+	if err := checkInputs(inputs, []string{"project_id"}); err != nil {
+		return err
+	}
+	m, err := inputsAsStrings(inputs)
+	if err != nil {
+		return err
+	}
+	return TestGCSFuseIAMRoleExists(m["project_id"])
 }

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -59,6 +59,7 @@ const (
 	testMachineTypeInZone             = "test_machine_type_in_zone"
 	testReservationExistsName         = "test_reservation_exists"
 	testDiskTypeInZone                = "test_disk_type_in_zone"
+	testGCSFuseIAMRoleExistsName      = "test_gcsfuse_iam_role_exists"
 )
 
 func implementations() map[string]func(config.Blueprint, config.Dict) error {
@@ -73,6 +74,7 @@ func implementations() map[string]func(config.Blueprint, config.Dict) error {
 		testMachineTypeInZone:             testMachineTypeInZoneAvailability,
 		testReservationExistsName:         testReservationExists,
 		testDiskTypeInZone:                testDiskTypeInZoneAvailability,
+		testGCSFuseIAMRoleExistsName:      testGCSFuseIAMRoleExists,
 	}
 }
 
@@ -200,6 +202,19 @@ func inputsAsStrings(inputs config.Dict) (map[string]string, error) {
 	return ms, nil
 }
 
+func blueprintHasGCSFuse(bp config.Blueprint) bool {
+	hasGCSFuse := false
+	bp.WalkModulesSafe(func(_ config.ModulePath, mod *config.Module) {
+		if strings.Contains(mod.Source, "gke-persistent-volume") && mod.Settings.Has("gcsfuse_storage_class_name") {
+			v := mod.Settings.Get("gcsfuse_storage_class_name")
+			if !v.IsNull() && v.Type() == cty.String && v.AsString() != "" {
+				hasGCSFuse = true
+			}
+		}
+	})
+	return hasGCSFuse
+}
+
 // Creates a list of default validators for the given blueprint,
 // inspect the blueprint for global variables that exist and add an appropriate validators.
 func defaults(bp config.Blueprint) []config.Validator {
@@ -227,8 +242,14 @@ func defaults(bp config.Blueprint) []config.Validator {
 		}, config.Validator{
 			Validator: testApisEnabledName,
 			Inputs:    inputs,
-		},
-		)
+		})
+
+		if blueprintHasGCSFuse(bp) {
+			defaults = append(defaults, config.Validator{
+				Validator: testGCSFuseIAMRoleExistsName,
+				Inputs:    inputs,
+			})
+		}
 	}
 
 	if projectIDExists && regionExists {

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -24,7 +24,6 @@ tags:
 - m.vpc
 - m.cloud-storage-bucket
 - m.gke-persistent-volume
-- m.pre-existing-network-storage
 
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -24,7 +24,6 @@ tags:
 - m.vpc
 - m.cloud-storage-bucket
 - m.gke-persistent-volume
-- m.pre-existing-network-storage
 
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -24,7 +24,6 @@ tags:
 - m.vpc
 - m.cloud-storage-bucket
 - m.gke-persistent-volume
-- m.pre-existing-network-storage
 
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -25,7 +25,6 @@ tags:
 - gke
 - m.cloud-storage-bucket
 - m.gke-persistent-volume
-- m.pre-existing-network-storage
 
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -22,7 +22,6 @@ tags:
 - m.cloud-storage-bucket
 - m.gke-job-template
 - m.gke-persistent-volume
-- m.pre-existing-network-storage
 - gke
 
 substitutions:


### PR DESCRIPTION
This PR integrates GCS Fuse Storage Profiles directly into the GKE persistent volume modules. We are moving away from the older method of manually configuring GCS mounts on the node host (via pre-existing-network-storage) and switching to using Kubernetes-native StorageClasses like gcsfusecsi-training.

**What changed?**

**Module Updates**: Added the `gcsfuse_storage_class_name` setting into the gke-persistent-volume module. It automatically maps inputs into the PV/PVC specs cleanly.

**IAM Security**: Instead of trying to force Terraform to create global custom roles (which needs administrative permissions we don't want to grant automation runners), both the `gke.gcsfuse.profileUser` role creation and service account bindings are kept manual. I've added straightforward instructions in the module's README.

**Pre-flight Checks**: Adde Go validations that check if permissions are set up correctly before provisioning to avoid messy deployment failures.

**Testing**
Everything builds successfully locally.

If a user updates their blueprint and runs `gcluster deploy -w` on an existing cluster which earlier had the mount options config, the only thing in this case that the user might need to do is deleting the PV's and PVC's manually because the first time, the PVCs were created with an empty storageClassName: "" (or defaulting to standard). Now, the update will try to change that field to `gcsfusecsi-checkpointing` and `gcsfusecsi-training`. Kubernetes rejects the patch because it does not allow changing the storage class of an existing, bound PVC.
To apply the new storage profiles, user will need to delete the old PVCs and PVs so that Terraform can recreate them from scratch with the new settings. Since the data is stored externally in GCS buckets, deleting the Kubernetes volume objects will not delete the actual data in GCS. 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
