### PR TITLE
Remove duplicate google-cloud-secret-manager dependency

### DIFF
--- a/community/front-end/ofe/requirements.txt
+++ b/community/front-end/ofe/requirements.txt
@@ -38,7 +38,6 @@ google-cloud-core==2.5.1
 google-cloud-pubsub==2.36.0
 google-cloud-compute==1.47.0
 google-cloud-storage==3.10.1
-google-cloud-secret-manager==2.27.0
 google-crc32c==1.8.0
 google-resumable-media==2.8.2
 googleapis-common-protos==1.73.1


### PR DESCRIPTION
The package google-cloud-secret-manager is duplicated in the requirements file (lines 34 and 41). One of these entries should be removed to maintain a clean and maintainable dependency list.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
