### PR TITLE
Revamp GKE A3 Mega blueprint and align integration tests

### DIFF
--- a/examples/gke-a3-megagpu/README.md
+++ b/examples/gke-a3-megagpu/README.md
@@ -1,6 +1,172 @@
-Refer to [Deploy an A3 Mega GKE cluster for ML training](https://cloud.google.com/cluster-toolkit/docs/deploy/deploy-a3-mega-gke-cluster) for instructions on creating the GKE-A3M cluster.
+# Deploy an A3 Mega GKE cluster for ML training
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A3M cluster.
+This blueprint provisions a Google Kubernetes Engine (GKE) cluster with A3 Mega nodes (`a3-megagpu-8g`). A3 Mega VMs feature 8 NVIDIA H100 GPUs and high-bandwidth networking.
+
+The blueprint automatically configures the following components to enable optimal GPU performance and multi-networking:
+
+- **GPU-Direct TCPXO**: Optimized networking stack for high-bandwidth, low-latency GPU communication, specifically designed for A3 Mega.
+- **Multi-networking**: Configures 8 secondary interfaces (VPC networks) for dedicated GPU-to-GPU traffic.
+- **NRI Device Injector**: Automatically injects required networking and GPU configurations into your ML containers.
+- **Kueue and JobSet**: Kubernetes-native tools for managing large-scale, multi-node training jobs with Topology Aware Scheduling (TAS).
+
+## Prerequisites
+
+1. **Cluster Toolkit:** Ensure you have installed all the dependencies required in cluster toolkit and followed the setup instructions.
+    1. Install [dependencies](https://docs.cloud.google.com/cluster-toolkit/docs/setup/install-dependencies).
+    2. Set up [Cluster Toolkit](https://docs.cloud.google.com/cluster-toolkit/docs/setup/configure-environment). For building the `gcluster` binary, see [Install Cluster Toolkit](https://docs.cloud.google.com/cluster-toolkit/docs/setup/configure-environment#install).
+2. **Quota**: Ensure you have sufficient quota for `a3-megagpu-8g` machines in your chosen region.
+3. **IP Address**: You will need the public IP address of the machine where you run `gcluster` to configure the cluster's authorized networks.
+
+## Configuration
+
+Before deploying, fill out the `gke-a3-megagpu-deployment.yaml` file with your project-specific values:
+
+| Variable | Description |
+| :--- | :--- |
+| `project_id` | Your Google Cloud Project ID. |
+| `deployment_name` | A unique name for this Cluster Toolkit deployment. |
+| `region` / `zone` | The GCP region and zone (e.g., `us-east5`, `us-east5-a`). |
+| `authorized_cidr` | Your public IP address in CIDR notation (e.g., `1.2.3.4/32`). |
+| `static_node_count` | Number of A3 Mega nodes to provision. |
+| `reservation` | (Optional) The name of a GCE reservation to use. |
+| `bucket` | Name of the GCS bucket to store Terraform state. |
+
+## Deploy the Cluster
+
+1. Switch to the toolkit directory:
+
+    ```bash
+    cd ~/cluster-toolkit
+    ```
+
+2. Build the toolkit:
+
+    ```bash
+    make
+    ```
+
+3. Deploy the infrastructure:
+
+    ```bash
+    ./gcluster deploy \
+        examples/gke-a3-megagpu/gke-a3-megagpu.yaml \
+        -d examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
+    ```
+
+## Verify NCCL Performance
+
+After deployment, you can verify the GPU and networking performance using the included NCCL test manifest:
+
+1. Get cluster credentials:
+
+    ```bash
+    gcloud container clusters get-credentials DEPLOYMENT_NAME --region REGION --project PROJECT_ID
+    ```
+
+    Replace `DEPLOYMENT_NAME`, `REGION`, and `PROJECT_ID` with the ones used in your `gke-a3-megagpu-deployment.yaml` file.
+
+2. Verify that the GPUDirect TCPXO driver installers and device injectors are running on all nodes.
+
+    ```bash
+    kubectl get daemonsets -n kube-system nccl-tcpxo-installer
+    kubectl get pods -n kube-system | grep device-injector
+    ```
+
+    *Example Output:*
+
+    ```text
+    NAME                   DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
+    nccl-tcpxo-installer   2         2         2       2            2           <none>          30h
+    device-injector-dzblk                                      1/1     Running   0              30h
+    device-injector-r44p5                                      1/1     Running   0              30h
+    ```
+
+3. Apply the NCCL test manifest:
+
+    ```bash
+    kubectl apply -f examples/gke-a3-megagpu/nccl-test-latest.yaml
+    ```
+
+4. Wait for the pods to be ready:
+
+    ```bash
+    kubectl get pods
+    ```
+
+    *Example Output:*
+
+    ```text
+    NAME               READY   STATUS    RESTARTS   AGE
+    nccl-test-host-1   2/2     Running   0          17s
+    nccl-test-host-2   2/2     Running   0          17s
+    ```
+
+5. Run the benchmark:
+
+    ```bash
+    kubectl exec nccl-test-host-1 -c nccl-test -- /scripts/allgather.sh nccl-host-1 nccl-host-2
+    ```
+
+    *Example Output:*
+
+    ```text
+    #                                                              out-of-place                       in-place          
+    #     size         count      type   redop    root     time   algbw   busbw  #wrong     time   algbw   busbw  #wrong 
+    #     (B)    (elements)                               (us)  (GB/s)  (GB/s)             (us)  (GB/s)  (GB/s)         
+           0             0     float    none      -1     0.30    0.00    0.00       0     0.26    0.00    0.00       0
+           0             0     float    none      -1     0.26    0.00    0.00       0     0.25    0.00    0.00       0
+           0             0     float    none      -1     0.27    0.00    0.00       0     0.25    0.00    0.00       0
+           0             0     float    none      -1     0.25    0.00    0.00       0     0.30    0.00    0.00       0
+           0             0     float    none      -1     0.24    0.00    0.00       0     0.25    0.00    0.00       0
+         256             4     float    none      -1    86.95    0.00    0.00       0    88.21    0.00    0.00       0
+         512             8     float    none      -1    85.70    0.01    0.01       0    84.64    0.01    0.01       0
+        1024            16     float    none      -1    85.27    0.01    0.01       0    86.81    0.01    0.01       0
+        2048            32     float    none      -1    84.50    0.02    0.02       0    84.02    0.02    0.02       0
+        4096            64     float    none      -1    85.55    0.05    0.04       0    84.46    0.05    0.05       0
+        8192           128     float    none      -1    84.25    0.10    0.09       0    84.08    0.10    0.09       0
+       16384           256     float    none      -1    84.41    0.19    0.18       0    84.81    0.19    0.18       0
+       32768           512     float    none      -1    92.99    0.35    0.33       0    95.44    0.34    0.32       0
+       65536          1024     float    none      -1    96.98    0.68    0.63       0    93.80    0.70    0.66       0
+      131072          2048     float    none      -1    98.33    1.33    1.25       0   112.25    1.17    1.09       0
+      262144          4096     float    none      -1   129.67    2.02    1.90       0   130.32    2.01    1.89       0
+      524288          8192     float    none      -1   126.01    4.16    3.90       0   127.00    4.13    3.87       0
+     1048576         16384     float    none      -1   133.87    7.83    7.34       0   128.95    8.13    7.62       0
+     2097152         32768     float    none      -1   136.34   15.38   14.42       0   133.81   15.67   14.69       0
+     4194304         65536     float    none      -1   148.45   28.25   26.49       0   148.47   28.25   26.49       0
+     8388608        131072     float    none      -1   166.11   50.50   47.34       0   161.13   52.06   48.81       0
+    16777216        262144     float    none      -1   197.88   84.79   79.49       0   196.38   85.43   80.09       0
+    33554432        524288     float    none      -1   290.54  115.49  108.27       0   284.11  118.10  110.72       0
+    67108864       1048576     float    none      -1   517.87  129.59  121.49       0   444.29  151.05  141.61       0
+    134217728       2097152     float    none      -1   806.59  166.40  156.00       0   790.70  169.74  159.14       0
+    268435456       4194304     float    none      -1  1510.98  177.66  166.55       0  1507.46  178.07  166.94       0
+    536870912       8388608     float    none      -1  2880.08  186.41  174.76       0  2872.37  186.91  175.23       0
+    1073741824      16777216     float    none      -1  5531.01  194.13  182.00       0  5489.29  195.61  183.38       0
+    2147483648      33554432     float    none      -1  10820.2  198.47  186.07       0  10805.3  198.74  186.32       0
+    4294967296      67108864     float    none      -1  21430.5  200.41  187.89       0  21413.4  200.57  188.04       0
+    8589934592     134217728     float    none      -1  42668.7  201.32  188.73       0  42630.7  201.50  188.90       0
+    # Out of bounds values : 0 OK
+    # Avg bus bandwidth    : 53.8932 
+    ```
+
+6. When you have finished validating the nodes, clean up the test resources so the nodes can be used by other workloads:
+
+    ```bash
+    kubectl delete -f examples/gke-a3-megagpu/nccl-test-latest.yaml
+    ```
+
+## Clean Up
+
+To avoid incurring charges for the resources created, destroy the deployment:
+
+```bash
+./gcluster destroy DEPLOYMENT_NAME
+```
+
+## Additional Resources
+
+Refer to [Deploy an A3 Mega GKE cluster for ML training](https://cloud.google.com/cluster-toolkit/docs/deploy/deploy-a3-mega-gke-cluster) for more instructions on creating the GKE-A3M cluster.
+
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for more instructions on running a NCCL test on the GKE-A3M cluster.
 
 ### Additional Consumption Options
 The Cluster Toolkit supports alternative consumption options such as Spot VMs or Dynamic Workload Scheduler (DWS) Flex-start.

--- a/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
@@ -34,7 +34,8 @@ vars:
   zone:
 
   # Cidr block containing the IP of the machine calling terraform.
-  # The following line must be updated for this example to work.
+  # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
+  # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
   # The number of nodes to be created

--- a/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu-deployment.yaml
@@ -17,31 +17,31 @@ terraform_backend_defaults:
   type: gcs
   configuration:
     # The GCS bucket used for storing terraform state
-    bucket: BUCKET_NAME
+    bucket:
 
 vars:
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
-  deployment_name: DEPLOYMENT_NAME
+  deployment_name:
 
   # Your GCP Project ID
-  project_id: PROJECT_ID
+  project_id:
 
   # The GCP Region used for this deployment.
-  region: COMPUTE_REGION
+  region:
 
   # The GCP Zone used for this deployment.
-  zone: COMPUTE_ZONE
+  zone:
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <IP_ADDRESS>/<SUFFIX>
+  authorized_cidr:
 
   # The number of nodes to be created
-  static_node_count: NODE_COUNT
+  static_node_count:
 
   # The name of the compute engine reservation in the form of
   # <reservation-name>
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
-  reservation: RESERVATION_NAME
+  reservation:

--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -32,11 +32,14 @@ vars:
   zone:
 
   # Cidr block containing the IP of the machine calling terraform.
-  # The following line must be updated for this example to work.
+  # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
+  # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
   gcp_public_cidrs_access_enabled: false
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+  nccl_tcpxo_installer_path: $(ghpc_stage("./nccl-tcpxo-installer.yaml.tftpl"))
+  nri_device_injector_path: $(ghpc_stage("./nri-device-injector.yaml"))
 
   # The number of nodes to be created
   static_node_count:
@@ -49,8 +52,6 @@ vars:
 
   accelerator_type: nvidia-h100-mega-80gb
   version_prefix: "1.32."
-  nccl_tcpxo_installer_path: $(ghpc_stage("./nccl-tcpxo-installer.yaml.tftpl"))
-  nri_device_injector_path: $(ghpc_stage("./nri-device-injector.yaml"))
   nccl_tcpxo_version: v1.0.15
 
 deployment_groups:

--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -26,10 +26,10 @@ vars:
   deployment_name: gke-a3-mega
 
   # The GCP Region used for this deployment.
-  region: us-central1
+  region:
 
   # The GCP Zone used for this deployment.
-  zone: us-central1-c
+  zone:
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
@@ -39,7 +39,7 @@ vars:
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # The number of nodes to be created
-  static_node_count: 2
+  static_node_count:
 
   # The name of the compute engine reservation in the form of
   # <reservation-name>
@@ -49,6 +49,9 @@ vars:
 
   accelerator_type: nvidia-h100-mega-80gb
   version_prefix: "1.32."
+  nccl_tcpxo_installer_path: $(ghpc_stage("./nccl-tcpxo-installer.yaml.tftpl"))
+  nri_device_injector_path: $(ghpc_stage("./nri-device-injector.yaml"))
+  nccl_tcpxo_version: v1.0.15
 
 deployment_groups:
 - group: primary
@@ -123,6 +126,7 @@ deployment_groups:
     source: modules/compute/gke-node-pool
     use: [gke_cluster, gpunets, node_pool_service_account]
     settings:
+      install_gpu_direct_manifests: false
       machine_type: a3-megagpu-8g
       static_node_count: $(vars.static_node_count)
       zones: [$(vars.zone)]
@@ -139,6 +143,12 @@ deployment_groups:
     source: modules/management/kubectl-apply
     use: [gke_cluster]
     settings:
+      apply_manifests:
+      - source: $(vars.nri_device_injector_path)
+      - source: $(vars.nccl_tcpxo_installer_path)
+        template_vars:
+          accelerator_type: $(vars.accelerator_type)
+          version: $(vars.nccl_tcpxo_version)
       kueue:
         install: true
         wait: true

--- a/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
+++ b/examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -127,6 +127,7 @@ deployment_groups:
     use: [gke_cluster, gpunets, node_pool_service_account]
     settings:
       install_gpu_direct_manifests: false
+      run_workload_script: false
       machine_type: a3-megagpu-8g
       static_node_count: $(vars.static_node_count)
       zones: [$(vars.zone)]

--- a/examples/gke-a3-megagpu/nccl-tcpxo-installer.yaml.tftpl
+++ b/examples/gke-a3-megagpu/nccl-tcpxo-installer.yaml.tftpl
@@ -1,0 +1,109 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Upstream source: https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/1d592a4c9689a7757ee212cc62fa928ab6a61a00/gpudirect-tcpxo/nccl-tcpxo-installer.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nccl-tcpxo-installer
+  namespace: kube-system
+  labels:
+    k8s-app: nccl-tcpxo-installer
+spec:
+  selector:
+    matchLabels:
+      k8s-app: nccl-tcpxo-installer
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: nccl-tcpxo-installer
+        k8s-app: nccl-tcpxo-installer
+    spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: cloud.google.com/gke-accelerator
+                    operator: In
+                    values:
+                      - ${accelerator_type}
+      tolerations:
+        - operator: "Exists"
+      hostNetwork: true
+      hostPID: true
+      volumes:
+        - name: var-lib
+          hostPath:
+            path: /var/lib
+        - name: tcpxo
+          hostPath:
+            path: /var/lib/tcpxo
+        - name: library-dir-host
+          hostPath:
+            path: /home/kubernetes/bin
+      initContainers:
+        - image: "ubuntu"
+          name: pre-installation
+          securityContext:
+            privileged: true
+          command:
+            - nsenter
+            - -at
+            - '1'
+            - --
+            - sh
+            - -c
+            - |
+              /sbin/iptables -I INPUT -p tcp -m tcp -j ACCEPT && modprobe import-helper
+              sudo mkdir -p /dev/aperture_devices
+              while IFS= read -r line; do
+                BDF=$( echo "$line" | awk '{print $1}' );
+                target_aperture_path="/dev/aperture_devices/$BDF"
+                host_aperture_device=$(readlink -f "/sys/bus/pci/devices/$BDF");
+                sudo mkdir -p $target_aperture_path;
+                sudo umount -R $target_aperture_path;
+                sudo mount --bind $host_aperture_device $target_aperture_path;
+              done < <(lspci -nn -D | grep '1ae0:0084')
+              if [ -d /dev/aperture_devices ]; then
+                  chmod -R a+r /dev/aperture_devices/
+                  chmod a+rw /dev/aperture_devices/*/resource*
+              fi
+        - name: nccl-tcpxo-installer
+          image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:${version}
+          resources:
+            requests:
+              cpu: 150m
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: var-lib
+              mountPath: /var/lib
+            - name: library-dir-host
+              mountPath: /usr/local
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -ex
+              chmod 755 /scripts/container_entry.sh
+              /scripts/container_entry.sh install --install-nccl
+              mkdir -p /usr/local/nvidia/lib64
+              cp -r /var/lib/tcpxo/lib64/. /usr/local/nvidia/lib64
+              echo "installation finishes"
+      containers:
+        - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
+          name: pause

--- a/examples/gke-a3-megagpu/nccl-test-latest.yaml
+++ b/examples/gke-a3-megagpu/nccl-test-latest.yaml
@@ -237,6 +237,7 @@ spec:
     - name: LD_LIBRARY_PATH
       value: /usr/local/nvidia/lib64
   - name: nccl-test
+   # Note: This version matches nccl_tcpxo_version in examples/gke-a3-megagpu/gke-a3-megagpu.yaml
     image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
     imagePullPolicy: Always
     #      securityContext:

--- a/examples/gke-a3-megagpu/nccl-test-latest.yaml
+++ b/examples/gke-a3-megagpu/nccl-test-latest.yaml
@@ -1,0 +1,292 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Upstream source: https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/70cf61092e4743336aea894612da4577263fb1b6/gpudirect-tcpxo/nccl-test-latest.yaml
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: nccl-host-1
+spec:
+  selector:
+    name: nccl-host-1
+  clusterIP: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nccl-host-2
+spec:
+  selector:
+    name: nccl-host-2
+  clusterIP: None
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nccl-test-host-1
+  labels:
+    name: nccl-host-1
+    tcpxo: daemon
+  annotations:
+    devices.gke.io/container.tcpxo-daemon: |+
+      - path: /dev/nvidia0
+      - path: /dev/nvidia1
+      - path: /dev/nvidia2
+      - path: /dev/nvidia3
+      - path: /dev/nvidia4
+      - path: /dev/nvidia5
+      - path: /dev/nvidia6
+      - path: /dev/nvidia7
+      - path: /dev/nvidiactl
+      - path: /dev/nvidia-uvm
+      - path: /dev/dmabuf_import_helper
+    networking.gke.io/default-interface: 'eth0'
+    networking.gke.io/interfaces: |
+      [
+        {"interfaceName":"eth0","network":"default"},
+        {"interfaceName":"eth1","network":"vpc1"},
+        {"interfaceName":"eth2","network":"vpc2"},
+        {"interfaceName":"eth3","network":"vpc3"},
+        {"interfaceName":"eth4","network":"vpc4"},
+        {"interfaceName":"eth5","network":"vpc5"},
+        {"interfaceName":"eth6","network":"vpc6"},
+        {"interfaceName":"eth7","network":"vpc7"},
+        {"interfaceName":"eth8","network":"vpc8"}
+      ]
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
+  hostname: host1
+  subdomain: nccl-host-1
+  #  hostNetwork: true
+  #  dnsPolicy: ClusterFirstWithHostNet
+  containers:
+  - name: tcpxo-daemon
+    image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+    imagePullPolicy: Always
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      set -ex
+      chmod 755 /fts/entrypoint_rxdm_container.sh
+      /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+    securityContext:
+      #        privileged: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_BIND_SERVICE
+    volumeMounts:
+    - name: nvidia
+      mountPath: /usr/local/nvidia/lib64
+    - name: sys
+      mountPath: /hostsysfs
+    - name: proc-sys
+      mountPath: /hostprocsysfs
+    env:
+    - name: LD_LIBRARY_PATH
+      value: /usr/local/nvidia/lib64
+  - name: nccl-test
+    image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+    imagePullPolicy: Always
+    #      securityContext:
+    #        privileged: true
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -ex
+      chmod 755  /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+      cat >/scripts/allgather.sh <<EOF
+      #!/bin/bash
+      /scripts/init_ssh.sh \${@};
+      pushd /scripts;
+      /scripts/gen_hostfiles.sh \${@};
+      popd;
+      BENCHMARK=all_gather_perf NHOSTS=2 NCCL_LIB_DIR="${LD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+      EOF
+      chmod +x /scripts/allgather.sh
+      service ssh restart;
+      sleep infinity;
+    env:
+    - name: LD_LIBRARY_PATH
+      value: /usr/local/nvidia/lib64
+    - name: NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY
+      value: /dev/aperture_devices
+    volumeMounts:
+    - name: nvidia
+      mountPath: /usr/local/nvidia/lib64
+    - name: shared-memory
+      mountPath: /dev/shm
+    - name: aperture-devices
+      mountPath: /dev/aperture_devices
+    resources:
+      limits:
+        nvidia.com/gpu: 8
+  volumes:
+  - name: nvidia
+    hostPath:
+      path: /home/kubernetes/bin/nvidia/lib64
+  - name: shared-memory
+    emptyDir:
+      medium: "Memory"
+      sizeLimit: 1Gi
+  - name: sys
+    hostPath:
+      path: /sys
+  - name: proc-sys
+    hostPath:
+      path: /proc/sys
+  - name: aperture-devices
+    hostPath:
+      path: /dev/aperture_devices
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nccl-test-host-2
+  labels:
+    name: nccl-host-2
+    tcpxo: daemon
+  annotations:
+    devices.gke.io/container.tcpxo-daemon: |+
+      - path: /dev/nvidia0
+      - path: /dev/nvidia1
+      - path: /dev/nvidia2
+      - path: /dev/nvidia3
+      - path: /dev/nvidia4
+      - path: /dev/nvidia5
+      - path: /dev/nvidia6
+      - path: /dev/nvidia7
+      - path: /dev/nvidiactl
+      - path: /dev/nvidia-uvm
+      - path: /dev/dmabuf_import_helper
+    networking.gke.io/default-interface: 'eth0'
+    networking.gke.io/interfaces: |
+      [
+        {"interfaceName":"eth0","network":"default"},
+        {"interfaceName":"eth1","network":"vpc1"},
+        {"interfaceName":"eth2","network":"vpc2"},
+        {"interfaceName":"eth3","network":"vpc3"},
+        {"interfaceName":"eth4","network":"vpc4"},
+        {"interfaceName":"eth5","network":"vpc5"},
+        {"interfaceName":"eth6","network":"vpc6"},
+        {"interfaceName":"eth7","network":"vpc7"},
+        {"interfaceName":"eth8","network":"vpc8"}
+      ]
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: tcpxo
+            operator: In
+            values:
+            - daemon
+        topologyKey: "kubernetes.io/hostname"
+  hostname: host2
+  subdomain: nccl-host-2
+  #  hostNetwork: true
+  #  dnsPolicy: ClusterFirstWithHostNet
+  containers:
+  - name: tcpxo-daemon
+    image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.21
+    imagePullPolicy: Always
+    command: ["/bin/sh", "-c"]
+    args:
+    - |
+      set -ex
+      chmod 755 /fts/entrypoint_rxdm_container.sh
+      /fts/entrypoint_rxdm_container.sh --num_hops=2 --num_nics=8
+    securityContext:
+      #        privileged: true
+      capabilities:
+        add:
+        - NET_ADMIN
+        - NET_BIND_SERVICE
+    volumeMounts:
+    - name: nvidia
+      mountPath: /usr/local/nvidia/lib64
+    - name: sys
+      mountPath: /hostsysfs
+    - name: proc-sys
+      mountPath: /hostprocsysfs
+    env:
+    - name: LD_LIBRARY_PATH
+      value: /usr/local/nvidia/lib64
+  - name: nccl-test
+    image: us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.15
+    imagePullPolicy: Always
+    #      securityContext:
+    #        privileged: true
+    command:
+    - /bin/sh
+    - -c
+    - |
+      set -ex
+      chmod 755  /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+      cat >/scripts/allgather.sh <<EOF
+      #!/bin/bash
+      /scripts/init_ssh.sh \${@};
+      pushd /scripts;
+      /scripts/gen_hostfiles.sh \${@};
+      popd;
+      BENCHMARK=all_gather_perf NHOSTS=2 NCCL_LIB_DIR="${LD_LIBRARY_PATH}" LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" /scripts/demo-run-nccl-test-tcpxo-via-mpi.sh
+      EOF
+      chmod +x /scripts/allgather.sh
+      service ssh restart;
+      sleep infinity;
+    env:
+    - name: LD_LIBRARY_PATH
+      value: /usr/local/nvidia/lib64
+    - name: NCCL_FASTRAK_LLCM_DEVICE_DIRECTORY
+      value: /dev/aperture_devices
+    volumeMounts:
+    - name: nvidia
+      mountPath: /usr/local/nvidia/lib64
+    - name: shared-memory
+      mountPath: /dev/shm
+    - name: aperture-devices
+      mountPath: /dev/aperture_devices
+    resources:
+      limits:
+        nvidia.com/gpu: 8
+  volumes:
+  - name: nvidia
+    hostPath:
+      path: /home/kubernetes/bin/nvidia/lib64
+  - name: shared-memory
+    emptyDir:
+      medium: "Memory"
+      sizeLimit: 1Gi
+  - name: sys
+    hostPath:
+      path: /sys
+  - name: proc-sys
+    hostPath:
+      path: /proc/sys
+  - name: aperture-devices
+    hostPath:
+      path: /dev/aperture_devices

--- a/examples/gke-a3-megagpu/nri-device-injector.yaml
+++ b/examples/gke-a3-megagpu/nri-device-injector.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Upstream source: https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/70cf61092e4743336aea894612da4577263fb1b6/nri_device_injector/nri-device-injector.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: device-injector
+  namespace: kube-system
+  labels:
+    k8s-app: device-injector
+spec:
+  selector:
+    matchLabels:
+      k8s-app: device-injector
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        name: device-injector
+        k8s-app: device-injector
+    spec:
+      priorityClassName: system-node-critical
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: cloud.google.com/gke-accelerator
+                operator: In
+                values:
+                - nvidia-rtx-pro-6000
+                - nvidia-h100-80gb
+                - nvidia-h100-mega-80gb
+      tolerations:
+      - operator: "Exists"
+      hostNetwork: true
+      hostPID: true
+      containers:
+      - image: "gcr.io/gke-release/nri-device-injector@sha256:6e79483d52abdc28454bf186320b10a56b0f117a10e8d65d5c74dbb821a76970"
+        name: device-injector
+        resources:
+          requests:
+            cpu: 150m
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: dev
+          mountPath: /dev
+        - name: nri
+          mountPath: /var/run/nri
+      volumes:
+      - name: root
+        hostPath:
+          path: /
+      - name: nri
+        hostPath:
+          path: /var/run/nri
+      - name: dev
+        hostPath:
+          path: /dev

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-a3-mega.yml
@@ -23,31 +23,43 @@
   ansible.builtin.shell: |
     gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
 
-- name: Download NCCL test file
+- name: Get GKE cluster version
   delegate_to: localhost
   ansible.builtin.shell: |
-    wget -O {{ workspace }}/examples/nccl-test.yaml \
-      https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/a32cd5152c6ac430ed0651199484853baa14f2d0/gpudirect-tcpxo/nccl-test-latest.yaml
-    cat {{ workspace }}/examples/nccl-test.yaml
-  register: nccl_test_file_contents
+    gcloud container clusters describe {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --format="value(currentMasterVersion)"
+  register: gke_version_info
 
-- name: Display NCCL test file
-  debug:
-    msg: "{{nccl_test_file_contents.stdout}}"
+- name: Print GKE cluster version
+  ansible.builtin.debug:
+    msg: "GKE Cluster Version: {{ gke_version_info.stdout }}"
+
+- name: Verify TCPXO and NRI DaemonSets are fully deployed
+  delegate_to: localhost
+  ansible.builtin.shell: |
+    echo "Waiting for nccl-tcpxo-installer daemonset..."
+    kubectl rollout status daemonset nccl-tcpxo-installer -n kube-system --timeout=1200s
+    echo "Waiting for device-injector daemonset..."
+    kubectl rollout status daemonset device-injector -n kube-system --timeout=1200s
+    kubectl get daemonsets -n kube-system nccl-tcpxo-installer device-injector
+  register: daemonset_status
+
+- name: Print DaemonSet status
+  ansible.builtin.debug:
+    msg: "{{ daemonset_status.stdout }}"
 
 - name: Deploy pods with NCCL test workload
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl apply -f {{ workspace }}/examples/nccl-test.yaml -v=9
+    kubectl apply -f {{ workspace }}/examples/gke-a3-megagpu/nccl-test-latest.yaml -v=9
 
-- name: Wait until 2 pods are running
+- name: Wait for NCCL test Pods to be ready
   delegate_to: localhost
   ansible.builtin.shell: |
     kubectl get pod --field-selector status.phase=Running --no-headers -v=9
   register: pod_running
   until: pod_running.stdout_lines | length == 2
   retries: 20
-  delay: 10
+  delay: 15
 
 - name: Trigger all-gather NCCL test
   delegate_to: localhost
@@ -58,7 +70,7 @@
 
 - name: Print the NCCL test logs
   debug:
-    msg: "{{nccl_test_logs.stdout}}"
+    msg: "{{ nccl_test_logs.stdout }}"
 
 - name: Ensure average bus bandwidth is >= 30 GB/s
   delegate_to: localhost
@@ -70,5 +82,4 @@
 - name: Clean up
   delegate_to: localhost
   ansible.builtin.shell: |
-    kubectl delete pod --all -v=9
-    kubectl delete service --all -v=9
+    kubectl delete -f {{ workspace }}/examples/gke-a3-megagpu/nccl-test-latest.yaml -v=9


### PR DESCRIPTION
### Summary
This PR natively bundles GPUDirect manifests and refactors the A3 Mega blueprint for improved stability, predictability, and standardization across A* accelerator instances.

### Motivation
- **Architectural Alignment**: Standardizes A3 Mega with other modern accelerator blueprints (A3 High, Ultra) where GPUDirect assets are version-controlled locally
- **Improved Stability**: Eliminates runtime instability from upstream remote manifests and insulates deployments from breaking changes
- **Enhanced Customization**: Direct control to patch configurations and customize components for specific workloads

### Changes
- **Added GPUDirect Manifests** (`examples/gke-a3-megagpu/`):  `nccl-tcpxo-installer.yaml.tftpl`, `nri-device-injector.yaml`, and `nccl-test-latest.yaml`
- **Refactored Blueprint** (`gke-a3-megagpu.yaml`): Updated workload component install step to apply GPUDirect manifests directly during deployment; set `install_gpu_direct_manifests: false` on node pool
- **Enhanced Documentation**: Comprehensive README with deployment instructions, prerequisites, and NCCL validation procedures

### Testing
A3M Spot Integration Tests: Validated with improved test automation including explicit DaemonSet verification and pod readiness checks.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
