### PR TITLE
Update base image driver to 580 in a3m and a4x blueprint

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -35,7 +35,7 @@ vars:
   enable_login_public_ips: true
   enable_controller_public_ips: true
   localssd_mountpoint: /mnt/localssd
-  build_slurm_from_git_ref: 6.10.10
+  build_slurm_from_git_ref: 6.12.1
   #Provisioning models (set to true or fill in reservation name, pick only one)
   a3mega_reservation_name: ""  # supply reservation name
   a3mega_dws_flex_enabled: false

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -26,7 +26,7 @@ vars:
   sys_net_range: 172.16.0.0/16
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260225
   a3mega_partition_name: a3mega
   local_mount_homefs: /home
   instance_image:
@@ -83,6 +83,12 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - type: data
+        destination: /etc/apt/preferences.d/block-broken-nvidia-container
+        content: |
+          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
+          Pin: version 1.17.7-1
+          Pin-Priority: 100
 
       # The following holds NVIDIA software that was already installed on the
       # accelerator base image to be the same driver version. This reduces the
@@ -153,46 +159,24 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
-      - type: ansible-local
-        destination: update-gvnic.yml
-        content: |
-          ---
-          - name: Install updated gVNIC driver from GitHub
-            hosts: all
-            become: true
-            vars:
-              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.4.3/gve-dkms_1.4.3_all.deb
-              package_filename: /tmp/{{ package_url | basename }}
-            tasks:
-            - name: Install driver dependencies
-              ansible.builtin.apt:
-                name:
-                - dkms
-            - name: Download gVNIC package
-              ansible.builtin.get_url:
-                url: "{{ package_url }}"
-                dest: "{{ package_filename }}"
-            - name: Install updated gVNIC
-              ansible.builtin.apt:
-                deb: "{{ package_filename }}"
-                state: present
       - type: shell
         destination: install-cuda-toolkit.sh
         content: |
           #!/bin/bash
           set -ex -o pipefail
-          add-nvidia-repositories -y
-          apt update -y
-          apt install -y \
-              cuda-toolkit-12-8 \
-              nvidia-container-toolkit \
-              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
-              datacenter-gpu-manager-4-core=1:4.5.2-1
+           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
+           dpkg -i /tmp/cuda-keyring.deb
+           apt update -y
+           apt install -y \
+               cuda-toolkit-13-0 \
+               nvidia-container-toolkit \
+               datacenter-gpu-manager-4-cuda13 \
+               datacenter-gpu-manager-4-dev \
+               datacenter-gpu-manager-4-core
 
           # 2. Hold ALL components
           apt-mark hold \
-              datacenter-gpu-manager-4-cuda12 \
+              datacenter-gpu-manager-4-cuda13 \
               datacenter-gpu-manager-4-dev \
               datacenter-gpu-manager-4-core
       # this duplicates the ulimits configuration of the HPC VM Image
@@ -213,6 +197,21 @@ deployment_groups:
           ENROOT_CACHE_PATH      /mnt/localssd/${UID}/enroot/cache
           ENROOT_DATA_PATH       /mnt/localssd/${UID}/enroot/data
           ENROOT_TEMP_PATH       /mnt/localssd/${UID}/enroot
+      - type: shell
+        destination: fix_enroot_env.sh
+        content: |
+          #!/bin/bash
+          # 1. Disable Ubuntu 24.04 restriction on unprivileged user namespaces
+          # Required for enroot/pyxis to work
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+            echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/90-enroot-namespaces.conf
+          fi
+
+          # 2. Ensure /etc/hostname exists (needed by enroot/pyxis)
+          if [ ! -f /etc/hostname ]; then
+            hostname > /etc/hostname
+          fi
       - type: ansible-local
         destination: configure_gpu_monitoring.yml
         content: |
@@ -263,31 +262,44 @@ deployment_groups:
                 state: stopped
                 enabled: false
 
-      - type: ansible-local
-        destination: install_dmabuf.yml
+      - type: shell
+        destination: install_dmabuf_patched.sh
         content: |
-          ---
-          - name: Install DMBABUF import helper
-            hosts: all
-            become: true
-            tasks:
-            - name: Setup apt-transport-artifact-registry repository
-              ansible.builtin.apt_repository:
-                repo: deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main
-                state: present
-            - name: Install driver dependencies
-              ansible.builtin.apt:
-                name:
-                - dkms
-                - apt-transport-artifact-registry
-            - name: Setup gpudirect-tcpxo apt repository
-              ansible.builtin.apt_repository:
-                repo: deb [arch=all trusted=yes ] ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-tcpxo-apt main
-                state: present
-            - name: Install DMABUF import helper DKMS package
-              ansible.builtin.apt:
-                name: dmabuf-import-helper
-                state: present
+          #!/bin/bash
+          set -ex -o pipefail
+          
+          # 1. Add Artifact Registry apt repo driver repo
+          echo "deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main" > /etc/apt/sources.list.d/artifact-registry.list
+          apt-get update
+          apt-get install -y apt-transport-artifact-registry
+
+          # 2. Now add the ar+https repo
+          echo "deb [arch=all trusted=yes ] ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-tcpxo-apt main" > /etc/apt/sources.list.d/gpudirect-tcpxo.list
+          
+          # 3. Install dependencies
+          apt-get update
+          apt-get install -y dkms
+          
+          # 3. Download package
+          mkdir -p /tmp/dmabuf_pkg
+          cd /tmp/dmabuf_pkg
+          apt-get update # Update again to make sure we see the new repo
+          apt-get download dmabuf-import-helper
+          
+          # 4. Extract package
+          dpkg -x *.deb .
+          
+          # 5. Move source to /usr/src
+          rm -rf /usr/src/dmabuf-import-helper-1.1
+          mv usr/src/dmabuf-import-helper-1.1 /usr/src/
+          
+          # 6. Apply fix for kernel 6.17
+          sed -i 's/MODULE_IMPORT_NS(DMA_BUF)/MODULE_IMPORT_NS("DMA_BUF")/' /usr/src/dmabuf-import-helper-1.1/import-helper.c
+          
+          # 7. Build and install via DKMS
+          dkms add -m dmabuf-import-helper -v 1.1
+          dkms build -m dmabuf-import-helper -v 1.1
+          dkms install -m dmabuf-import-helper -v 1.1
       - type: ansible-local
         destination: aperture_devices.yml
         content: |
@@ -341,6 +353,14 @@ deployment_groups:
           apt-get install --assume-yes google-cloud-cli
           # Clean up the bash executable hash for subsequent steps using gsutil
           hash -r
+      - type: shell
+        destination: stop_packer_early.sh
+        content: |
+          #!/bin/bash
+          BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
+          LOG_DEST=`curl -s -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null`
+          if [ -n "\$LOG_DEST" ]; then rm -f "\$LOG_DEST"; fi
+          gcloud compute instances add-metadata `hostname -s` --metadata "startup-script-status"="done" --zone $(vars.zone)
 
 - group: slurm-build
   modules:

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -35,7 +35,7 @@ vars:
   enable_login_public_ips: true
   enable_controller_public_ips: true
   localssd_mountpoint: /mnt/localssd
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.10.10
   #Provisioning models (set to true or fill in reservation name, pick only one)
   a3mega_reservation_name: ""  # supply reservation name
   a3mega_dws_flex_enabled: false
@@ -267,7 +267,7 @@ deployment_groups:
         content: |
           #!/bin/bash
           set -ex -o pipefail
-          
+
           # 1. Add Artifact Registry apt repo driver repo
           echo "deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main" > /etc/apt/sources.list.d/artifact-registry.list
           apt-get update
@@ -275,27 +275,27 @@ deployment_groups:
 
           # 2. Now add the ar+https repo
           echo "deb [arch=all trusted=yes ] ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-tcpxo-apt main" > /etc/apt/sources.list.d/gpudirect-tcpxo.list
-          
+
           # 3. Install dependencies
           apt-get update
           apt-get install -y dkms
-          
+
           # 3. Download package
           mkdir -p /tmp/dmabuf_pkg
           cd /tmp/dmabuf_pkg
           apt-get update # Update again to make sure we see the new repo
           apt-get download dmabuf-import-helper
-          
+
           # 4. Extract package
           dpkg -x *.deb .
-          
+
           # 5. Move source to /usr/src
           rm -rf /usr/src/dmabuf-import-helper-1.1
           mv usr/src/dmabuf-import-helper-1.1 /usr/src/
-          
+
           # 6. Apply fix for kernel 6.17
           sed -i 's/MODULE_IMPORT_NS(DMA_BUF)/MODULE_IMPORT_NS("DMA_BUF")/' /usr/src/dmabuf-import-helper-1.1/import-helper.c
-          
+
           # 7. Build and install via DKMS
           dkms add -m dmabuf-import-helper -v 1.1
           dkms build -m dmabuf-import-helper -v 1.1

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -29,7 +29,7 @@ vars:
   sys_net_range: 172.16.0.0/16
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2204-amd64-with-nvidia-570-v20260210
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
   a3mega_partition_name: a3mega
   local_mount_homefs: /home
   instance_image:
@@ -96,6 +96,12 @@ deployment_groups:
         enabled: true
         world_writable: true
       runners:
+      - type: data
+        destination: /etc/apt/preferences.d/block-broken-nvidia-container
+        content: |
+          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
+          Pin: version 1.17.7-1
+          Pin-Priority: 100
 
       # The following holds NVIDIA software that was already installed on the
       # accelerator base image to be the same driver version. This reduces the
@@ -166,46 +172,24 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
-      - type: ansible-local
-        destination: update-gvnic.yml
-        content: |
-          ---
-          - name: Install updated gVNIC driver from GitHub
-            hosts: all
-            become: true
-            vars:
-              package_url: https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux/releases/download/v1.4.3/gve-dkms_1.4.3_all.deb
-              package_filename: /tmp/{{ package_url | basename }}
-            tasks:
-            - name: Install driver dependencies
-              ansible.builtin.apt:
-                name:
-                - dkms
-            - name: Download gVNIC package
-              ansible.builtin.get_url:
-                url: "{{ package_url }}"
-                dest: "{{ package_filename }}"
-            - name: Install updated gVNIC
-              ansible.builtin.apt:
-                deb: "{{ package_filename }}"
-                state: present
       - type: shell
         destination: install-cuda-toolkit.sh
         content: |
           #!/bin/bash
           set -ex -o pipefail
-          add-nvidia-repositories -y
-          apt update -y
-          apt install -y \
-              cuda-toolkit-12-8 \
-              nvidia-container-toolkit \
-              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
-              datacenter-gpu-manager-4-core=1:4.5.3-1
+           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
+           dpkg -i /tmp/cuda-keyring.deb
+           apt update -y
+           apt install -y \
+               cuda-toolkit-13-0 \
+               nvidia-container-toolkit \
+               datacenter-gpu-manager-4-cuda13 \
+               datacenter-gpu-manager-4-dev \
+               datacenter-gpu-manager-4-core
 
           # 2. Hold ALL components
           apt-mark hold \
-              datacenter-gpu-manager-4-cuda12 \
+              datacenter-gpu-manager-4-cuda13 \
               datacenter-gpu-manager-4-dev \
               datacenter-gpu-manager-4-core
       # this duplicates the ulimits configuration of the HPC VM Image
@@ -226,6 +210,21 @@ deployment_groups:
           ENROOT_CACHE_PATH      /mnt/localssd/${UID}/enroot/cache
           ENROOT_DATA_PATH       /mnt/localssd/${UID}/enroot/data
           ENROOT_TEMP_PATH       /mnt/localssd/${UID}/enroot
+      - type: shell
+        destination: fix_enroot_env.sh
+        content: |
+          #!/bin/bash
+          # 1. Disable Ubuntu 24.04 restriction on unprivileged user namespaces
+          # Required for enroot/pyxis to work
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+            echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/90-enroot-namespaces.conf
+          fi
+
+          # 2. Ensure /etc/hostname exists (needed by enroot/pyxis)
+          if [ ! -f /etc/hostname ]; then
+            hostname > /etc/hostname
+          fi
       - type: ansible-local
         destination: configure_gpu_monitoring.yml
         content: |
@@ -280,7 +279,7 @@ deployment_groups:
         destination: install_dmabuf.yml
         content: |
           ---
-          - name: Install DMBABUF import helper
+          - name: Install patched DMABUF import helper
             hosts: all
             become: true
             tasks:
@@ -288,19 +287,87 @@ deployment_groups:
               ansible.builtin.apt_repository:
                 repo: deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main
                 state: present
+                filename: artifact-registry
+
             - name: Install driver dependencies
               ansible.builtin.apt:
                 name:
-                - dkms
                 - apt-transport-artifact-registry
+                - dkms
+                state: present
+                update_cache: true
+
             - name: Setup gpudirect-tcpxo apt repository
               ansible.builtin.apt_repository:
-                repo: deb [arch=all trusted=yes ] ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-tcpxo-apt main
+                repo: deb [arch=all trusted=yes] ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-tcpxo-apt main
                 state: present
-            - name: Install DMABUF import helper DKMS package
-              ansible.builtin.apt:
-                name: dmabuf-import-helper
-                state: present
+                filename: gpudirect-tcpxo
+
+            - name: Create temp directory for dmabuf package
+              ansible.builtin.file:
+                path: /tmp/dmabuf_pkg
+                state: directory
+                mode: '0755'
+
+            - name: Download dmabuf-import-helper package
+              ansible.builtin.command:
+                cmd: apt-get download dmabuf-import-helper
+                chdir: /tmp/dmabuf_pkg
+              register: download_res
+              changed_when: download_res.rc == 0
+
+            - name: Extract dmabuf-import-helper deb package
+              ansible.builtin.command:
+                cmd: dpkg-deb -x "{{ item }}" .
+                chdir: /tmp/dmabuf_pkg
+              with_fileglob:
+              - "/tmp/dmabuf_pkg/*.deb"
+              register: extract_res
+              changed_when: extract_res.rc == 0
+
+            - name: Clean existing dmabuf source in /usr/src
+              ansible.builtin.file:
+                path: /usr/src/dmabuf-import-helper-1.1
+                state: absent
+
+            - name: Move dmabuf-import-helper source to /usr/src
+              ansible.builtin.command:
+                cmd: mv /tmp/dmabuf_pkg/usr/src/dmabuf-import-helper-1.1 /usr/src/
+              register: move_res
+              changed_when: move_res.rc == 0
+
+            - name: Patch import-helper.c for kernel 6.17 compatibility
+              ansible.builtin.replace:
+                path: /usr/src/dmabuf-import-helper-1.1/import-helper.c
+                regexp: 'MODULE_IMPORT_NS\(DMA_BUF\)'
+                replace: 'MODULE_IMPORT_NS("DMA_BUF")'
+
+            - name: Check if dmabuf-import-helper DKMS module is already added
+              ansible.builtin.command:
+                cmd: dkms status -m dmabuf-import-helper -v 1.1
+              register: dkms_status
+              failed_when: false
+              changed_when: false
+
+            - name: Add dmabuf-import-helper to DKMS
+              ansible.builtin.command:
+                cmd: dkms add -m dmabuf-import-helper -v 1.1
+              when: "'added' not in dkms_status.stdout and 'installed' not in dkms_status.stdout"
+
+            - name: Build dmabuf-import-helper via DKMS
+              ansible.builtin.command:
+                cmd: dkms build -m dmabuf-import-helper -v 1.1
+              when: "'installed' not in dkms_status.stdout"
+
+            - name: Install dmabuf-import-helper via DKMS
+              ansible.builtin.command:
+                cmd: dkms install -m dmabuf-import-helper -v 1.1
+              when: "'installed' not in dkms_status.stdout"
+
+            - name: Clean up temp directory
+              ansible.builtin.file:
+                path: /tmp/dmabuf_pkg
+                state: absent
       - type: ansible-local
         destination: aperture_devices.yml
         content: |
@@ -385,6 +452,7 @@ deployment_groups:
       metadata:
         user-data: |
           #cloud-config
+          create_hostname_file: true
           write_files:
           - path: /etc/apt/apt.conf.d/20auto-upgrades
             permissions: '0644'

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -172,26 +172,50 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
-      - type: shell
-        destination: install-cuda-toolkit.sh
-        content: |
-          #!/bin/bash
-          set -ex -o pipefail
-           wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb -O /tmp/cuda-keyring.deb
-           dpkg -i /tmp/cuda-keyring.deb
-           apt update -y
-           apt install -y \
-               cuda-toolkit-13-0 \
-               nvidia-container-toolkit \
-               datacenter-gpu-manager-4-cuda13 \
-               datacenter-gpu-manager-4-dev \
-               datacenter-gpu-manager-4-core
 
-          # 2. Hold ALL components
-          apt-mark hold \
-              datacenter-gpu-manager-4-cuda13 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
+      - type: ansible-local
+        destination: install_cuda_and_dcgm.yml
+        content: |
+          ---
+          - name: Install and Configure CUDA 13 / DCGM
+            hosts: all
+            become: true
+            vars:
+              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
+              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
+              nvidia_packages:
+                - cuda-toolkit-13-0
+                - nvidia-container-toolkit
+                - datacenter-gpu-manager-4-cuda13
+                - datacenter-gpu-manager-4-dev
+                - datacenter-gpu-manager-4-core
+            tasks:
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: "{{ cuda_repo_url }}"
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install NVIDIA packages
+                ansible.builtin.apt:
+                  name: "{{ nvidia_packages }}"
+                  state: present
+                  allow_downgrade: yes
+
+              - name: Hold DCGM packages
+                ansible.builtin.command:
+                  argv:
+                    - apt-mark
+                    - hold
+                    - "{{ item }}"
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
+
       # this duplicates the ulimits configuration of the HPC VM Image
       - type: data
         destination: /etc/security/limits.d/99-unlimited.conf
@@ -221,10 +245,6 @@ deployment_groups:
             echo "kernel.apparmor_restrict_unprivileged_userns = 0" > /etc/sysctl.d/90-enroot-namespaces.conf
           fi
 
-          # 2. Ensure /etc/hostname exists (needed by enroot/pyxis)
-          if [ ! -f /etc/hostname ]; then
-            hostname > /etc/hostname
-          fi
       - type: ansible-local
         destination: configure_gpu_monitoring.yml
         content: |
@@ -282,6 +302,8 @@ deployment_groups:
           - name: Install patched DMABUF import helper
             hosts: all
             become: true
+            vars:
+              dmabuf_version: "1.1"
             tasks:
             - name: Setup apt-transport-artifact-registry repository
               ansible.builtin.apt_repository:
@@ -303,71 +325,71 @@ deployment_groups:
                 state: present
                 filename: gpudirect-tcpxo
 
-            - name: Create temp directory for dmabuf package
-              ansible.builtin.file:
-                path: /tmp/dmabuf_pkg
-                state: directory
-                mode: '0755'
-
-            - name: Download dmabuf-import-helper package
+            - name: Check if dmabuf-import-helper DKMS module is already installed
               ansible.builtin.command:
-                cmd: apt-get download dmabuf-import-helper
-                chdir: /tmp/dmabuf_pkg
-              register: download_res
-              changed_when: download_res.rc == 0
-
-            - name: Extract dmabuf-import-helper deb package
-              ansible.builtin.command:
-                cmd: dpkg-deb -x "{{ item }}" .
-                chdir: /tmp/dmabuf_pkg
-              with_fileglob:
-              - "/tmp/dmabuf_pkg/*.deb"
-              register: extract_res
-              changed_when: extract_res.rc == 0
-
-            - name: Clean existing dmabuf source in /usr/src
-              ansible.builtin.file:
-                path: /usr/src/dmabuf-import-helper-1.1
-                state: absent
-
-            - name: Move dmabuf-import-helper source to /usr/src
-              ansible.builtin.command:
-                cmd: mv /tmp/dmabuf_pkg/usr/src/dmabuf-import-helper-1.1 /usr/src/
-              register: move_res
-              changed_when: move_res.rc == 0
-
-            - name: Patch import-helper.c for kernel 6.17 compatibility
-              ansible.builtin.replace:
-                path: /usr/src/dmabuf-import-helper-1.1/import-helper.c
-                regexp: 'MODULE_IMPORT_NS\(DMA_BUF\)'
-                replace: 'MODULE_IMPORT_NS("DMA_BUF")'
-
-            - name: Check if dmabuf-import-helper DKMS module is already added
-              ansible.builtin.command:
-                cmd: dkms status -m dmabuf-import-helper -v 1.1
+                cmd: dkms status -m dmabuf-import-helper -v {{ dmabuf_version }}
               register: dkms_status
               failed_when: false
               changed_when: false
 
-            - name: Add dmabuf-import-helper to DKMS
-              ansible.builtin.command:
-                cmd: dkms add -m dmabuf-import-helper -v 1.1
-              when: "'added' not in dkms_status.stdout and 'installed' not in dkms_status.stdout"
+            - name: Install and patch dmabuf-import-helper
+              block:
+                - name: Create temp directory for dmabuf package
+                  ansible.builtin.tempfile:
+                    state: directory
+                    suffix: dmabuf
+                  register: tempdir
 
-            - name: Build dmabuf-import-helper via DKMS
-              ansible.builtin.command:
-                cmd: dkms build -m dmabuf-import-helper -v 1.1
+                - name: Download dmabuf-import-helper package
+                  ansible.builtin.command:
+                    cmd: apt-get download dmabuf-import-helper
+                    chdir: "{{ tempdir.path }}"
+                  register: download_res
+                  changed_when: download_res.rc == 0
+
+                - name: Extract dmabuf-import-helper deb package
+                  ansible.builtin.shell:
+                    cmd: dpkg-deb -x *.deb .
+                    chdir: "{{ tempdir.path }}"
+                  register: extract_res
+                  changed_when: extract_res.rc == 0
+
+                - name: Clean existing dmabuf source in /usr/src
+                  ansible.builtin.file:
+                    path: /usr/src/dmabuf-import-helper-{{ dmabuf_version }}
+                    state: absent
+
+                - name: Move dmabuf-import-helper source to /usr/src
+                  ansible.builtin.command:
+                    cmd: mv "{{ tempdir.path }}/usr/src/dmabuf-import-helper-{{ dmabuf_version }}" /usr/src/
+                  register: move_res
+                  changed_when: move_res.rc == 0
+
+                - name: Patch import-helper.c for kernel 6.17 compatibility
+                  ansible.builtin.replace:
+                    path: /usr/src/dmabuf-import-helper-{{ dmabuf_version }}/import-helper.c
+                    regexp: 'MODULE_IMPORT_NS\(DMA_BUF\)'
+                    replace: 'MODULE_IMPORT_NS("DMA_BUF")'
+
+                - name: Add dmabuf-import-helper to DKMS
+                  ansible.builtin.command:
+                    cmd: dkms add -m dmabuf-import-helper -v {{ dmabuf_version }}
+                  when: "'added' not in dkms_status.stdout"
+
+                - name: Build dmabuf-import-helper via DKMS
+                  ansible.builtin.command:
+                    cmd: dkms build -m dmabuf-import-helper -v {{ dmabuf_version }}
+
+                - name: Install dmabuf-import-helper via DKMS
+                  ansible.builtin.command:
+                    cmd: dkms install -m dmabuf-import-helper -v {{ dmabuf_version }}
+
+                - name: Clean up temp directory
+                  ansible.builtin.file:
+                    path: "{{ tempdir.path }}"
+                    state: absent
               when: "'installed' not in dkms_status.stdout"
 
-            - name: Install dmabuf-import-helper via DKMS
-              ansible.builtin.command:
-                cmd: dkms install -m dmabuf-import-helper -v 1.1
-              when: "'installed' not in dkms_status.stdout"
-
-            - name: Clean up temp directory
-              ansible.builtin.file:
-                path: /tmp/dmabuf_pkg
-                state: absent
       - type: ansible-local
         destination: aperture_devices.yml
         content: |

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -25,7 +25,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-arm64-with-nvidia-570-v20260218
+    image: ubuntu-accelerator-2404-arm64-with-nvidia-580-v20260316
   image_build_machine_type: c4a-highcpu-16
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100
@@ -177,8 +177,8 @@ deployment_groups:
               cuda_repo_url: https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/sbsa/cuda-keyring_1.1-1_all.deb
               cuda_repo_filename: /tmp/{{ cuda_repo_url | basename }}
               nvidia_packages:
-              - cuda-toolkit-12-8
-              - datacenter-gpu-manager-4-cuda12
+              - cuda-toolkit-13-0
+              - datacenter-gpu-manager-4-cuda13
               - datacenter-gpu-manager-4-dev
             tasks:
             - name: Download NVIDIA repository package

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -242,15 +242,6 @@ deployment_groups:
                 name: nvidia-persistenced.service
                 state: stopped
                 enabled: false
-      # The script below is intended to bypass the packer script that fails on Ubuntu 24.04 images
-      # Once Ubuntu 24.04 no longer sets ${HOSTNAME} to the FQDN, this can be removed
-      - type: shell
-        destination: stop_packer_early.sh
-        content: |
-          #!/bin/bash
-          BASEMETADATAURL=http://metadata.google.internal/computeMetadata/v1/instance/
-          rm \$(curl -f -H "Metadata-Flavor: Google" ${BASEMETADATAURL}/attributes/startup-script-log-dest 2> /dev/null)
-          gcloud compute instances add-metadata \$(hostname -s) --metadata "startup-script-status"="done" --zone $(vars.zone)
 
 - group: image
   modules:

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -28,7 +28,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-arm64-with-nvidia-580-v20260316
+    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
   image_build_machine_type: c4a-highcpu-16
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -28,7 +28,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-arm64-with-nvidia-570-v20260218
+    image: ubuntu-accelerator-2404-arm64-with-nvidia-580-v20260316
   image_build_machine_type: c4a-highcpu-16
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100
@@ -184,8 +184,8 @@ deployment_groups:
               cuda_repo_url: https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/sbsa/cuda-keyring_1.1-1_all.deb
               cuda_repo_filename: /tmp/{{ cuda_repo_url | basename }}
               nvidia_packages:
-              - cuda-toolkit-12-8
-              - datacenter-gpu-manager-4-cuda12
+              - cuda-toolkit-13-0
+              - datacenter-gpu-manager-4-cuda13
               - datacenter-gpu-manager-4-dev
             tasks:
             - name: Download NVIDIA repository package

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -28,7 +28,7 @@ vars:
   # Image settings
   base_image:
     project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
+    image: ubuntu-accelerator-2404-arm64-with-nvidia-580-v20260522
   image_build_machine_type: c4a-highcpu-16
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
@@ -58,4 +58,4 @@ cli_deployment_vars:
   enable_nvidia_dcgm: "true"
   a3mega_reservation_name: a3mega-reservation-0
   enable_nvidia_persistenced: true
-  final_image_family: "{{ deployment_name}}-u22"
+  final_image_family: "{{ deployment_name}}-u24"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
@@ -57,4 +57,4 @@ cli_deployment_vars:
   enable_nvidia_dcgm: "true"
   a3mega_reservation_name: a3mega-reservation-0
   enable_nvidia_persistenced: true
-  final_image_family: "{{ deployment_name}}-u22"
+  final_image_family: "{{ deployment_name}}-u24"


### PR DESCRIPTION
### Summary

This pull request migrates the A3 Mega and A4x high GPU infrastructures to Ubuntu 24.04 and NVIDIA driver 580.

### Key changes

- **Base Image Upgrade:** Updated the base image for A3 Mega GPU configurations from Ubuntu 22.04 to Ubuntu 24.04.
- **NVIDIA Driver and Toolkit Updates:** Upgraded NVIDIA components to version 580 and updated the CUDA toolkit installation to version 13.0.
- **Compatibility Fixes:** Added shell scripts to handle Enroot environment requirements, patched the DMABUF import helper for kernel 6.17 compatibility, and implemented a mechanism to signal early completion of the packer process.
