### PR TITLE
adding new dns-managed-zone module.

### DIFF
--- a/modules/network/dns-managed-zone/README.md
+++ b/modules/network/dns-managed-zone/README.md
@@ -1,50 +1,40 @@
-# DNS Managed Zone Module
+## Description
 
 This module creates a Google Cloud DNS Managed Zone.
 
-## Usage
+## Example usage
 
-```hcl
-module "dns_managed_zone" {
-  source = "path/to/module"
-
-  project_id = "your-project-id"
-  zone_name  = "my-zone"
-  dns_name   = "example.com."
-  
-  description = "My DNS Zone"
-  labels = {
-    env = "dev"
-  }
-  recordsets = [
-    {
-      name    = "www"
-      type    = "A"
-      ttl     = 300
-      rrdatas = ["1.2.3.4"]
-    }
-  ]
-}
+```yaml
+- id: dns_managed_zone
+  source: modules/network/dns-managed-zone
+  settings:
+    project_id: $(vars.project_id)
+    zone_name: my-zone
+    dns_name: example.com.
+    description: "My DNS Zone"
+    labels:
+      env: "dev"
+    recordsets:
+    - name: "www"
+      type: "A"
+      ttl: 300
+      rrdatas:
+      - "1.2.3.4"
 ```
 
-## Inputs
+Copyright 2026 Google LLC
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| `project_id` | Project ID | `string` | n/a | yes |
-| `zone_name` | The name of the DNS zone | `string` | n/a | yes |
-| `dns_name` | The DNS name of this managed zone, e.g. 'example.com.' | `string` | n/a | yes |
-| `description` | Description of the zone | `string` | `"Managed by Cluster Toolkit"` | no |
-| `labels` | Labels to apply to the zone | `map(string)` | `{}` | no |
-| `recordsets` | List of recordsets to create | <pre>list(object({<br>  name    = string<br>  type    = string<br>  ttl     = number<br>  rrdatas = list(string)<br>}))</pre> | `[]` | no |
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-## Outputs
+     http://www.apache.org/licenses/LICENSE-2.0
 
-| Name | Description |
-|------|-------------|
-| `name_servers` | The name servers for the zone |
-| `zone_name` | The name of the managed DNS zone |
-| `managed_zone_id` | The fully qualified ID of the DNS Managed Zone |
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC

--- a/modules/network/dns-managed-zone/README.md
+++ b/modules/network/dns-managed-zone/README.md
@@ -1,0 +1,107 @@
+# DNS Managed Zone Module
+
+This module creates a Google Cloud DNS Managed Zone.
+
+## Usage
+
+```hcl
+module "dns_managed_zone" {
+  source = "path/to/module"
+
+  project_id = "your-project-id"
+  zone_name  = "my-zone"
+  dns_name   = "example.com."
+  
+  description = "My DNS Zone"
+  labels = {
+    env = "dev"
+  }
+  recordsets = [
+    {
+      name    = "www"
+      type    = "A"
+      ttl     = 300
+      rrdatas = ["1.2.3.4"]
+    }
+  ]
+}
+```
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| `project_id` | Project ID | `string` | n/a | yes |
+| `zone_name` | The name of the DNS zone | `string` | n/a | yes |
+| `dns_name` | The DNS name of this managed zone, e.g. 'example.com.' | `string` | n/a | yes |
+| `description` | Description of the zone | `string` | `"Managed by Cluster Toolkit"` | no |
+| `labels` | Labels to apply to the zone | `map(string)` | `{}` | no |
+| `recordsets` | List of recordsets to create | <pre>list(object({<br>  name    = string<br>  type    = string<br>  ttl     = number<br>  rrdatas = list(string)<br>}))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `name_servers` | The name servers for the zone |
+| `zone_name` | The name of the managed DNS zone |
+| `managed_zone_id` | The fully qualified ID of the DNS Managed Zone |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.73.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_dns_managed_zone.zone](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_managed_zone) | resource |
+| [google_dns_record_set.record](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
+| [google_project_service.dns_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_description"></a> [description](#input\_description) | A textual description of this managed zone | `string` | `"Managed by Cluster Toolkit"` | no |
+| <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | The DNS name of this managed zone, e.g. 'example.com.' | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this ManagedZone | `map(string)` | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |
+| <a name="input_recordsets"></a> [recordsets](#input\_recordsets) | List of DNS record sets to create in the zone | <pre>list(object({<br/>    name    = string<br/>    type    = string<br/>    ttl     = number<br/>    rrdatas = list(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the DNS zone | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_managed_zone_id"></a> [managed\_zone\_id](#output\_managed\_zone\_id) | The fully qualified ID of the DNS Managed Zone. |
+| <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | The delegated name servers for the zone. |
+| <a name="output_zone_name"></a> [zone\_name](#output\_zone\_name) | The name of the managed DNS zone. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/dns-managed-zone/README.md
+++ b/modules/network/dns-managed-zone/README.md
@@ -22,19 +22,7 @@ This module creates a Google Cloud DNS Managed Zone.
       - "1.2.3.4"
 ```
 
-Copyright 2026 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC

--- a/modules/network/dns-managed-zone/main.tf
+++ b/modules/network/dns-managed-zone/main.tf
@@ -33,7 +33,7 @@ resource "google_dns_managed_zone" "zone" {
   labels      = local.labels
 }
 resource "google_dns_record_set" "record" {
-  for_each     = { for rs in var.recordsets : "$${rs.name}-$${rs.type}" => rs }
+  for_each     = { for i, rs in var.recordsets : tostring(i) => rs }
   project      = google_project_service.dns_api.project
   managed_zone = google_dns_managed_zone.zone.name
   name         = each.value.name

--- a/modules/network/dns-managed-zone/main.tf
+++ b/modules/network/dns-managed-zone/main.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+
+resource "google_project_service" "dns_api" {
+  project            = var.project_id
+  service            = "dns.googleapis.com"
+  disable_on_destroy = false
+}
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "dns-managed-zone", ghpc_role = "network" })
+}
+resource "google_dns_managed_zone" "zone" {
+  project     = google_project_service.dns_api.project
+  name        = var.zone_name
+  dns_name    = var.dns_name
+  description = var.description
+  labels      = local.labels
+}
+resource "google_dns_record_set" "record" {
+  for_each     = { for rs in var.recordsets : "$${rs.name}-$${rs.type}" => rs }
+  project      = google_project_service.dns_api.project
+  managed_zone = google_dns_managed_zone.zone.name
+  name         = each.value.name
+  type         = each.value.type
+  ttl          = each.value.ttl
+  rrdatas      = each.value.rrdatas
+}

--- a/modules/network/dns-managed-zone/main.tf
+++ b/modules/network/dns-managed-zone/main.tf
@@ -36,7 +36,7 @@ resource "google_dns_record_set" "record" {
   for_each     = { for i, rs in var.recordsets : tostring(i) => rs }
   project      = google_project_service.dns_api.project
   managed_zone = google_dns_managed_zone.zone.name
-  name         = each.value.name
+  name         = endswith(each.value.name, ".") ? each.value.name : "${each.value.name}.${google_dns_managed_zone.zone.dns_name}"
   type         = each.value.type
   ttl          = each.value.ttl
   rrdatas      = each.value.rrdatas

--- a/modules/network/dns-managed-zone/main.tf
+++ b/modules/network/dns-managed-zone/main.tf
@@ -21,10 +21,12 @@ resource "google_project_service" "dns_api" {
   service            = "dns.googleapis.com"
   disable_on_destroy = false
 }
+
 locals {
   # This label allows for billing report tracking based on module.
   labels = merge(var.labels, { ghpc_module = "dns-managed-zone", ghpc_role = "network" })
 }
+
 resource "google_dns_managed_zone" "zone" {
   project     = google_project_service.dns_api.project
   name        = var.zone_name
@@ -32,11 +34,12 @@ resource "google_dns_managed_zone" "zone" {
   description = var.description
   labels      = local.labels
 }
+
 resource "google_dns_record_set" "record" {
-  for_each     = { for i, rs in var.recordsets : tostring(i) => rs }
+  for_each     = { for rs in var.recordsets : "${rs.name}-${rs.type}" => rs }
   project      = google_project_service.dns_api.project
   managed_zone = google_dns_managed_zone.zone.name
-  name         = endswith(each.value.name, ".") ? each.value.name : "${each.value.name}.${google_dns_managed_zone.zone.dns_name}"
+  name         = (each.value.name == "" || each.value.name == "@") ? google_dns_managed_zone.zone.dns_name : (endswith(each.value.name, ".") ? each.value.name : "${each.value.name}.${google_dns_managed_zone.zone.dns_name}")
   type         = each.value.type
   ttl          = each.value.ttl
   rrdatas      = each.value.rrdatas

--- a/modules/network/dns-managed-zone/metadata.yaml
+++ b/modules/network/dns-managed-zone/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+spec:
+  requirements:
+    services:
+    - dns.googleapis.com

--- a/modules/network/dns-managed-zone/metadata.yaml
+++ b/modules/network/dns-managed-zone/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/network/dns-managed-zone/outputs.tf
+++ b/modules/network/dns-managed-zone/outputs.tf
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+output "zone_name" {
+  description = "The name of the managed DNS zone."
+  value       = google_dns_managed_zone.zone.name
+}
+
+output "name_servers" {
+  description = "The delegated name servers for the zone."
+  value       = google_dns_managed_zone.zone.name_servers
+}
+
+output "managed_zone_id" {
+  description = "The fully qualified ID of the DNS Managed Zone."
+  value       = google_dns_managed_zone.zone.id
+}

--- a/modules/network/dns-managed-zone/variables.tf
+++ b/modules/network/dns-managed-zone/variables.tf
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+
+variable "project_id" {
+  type        = string
+  description = "Project ID"
+}
+variable "zone_name" {
+  type        = string
+  description = "The name of the DNS zone"
+}
+variable "dns_name" {
+  type        = string
+  description = "The DNS name of this managed zone, e.g. 'example.com.'"
+}
+variable "description" {
+  type        = string
+  description = "A textual description of this managed zone"
+  default     = "Managed by Cluster Toolkit"
+}
+variable "labels" {
+  type        = map(string)
+  description = "A set of key/value label pairs to assign to this ManagedZone"
+  default     = {}
+}
+variable "recordsets" {
+  type = list(object({
+    name    = string
+    type    = string
+    ttl     = number
+    rrdatas = list(string)
+  }))
+  description = "List of DNS record sets to create in the zone"
+  default     = []
+}

--- a/modules/network/dns-managed-zone/variables.tf
+++ b/modules/network/dns-managed-zone/variables.tf
@@ -19,24 +19,29 @@ variable "project_id" {
   type        = string
   description = "Project ID"
 }
+
 variable "zone_name" {
   type        = string
   description = "The name of the DNS zone"
 }
+
 variable "dns_name" {
   type        = string
   description = "The DNS name of this managed zone, e.g. 'example.com.'"
 }
+
 variable "description" {
   type        = string
   description = "A textual description of this managed zone"
   default     = "Managed by Cluster Toolkit"
 }
+
 variable "labels" {
   type        = map(string)
   description = "A set of key/value label pairs to assign to this ManagedZone"
   default     = {}
 }
+
 variable "recordsets" {
   type = list(object({
     name    = string

--- a/modules/network/dns-managed-zone/versions.tf
+++ b/modules/network/dns-managed-zone/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.73.0"
+    }
+  }
+
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
adding a new module to manage Cloud DNS zones and recordsets.

This module provisions a Cloud DNS Managed Zone and supports the bulk creation of DNS recordsets. It includes automated labeling for cost tracking consistent with Cluster Toolkit standards.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
