### PR TITLE
Adding A4X Integration Test

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -1,0 +1,77 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- slurm6
+- m.filestore
+- m.multivpc
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.service-account
+- m.startup-script
+- m.vpc
+- m.custom-image
+
+substitutions:
+  _TEST_PREFIX: "" # Default to no prefix
+
+timeout: 14400s  # 4hr
+steps:
+# While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml"
+
+- id: ml-a4x-highgpu-slurm
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace
+    if [ "${_TEST_PREFIX}" == "daily-" ]; then
+        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
+        unzip -o gcluster-bundle.zip
+        # Grant execution permissions to the binary
+        chmod +x gcluster
+    else
+        make
+    fi
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    REGION=us-west8
+    ZONE=us-west8-a
+
+    BLUEPRINT="/workspace/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml"
+
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
+
+    sed -i -e '/- id: a4x-slurm-net-0/,/- id: a4x-slurm-net-1/ s/network_name: .*/network_name: $(vars.base_network_name)/' $${BLUEPRINT}
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --user=sa_106486320838376751393 \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
+      --extra-vars="region=$${REGION} zone=$${ZONE} "\
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml"
+  secretEnv: ['GCLUSTER_GCS_PATH']
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
+    env: 'GCLUSTER_GCS_PATH'

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -16,12 +16,10 @@
 tags:
 - slurm6
 - m.filestore
-- m.multivpc
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
 - m.schedmd-slurm-gcp-v6-nodeset
 - m.schedmd-slurm-gcp-v6-partition
-- m.service-account
 - m.startup-script
 - m.vpc
 - m.custom-image

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -25,6 +25,9 @@ tags:
 - m.startup-script
 - m.vpc
 - m.custom-image
+- m.cloud-storage-bucket
+- m.gpu-rdma-vpc
+- m.pre-existing-network-storage
 
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -65,6 +65,10 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     sed -i -e '/- id: a4x-slurm-net-0/,/- id: a4x-slurm-net-1/ s/network_name: .*/network_name: $(vars.base_network_name)/' $${BLUEPRINT}
+    # Adding this as filestore APIs are not available on us-west8-a. Should be removed once reservation is moved or updated to non us-west8-a region
+    sed -i '/- id: homefs/,/- network_storage/d' $${BLUEPRINT}
+    sed -i '/- homefs/d' $${BLUEPRINT}
+    sed -i '/filestore_ip_range:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\

--- a/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+test_name: a4x-slurm
+deployment_name: a4x-{{ build }}
+slurm_cluster_name: "a4x{{ build[0:4] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml"
+login_node: "{{ slurm_cluster_name }}-slurm-login-*"
+controller_node: "{{ slurm_cluster_name }}-controller"
+network: "{{ test_name }}"
+# Skipping nccl_test_path for now as it uses ramble
+sub_network: "{{ deployment_name }}-sub-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
+- test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
+# Skipping test-nccl.yml for now
+post_destroy_tasks:
+- post-destroy-tasks/delete-image.yml
+custom_vars:
+  gpu_partition: a4x
+  gpu_count: 4
+  partitions:
+  - a4x
+  mounts:
+  - /home
+cli_deployment_vars:
+  base_network_name: '{{ test_name }}'
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  a4x_reservation_name: "nvidia-gb200-uyrez5en64cu7"
+  slurm_cluster_name: "{{ slurm_cluster_name }}"
+  a4x_cluster_size: 2


### PR DESCRIPTION
This Pull Request adds a new integration test for the A4X HighGPU Slurm blueprint within the Cluster Toolkit. It introduces the necessary Cloud Build and Ansible configurations to automate the validation of machine learning clusters using NVIDIA GB200 resources.

Note: NCCL tests are currently skipped as they require Ramble.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
