### PR TITLE
Fix: Correct Managed-Lustre path in deprecated DDN-EXAScaler README

### DIFF
--- a/community/modules/file-system/DDN-EXAScaler/README.md
+++ b/community/modules/file-system/DDN-EXAScaler/README.md
@@ -1,1 +1,1 @@
-Note: The Cluster Toolkit no longer includes support for the DDN-EXAScaler file system. Please use alternate, currently supported option such as **[Managed-Lustre](modules/file-system/managed-lustre)**
+Note: The Cluster Toolkit no longer includes support for the DDN-EXAScaler file system. Please use alternate, currently supported option such as **[Managed-Lustre](/modules/file-system/managed-lustre)**


### PR DESCRIPTION
This PR updates the relative path of Managed-Lustre module within the deprecated DDN-EXAScaler module's README.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
