### PR TITLE
Support Compute Endpoint Override for Slurm image building and cluster deployment

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -257,16 +257,19 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_accelerator_count"></a> [accelerator\_count](#input\_accelerator\_count) | Number of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `number` | `null` | no |
 | <a name="input_accelerator_type"></a> [accelerator\_type](#input\_accelerator\_type) | Type of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `string` | `null` | no |
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br/>    playbook_file   = string<br/>    galaxy_file     = string<br/>    extra_arguments = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM ("ssh" or "winrm") | `string` | `null` | no |
+| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version (e.g., staging\_v1) | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Cluster Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of persistent disk to provision | `string` | `"pd-balanced"` | no |
 | <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration (var.shielded\_instance\_config). | `bool` | `false` | no |
+| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Path to the directory containing the gcloud binary to use as an override for local execution | `string` | `""` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |
+| <a name="input_image_licenses"></a> [image\_licenses](#input\_image\_licenses) | List of licenses to apply to the image | `list(string)` | <pre>[<br/>  "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"<br/>]</pre> | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |
 | <a name="input_image_storage_locations"></a> [image\_storage\_locations](#input\_image\_storage\_locations) | Storage location, either regional or multi-regional, where snapshot content is to be stored and only accepts 1 value.<br/>See https://developer.hashicorp.com/packer/plugins/builders/googlecompute#image_storage_locations | `list(string)` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the short-lived VM | `map(string)` | `null` | no |
@@ -277,6 +280,7 @@ No resources.
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `true` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except the use of GPUs requires it to be `TERMINATE` | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which to create VM and image | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Cloud region in which to provision image building VM | `string` | `null` | no |
 | <a name="input_scopes"></a> [scopes](#input\_scopes) | DEPRECATED: use var.service\_account\_scopes | `set(string)` | `null` | no |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The service account email to use. If null or 'default', then the default Compute Engine service account will be used. | `string` | `null` | no |
 | <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Service account scopes to attach to the instance. See<br/>https://cloud.google.com/compute/docs/access/service-accounts. | `set(string)` | <pre>[<br/>  "https://www.googleapis.com/auth/cloud-platform"<br/>]</pre> | no |

--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -257,17 +257,17 @@ No resources.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_accelerator_count"></a> [accelerator\_count](#input\_accelerator\_count) | Number of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `number` | `null` | no |
 | <a name="input_accelerator_type"></a> [accelerator\_type](#input\_accelerator\_type) | Type of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `string` | `null` | no |
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br/>    playbook_file   = string<br/>    galaxy_file     = string<br/>    extra_arguments = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM ("ssh" or "winrm") | `string` | `null` | no |
-| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version (e.g., staging\_v1) | `string` | `null` | no |
+| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Cluster Toolkit deployment name | `string` | n/a | yes |
 | <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | Size of disk image in GB | `number` | `null` | no |
 | <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Type of persistent disk to provision | `string` | `"pd-balanced"` | no |
 | <a name="input_enable_shielded_vm"></a> [enable\_shielded\_vm](#input\_enable\_shielded\_vm) | Enable the Shielded VM configuration (var.shielded\_instance\_config). | `bool` | `false` | no |
-| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Path to the directory containing the gcloud binary to use as an override for local execution | `string` | `""` | no |
+| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Path to the directory containing the gcloud binary to use as an override for local execution. | `string` | `""` | no |
 | <a name="input_image_family"></a> [image\_family](#input\_image\_family) | The family name of the image to be built. Defaults to `deployment_name` | `string` | `null` | no |
 | <a name="input_image_licenses"></a> [image\_licenses](#input\_image\_licenses) | List of licenses to apply to the image | `list(string)` | <pre>[<br/>  "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"<br/>]</pre> | no |
 | <a name="input_image_name"></a> [image\_name](#input\_image\_name) | The name of the image to be built. If not supplied, it will be set to image\_family-$ISO\_TIMESTAMP | `string` | `null` | no |

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -91,7 +91,8 @@ locals {
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
-
+  override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
+  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {
@@ -208,8 +209,11 @@ build {
     ]
     inline_shebang = "/bin/bash -e"
     inline = [
-      "if [[ -n \"${var.gcloud_path_override}\" ]]; then",
-      "  export PATH=\"${var.gcloud_path_override}:\\$PATH\"",
+      "if [[ -n \"${local.override_gcloud_path}\" ]]; then",
+      "  export PATH=\"${local.override_gcloud_path}:\\$PATH\"",
+      "fi",
+      "if [[ -n \"${local.compute_version}\" ]]; then",
+      "  export CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=\"https://www.googleapis.com/compute/${local.compute_version}/\"",
       "fi",
       "type -P gcloud > /dev/null || exit 0",
       "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -24,6 +24,9 @@ locals {
   # construct vm image name for use when getting logs
   instance_name = "packer-${substr(uuidv4(), 0, 6)}"
 
+  # construct custom compute endpoint URL if version is provided
+  compute_endpoint_url = var.compute_endpoint_version != null ? "https://www.googleapis.com/compute/${var.compute_endpoint_version}/" : null
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -88,9 +91,7 @@ locals {
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+
 }
 
 source "googlecompute" "toolkit_image" {
@@ -102,6 +103,7 @@ source "googlecompute" "toolkit_image" {
   instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
+  region                      = var.region
   accelerator_count           = var.accelerator_count
   on_host_maintenance         = local.on_host_maintenance
   disk_size                   = var.disk_size
@@ -132,7 +134,11 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses              = local.image_licenses
+  image_licenses              = var.image_licenses
+
+  custom_endpoints = local.compute_endpoint_url != null ? {
+    "compute" = local.compute_endpoint_url
+  } : {}
 }
 
 build {
@@ -202,6 +208,9 @@ build {
     ]
     inline_shebang = "/bin/bash -e"
     inline = [
+      "if [[ -n \"${var.gcloud_path_override}\" ]]; then",
+      "  export PATH=\"${var.gcloud_path_override}:\\$PATH\"",
+      "fi",
       "type -P gcloud > /dev/null || exit 0",
       "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
       "echo 'Error building image try checking logs:'",

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -92,7 +92,7 @@ locals {
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
   override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
-  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
+  compute_version      = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -45,6 +45,12 @@ variable "zone" {
   type        = string
 }
 
+variable "region" {
+  description = "Cloud region in which to provision image building VM"
+  type        = string
+  default     = null
+}
+
 variable "network_project_id" {
   description = "Project ID of Shared VPC network"
   type        = string
@@ -273,4 +279,22 @@ variable "shielded_instance_config" {
     enable_vtpm                 = true
     enable_integrity_monitoring = true
   }
+}
+
+variable "compute_endpoint_version" {
+  description = "Custom Google Compute API endpoint version (e.g., staging_v1)"
+  type        = string
+  default     = null
+}
+
+variable "gcloud_path_override" {
+  description = "Path to the directory containing the gcloud binary to use as an override for local execution"
+  type        = string
+  default     = ""
+}
+
+variable "image_licenses" {
+  description = "List of licenses to apply to the image"
+  type        = list(string)
+  default     = ["projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"]
 }

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -282,13 +282,13 @@ variable "shielded_instance_config" {
 }
 
 variable "compute_endpoint_version" {
-  description = "Custom Google Compute API endpoint version (e.g., staging_v1)"
+  description = "Custom Google Compute API endpoint version."
   type        = string
   default     = null
 }
 
 variable "gcloud_path_override" {
-  description = "Path to the directory containing the gcloud binary to use as an override for local execution"
+  description = "Path to the directory containing the gcloud binary to use as an override for local execution."
   type        = string
   default     = ""
 }

--- a/modules/packer/custom-image/versions.pkr.hcl
+++ b/modules/packer/custom-image/versions.pkr.hcl
@@ -18,7 +18,7 @@ packer {
   # packer plugin 1.0.16 and above includes HPC VM Image
   required_plugins {
     googlecompute = {
-      version = "~> 1.1.0"
+      version = "~> 1.2.5"
       source  = "github.com/hashicorp/googlecompute"
     }
   }

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -288,7 +288,7 @@ limitations under the License.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
@@ -297,7 +297,7 @@ limitations under the License.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
@@ -309,7 +309,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_storage_bucket.configs_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_object.scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
@@ -319,15 +319,17 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
 | <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Additional service accounts or groups, users, and domains to which to grant read-only access to startup-script bucket (leave unset if using default Compute Engine service account) | `list(string)` | `[]` | no |
+| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version (e.g., staging\_v1) | `string` | `null` | no |
 | <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br/>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br/>  Ex: "hpc*", "hpc01*", "ml*"<br/>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br/>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
 | <a name="input_docker"></a> [docker](#input\_docker) | Install and configure Docker | <pre>object({<br/>    enabled        = optional(bool, false)<br/>    world_writable = optional(bool, false)<br/>    daemon_config  = optional(string, "")<br/>  })</pre> | <pre>{<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_enable_docker_world_writable"></a> [enable\_docker\_world\_writable](#input\_enable\_docker\_world\_writable) | DEPRECATED: use var.docker | `bool` | `null` | no |
 | <a name="input_enable_gpu_network_wait_online"></a> [enable\_gpu\_network\_wait\_online](#input\_enable\_gpu\_network\_wait\_online) | Enable a SystemD unit that blocks execution of startup-scripts until after all network interfaces are online. (Works on reboots or boots of an image built using this solution) | `bool` | `false` | no |
+| <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Path to the directory containing the gcloud binary to use as an override for local execution. | `string` | `""` | no |
 | <a name="input_gcs_bucket_path"></a> [gcs\_bucket\_path](#input\_gcs\_bucket\_path) | The GCS path for storage bucket and the object, starting with `gs://`. | `string` | `null` | no |
 | <a name="input_http_no_proxy"></a> [http\_no\_proxy](#input\_http\_no\_proxy) | Domains for which to disable http\_proxy behavior. Honored only if var.http\_proxy is set | `string` | `".google.com,.googleapis.com,metadata.google.internal,localhost,127.0.0.1"` | no |
 | <a name="input_http_proxy"></a> [http\_proxy](#input\_http\_proxy) | Web (http and https) proxy configuration for pip, apt, and yum/dnf and interactive shells | `string` | `""` | no |
@@ -348,7 +350,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_compute_startup_script"></a> [compute\_startup\_script](#output\_compute\_startup\_script) | script to load and run all runners, as a string value. Targets the inputs for the slurm controller. |
 | <a name="output_controller_startup_script"></a> [controller\_startup\_script](#output\_controller\_startup\_script) | script to load and run all runners, as a string value. Targets the inputs for the slurm controller. |
 | <a name="output_startup_script"></a> [startup\_script](#output\_startup\_script) | script to load and run all runners, as a string value. |

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -288,7 +288,7 @@ limitations under the License.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
@@ -297,7 +297,7 @@ limitations under the License.
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.41 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
@@ -309,7 +309,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_storage_bucket.configs_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_binding.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_binding) | resource |
 | [google_storage_bucket_object.scripts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
@@ -319,10 +319,10 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_ansible_virtualenv_path"></a> [ansible\_virtualenv\_path](#input\_ansible\_virtualenv\_path) | Virtual environment path in which to install Ansible | `string` | `"/usr/local/ghpc-venv"` | no |
 | <a name="input_bucket_viewers"></a> [bucket\_viewers](#input\_bucket\_viewers) | Additional service accounts or groups, users, and domains to which to grant read-only access to startup-script bucket (leave unset if using default Compute Engine service account) | `list(string)` | `[]` | no |
-| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version (e.g., staging\_v1) | `string` | `null` | no |
+| <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version. | `string` | `null` | no |
 | <a name="input_configure_ssh_host_patterns"></a> [configure\_ssh\_host\_patterns](#input\_configure\_ssh\_host\_patterns) | If specified, it will automate ssh configuration by:<br/>  - Defining a Host block for every element of this variable and setting StrictHostKeyChecking to 'No'.<br/>  Ex: "hpc*", "hpc01*", "ml*"<br/>  - The first time users log-in, it will create ssh keys that are added to the authorized keys list<br/>  This requires a shared /home filesystem and relies on specifying the right prefix. | `list(string)` | `[]` | no |
 | <a name="input_debug_file"></a> [debug\_file](#input\_debug\_file) | Path to an optional local to be written with 'startup\_script'. | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the HPC deployment, used to name GCS bucket for startup scripts. | `string` | n/a | yes |
@@ -350,7 +350,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_compute_startup_script"></a> [compute\_startup\_script](#output\_compute\_startup\_script) | script to load and run all runners, as a string value. Targets the inputs for the slurm controller. |
 | <a name="output_controller_startup_script"></a> [controller\_startup\_script](#output\_controller\_startup\_script) | script to load and run all runners, as a string value. Targets the inputs for the slurm controller. |
 | <a name="output_startup_script"></a> [startup\_script](#output\_startup\_script) | script to load and run all runners, as a string value. |

--- a/modules/scripts/startup-script/main.tf
+++ b/modules/scripts/startup-script/main.tf
@@ -47,6 +47,9 @@ locals {
   prefix_file                  = "/tmp/prefix_file.json"
   ansible_docker_settings_file = "/tmp/ansible_docker_settings.json"
 
+  # construct custom compute endpoint URL if compute version is provided
+  compute_endpoint_url = var.compute_endpoint_version != null ? "https://www.googleapis.com/compute/${var.compute_endpoint_version}/" : null
+
   docker_config    = try(jsondecode(var.docker.daemon_config), {})
   docker_data_root = try(local.docker_config.data-root, null)
 
@@ -221,9 +224,11 @@ locals {
   load_runners = templatefile(
     "${path.module}/templates/startup-script-custom.tftpl",
     {
-      bucket     = local.storage_bucket_name,
-      http_proxy = var.http_proxy,
-      no_proxy   = var.http_no_proxy,
+      bucket                      = local.storage_bucket_name,
+      http_proxy                  = var.http_proxy,
+      no_proxy                    = var.http_no_proxy,
+      custom_compute_endpoint_url = local.compute_endpoint_url == null ? "" : local.compute_endpoint_url,
+      gcloud_path_override        = var.gcloud_path_override == null ? "" : var.gcloud_path_override,
       runners = [
         for runner in local.runners : {
           object      = google_storage_bucket_object.scripts[basename(runner["destination"])].output_name

--- a/modules/scripts/startup-script/templates/startup-script-custom.tftpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tftpl
@@ -56,6 +56,25 @@ stdlib::load_runners(){
   export NO_PROXY=${no_proxy}
   %{endif ~}
 
+  %{if custom_compute_endpoint_url != "" && gcloud_path_override != "" ~}
+  stdlib::info "=== Creating gcloud wrapper with custom path and compute endpoint ==="
+  
+  cat <<EOF > /usr/local/bin/gcloud
+#!/bin/bash
+
+export CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE="${custom_compute_endpoint_url}"
+
+if [[ -x "${gcloud_path_override}/gcloud" ]]; then
+    exec "${gcloud_path_override}/gcloud" "\$@"
+else
+    exec "/usr/bin/gcloud" "\$@"
+fi
+EOF
+  chmod +x /usr/local/bin/gcloud
+  export PATH="/usr/local/bin:$PATH"
+  %{endif ~}
+
+
   %{for r in runners ~}
   stdlib::runner "${r.type}" "${r.object}" "${r.destination}" $${tmpdir} "${r.args}"
   %{endfor ~}

--- a/modules/scripts/startup-script/templates/startup-script-custom.tftpl
+++ b/modules/scripts/startup-script/templates/startup-script-custom.tftpl
@@ -56,7 +56,7 @@ stdlib::load_runners(){
   export NO_PROXY=${no_proxy}
   %{endif ~}
 
-  %{if custom_compute_endpoint_url != "" && gcloud_path_override != "" ~}
+  %{if custom_compute_endpoint_url != "" || gcloud_path_override != "" ~}
   stdlib::info "=== Creating gcloud wrapper with custom path and compute endpoint ==="
   
   cat <<EOF > /usr/local/bin/gcloud

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -296,3 +296,15 @@ variable "enable_gpu_network_wait_online" {
   type        = bool
   default     = false
 }
+
+variable "compute_endpoint_version" {
+  description = "Custom Google Compute API endpoint version (e.g., staging_v1)"
+  type        = string
+  default     = null
+}
+
+variable "gcloud_path_override" {
+  description = "Path to the directory containing the gcloud binary to use as an override for local execution."
+  type        = string
+  default     = ""
+}

--- a/modules/scripts/startup-script/variables.tf
+++ b/modules/scripts/startup-script/variables.tf
@@ -298,7 +298,7 @@ variable "enable_gpu_network_wait_online" {
 }
 
 variable "compute_endpoint_version" {
-  description = "Custom Google Compute API endpoint version (e.g., staging_v1)"
+  description = "Custom Google Compute API endpoint version."
   type        = string
   default     = null
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -131,6 +131,7 @@ deployment_groups:
           deployment_name: ((var.deployment_name))
           labels: ((var.labels))
           project_id: ((var.project_id))
+          region: ((var.region))
           startup_script: ((module.script.startup_script))
           subnetwork_name: ((module.network0.subnetwork_name))
           windows_startup_ps1: ((flatten([module.windows_startup.windows_startup_ps1])))

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/defaults.auto.pkrvars.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/defaults.auto.pkrvars.hcl
@@ -23,4 +23,6 @@ labels = {
 
 project_id = "invalid-project"
 
+region = "us-east4"
+
 zone = "us-east4-c"

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -92,7 +92,7 @@ locals {
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
   override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
-  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
+  compute_version      = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -24,6 +24,9 @@ locals {
   # construct vm image name for use when getting logs
   instance_name = "packer-${substr(uuidv4(), 0, 6)}"
 
+  # construct custom compute endpoint URL if version is provided
+  compute_endpoint_url = var.compute_endpoint_version != null ? "https://www.googleapis.com/compute/${var.compute_endpoint_version}/" : null
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -88,9 +91,8 @@ locals {
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+  override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
+  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {
@@ -102,6 +104,7 @@ source "googlecompute" "toolkit_image" {
   instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
+  region                      = var.region
   accelerator_count           = var.accelerator_count
   on_host_maintenance         = local.on_host_maintenance
   disk_size                   = var.disk_size
@@ -132,7 +135,11 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses              = local.image_licenses
+  image_licenses              = var.image_licenses
+
+  custom_endpoints = local.compute_endpoint_url != null ? {
+    "compute" = local.compute_endpoint_url
+  } : {}
 }
 
 build {
@@ -202,6 +209,12 @@ build {
     ]
     inline_shebang = "/bin/bash -e"
     inline = [
+      "if [[ -n \"${local.override_gcloud_path}\" ]]; then",
+      "  export PATH=\"${local.override_gcloud_path}:\\$PATH\"",
+      "fi",
+      "if [[ -n \"${local.compute_version}\" ]]; then",
+      "  export CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=\"https://www.googleapis.com/compute/${local.compute_version}/\"",
+      "fi",
       "type -P gcloud > /dev/null || exit 0",
       "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
       "echo 'Error building image try checking logs:'",

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
@@ -45,6 +45,12 @@ variable "zone" {
   type        = string
 }
 
+variable "region" {
+  description = "Cloud region in which to provision image building VM"
+  type        = string
+  default     = null
+}
+
 variable "network_project_id" {
   description = "Project ID of Shared VPC network"
   type        = string
@@ -273,4 +279,22 @@ variable "shielded_instance_config" {
     enable_vtpm                 = true
     enable_integrity_monitoring = true
   }
+}
+
+variable "compute_endpoint_version" {
+  description = "Custom Google Compute API endpoint version."
+  type        = string
+  default     = null
+}
+
+variable "gcloud_path_override" {
+  description = "Path to the directory containing the gcloud binary to use as an override for local execution."
+  type        = string
+  default     = ""
+}
+
+variable "image_licenses" {
+  description = "List of licenses to apply to the image"
+  type        = list(string)
+  default     = ["projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"]
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/versions.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/versions.pkr.hcl
@@ -18,7 +18,7 @@ packer {
   # packer plugin 1.0.16 and above includes HPC VM Image
   required_plugins {
     googlecompute = {
-      version = "~> 1.1.0"
+      version = "~> 1.2.5"
       source  = "github.com/hashicorp/googlecompute"
     }
   }

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -92,7 +92,7 @@ locals {
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
   override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
-  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
+  compute_version      = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -24,6 +24,9 @@ locals {
   # construct vm image name for use when getting logs
   instance_name = "packer-${substr(uuidv4(), 0, 6)}"
 
+  # construct custom compute endpoint URL if version is provided
+  compute_endpoint_url = var.compute_endpoint_version != null ? "https://www.googleapis.com/compute/${var.compute_endpoint_version}/" : null
+
   # default to explicit var.communicator, otherwise in-order: ssh/winrm/none
   shell_script_communicator      = length(var.shell_scripts) > 0 ? "ssh" : ""
   ansible_playbook_communicator  = length(var.ansible_playbooks) > 0 ? "ssh" : ""
@@ -88,9 +91,8 @@ locals {
   enable_secure_boot          = var.enable_shielded_vm && var.shielded_instance_config.enable_secure_boot
   enable_vtpm                 = var.enable_shielded_vm && var.shielded_instance_config.enable_vtpm
 
-  image_licenses = [
-    "projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"
-  ]
+  override_gcloud_path = var.gcloud_path_override == null ? "" : var.gcloud_path_override
+  compute_version = var.compute_endpoint_version == null ? "" : var.compute_endpoint_version
 }
 
 source "googlecompute" "toolkit_image" {
@@ -102,6 +104,7 @@ source "googlecompute" "toolkit_image" {
   instance_name               = local.instance_name
   machine_type                = var.machine_type
   accelerator_type            = local.accelerator_type
+  region                      = var.region
   accelerator_count           = var.accelerator_count
   on_host_maintenance         = local.on_host_maintenance
   disk_size                   = var.disk_size
@@ -132,7 +135,11 @@ source "googlecompute" "toolkit_image" {
   enable_secure_boot          = local.enable_secure_boot
   enable_vtpm                 = local.enable_vtpm
   enable_integrity_monitoring = local.enable_integrity_monitoring
-  image_licenses              = local.image_licenses
+  image_licenses              = var.image_licenses
+
+  custom_endpoints = local.compute_endpoint_url != null ? {
+    "compute" = local.compute_endpoint_url
+  } : {}
 }
 
 build {
@@ -202,6 +209,12 @@ build {
     ]
     inline_shebang = "/bin/bash -e"
     inline = [
+      "if [[ -n \"${local.override_gcloud_path}\" ]]; then",
+      "  export PATH=\"${local.override_gcloud_path}:\\$PATH\"",
+      "fi",
+      "if [[ -n \"${local.compute_version}\" ]]; then",
+      "  export CLOUDSDK_API_ENDPOINT_OVERRIDES_COMPUTE=\"https://www.googleapis.com/compute/${local.compute_version}/\"",
+      "fi",
       "type -P gcloud > /dev/null || exit 0",
       "INST_ID=$(gcloud compute instances describe $INST_NAME --project $PRJ_ID --format=\"value(id)\" --zone=$ZONE)",
       "echo 'Error building image try checking logs:'",

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
@@ -45,6 +45,12 @@ variable "zone" {
   type        = string
 }
 
+variable "region" {
+  description = "Cloud region in which to provision image building VM"
+  type        = string
+  default     = null
+}
+
 variable "network_project_id" {
   description = "Project ID of Shared VPC network"
   type        = string
@@ -273,4 +279,22 @@ variable "shielded_instance_config" {
     enable_vtpm                 = true
     enable_integrity_monitoring = true
   }
+}
+
+variable "compute_endpoint_version" {
+  description = "Custom Google Compute API endpoint version."
+  type        = string
+  default     = null
+}
+
+variable "gcloud_path_override" {
+  description = "Path to the directory containing the gcloud binary to use as an override for local execution."
+  type        = string
+  default     = ""
+}
+
+variable "image_licenses" {
+  description = "List of licenses to apply to the image"
+  type        = list(string)
+  default     = ["projects/click-to-deploy-images/global/licenses/hpc-toolkit-vm-image"]
 }

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/versions.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/versions.pkr.hcl
@@ -18,7 +18,7 @@ packer {
   # packer plugin 1.0.16 and above includes HPC VM Image
   required_plugins {
     googlecompute = {
-      version = "~> 1.1.0"
+      version = "~> 1.2.5"
       source  = "github.com/hashicorp/googlecompute"
     }
   }


### PR DESCRIPTION
### Summary
This PR enables Cluster Toolkit to provide custom compute endpoint overrides for Slurm image building and cluster deployment. 

**Packer Upgrade:** I upgraded the googlecompute Packer plugin to ~> 1.2.5, as older versions don't support the custom_endpoints variable.
**Gcloud override & Compute endpoint Variables:** I added gcloud_path_override and compute_endpoint_version as input variables to both the Packer and startup-script modules. This lets us pass these values directly from the blueprint.
**Startup Script Wrapper:** I added a gcloud wrapper in the startup script to set the custom compute endpoint. This ensures that when ansible-pull runs the slurm-gcp playbook to install Slurm, all underlying gcloud commands correctly use the provided override.
**Customizable Licenses:** I changed image_licenses field into a variable, to allow it to be overridden as the default production license URL may not be available.
**Explicit Region:** Introduced an explicit `region` variable for the `googlecompute` builder. Without this change, the logic truncated the zone name to infer the region name, which failed for zones that did not follow the `region-[a-z]` naming convention.

### Testing
I verified these changes by building and deploying a4high, a4x, and g4 clusters. I also verified Rocky Linux 8 image building and cluster creation using the hpc-build-slurm-image.yaml blueprint.