### PR TITLE
Update GKE version prefix for gke blueprints to enable support features

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -33,7 +33,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-h200-141gb
-  version_prefix: "1.33."
+  version_prefix: "1.34."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -33,7 +33,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-h200-141gb
-  version_prefix: "1.34."
+  version_prefix: "1.35."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -48,7 +48,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a4_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-b200
-  version_prefix: "1.34."
+  version_prefix: "1.35."
 
   auto_monitoring_scope: "NONE"
 

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -48,7 +48,7 @@ vars:
   system_node_pool_disk_size_gb: 200
   a4_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-b200
-  version_prefix: "1.33."
+  version_prefix: "1.34."
 
   auto_monitoring_scope: "NONE"
 

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -56,7 +56,7 @@ vars:
   nvidia_dra_driver_path: $(ghpc_stage("./nvidia-dra-driver.yaml"))
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   accelerator_type: nvidia-gb200
-  version_prefix: "1.34."
+  version_prefix: "1.35."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -56,7 +56,7 @@ vars:
   nvidia_dra_driver_path: $(ghpc_stage("./nvidia-dra-driver.yaml"))
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   accelerator_type: nvidia-gb200
-  version_prefix: "1.33."
+  version_prefix: "1.34."
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -39,7 +39,7 @@ Before you start, make sure you have performed the following tasks:
    - `roles/iam.serviceAccountAdmin`
 5. **Note the GKE Version Requirement**: Be aware that Cloud TPU 7x requires a specific minimum GKE version to function correctly.
    - **Minimum Version**: `1.34.3-gke.1318000` or later.
-   - **Blueprint Configuration**: The provided `gke-tpu-7x.yaml` blueprint is already configured to use a compatible version from the `RAPID` release channel. If you customize the blueprint, ensure you do not select a version older than this minimum requirement.
+   - **Blueprint Configuration**: The provided `gke-tpu-7x.yaml` blueprint is already configured to use a compatible version from the `REGULAR` release channel. If you customize the blueprint, ensure you do not select a version older than this minimum requirement.
 
 ## Create a cluster using Cluster Toolkit
 

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -190,7 +190,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34.1"
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -119,7 +119,7 @@ deployment_groups:
         display_name: "kubectl-access-network"
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34."
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -51,7 +51,7 @@ vars:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
-  version_prefix: "1.34."
+  version_prefix: "1.35."
 
   # Kueue configuration
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -51,7 +51,7 @@ vars:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
-  version_prefix: "1.33."
+  version_prefix: "1.34."
 
   # Kueue configuration
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -156,7 +156,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.34."
+      version_prefix: "1.35."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -156,7 +156,7 @@ deployment_groups:
         ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
-      version_prefix: "1.32."
+      version_prefix: "1.34."
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite


### PR DESCRIPTION
This PR updates the GKE version prefix  for TPU7x to 1.35. to enable latest features of Dynamic Super Slicing. 
It also updated the GKE version prefix for A3/A4/A4x and TPU (v6e) to enable latest features of DRANET.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
