### PR TITLE
Update the kueue version to latest v0.17.1

### DIFF
--- a/community/examples/xpk-n2-filestore/kueue-xpk-configuration.yaml.tftpl
+++ b/community/examples/xpk-n2-filestore/kueue-xpk-configuration.yaml.tftpl
@@ -1,10 +1,10 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "1x${machine_type}-${vms_per_slice}"
 spec: {}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -18,7 +18,7 @@ spec:
       - name: "cpu"
         nominalQuota: ${cpu_count}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: multislice-queue

--- a/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
+++ b/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
@@ -31,7 +31,7 @@ vars:
   slice_vm_count: 2
   slice_cpu_count: 64
   xpk_version: v0.8.0
-  kueue_version: v0.11.1
+  kueue_version: v0.17.1
   jobset_version: 0.10.1
   kjob_version: f775609365df47bdc3e7c10290d8efae7f512464
 

--- a/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
@@ -159,7 +159,7 @@ deployment_groups:
       kueue:
         install: true
         wait: true
-        version: "0.14.4"
+        version: "0.17.1"
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a3_highgpu_pool.static_gpu_count)

--- a/examples/gke-a3-highgpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-highgpu/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a3-high"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a3-high"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: Topology
 metadata:
   name: "gke-default"

--- a/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-megagpu/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a3-mega"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a3-mega"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: Topology
 metadata:
   name: "gke-default"

--- a/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a3-ultragpu/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a3-ultra"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a3-ultra"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
@@ -19,7 +19,7 @@ metadata:
   name: ramble
   namespace: ramble
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "ramble"

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
@@ -19,7 +19,7 @@ metadata:
   name: ramble
   namespace: ramble
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "ramble"

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
@@ -19,7 +19,7 @@ metadata:
   name: ramble
   namespace: ramble
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "ramble"

--- a/examples/gke-a4/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a4/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a4"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a4"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-a4/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a4/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: Topology
 metadata:
   name: "gke-default"

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -278,7 +278,7 @@ deployment_groups:
       target_architecture: "arm64"
       kueue:
         install: true
-        version: "0.14.4"
+        version: "0.17.1"
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a4x-max-pool.static_gpu_count)

--- a/examples/gke-a4x-max-bm/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a4x-max-bm/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "a4x-max-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a4x-max"
 spec:
@@ -39,7 +39,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a4x-max"
@@ -53,7 +53,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -188,10 +188,10 @@ deployment_groups:
       enable_gcsfuse_csi: true
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       enable_k8s_beta_apis:
-      - "resource.k8s.io/v1beta1/deviceclasses"
-      - "resource.k8s.io/v1beta1/resourceclaims"
-      - "resource.k8s.io/v1beta1/resourceclaimtemplates"
-      - "resource.k8s.io/v1beta1/resourceslices"
+      - "resource.k8s.io/v1beta2/deviceclasses"
+      - "resource.k8s.io/v1beta2/resourceclaims"
+      - "resource.k8s.io/v1beta2/resourceclaimtemplates"
+      - "resource.k8s.io/v1beta2/resourceslices"
       enable_private_endpoint: false  # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       k8s_service_account_name: $(vars.k8s_service_account_name)

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -317,7 +317,7 @@ deployment_groups:
       target_architecture: "arm64"
       kueue:
         install: true
-        version: "0.14.4"
+        version: "0.17.1"
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           num_gpus: $(a4x-pool.static_gpu_count)

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -188,10 +188,10 @@ deployment_groups:
       enable_gcsfuse_csi: true
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       enable_k8s_beta_apis:
-      - "resource.k8s.io/v1beta2/deviceclasses"
-      - "resource.k8s.io/v1beta2/resourceclaims"
-      - "resource.k8s.io/v1beta2/resourceclaimtemplates"
-      - "resource.k8s.io/v1beta2/resourceslices"
+      - "resource.k8s.io/v1beta1/deviceclasses"
+      - "resource.k8s.io/v1beta1/resourceclaims"
+      - "resource.k8s.io/v1beta1/resourceclaimtemplates"
+      - "resource.k8s.io/v1beta1/resourceslices"
       enable_private_endpoint: false  # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       k8s_service_account_name: $(vars.k8s_service_account_name)

--- a/examples/gke-a4x/kueue-configuration.yaml.tftpl
+++ b/examples/gke-a4x/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "a4x-default"
@@ -25,7 +25,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "a4x"
 spec:
@@ -40,7 +40,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "a4x"
@@ -54,7 +54,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_gpus}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/dws-queues.yaml.tftpl
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/dws-queues.yaml.tftpl
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "default-flavor"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: AdmissionCheck
 metadata:
   name: dws-prov
@@ -28,7 +28,7 @@ spec:
     kind: ProvisioningRequestConfig
     name: dws-config
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ProvisioningRequestConfig
 metadata:
   name: dws-config
@@ -37,7 +37,7 @@ spec:
   managedResources:
   - nvidia.com/gpu
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "dws-cluster-queue"
@@ -53,7 +53,7 @@ spec:
   admissionChecks:
   - dws-prov
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/tpu-dws-queues.yaml.tftpl
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/tpu-dws-queues.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpu-flavor"
@@ -24,7 +24,7 @@ spec:
     key: google.com/tpu
     value: "present"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: AdmissionCheck
 metadata:
   name: dws-prov
@@ -35,7 +35,7 @@ spec:
     kind: ProvisioningRequestConfig
     name: dws-config
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ProvisioningRequestConfig
 metadata:
   name: dws-config
@@ -46,7 +46,7 @@ spec:
   parameters:
     tpu-topology: "${tpu_topology}"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "dws-cluster-queue"
@@ -62,7 +62,7 @@ spec:
   admissionChecks:
   - dws-prov
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/kueue-configuration.yaml.tftpl
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpu7x-flavor"
@@ -24,7 +24,7 @@ spec:
     key: google.com/tpu
     value: "present"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -38,7 +38,7 @@ spec:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/kueue-configuration.yaml.tftpl
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpuv6e-flavor"
@@ -24,7 +24,7 @@ spec:
     key: google.com/tpu
     value: "present"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -38,7 +38,7 @@ spec:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-tpu-7x/kueue-configuration.yaml.tftpl
+++ b/examples/gke-tpu-7x/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpu7x-flavor"
@@ -24,7 +24,7 @@ spec:
     key: google.com/tpu
     value: "present"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -38,7 +38,7 @@ spec:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/examples/gke-tpu-v6e/kueue-configuration.yaml.tftpl
+++ b/examples/gke-tpu-v6e/kueue-configuration.yaml.tftpl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpuv6e-flavor"
@@ -24,7 +24,7 @@ spec:
     key: google.com/tpu
     value: "present"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "cluster-queue"
@@ -38,7 +38,7 @@ spec:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -84,7 +84,7 @@ You can specify a particular kueue version that you would like to use using the 
     settings:
       kueue:
         install: true
-        version: v0.17.1
+        version: 0.17.1
         config_path: $(ghpc_stage("manifests/user-provided-kueue-config.yaml.tftpl"))
         config_template_vars: {name: "dev-config", public: "false"}
       jobset:

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -75,7 +75,7 @@ The `config_path` field in `kueue` installation accepts a template file, too. Yo
         install: true
 ```
 
-You can specify a particular kueue version that you would like to use using the `version` flag. By default, we recommend customers to [use v0.17.1](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L68). You can find the list of supported kueue versions [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L18).
+You can specify a particular kueue version that you would like to use using the `version` flag. By default, we recommend customers to [use v0.17.1](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L126). You can find the list of supported kueue versions [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L24).
 
 ```yaml
   - id: workload_component_install

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -153,7 +153,7 @@ The module applies manifests from the `apply_manifests` list in parallel. This c
 
 There is **no guarantee** that the CRD will be applied before the resource that uses it. This can lead to non-deterministic deployment failures with errors like:
 
-```Error: resource [kueue.x-k8s.io/v1beta1/ClusterQueue] isn't valid for cluster```
+```Error: resource [kueue.x-k8s.io/v1beta2/ClusterQueue] isn't valid for cluster```
 
 ##### **Recommended Workaround: Two-Stage Apply**
 

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -75,7 +75,7 @@ The `config_path` field in `kueue` installation accepts a template file, too. Yo
         install: true
 ```
 
-You can specify a particular kueue version that you would like to use using the `version` flag. By default, we recommend customers to [use v0.10.0](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L68). You can find the list of supported kueue versions [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L18).
+You can specify a particular kueue version that you would like to use using the `version` flag. By default, we recommend customers to [use v0.17.1](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L68). You can find the list of supported kueue versions [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L18).
 
 ```yaml
   - id: workload_component_install
@@ -84,7 +84,7 @@ You can specify a particular kueue version that you would like to use using the 
     settings:
       kueue:
         install: true
-        version: v0.10.0
+        version: v0.17.1
         config_path: $(ghpc_stage("manifests/user-provided-kueue-config.yaml.tftpl"))
         config_template_vars: {name: "dev-config", public: "false"}
       jobset:
@@ -264,7 +264,7 @@ limitations under the License.
 | <a name="input_gke_cluster_exists"></a> [gke\_cluster\_exists](#input\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster has been created. | `bool` | `false` | no |
 | <a name="input_gpu_operator"></a> [gpu\_operator](#input\_gpu\_operator) | Install [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) which uses the [Kubernetes operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to automate the management of all NVIDIA software components needed to provision GPU. | <pre>object({<br/>    install = optional(bool, false)<br/>    version = optional(string, "v25.3.0")<br/>  })</pre> | `{}` | no |
 | <a name="input_jobset"></a> [jobset](#input\_jobset) | Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit. | <pre>object({<br/>    install = optional(bool, false)<br/>    version = optional(string, "0.10.1")<br/>  })</pre> | `{}` | no |
-| <a name="input_kueue"></a> [kueue](#input\_kueue) | Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. A configuration yaml/template file can be provided with config\_path to be applied right after kueue installation. If a template file provided, its variables can be set to config\_template\_vars. | <pre>object({<br/>    install                  = optional(bool, false)<br/>    version                  = optional(string, "0.13.3")<br/>    config_path              = optional(string, null)<br/>    config_template_vars     = optional(map(any), null)<br/>    enable_pathways_for_tpus = optional(bool, false)<br/>  })</pre> | `{}` | no |
+| <a name="input_kueue"></a> [kueue](#input\_kueue) | Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. A configuration yaml/template file can be provided with config\_path to be applied right after kueue installation. If a template file provided, its variables can be set to config\_template\_vars. | <pre>object({<br/>    install                  = optional(bool, false)<br/>    version                  = optional(string, "0.17.1")<br/>    config_path              = optional(string, null)<br/>    config_template_vars     = optional(map(any), null)<br/>    enable_pathways_for_tpus = optional(bool, false)<br/>  })</pre> | `{}` | no |
 | <a name="input_module_id"></a> [module\_id](#input\_module\_id) | The ID of the module as defined in the blueprint. Injected by ghpc. | `string` | `"kubectl-apply"` | no |
 | <a name="input_nvidia_dra_driver"></a> [nvidia\_dra\_driver](#input\_nvidia\_dra\_driver) | Installs [Nvidia DRA driver](https://github.com/NVIDIA/k8s-dra-driver-gpu) which supports Dynamic Resource Allocation for NVIDIA GPUs in Kubernetes | <pre>object({<br/>    install          = optional(bool, false)<br/>    version          = optional(string, "v25.3.0")<br/>    accelerator_type = optional(string, "nvidia-gb200")<br/>  })</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID that hosts the gke cluster. | `string` | n/a | yes |

--- a/modules/management/kubectl-apply/kueue/pathways.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/pathways.yaml.tftpl
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: pathways-flavor
@@ -6,7 +6,7 @@ spec:
   nodeLabels:
     cloud.google.com/gke-nodepool: "${pathways_nodepool_name}"
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -21,7 +21,7 @@ locals {
 
   # Note: The apiVersion associated with the Topology kind should be
   # kueue.x-k8s.io/v1beta1 when using v0.14.0 or higher. Refer: https://github.com/kubernetes-sigs/kueue/blob/main/CHANGELOG/CHANGELOG-0.14.md#api-change
-  kueue_supported_versions = ["0.14.4", "0.14.3", "0.14.2", "0.14.1", "0.13.9", "0.13.8", "0.13.7", "0.13.6", "0.13.3", "0.13.2", "0.13.1", "0.13.0"]
+  kueue_supported_versions = ["0.17.1", "0.14.4", "0.14.3", "0.14.2", "0.14.1", "0.13.9", "0.13.8", "0.13.7", "0.13.6", "0.13.3", "0.13.2", "0.13.1", "0.13.0"]
 
   # Officially supported latest helm chart versions of Jobset.
   # For details refer the official change log https://github.com/kubernetes-sigs/jobset/releases
@@ -123,7 +123,7 @@ variable "kueue" {
   description = "Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. A configuration yaml/template file can be provided with config_path to be applied right after kueue installation. If a template file provided, its variables can be set to config_template_vars."
   type = object({
     install                  = optional(bool, false)
-    version                  = optional(string, "0.13.3")
+    version                  = optional(string, "0.17.1")
     config_path              = optional(string, null)
     config_template_vars     = optional(map(any), null)
     enable_pathways_for_tpus = optional(bool, false)

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -19,9 +19,9 @@ locals {
   # The list should be updated as new versions are tested and approved.
   # Refer https://github.com/kubernetes-sigs/kueue/tree/main/CHANGELOG
 
-  # Note: The apiVersion associated with the Topology kind should be
-  # kueue.x-k8s.io/v1beta1 when using v0.14.0 or higher. Refer: https://github.com/kubernetes-sigs/kueue/blob/main/CHANGELOG/CHANGELOG-0.14.md#api-change
-  kueue_supported_versions = ["0.17.1", "0.14.4", "0.14.3", "0.14.2", "0.14.1", "0.13.9", "0.13.8", "0.13.7", "0.13.6", "0.13.3", "0.13.2", "0.13.1", "0.13.0"]
+  # Note: The apiVersion associated with the kueue resources should be kueue.x-k8s.io/v1beta2 when using v0.15.0 or higher.
+  # Refer: https://github.com/kubernetes-sigs/kueue/blob/main/CHANGELOG/CHANGELOG-0.15.md#v0150
+  kueue_supported_versions = ["0.17.1", "0.16.0", "0.15.3", "0.15.2", "0.15.1", "0.15.0"]
 
   # Officially supported latest helm chart versions of Jobset.
   # For details refer the official change log https://github.com/kubernetes-sigs/jobset/releases

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/kueue-configuration.yaml.tftpl
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/kueue-configuration.yaml.tftpl
@@ -1,4 +1,4 @@
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gke-1xh100-mega-80gb-8
@@ -7,7 +7,7 @@ spec:
     cloud.google.com/gke-accelerator: system
 ---
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: cluster-queue
@@ -24,7 +24,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: ${num_chips}
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: default

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues-template.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues-template.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "tas-flavor"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "tas-cluster-queue"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: 10000000  # infinite quota
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues-template.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues-template.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: Topology
 metadata:
   name: "gke-default"

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: Topology
 metadata:
   name: "gke-default"
@@ -24,7 +24,7 @@ spec:
   - nodeLabel: "kubernetes.io/hostname"
 ---
 kind: ResourceFlavor
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 metadata:
   name: "tas-flavor"
 spec:
@@ -36,7 +36,7 @@ spec:
     operator: "Exists"
     effect: NoSchedule
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: "tas-cluster-queue"
@@ -50,7 +50,7 @@ spec:
       - name: "nvidia.com/gpu"
         nominalQuota: 10000000  # infinite quota
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   namespace: "default"

--- a/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/kueue-config-files/tas-queues.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: kueue.x-k8s.io/v1alpha1
+apiVersion: kueue.x-k8s.io/v1beta1
 kind: Topology
 metadata:
   name: "gke-default"


### PR DESCRIPTION
This PR updates the default kueue version to 0.17.1 and also migrates all configuration files from Kueue API v1alpha1 to v1beta2.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
