### PR TITLE
fix(slurm): respect visible_core_count in cloud.conf generation

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -2038,10 +2038,17 @@ class Lookup:
         machine_conf.sockets_per_board = machine_conf.sockets // machine_conf.boards
         machine_conf.threads_per_core = 1
         _div = 2 if getThreadsPerCore(template) == 1 else 1
-        machine_conf.cpus = (
-            int(machine.guest_cpus / _div) if machine.supports_smt else machine.guest_cpus
-        )
-        machine_conf.cores_per_socket = int(machine_conf.cpus / machine_conf.sockets)
+        # Check if visibleCoreCount is specified in the instance template
+        visible_cores = template.advancedMachineFeatures.visibleCoreCount
+        if visible_cores:
+            machine_conf.cpus = int(visible_cores) * getThreadsPerCore(template)
+            machine_conf.cores_per_socket = int(visible_cores) // machine_conf.sockets
+        else:
+            machine_conf.cpus = (
+                int(machine.guest_cpus / _div) if machine.supports_smt else machine.guest_cpus
+            )
+            machine_conf.cores_per_socket = int(machine_conf.cpus / machine_conf.sockets)
+
         # Because the actual memory on the host will be different than
         # what is configured (e.g. kernel will take it). From
         # experiments, about 16 MB per GB are used (plus about 400 MB

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -2042,13 +2042,12 @@ class Lookup:
         visible_cores = template.advancedMachineFeatures.visibleCoreCount
         if visible_cores:
             machine_conf.cpus = int(visible_cores) * getThreadsPerCore(template)
-            machine_conf.cores_per_socket = int(visible_cores) // machine_conf.sockets
         else:
             machine_conf.cpus = (
                 int(machine.guest_cpus / _div) if machine.supports_smt else machine.guest_cpus
             )
-            machine_conf.cores_per_socket = int(machine_conf.cpus / machine_conf.sockets)
-
+        # Calculate cores_per_socket once for both cases
+        machine_conf.cores_per_socket = machine_conf.cpus // machine_conf.sockets
         # Because the actual memory on the host will be different than
         # what is configured (e.g. kernel will take it). From
         # experiments, about 16 MB per GB are used (plus about 400 MB


### PR DESCRIPTION
## Description
This PR fixes an issue where the `visible_core_count` setting (used to restrict OS-visible CPUs on supported machine types like C4) was ignored by the Slurm configuration generation scripts on the controller.

Previously, the scripts defaulted to the full CPU capacity of the machine type when writing `cloud.conf`, causing a mismatch with the actual restricted hardware. This led to nodes failing to register with `INVALID_REG` (Low CPUs) errors.

## Changes
- Modified `template_machine_conf` in `community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py` to check for `visibleCoreCount` in the instance template's `advancedMachineFeatures`.
- If set, `CPUs` and `CoresPerSocket` are calculated based on the restricted count instead of the full machine type capacity.

## Verification
- Deployed a cluster with a blueprint setting `visible_core_count` to 18, 36, 72, and 144 on `c4-highmem-288` instances.
- Verified that `scontrol show node` now reports the correct restricted CPU counts (18, 36, 72, 144) in `CfgTRES` and `CPUTot`, resolving the configuration mismatch.
- (Note: VM-level verification via `lscpu` was blocked by project quota errors preventing VM creation, but the fix for the Slurm configuration side is confirmed).

Fixes b/503047910
