### PR TITLE
[kubectl-apply] Add dynamic wait for Kueue webhook readiness

### DIFF
--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -249,6 +249,7 @@ limitations under the License.
 | [terraform_data.initial_gib_version](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.jobset_validations](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.kueue_validations](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+| [terraform_data.wait_for_kueue_webhook](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 | [http_http.manifest_from_url](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |

--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -191,6 +191,19 @@ module "install_kueue" {
   depends_on = [var.gke_cluster_exists]
 }
 
+resource "terraform_data" "wait_for_kueue_webhook" {
+  count = local.install_kueue ? 1 : 0
+
+  provisioner "local-exec" {
+    command = <<EOF
+      gcloud container clusters get-credentials ${local.cluster_name} --region ${local.cluster_location} --project ${local.project_id}
+      kubectl wait --for=condition=Available deployment/kueue-controller-manager -n kueue-system --timeout=300s
+    EOF
+  }
+
+  depends_on = [module.install_kueue]
+}
+
 module "configure_kueue" {
   source           = "./helm_install"
   count            = local.configure_kueue ? 1 : 0
@@ -207,8 +220,7 @@ module "configure_kueue" {
     })
   ]
 
-  depends_on = [module.install_kueue]
-
+  depends_on = [module.install_kueue, terraform_data.wait_for_kueue_webhook]
 }
 
 module "install_jobset" {


### PR DESCRIPTION
### Summary
**Problem**
During integration tests, a race condition frequently occurs where Terraform attempts to apply Kueue custom resources (such as ResourceFlavor or ClusterQueue) using kueue config file before the kueue webhook is fully provisioned.

This happens because Kueue requires a few extra seconds to fully boot its internal systems in the background. Since Terraform runs extremely fast, it attempts to push configurations into the cluster before Kueue is actually ready to receive them, causing the test to error out with failed calling webhook... No agent available.

**Solution**
After installing Kueue, Terraform will now pause and actively check cluster health using kubectl wait.
Once it verifies that the Kueue controller is running and fully operational, it immediately releases the lock and lets the deployment finish.