### PR TITLE
Keep Test Name as VPC name for All Tests 

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -120,7 +120,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={{ use_fixed_vpc | default(false) | ternary(test_prefix + test_name + '-0', network) }}
+        - --network={% if use_fixed_vpc | default(false) %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -120,7 +120,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={{ network }}
+        - --network={{ use_fixed_vpc | default(false) | ternary(test_prefix + test_name + '-0', network) }}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -141,7 +141,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={{ use_fixed_vpc | default(false) | ternary(test_prefix + test_name + '-0', network) }}
+        - --network={% if use_fixed_vpc | default(false) %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -141,7 +141,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={{ network }}
+        - --network={{ use_fixed_vpc | default(false) | ternary(test_prefix + test_name + '-0', network) }}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -79,5 +79,6 @@ steps:
     echo '      timeout: 10800'                                   >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml"

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -67,6 +67,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/serverless-batch-mpi.yaml
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
+    python3 tools/fix_vpc_name.py $${SG_EXAMPLE} "${_TEST_PREFIX}"
 
     sed -i "s/#   spack mirror add .*/spack mirror add --scope site gcs_cache $${SPACK_CACHE_WRF//\//\\\/}/" $${SG_EXAMPLE}
     sed -i "s/# spack buildcache keys .*/spack buildcache keys --install --trust/" $${SG_EXAMPLE}

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -54,6 +54,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT=examples/serverless-batch.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -57,6 +57,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/cloud-batch.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -99,6 +99,7 @@ steps:
     cat $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -95,6 +95,7 @@ steps:
     sed -i '/reservation/d' $${EXAMPLE_BP}
     sed -i '/placement_policy:/,+1d' $${EXAMPLE_BP}
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
+    python3 tools/fix_vpc_name.py $${EXAMPLE_BP} "${_TEST_PREFIX}"
     cat $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -79,6 +79,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
+    python3 tools/fix_vpc_name.py $${EXAMPLE_BP} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d.yml"

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -81,6 +81,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     python3 tools/fix_vpc_name.py $${EXAMPLE_BP} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -70,6 +70,7 @@ steps:
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     python3 tools/fix_vpc_name.py $${SG_EXAMPLE} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -68,6 +68,7 @@ steps:
     echo '      machine_type: e2-standard-2'       >> $${SG_EXAMPLE}
     echo '      zone: us-central1-b'               >> $${SG_EXAMPLE}
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
+    python3 tools/fix_vpc_name.py $${SG_EXAMPLE} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -83,6 +83,7 @@ steps:
       echo "INFO: Using $${H4D_VARS_FILE} as it is for SPOT provisioning."
     fi
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -85,6 +85,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -68,6 +68,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/hcls-blueprint.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -70,6 +70,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -54,9 +54,7 @@ steps:
   - |
     set -e -u -o pipefail
     echo "Sourcing find_available_zone.sh to determine zone."
-    # source /workspace/tools/cloud-build/find_available_zone.sh
-    ZONE="us-central1-b"
-    PROVISIONING_MODEL="SPOT"
+    source /workspace/tools/cloud-build/find_available_zone.sh
     if [ -z "$${ZONE:-}" ]; then
       echo "ERROR: ZONE not found" >&2
       exit 1
@@ -88,8 +86,6 @@ steps:
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
-    cat $${BLUEPRINT}
-    exit 0
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -54,7 +54,25 @@ steps:
   - |
     set -e -u -o pipefail
     echo "Sourcing find_available_zone.sh to determine zone."
-    
+    # source /workspace/tools/cloud-build/find_available_zone.sh
+    ZONE="us-central1-b"
+    PROVISIONING_MODELS="SPOT"
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
+    set -x
+    cd /workspace
+    if [ "${_TEST_PREFIX}" == "daily-" ]; then
+        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
+        unzip -o gcluster-bundle.zip
+        # Grant execution permissions to the binary
+        chmod +x gcluster
+    else
+        make
+    fi
+    REGION="$${ZONE%-*}"
+    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
 
     BLUEPRINT="/workspace/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml"
 

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -56,7 +56,7 @@ steps:
     echo "Sourcing find_available_zone.sh to determine zone."
     # source /workspace/tools/cloud-build/find_available_zone.sh
     ZONE="us-central1-b"
-    PROVISIONING_MODELS="SPOT"
+    PROVISIONING_MODEL="SPOT"
     if [ -z "$${ZONE:-}" ]; then
       echo "ERROR: ZONE not found" >&2
       exit 1

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -54,23 +54,7 @@ steps:
   - |
     set -e -u -o pipefail
     echo "Sourcing find_available_zone.sh to determine zone."
-    source /workspace/tools/cloud-build/find_available_zone.sh
-    if [ -z "$${ZONE:-}" ]; then
-      echo "ERROR: ZONE not found" >&2
-      exit 1
-    fi
-    set -x
-    cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
-        # Grant execution permissions to the binary
-        chmod +x gcluster
-    else
-        make
-    fi
-    REGION="$${ZONE%-*}"
-    BUILD_ID_SHORT="$${BUILD_ID:0:6}"
+    
 
     BLUEPRINT="/workspace/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml"
 
@@ -85,9 +69,9 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
-    python3 tools/fix_vpc_name.py $${BLUEPRINT} $${SLURM_VARS_FILE} "DAILY"
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     cat $${BLUEPRINT}
-
+    exit 0
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -85,6 +85,8 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} $${SLURM_VARS_FILE} "DAILY"
+    cat $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -87,6 +87,7 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -90,6 +90,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -65,6 +65,7 @@ steps:
     sed -i -e '/reason:/d' $${BLUEPRINT}
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
         --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -68,6 +68,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -59,6 +59,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -61,6 +61,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -83,6 +83,7 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -86,6 +86,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -92,6 +92,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -90,6 +90,7 @@ steps:
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -64,6 +64,7 @@ steps:
     sed -i -e '/deletion_protection:/{n;s/enabled: true/enabled: false/}' $${BLUEPRINT}
     sed -i -e '/reason:/d' $${BLUEPRINT}
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -66,6 +66,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -91,6 +91,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -88,6 +88,7 @@ steps:
 
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -72,6 +72,7 @@ steps:
     sed -i '/- homefs/d' $${BLUEPRINT}
     sed -i '/filestore_ip_range:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -64,6 +64,7 @@ steps:
     BLUEPRINT="/workspace/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml"
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     sed -i -e '/- id: a4x-slurm-net-0/,/- id: a4x-slurm-net-1/ s/network_name: .*/network_name: $(vars.base_network_name)/' $${BLUEPRINT}
     # Adding this as filestore APIs are not available on us-west8-a. Should be removed once reservation is moved or updated to non us-west8-a region

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -82,6 +82,7 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -84,6 +84,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -83,6 +83,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -81,6 +81,7 @@ steps:
     fi
 
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -63,6 +63,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -60,6 +60,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/ml-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -56,6 +56,7 @@ steps:
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/hpc-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -59,6 +59,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/tests/batch-mpi.yml
+++ b/tools/cloud-build/daily-tests/tests/batch-mpi.yml
@@ -27,5 +27,6 @@ custom_vars:
   mounts: [/share]
   batch_job_id: batch-job  # batch-job-template ID
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: us-west4
   zone: "{{ zone }}"

--- a/tools/cloud-build/daily-tests/tests/cloud-batch.yml
+++ b/tools/cloud-build/daily-tests/tests/cloud-batch.yml
@@ -27,5 +27,6 @@ custom_vars:
   mounts: [/sw]
   batch_job_id: batch-job  # batch-job-template ID
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: us-central1
   zone: "{{ zone }}"

--- a/tools/cloud-build/daily-tests/tests/gke-h4d-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-h4d-onspot.yml
@@ -24,6 +24,7 @@ network: "{{ deployment_name }}-net"
 remote_node: "{{ deployment_name }}-remote-node-0"
 static_node_count: 2
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   static_node_count: "{{ static_node_count }}"

--- a/tools/cloud-build/daily-tests/tests/gke-h4d.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-h4d.yml
@@ -27,6 +27,7 @@ remote_node: "{{ deployment_name }}-remote-node-0"
 static_node_count: 2
 reservation: h4d-9amhwllf9r5w4
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   static_node_count: "{{ static_node_count }}"

--- a/tools/cloud-build/daily-tests/tests/gke-storage.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-storage.yml
@@ -24,6 +24,7 @@ post_deploy_tests:
 - test-validation/test-zonal-bucket.yml
 - test-validation/test-anywhere-cache.yml
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   network_name: "{{ network }}"

--- a/tools/cloud-build/daily-tests/tests/h4d-vm.yml
+++ b/tools/cloud-build/daily-tests/tests/h4d-vm.yml
@@ -31,6 +31,7 @@ custom_vars:
     h4d_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   base_network_name: "{{ test_name }}"

--- a/tools/cloud-build/daily-tests/tests/hcls.yml
+++ b/tools/cloud-build/daily-tests/tests/hcls.yml
@@ -26,6 +26,7 @@ network: "{{ test_name }}-net"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   network_name: "{{ network }}"
   region: europe-west1
   zone: "{{ zone }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-highgpu-onspot-slurm.yml
@@ -46,6 +46,7 @@ custom_vars:
     a3high_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   tcpx_kernel_login: "{{ tcpx_kernel_login }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-onspot-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-onspot-slurm-ubuntu.yml
@@ -47,6 +47,7 @@ custom_vars:
     a3mega_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   network_name_system: "{{ network }}"
   subnetwork_name_system: "{{ sub_network}}"
   region: "{{ region }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml
@@ -46,6 +46,7 @@ custom_vars:
   mounts:
   - /home
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   network_name_system: "{{ network }}"
   subnetwork_name_system: "{{ sub_network}}"
   region: "{{ region }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml
@@ -31,6 +31,7 @@ custom_vars:
   mounts:
   - /home
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   a3u_reservation_name: hpc-exr-2

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-jbvms.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-jbvms.yml
@@ -32,6 +32,7 @@ custom_vars:
     a3ultra_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   a3u_provisioning_model: SPOT

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-onspot-slurm.yml
@@ -49,6 +49,7 @@ custom_vars:
     a3ultra_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   slurm_cluster_name: "{{ slurm_cluster_name }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml
@@ -43,6 +43,7 @@ custom_vars:
   - /home
   - /gcs
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   slurm_cluster_name: "{{ slurm_cluster_name }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-onspot-slurm.yml
@@ -47,6 +47,7 @@ custom_vars:
     a4high_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   slurm_cluster_name: "{{ slurm_cluster_name }}"

--- a/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml
@@ -41,6 +41,7 @@ custom_vars:
   mounts:
   - /home
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   base_network_name: '{{ test_name }}'
   region: "{{ region }}"
   zone: "{{ zone }}"

--- a/tools/cloud-build/daily-tests/tests/ml-g4-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-g4-onspot-slurm.yml
@@ -41,6 +41,7 @@ custom_vars:
     g4_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"
   slurm_cluster_name: "{{ slurm_cluster_name }}"

--- a/tools/cloud-build/daily-tests/tests/ml-h4d-onspot-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-h4d-onspot-slurm.yml
@@ -39,6 +39,7 @@ custom_vars:
     h4d_onspot: true
   enable_spot: true
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   deployment_name: "{{ deployment_name }}"
   region: "{{ region }}"
   zone: "{{ zone }}"

--- a/tools/cloud-build/daily-tests/tests/ml-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-slurm.yml
@@ -22,4 +22,5 @@ blueprint_yaml: "{{ workspace }}/examples/ml-slurm.yaml"
 packer_group_name: packer
 packer_module_id: custom-image
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   network_name: "{{ network }}"

--- a/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
+++ b/tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml
@@ -21,6 +21,7 @@ deployment_name: "rock-8-{{ build }}"
 slurm_cluster_name: "rock8{{ build[0:5] }}"
 
 cli_deployment_vars:
+  test_name: "{{ test_name }}"
   network_name: "{{ network }}"
   region: us-central1
   zone: us-central1-a

--- a/tools/fix_vpc_name.py
+++ b/tools/fix_vpc_name.py
@@ -1,0 +1,129 @@
+import sys
+import yaml
+import re
+
+def main():
+    if len(sys.argv) != 4:
+        print("Usage: python fix_vpc_name.py <blueprint_file> <vars_file> <prefix>")
+        sys.exit(1)
+
+    blueprint_file = sys.argv[1]
+    vars_file = sys.argv[2]
+    prefix = sys.argv[3]
+
+    # Read test_name from vars file
+    with open(vars_file, 'r') as f:
+        vars_data = yaml.safe_load(f)
+    
+    test_name = vars_data.get('test_name')
+    if not test_name:
+        print(f"Error: test_name not found in {vars_file}")
+        sys.exit(1)
+
+    new_vpc_name = f"{prefix}-{test_name}"
+    print(f"New VPC Name: {new_vpc_name}")
+
+    # Read blueprint to find the network module ID
+    with open(blueprint_file, 'r') as f:
+        blueprint_data = yaml.safe_load(f)
+
+    filestore_module_id = None
+    network_module_id = None
+
+    # Find filestore module and its network dependency
+    for group in blueprint_data.get('deployment_groups', []):
+        for module in group.get('modules', []):
+            if module.get('source') == 'modules/file-system/filestore':
+                filestore_module_id = module.get('id')
+                uses = module.get('use', [])
+                # Find a module in uses that is a VPC network
+                for u in uses:
+                    # Look for module with id 'u' in the blueprint
+                    for g2 in blueprint_data.get('deployment_groups', []):
+                        for m2 in g2.get('modules', []):
+                            if m2.get('id') == u and m2.get('source') == 'modules/network/vpc':
+                                network_module_id = u
+                                break
+                        if network_module_id:
+                            break
+                if network_module_id:
+                    break
+        if network_module_id:
+            break
+
+    if not network_module_id:
+        print("Error: Could not find network module used by filestore")
+        sys.exit(1)
+
+    print(f"Found network module ID: {network_module_id}")
+
+    # Now read the original file as text and modify it
+    with open(blueprint_file, 'r') as f:
+        content = f.read()
+
+    lines = content.splitlines()
+    new_lines = []
+    in_network_module = False
+    in_settings = False
+    replaced = False
+    indent_level = 0
+
+    for line in lines:
+        stripped = line.strip()
+        if not in_network_module:
+            new_lines.append(line)
+            if stripped.startswith("- id:") and stripped.endswith(network_module_id):
+                # Verify it matches exactly "- id: network_module_id"
+                parts = stripped.split(":")
+                if len(parts) == 2 and parts[1].strip() == network_module_id:
+                    in_network_module = True
+                    indent_level = len(line) - len(line.lstrip())
+        else:
+            # We are inside the network module block
+            current_indent = len(line) - len(line.lstrip())
+            
+            if stripped.startswith("- id:") and current_indent == indent_level:
+                # We hit the next module at the same indentation level
+                if in_settings and not replaced:
+                    new_lines.append(" " * (indent_level + 4) + f"network_name: {new_vpc_name}")
+                    replaced = True
+                in_network_module = False
+                in_settings = False
+                new_lines.append(line)
+            elif stripped == "settings:":
+                in_settings = True
+                new_lines.append(line)
+            elif in_settings and stripped.startswith("network_name:"):
+                # Found it, replace it
+                parts = line.split(":")
+                indent = len(line) - len(line.lstrip())
+                new_lines.append(" " * indent + f"network_name: {new_vpc_name}")
+                replaced = True
+                in_settings = False # assume only one network_name per settings
+            else:
+                new_lines.append(line)
+
+    # Handle case where file ends while in network module
+    if in_network_module and in_settings and not replaced:
+         new_lines.append(" " * (indent_level + 4) + f"network_name: {new_vpc_name}")
+         replaced = True
+
+    if not replaced and in_network_module and not in_settings:
+        # Found module but no settings, try to add settings
+        print("Warning: Found module but no settings. Injecting settings.")
+        # Find where to inject. Usually after 'source:' or 'id:'
+        # Let's just append it to the module block if we can find the end of it.
+        # This is getting complex. Let's assume settings exists for now as in the examples.
+        pass
+
+    if not replaced:
+        print("Failed to replace network_name.")
+        sys.exit(1)
+
+    with open(blueprint_file, 'w') as f:
+        f.write("\n".join(new_lines) + "\n")
+
+    print("Successfully modified blueprint.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/fix_vpc_name.py
+++ b/tools/fix_vpc_name.py
@@ -1,3 +1,17 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import yaml
 import sys
 

--- a/tools/fix_vpc_name.py
+++ b/tools/fix_vpc_name.py
@@ -1,129 +1,29 @@
-import sys
 import yaml
-import re
+import sys
 
-def main():
-    if len(sys.argv) != 4:
-        print("Usage: python fix_vpc_name.py <blueprint_file> <vars_file> <prefix>")
-        sys.exit(1)
+def modify_vpcs(blueprint_path, prefix):
+    with open(blueprint_path, 'r') as f:
+        data = yaml.safe_load(f)
 
-    blueprint_file = sys.argv[1]
-    vars_file = sys.argv[2]
-    prefix = sys.argv[3]
+    vpc_count = 0
+    # Iterate through all deployment groups and modules
+    if data and 'deployment_groups' in data:
+        for group in data['deployment_groups']:
+            for module in group.get('modules', []):
+                # Identify VPC modules by their source path
+                if 'modules/network/vpc' in module.get('source', ''):
+                    if 'settings' not in module:
+                        module['settings'] = {}
+                    # Set the consecutive name using the $(vars.test_name) variable
+                    module['settings']['network_name'] = f"{prefix}$(vars.test_name)-{vpc_count}"
+                    print(f"Updated module '{module.get('id')}' to: {prefix}$(vars.test_name)-{vpc_count}")
+                    vpc_count += 1
 
-    # Read test_name from vars file
-    with open(vars_file, 'r') as f:
-        vars_data = yaml.safe_load(f)
-    
-    test_name = vars_data.get('test_name')
-    if not test_name:
-        print(f"Error: test_name not found in {vars_file}")
-        sys.exit(1)
-
-    new_vpc_name = f"{prefix}-{test_name}"
-    print(f"New VPC Name: {new_vpc_name}")
-
-    # Read blueprint to find the network module ID
-    with open(blueprint_file, 'r') as f:
-        blueprint_data = yaml.safe_load(f)
-
-    filestore_module_id = None
-    network_module_id = None
-
-    # Find filestore module and its network dependency
-    for group in blueprint_data.get('deployment_groups', []):
-        for module in group.get('modules', []):
-            if module.get('source') == 'modules/file-system/filestore':
-                filestore_module_id = module.get('id')
-                uses = module.get('use', [])
-                # Find a module in uses that is a VPC network
-                for u in uses:
-                    # Look for module with id 'u' in the blueprint
-                    for g2 in blueprint_data.get('deployment_groups', []):
-                        for m2 in g2.get('modules', []):
-                            if m2.get('id') == u and m2.get('source') == 'modules/network/vpc':
-                                network_module_id = u
-                                break
-                        if network_module_id:
-                            break
-                if network_module_id:
-                    break
-        if network_module_id:
-            break
-
-    if not network_module_id:
-        print("Error: Could not find network module used by filestore")
-        sys.exit(1)
-
-    print(f"Found network module ID: {network_module_id}")
-
-    # Now read the original file as text and modify it
-    with open(blueprint_file, 'r') as f:
-        content = f.read()
-
-    lines = content.splitlines()
-    new_lines = []
-    in_network_module = False
-    in_settings = False
-    replaced = False
-    indent_level = 0
-
-    for line in lines:
-        stripped = line.strip()
-        if not in_network_module:
-            new_lines.append(line)
-            if stripped.startswith("- id:") and stripped.endswith(network_module_id):
-                # Verify it matches exactly "- id: network_module_id"
-                parts = stripped.split(":")
-                if len(parts) == 2 and parts[1].strip() == network_module_id:
-                    in_network_module = True
-                    indent_level = len(line) - len(line.lstrip())
-        else:
-            # We are inside the network module block
-            current_indent = len(line) - len(line.lstrip())
-            
-            if stripped.startswith("- id:") and current_indent == indent_level:
-                # We hit the next module at the same indentation level
-                if in_settings and not replaced:
-                    new_lines.append(" " * (indent_level + 4) + f"network_name: {new_vpc_name}")
-                    replaced = True
-                in_network_module = False
-                in_settings = False
-                new_lines.append(line)
-            elif stripped == "settings:":
-                in_settings = True
-                new_lines.append(line)
-            elif in_settings and stripped.startswith("network_name:"):
-                # Found it, replace it
-                parts = line.split(":")
-                indent = len(line) - len(line.lstrip())
-                new_lines.append(" " * indent + f"network_name: {new_vpc_name}")
-                replaced = True
-                in_settings = False # assume only one network_name per settings
-            else:
-                new_lines.append(line)
-
-    # Handle case where file ends while in network module
-    if in_network_module and in_settings and not replaced:
-         new_lines.append(" " * (indent_level + 4) + f"network_name: {new_vpc_name}")
-         replaced = True
-
-    if not replaced and in_network_module and not in_settings:
-        # Found module but no settings, try to add settings
-        print("Warning: Found module but no settings. Injecting settings.")
-        # Find where to inject. Usually after 'source:' or 'id:'
-        # Let's just append it to the module block if we can find the end of it.
-        # This is getting complex. Let's assume settings exists for now as in the examples.
-        pass
-
-    if not replaced:
-        print("Failed to replace network_name.")
-        sys.exit(1)
-
-    with open(blueprint_file, 'w') as f:
-        f.write("\n".join(new_lines) + "\n")
-
-    print("Successfully modified blueprint.")
+    with open(blueprint_path, 'w') as f:
+        yaml.dump(data, f, sort_keys=False)
 
 if __name__ == "__main__":
-    main()
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <blueprint_path> <prefix>", file=sys.stderr)
+        sys.exit(1)
+    modify_vpcs(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
This PR modifies the VPC Names of all the test which consumes filestore.
This ensures that all the test are having fixed VPC name and don't hit the filestore limit.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
