### PR TITLE
Add nscd caching to A4x slurm to prevent OSLogin timeouts

### DIFF
--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -666,6 +666,13 @@ deployment_groups:
           #!/bin/bash
           mkdir -p /mnt/localssd
           chmod 1777 /mnt/localssd
+      - type: shell
+        destination: install_nscd.sh
+        content: |
+          #!/bin/bash
+          sudo apt-get update && sudo apt-get install -y nscd
+          sudo systemctl enable nscd
+          sudo systemctl start nscd
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |


### PR DESCRIPTION
## Summary
Adds the installation and enablement of `nscd` (Name Service Cache Daemon) to the `controller_startup` script in the `a4x-highgpu-4g` Slurm blueprint.

## Why is this needed?
Under high concurrency (such as running large NCCL test suites on a scaled cluster), Slurm generates a rapid flood of user identity lookup requests via OSLogin. Without a local caching daemon like `nscd`, this results in ephemeral port exhaustion (`[Errno 99] Cannot assign requested address`) when connecting to the Google Metadata Server. This causes Slurm credential creation (`fetch_identity()`) to fail, which puts jobs into `JobHeldAdmin`.

## Changes
- Added a shell runner in the `controller_startup` module of `a4xhigh-slurm-blueprint.yaml` to install, enable, and start `nscd`