### PR TITLE
readme: add instructions for downloading and extracting tarball (.tgz) bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ The pre-built bundles are compiled for Linux and macOS execution environments an
 
 1. Download and extract the bundle:
 
-    > **_NOTE:_** The binary is available starting with version 1.82.0 [Only supports x86/amd64 arch]. Multi-architecture builds (amd64 and arm64) are available starting with version 1.85.0.
+    > **_NOTE:_** The binary is available starting with version 1.82.0 [Only supports x86/amd64 arch]. Multi-architecture builds (amd64 and arm64) are available starting with version 1.85.0. Tarball bundles (.tgz) are supported starting with version 1.89.0.
 
-    For versions v1.85.0 and newer (Multi-architecture):
+    For versions v1.85.0 and newer (Multi-architecture Zip):
 
     ```shell
     # Find all available releases at: https://github.com/GoogleCloudPlatform/cluster-toolkit/releases
@@ -74,6 +74,19 @@ The pre-built bundles are compiled for Linux and macOS execution environments an
     unzip gcluster_bundle_${OS}_${ARCH}.zip -d gcluster-bundle/
     cd gcluster-bundle
     chmod +x gcluster
+    ```
+
+    For versions v1.89.0 and newer (Multi-architecture Tarball):
+
+    ```shell
+    # Find all available releases at: https://github.com/GoogleCloudPlatform/cluster-toolkit/releases
+    # Set the desired version TAG (e.g., v1.89.0)
+    TAG=vX.Y.Z
+    # Set your OS (linux or mac) and Architecture (amd64 or arm64)
+    OS="linux"
+    ARCH="amd64"
+    # Download and extract the platform-specific bundle in a single step
+    mkdir -p gcluster-bundle && curl -L https://github.com/GoogleCloudPlatform/cluster-toolkit/releases/download/${TAG}/gcluster_bundle_${OS}_${ARCH}.tgz | tar -xz -C gcluster-bundle && cd gcluster-bundle && chmod +x gcluster
     ```
 
     For versions v1.82.0 through v1.84.0:


### PR DESCRIPTION
Starting from release v1.89.0, the Cluster Toolkit distributes pre-built gcluster bundles as both .zip and .tar.gz (.tgz) archives.

This PR updates README.md to:

- Add an installation instructions section for downloading and extracting the multi-architecture .tgz bundles.
- Provide a piped one-liner command that downloads and extracts the tarball directly into a folder without leaving residual archive files on disk.
- Update the installation NOTE to explicitly state that .tgz format support began in v1.89.0.