### PR TITLE
[Telemetry] Set up a Github workflow to cache release metadata 

### DIFF
--- a/.github/workflows/cache-metadata.yml
+++ b/.github/workflows/cache-metadata.yml
@@ -45,6 +45,21 @@ jobs:
       id: extract_tag
       run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-    - name: Populate Firestore Cache
+    - name: Populate Firestore Cache (with up to 3 retries)
       run: |
-        go run tools/cache_metadata/main.go -version ${{ env.VERSION }}
+        for i in 1 2 3; do
+          echo "Attempt $i..."
+          if go run tools/cache_metadata/main.go -version ${{ env.VERSION }}; then
+            echo "Success!"
+            exit 0
+          fi
+
+          echo "Attempt $i failed."
+          if [ $i -lt 3 ]; then
+            echo "Waiting 10 seconds before retrying..."
+            sleep 10
+          fi
+        done
+
+        echo "All 3 attempts failed. Aborting."
+        exit 1

--- a/.github/workflows/cache-metadata.yml
+++ b/.github/workflows/cache-metadata.yml
@@ -1,0 +1,50 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cache Release Metadata for Telemetry
+
+on:
+  push:
+    tags:
+    - 'v*' # Triggers on any tag starting with 'v'
+
+jobs:
+  update-firestore-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write' # Required for Workload Identity Federation
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: 'projects/266450182917/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+        service_account: 'cache-metadata@hpc-toolkit-gsc.iam.gserviceaccount.com'
+
+    - name: Extract Tag Name
+      id: extract_tag
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Populate Firestore Cache
+      run: |
+        go run tools/cache_metadata/main.go -version ${{ env.VERSION }}

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -41,14 +41,8 @@ type TreeResponse struct {
 	} `json:"tree"`
 }
 
-var cachedTree *TreeResponse
-
 // fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
 func fetchGitTree(version string) (*TreeResponse, error) {
-	if cachedTree != nil {
-		return cachedTree, nil
-	}
-
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -69,9 +63,7 @@ func fetchGitTree(version string) (*TreeResponse, error) {
 		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
 	}
 
-	// Cache the response before returning it so subsequent calls are instant
-	cachedTree = &treeResp
-	return cachedTree, nil
+	return &treeResp, nil
 }
 
 func main() {
@@ -120,7 +112,7 @@ func fetchStandardModules(version string) []string {
 		if item.Type == "blob" &&
 			(strings.HasPrefix(item.Path, "modules/") || strings.HasPrefix(item.Path, "community/modules/")) &&
 			(strings.HasSuffix(item.Path, ".tf") || strings.HasSuffix(item.Path, ".pkr.hcl")) {
-			moduleDir := filepath.ToSlash(filepath.Dir(item.Path))
+			moduleDir := path.Dir(item.Path)
 			if !moduleSet[moduleDir] {
 				moduleSet[moduleDir] = true
 				predefinedModules = append(predefinedModules, moduleDir)
@@ -149,8 +141,7 @@ func fetchStandardExampleFiles(version string) []string {
 		if item.Type == "blob" &&
 			(strings.HasPrefix(item.Path, "examples/") || strings.HasPrefix(item.Path, "community/examples/")) &&
 			strings.HasSuffix(item.Path, ".yaml") {
-			examplePath := filepath.ToSlash(item.Path)
-			predefinedExampleFiles = append(predefinedExampleFiles, examplePath)
+			predefinedExampleFiles = append(predefinedExampleFiles, item.Path)
 		}
 
 	}

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"hpc-toolkit/pkg/config"
 	"io"
 	"log"
 	"net/http"
@@ -43,6 +42,11 @@ type TreeResponse struct {
 		Path string `json:"path"`
 		Type string `json:"type"`
 	} `json:"tree"`
+}
+
+// MinimalBlueprint is a lightweight struct to extract only the blueprint_name
+type MinimalBlueprint struct {
+	BlueprintName string `yaml:"blueprint_name"`
 }
 
 var httpClient = &http.Client{
@@ -236,7 +240,7 @@ func worker(id int, version string, jobs <-chan string, results chan<- string, w
 		if resp.StatusCode == http.StatusOK {
 			body, err := io.ReadAll(resp.Body)
 			if err == nil {
-				var bp *config.Blueprint
+				var bp MinimalBlueprint
 				// Unmarshal gracefully ignores all fields except blueprint_name
 				if err := yaml.Unmarshal(body, &bp); err == nil && bp.BlueprintName != "" {
 					results <- bp.BlueprintName

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"hpc-toolkit/pkg/config"
+	"io"
 	"log"
 	"net/http"
 	"path"
@@ -26,6 +28,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -41,14 +44,15 @@ type TreeResponse struct {
 	} `json:"tree"`
 }
 
+var httpClient = &http.Client{
+	Timeout: 10 * time.Second,
+}
+
 // fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
 func fetchGitTree(version string) (*TreeResponse, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
 
-	resp, err := client.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from GitHub API: %v", err)
 	}
@@ -77,6 +81,7 @@ func main() {
 	// Fetch required metadata to be stored in Firestore
 	standardModules := fetchStandardModules(*version)
 	standardExampleFiles := fetchStandardExampleFiles(*version)
+	standardBlueprintNames := fetchStandardBlueprintNames(*version, standardExampleFiles)
 
 	// Write to Firestore
 	ctx := context.Background()
@@ -87,8 +92,9 @@ func main() {
 	defer client.Close()
 
 	_, err = client.Collection(releasesCollection).Doc(*version).Set(ctx, map[string]interface{}{
-		"modules":  standardModules,
-		"examples": standardExampleFiles,
+		"modules":         standardModules,
+		"examples":        standardExampleFiles,
+		"blueprint_names": standardBlueprintNames,
 	})
 
 	if err != nil {
@@ -153,4 +159,45 @@ func fetchStandardExampleFiles(version string) []string {
 	}
 
 	return predefinedExampleFiles
+}
+
+func fetchStandardBlueprintNames(version string, standardExampleFiles []string) []string {
+	blueprintNamesSet := make(map[string]bool)
+	blueprintNames := make([]string, 0)
+
+	for _, examplePath := range standardExampleFiles {
+		// Fetch the raw content of the YAML file from GitHub
+		rawURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/%s/%s", version, examplePath)
+		resp, err := httpClient.Get(rawURL)
+		if err != nil {
+			log.Printf("Warning: failed to fetch raw yaml %s: %v", rawURL, err)
+			continue
+		}
+
+		// Read and parse the YAML
+		if resp.StatusCode == http.StatusOK {
+			body, err := io.ReadAll(resp.Body)
+			if err == nil {
+				var bp *config.Blueprint
+				// Unmarshal will gracefully ignore all fields except blueprint_name
+				if err := yaml.Unmarshal(body, &bp); err == nil && bp.BlueprintName != "" {
+					if !blueprintNamesSet[bp.BlueprintName] {
+						blueprintNamesSet[bp.BlueprintName] = true
+						blueprintNames = append(blueprintNames, bp.BlueprintName)
+					}
+				}
+			}
+		} else {
+			log.Printf("Warning: received status %d when fetching %s", resp.StatusCode, rawURL)
+		}
+		resp.Body.Close()
+	}
+
+	if len(blueprintNames) == 0 {
+		log.Printf("No blueprint names found to cache for version %s", version)
+	} else {
+		fmt.Printf("Successfully fetched %d standard blueprint names for version %s.\n", len(blueprintNames), version)
+	}
+
+	return blueprintNames
 }

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -1,0 +1,165 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+const (
+	projectID          = "hpc-toolkit-gsc"
+	releasesCollection = "release_metadata"
+)
+
+// TreeResponse represents the expected JSON structure from the GitHub Git Trees API
+type TreeResponse struct {
+	Tree []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+	} `json:"tree"`
+}
+
+var cachedTree *TreeResponse
+
+// fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
+func fetchGitTree(version string) (*TreeResponse, error) {
+	if cachedTree != nil {
+		return cachedTree, nil
+	}
+
+	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from GitHub API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status: %s", resp.Status)
+	}
+
+	var treeResp TreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&treeResp); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
+	}
+
+	// Cache the response before returning it so subsequent calls are instant
+	cachedTree = &treeResp
+	return cachedTree, nil
+}
+
+func main() {
+	version := flag.String("version", "", "The toolkit version tag (e.g., v1.88.0)")
+	flag.Parse()
+
+	if *version == "" {
+		log.Fatal("Error: -version flag is required")
+	}
+
+	// Fetch required metadata to be stored in Firestore
+	standardModules := fetchStandardModules(*version)
+	standardExampleFiles := fetchStandardExampleFiles(*version)
+
+	// Write to Firestore
+	ctx := context.Background()
+	client, err := firestore.NewClient(ctx, projectID)
+	if err != nil {
+		log.Fatalf("Failed to create Firestore client: %v", err)
+	}
+	defer client.Close()
+
+	_, err = client.Collection(releasesCollection).Doc(*version).Set(ctx, map[string]interface{}{
+		"modules":  standardModules,
+		"examples": standardExampleFiles,
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to write cache to Firestore: %v", err)
+	}
+
+	fmt.Printf("Successfully cached metadata for version %s in Firestore.\n", *version)
+}
+
+func fetchStandardModules(version string) []string {
+	moduleSet := make(map[string]bool)
+	predefinedModules := make([]string, 0)
+	treeResp, err := fetchGitTree(version)
+	if err != nil {
+		log.Fatalf("Error fetching git tree for version: %v", err)
+	}
+
+	// Parse the remote tree
+	for _, item := range treeResp.Tree {
+		// Check for Terraform and Packer files in the module directories.
+		if item.Type == "blob" &&
+			(strings.HasPrefix(item.Path, "modules/") || strings.HasPrefix(item.Path, "community/modules/")) &&
+			(strings.HasSuffix(item.Path, ".tf") || strings.HasSuffix(item.Path, ".pkr.hcl")) {
+			moduleDir := filepath.ToSlash(filepath.Dir(item.Path))
+			if !moduleSet[moduleDir] {
+				moduleSet[moduleDir] = true
+				predefinedModules = append(predefinedModules, moduleDir)
+			}
+		}
+	}
+	if len(predefinedModules) == 0 {
+		log.Printf("No modules found to cache for version %s", version)
+	} else {
+		fmt.Printf("Successfully fetched %d standard modules for version %s.\n", len(predefinedModules), version)
+	}
+
+	return predefinedModules
+}
+
+func fetchStandardExampleFiles(version string) []string {
+	predefinedExampleFiles := make([]string, 0)
+	treeResp, err := fetchGitTree(version)
+	if err != nil {
+		log.Fatalf("Error fetching git tree for examples: %v", err)
+	}
+
+	// Parse the remote tree
+	for _, item := range treeResp.Tree {
+		// Check for YAML files in the example directories.
+		if item.Type == "blob" &&
+			(strings.HasPrefix(item.Path, "examples/") || strings.HasPrefix(item.Path, "community/examples/")) &&
+			strings.HasSuffix(item.Path, ".yaml") {
+			examplePath := filepath.ToSlash(item.Path)
+			predefinedExampleFiles = append(predefinedExampleFiles, examplePath)
+		}
+
+	}
+
+	if len(predefinedExampleFiles) == 0 {
+		log.Printf("No examples found to cache for version %s", version)
+	} else {
+		fmt.Printf("Successfully fetched %d standard example files for version %s.\n", len(predefinedExampleFiles), version)
+	}
+
+	return predefinedExampleFiles
+}

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -49,39 +49,22 @@ var httpClient = &http.Client{
 	Timeout: 10 * time.Second,
 }
 
-// fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
-func fetchGitTree(version string) (*TreeResponse, error) {
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
-
-	resp, err := httpClient.Get(url)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch from GitHub API: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("GitHub API returned status: %s", resp.Status)
-	}
-
-	var treeResp TreeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&treeResp); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
-	}
-
-	return &treeResp, nil
-}
-
 func main() {
 	version := flag.String("version", "", "The toolkit version tag (e.g., v1.88.0)")
 	flag.Parse()
-
 	if *version == "" {
 		log.Fatal("Error: -version flag is required")
 	}
 
+	// Fetch the tree once to avoid redundant API calls
+	treeResp, err := fetchGitTree(*version)
+	if err != nil {
+		log.Fatalf("Error fetching git tree for version %s: %v", *version, err)
+	}
+
 	// Fetch required metadata to be stored in Firestore
-	standardModules := fetchStandardModules(*version)
-	standardExampleFiles := fetchStandardExampleFiles(*version)
+	standardModules := fetchStandardModules(treeResp, *version)
+	standardExampleFiles := fetchStandardExampleFiles(treeResp, *version)
 	standardBlueprintNames := fetchStandardBlueprintNames(*version, standardExampleFiles)
 
 	// Write to Firestore
@@ -105,13 +88,31 @@ func main() {
 	fmt.Printf("Successfully cached metadata for version %s in Firestore.\n", *version)
 }
 
-func fetchStandardModules(version string) []string {
+// fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
+func fetchGitTree(version string) (*TreeResponse, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
+
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch from GitHub API: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GitHub API returned status: %s", resp.Status)
+	}
+
+	var treeResp TreeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&treeResp); err != nil {
+		return nil, fmt.Errorf("failed to decode JSON response: %v", err)
+	}
+
+	return &treeResp, nil
+}
+
+func fetchStandardModules(treeResp *TreeResponse, version string) []string {
 	moduleSet := make(map[string]bool)
 	predefinedModules := make([]string, 0)
-	treeResp, err := fetchGitTree(version)
-	if err != nil {
-		log.Fatalf("Error fetching git tree for version: %v", err)
-	}
 
 	// Parse the remote tree
 	for _, item := range treeResp.Tree {
@@ -135,12 +136,8 @@ func fetchStandardModules(version string) []string {
 	return predefinedModules
 }
 
-func fetchStandardExampleFiles(version string) []string {
+func fetchStandardExampleFiles(treeResp *TreeResponse, version string) []string {
 	predefinedExampleFiles := make([]string, 0)
-	treeResp, err := fetchGitTree(version)
-	if err != nil {
-		log.Fatalf("Error fetching git tree for examples: %v", err)
-	}
 
 	// Parse the remote tree
 	for _, item := range treeResp.Tree {
@@ -150,7 +147,6 @@ func fetchStandardExampleFiles(version string) []string {
 			strings.HasSuffix(item.Path, ".yaml") {
 			predefinedExampleFiles = append(predefinedExampleFiles, item.Path)
 		}
-
 	}
 
 	if len(predefinedExampleFiles) == 0 {
@@ -160,47 +156,6 @@ func fetchStandardExampleFiles(version string) []string {
 	}
 
 	return predefinedExampleFiles
-}
-
-// worker fetches YAML files from GitHub and extracts the blueprint_name
-func worker(id int, version string, jobs <-chan string, results chan<- string, wg *sync.WaitGroup) {
-	defer wg.Done()
-
-	for examplePath := range jobs {
-		// Create a context with a strict 10-second timeout for each file fetch
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-
-		rawURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/%s/%s", version, examplePath)
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
-		if err != nil {
-			log.Printf("Warning [Worker %d]: failed to create request %s: %v", id, rawURL, err)
-			cancel()
-			continue
-		}
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			log.Printf("Warning [Worker %d]: failed to fetch raw yaml %s: %v", id, rawURL, err)
-			cancel()
-			continue
-		}
-
-		if resp.StatusCode == http.StatusOK {
-			body, err := io.ReadAll(resp.Body)
-			if err == nil {
-				var bp *config.Blueprint
-				// Unmarshal gracefully ignores all fields except blueprint_name
-				if err := yaml.Unmarshal(body, &bp); err == nil && bp.BlueprintName != "" {
-					results <- bp.BlueprintName
-				}
-			}
-		} else {
-			log.Printf("Warning [Worker %d]: received status %d when fetching %s", id, resp.StatusCode, rawURL)
-		}
-
-		resp.Body.Close()
-		cancel() // Release the context resources
-	}
 }
 
 func fetchStandardBlueprintNames(version string, standardExampleFiles []string) []string {
@@ -253,4 +208,45 @@ func fetchStandardBlueprintNames(version string, standardExampleFiles []string) 
 	}
 
 	return blueprintNames
+}
+
+// worker fetches YAML files from GitHub and extracts the blueprint_name
+func worker(id int, version string, jobs <-chan string, results chan<- string, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	for examplePath := range jobs {
+		// Create a context with a strict 10-second timeout for each file fetch
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
+		rawURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/%s/%s", version, examplePath)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			log.Printf("Warning [Worker %d]: failed to create request %s: %v", id, rawURL, err)
+			cancel()
+			continue
+		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			log.Printf("Warning [Worker %d]: failed to fetch raw yaml %s: %v", id, rawURL, err)
+			cancel()
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			body, err := io.ReadAll(resp.Body)
+			if err == nil {
+				var bp *config.Blueprint
+				// Unmarshal gracefully ignores all fields except blueprint_name
+				if err := yaml.Unmarshal(body, &bp); err == nil && bp.BlueprintName != "" {
+					results <- bp.BlueprintName
+				}
+			}
+		} else {
+			log.Printf("Warning [Worker %d]: received status %d when fetching %s", id, resp.StatusCode, rawURL)
+		}
+
+		resp.Body.Close()
+		cancel() // Release the context resources
+	}
 }

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"cloud.google.com/go/firestore"
@@ -161,36 +162,88 @@ func fetchStandardExampleFiles(version string) []string {
 	return predefinedExampleFiles
 }
 
-func fetchStandardBlueprintNames(version string, standardExampleFiles []string) []string {
-	blueprintNamesSet := make(map[string]bool)
-	blueprintNames := make([]string, 0)
+// worker fetches YAML files from GitHub and extracts the blueprint_name
+func worker(id int, version string, jobs <-chan string, results chan<- string, wg *sync.WaitGroup) {
+	defer wg.Done()
 
-	for _, examplePath := range standardExampleFiles {
-		// Fetch the raw content of the YAML file from GitHub
+	for examplePath := range jobs {
+		// Create a context with a strict 10-second timeout for each file fetch
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+
 		rawURL := fmt.Sprintf("https://raw.githubusercontent.com/GoogleCloudPlatform/cluster-toolkit/%s/%s", version, examplePath)
-		resp, err := httpClient.Get(rawURL)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 		if err != nil {
-			log.Printf("Warning: failed to fetch raw yaml %s: %v", rawURL, err)
+			log.Printf("Warning [Worker %d]: failed to create request %s: %v", id, rawURL, err)
+			cancel()
 			continue
 		}
 
-		// Read and parse the YAML
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			log.Printf("Warning [Worker %d]: failed to fetch raw yaml %s: %v", id, rawURL, err)
+			cancel()
+			continue
+		}
+
 		if resp.StatusCode == http.StatusOK {
 			body, err := io.ReadAll(resp.Body)
 			if err == nil {
 				var bp *config.Blueprint
-				// Unmarshal will gracefully ignore all fields except blueprint_name
+				// Unmarshal gracefully ignores all fields except blueprint_name
 				if err := yaml.Unmarshal(body, &bp); err == nil && bp.BlueprintName != "" {
-					if !blueprintNamesSet[bp.BlueprintName] {
-						blueprintNamesSet[bp.BlueprintName] = true
-						blueprintNames = append(blueprintNames, bp.BlueprintName)
-					}
+					results <- bp.BlueprintName
 				}
 			}
 		} else {
-			log.Printf("Warning: received status %d when fetching %s", resp.StatusCode, rawURL)
+			log.Printf("Warning [Worker %d]: received status %d when fetching %s", id, resp.StatusCode, rawURL)
 		}
+
 		resp.Body.Close()
+		cancel() // Release the context resources
+	}
+}
+
+func fetchStandardBlueprintNames(version string, standardExampleFiles []string) []string {
+	blueprintNamesSet := make(map[string]bool)
+	blueprintNames := make([]string, 0)
+
+	numJobs := len(standardExampleFiles)
+	if numJobs == 0 {
+		log.Printf("No blueprint names found to cache for version %s", version)
+		return blueprintNames
+	}
+
+	jobs := make(chan string, numJobs)
+	results := make(chan string, numJobs)
+	var wg sync.WaitGroup
+
+	// Set up a bounded worker pool (e.g., 10 concurrent connections)
+	numWorkers := min(numJobs, 10)
+
+	// 1. Start the worker goroutines
+	for w := 1; w <= numWorkers; w++ {
+		wg.Add(1)
+		go worker(w, version, jobs, results, &wg)
+	}
+
+	// 2. Feed the jobs channel with the file paths
+	for _, examplePath := range standardExampleFiles {
+		jobs <- examplePath
+	}
+	close(jobs) // Signal that no more jobs will be sent
+
+	// 3. Wait for all workers to finish in the background, then close the results channel
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	// 4. Collect results synchronously (prevents race conditions on the map)
+	for bpName := range results {
+		if !blueprintNamesSet[bpName] {
+			blueprintNamesSet[bpName] = true
+			blueprintNames = append(blueprintNames, bpName)
+		}
 	}
 
 	if len(blueprintNames) == 0 {


### PR DESCRIPTION
Added a new `cache_metadata` workflow that is triggered upon every new release to extract metadata for that particular version (**standard modules, standard example files, and standard blueprint names**) and store it in a Firestore database. The implementation includes concurrent processing to ensure efficient data retrieval.

Changes:

* **New Metadata Caching Tool**: Added a Go-based utility to fetch and cache release metadata from the GitHub repository using the Git Trees API.
* **Firestore Integration**: Implemented functionality to store discovered modules, example files, and blueprint names into Google Cloud Firestore.
* **Performance Optimization**: Introduced a bounded worker pool to concurrently fetch and process YAML files, significantly improving efficiency over sequential requests.