### PR TITLE
fix(binary): improve bundle installation documentation and release versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ endif
 
 gcluster: warn-go-version warn-terraform-version warn-packer-version $(shell find ./cmd ./pkg gcluster.go -type f)
 	$(info **************** building gcluster ************************)
-	@go build -ldflags="-X 'main.gitTagVersion=$(GIT_TAG_VERSION)' -X 'main.gitBranch=$(GIT_BRANCH)' -X 'main.gitCommitInfo=$(GIT_COMMIT_INFO)' -X 'main.gitCommitHash=$(GIT_COMMIT_HASH)' -X 'main.gitInitialHash=$(GIT_INITIAL_HASH)'" gcluster.go
+	@go build -ldflags="-X 'main.gitTagVersion=$(GIT_TAG_VERSION)' -X 'main.gitBranch=$(GIT_BRANCH)' -X 'main.gitCommitInfo=$(GIT_COMMIT_INFO)' -X 'main.gitCommitHash=$(GIT_COMMIT_HASH)' -X 'main.gitInitialHash=$(GIT_INITIAL_HASH)' -X 'main.gitIsOfficial=$(GIT_IS_OFFICIAL)'" gcluster.go
 	@ln -sf gcluster ghpc
 
 ghpc: gcluster

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ The pre-built bundles are compiled for Linux and macOS execution environments an
     ARCH="amd64"
     # Download and extract the platform-specific bundle
     curl -LO https://github.com/GoogleCloudPlatform/cluster-toolkit/releases/download/${TAG}/gcluster_bundle_${OS}_${ARCH}.zip
-    unzip gcluster_bundle_${OS}_${ARCH}.zip -d gcluster-bundle/
-    cd gcluster-bundle
-    chmod +x gcluster
+    unzip gcluster_bundle_${OS}_${ARCH}.zip -d cluster-toolkit/
+    cd cluster-toolkit
     ```
 
     For versions v1.89.0 and newer (Multi-architecture Tarball):
@@ -86,7 +85,7 @@ The pre-built bundles are compiled for Linux and macOS execution environments an
     OS="linux"
     ARCH="amd64"
     # Download and extract the platform-specific bundle in a single step
-    mkdir -p gcluster-bundle && curl -L https://github.com/GoogleCloudPlatform/cluster-toolkit/releases/download/${TAG}/gcluster_bundle_${OS}_${ARCH}.tgz | tar -xz -C gcluster-bundle && cd gcluster-bundle && chmod +x gcluster
+    mkdir -p cluster-toolkit && curl -L https://github.com/GoogleCloudPlatform/cluster-toolkit/releases/download/${TAG}/gcluster_bundle_${OS}_${ARCH}.tgz | tar -xz -C cluster-toolkit && cd cluster-toolkit
     ```
 
     For versions v1.82.0 through v1.84.0:
@@ -99,9 +98,8 @@ The pre-built bundles are compiled for Linux and macOS execution environments an
     OS="linux"
     # Download and extract
     curl -LO https://github.com/GoogleCloudPlatform/cluster-toolkit/releases/download/${TAG}/gcluster_bundle_${OS}.zip
-    unzip gcluster_bundle_${OS}.zip -d gcluster-bundle/
-    cd gcluster-bundle
-    chmod +x gcluster
+    unzip gcluster_bundle_${OS}.zip -d cluster-toolkit/
+    cd cluster-toolkit
     ```
 
 2. Verify the Installation:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ var (
 	GitCommitInfo  string
 	GitCommitHash  string
 	GitInitialHash string
+	GitIsOfficial  string
 )
 
 var (
@@ -76,7 +77,11 @@ func Execute() error {
 
 	if len(GitCommitInfo) > 0 {
 		if len(GitTagVersion) == 0 {
-			GitTagVersion = "(official binary distribution)"
+			if GitIsOfficial == "true" {
+				GitTagVersion = "(official binary distribution)"
+			} else {
+				GitTagVersion = "- not built from official release"
+			}
 		}
 		if len(GitBranch) == 0 {
 			GitBranch = "detached HEAD"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,7 +76,7 @@ func Execute() error {
 
 	if len(GitCommitInfo) > 0 {
 		if len(GitTagVersion) == 0 {
-			GitTagVersion = "- not built from official release"
+			GitTagVersion = "(official binary distribution)"
 		}
 		if len(GitBranch) == 0 {
 			GitBranch = "detached HEAD"

--- a/gcluster.go
+++ b/gcluster.go
@@ -33,6 +33,7 @@ var gitBranch string
 var gitCommitInfo string
 var gitCommitHash string
 var gitInitialHash string
+var gitIsOfficial string
 
 func main() {
 	if err := dependencies.PatchPath(); err != nil {
@@ -45,6 +46,7 @@ func main() {
 	cmd.GitCommitInfo = gitCommitInfo
 	cmd.GitCommitHash = gitCommitHash
 	cmd.GitInitialHash = gitInitialHash
+	cmd.GitIsOfficial = gitIsOfficial
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR introduces documentation updates and addresses feedback raised in b/506109771 to improve the pre-built bundle installation.

- Updated README.md to guide users to extract pre-compiled bundles into cluster-toolkit/ (rather than gcluster-bundle/)
- Removed redundant chmod +x gcluster steps from README.md as release binaries arrive pre-packaged with execution permissions.
- Implemented an explicit gitIsOfficial build flag in gcluster.go and cmd/root.go. Official release binaries built in CI/CD will report themselves as (official binary distribution), while local source builds will correctly report as - not built from official release.
- Expanded the Makefile to accept and pass through the GIT_IS_OFFICIAL environment flag during Go compilation.

NOTE

Post-merge action required: Upon merging this PR, the Louhi Google Cloud Build (GCB) pipeline configuration will need to be updated to pass GIT_IS_OFFICIAL=true during the gcluster compilation steps.