### PR TITLE
Isolate Daily Test to run without any interference from other resources 

### DIFF
--- a/tools/cloud-build/check_running_build.sh
+++ b/tools/cloud-build/check_running_build.sh
@@ -16,10 +16,20 @@
 set -e
 
 TRIGGER_BUILD_CONFIG_PATH="$1"
+TEST_PREFIX="$2"
+IS_ONSPOT="${3:-false}"
 
-echo "$TRIGGER_BUILD_CONFIG_PATH"
+echo "Config Path: $TRIGGER_BUILD_CONFIG_PATH"
+echo "Test Prefix: $TEST_PREFIX"
+echo "Is On-Spot: $IS_ONSPOT"
 
-MATCHING_BUILDS=$(gcloud builds list --ongoing --format 'value(id)' --filter="substitutions.TRIGGER_BUILD_CONFIG_PATH=\"$TRIGGER_BUILD_CONFIG_PATH\"")
+if [ "$IS_ONSPOT" == "true" ] && [ -n "$TEST_PREFIX" ]; then
+	FILTER="substitutions.TRIGGER_BUILD_CONFIG_PATH=\"$TRIGGER_BUILD_CONFIG_PATH\" AND substitutions._TEST_PREFIX=\"$TEST_PREFIX\""
+else
+	FILTER="substitutions.TRIGGER_BUILD_CONFIG_PATH=\"$TRIGGER_BUILD_CONFIG_PATH\""
+fi
+
+MATCHING_BUILDS=$(gcloud builds list --ongoing --format 'value(id)' --filter="$FILTER")
 MATCHING_COUNT=$(echo "$MATCHING_BUILDS" | wc -w)
 
 if [ "$MATCHING_COUNT" -gt 1 ]; then

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml '${_TEST_PREFIX}' false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -36,7 +36,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ansible-vm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -27,8 +27,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ansible-vm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ansible-vm.yaml ${_TEST_PREFIX} false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -39,8 +39,16 @@ availableSecrets:
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/batch-mpi.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # Test Batch MPI
 - id: batch-mpi

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -40,7 +40,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml '${_TEST_PREFIX}' false"
 
 # Test Batch MPI
 - id: batch-mpi

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -48,7 +48,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/batch-mpi.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # Test Batch MPI
 - id: batch-mpi

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -40,7 +40,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml ${_TEST_PREFIX} false"
 
 # Test Batch MPI
 - id: batch-mpi

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -40,7 +40,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch-mpi.yaml \"${_TEST_PREFIX}\" false"
 
 # Test Batch MPI
 - id: batch-mpi

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: chrome-remote-desktop-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml ${_TEST_PREFIX} false"
 
 - id: chrome-remote-desktop-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -26,8 +26,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: chrome-remote-desktop-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml '${_TEST_PREFIX}' false"
 
 - id: chrome-remote-desktop-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -35,7 +35,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: chrome-remote-desktop-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml \"${_TEST_PREFIX}\" false"
 
 # Test chrome-remote-desktop module
 - id: chrome-remote-desktop

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -26,8 +26,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # Test chrome-remote-desktop module
 - id: chrome-remote-desktop

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml '${_TEST_PREFIX}' false"
 
 # Test chrome-remote-desktop module
 - id: chrome-remote-desktop

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -27,7 +27,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml ${_TEST_PREFIX} false"
 
 # Test chrome-remote-desktop module
 - id: chrome-remote-desktop

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -35,7 +35,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # Test chrome-remote-desktop module
 - id: chrome-remote-desktop

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -36,7 +36,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/cloud-batch.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # Test Cloud Batch Example
 - id: cloud-batch

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml \"${_TEST_PREFIX}\" false"
 
 # Test Cloud Batch Example
 - id: cloud-batch

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml '${_TEST_PREFIX}' false"
 
 # Test Cloud Batch Example
 - id: cloud-batch

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -27,8 +27,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/cloud-batch.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # Test Cloud Batch Example
 - id: cloud-batch

--- a/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/cloud-batch.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml ${_TEST_PREFIX} false"
 
 # Test Cloud Batch Example
 - id: cloud-batch

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -34,7 +34,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/e2e.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   automapSubstitutions: true

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -26,7 +26,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml ${_TEST_PREFIX} false"
 
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   automapSubstitutions: true

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -26,7 +26,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml '${_TEST_PREFIX}' false"
 
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   automapSubstitutions: true

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -25,8 +25,16 @@ timeout: 3600s  # 1hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/e2e.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   automapSubstitutions: true

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -26,7 +26,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/e2e.yaml \"${_TEST_PREFIX}\" false"
 
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   automapSubstitutions: true

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -30,7 +30,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # uses a pre-built Google Cloud image containing Docker CLI tool.
 - id: build-docker-image

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -22,7 +22,7 @@ timeout: 3600s  # 1hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml \"${_TEST_PREFIX}\" false"
 
 # uses a pre-built Google Cloud image containing Docker CLI tool.
 - id: build-docker-image

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -21,8 +21,16 @@ substitutions:
 timeout: 3600s  # 1hr
 steps:
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # uses a pre-built Google Cloud image containing Docker CLI tool.
 - id: build-docker-image

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -22,7 +22,7 @@ timeout: 3600s  # 1hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml ${_TEST_PREFIX} false"
 
 # uses a pre-built Google Cloud image containing Docker CLI tool.
 - id: build-docker-image

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -22,7 +22,7 @@ timeout: 3600s  # 1hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml '${_TEST_PREFIX}' false"
 
 # uses a pre-built Google Cloud image containing Docker CLI tool.
 - id: build-docker-image

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-a2-highgpu-kueue-onspot-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-a2-highgpu-kueue-onspot-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-a2-highgpu-kueue-onspot-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-a2-highgpu-kueue-onspot-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-a3-highgpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-a3-highgpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-a3-highgpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-a3-highgpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-a3-highgpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-a3-highgpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml ${_TEST_PREFIX} false"
 
 - id: gke-a3-highgpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-a3-highgpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-a3-megagpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-a3-megagpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-a3-megagpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-a3-megagpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-a3-megagpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-a3-megagpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-a3-megagpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml ${_TEST_PREFIX} false"
 
 - id: gke-a3-megagpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-a3-ultragpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-a3-ultragpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-a3-ultragpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-a3-ultragpu-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml ${_TEST_PREFIX} false"
 
 - id: gke-a3-ultragpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-a3-ultragpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-a3-ultragpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-a3-ultragpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-a4-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-a4-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-a4-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-a4-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -36,7 +36,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-a4x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -36,7 +36,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml ${_TEST_PREFIX} false"
 
 - id: gke-a4x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -35,8 +35,16 @@ timeout: 7200s
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-a4x.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-a4x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -36,7 +36,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-a4x.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-a4x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-g4
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-g4
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml ${_TEST_PREFIX} false"
 
 - id: gke-g4
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-g4.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-g4.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-g4
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-g4.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke-g4
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -32,8 +32,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: gke-h4d-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml '${_TEST_PREFIX}' true"
 
 - id: gke-h4d-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml \"${_TEST_PREFIX}\" true"
 
 - id: gke-h4d-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml ${_TEST_PREFIX} true"
 
 - id: gke-h4d-onspot
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-h4d
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml ${_TEST_PREFIX} false"
 
 - id: gke-h4d
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-h4d
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -32,8 +32,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-h4d.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-h4d.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-h4d
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml ${_TEST_PREFIX} false"
 
 - id: gke-inactive-reservation
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-inactive-reservation
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -29,8 +29,16 @@ timeout: 3600s  # 1hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-inactive-reservation
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-inactive-reservation
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml \"${_TEST_PREFIX}\" false"
 
 # Test GKE
 - id: gke-managed-hyperdisk

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # Test GKE
 - id: gke-managed-hyperdisk

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml '${_TEST_PREFIX}' false"
 
 # Test GKE
 - id: gke-managed-hyperdisk

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml ${_TEST_PREFIX} false"
 
 # Test GKE
 - id: gke-managed-hyperdisk

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # Test GKE
 - id: gke-managed-hyperdisk

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -32,8 +32,16 @@ timeout: 7200s
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-managed-lustre
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-managed-lustre
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -41,7 +41,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke-managed-lustre
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-managed-lustre
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml ${_TEST_PREFIX} false"
 
 - id: gke-managed-lustre
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -42,7 +42,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-storage.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 ## Test GKE
 - id: gke-storage

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-storage.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 ## Test GKE
 - id: gke-storage

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml '${_TEST_PREFIX}' false"
 
 ## Test GKE
 - id: gke-storage

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml \"${_TEST_PREFIX}\" false"
 
 ## Test GKE
 - id: gke-storage

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-storage.yaml ${_TEST_PREFIX} false"
 
 ## Test GKE
 - id: gke-storage

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke-tpu-7x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-tpu-7x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-tpu-7x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -30,8 +30,16 @@ timeout: 7200s
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-tpu-7x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml ${_TEST_PREFIX} false"
 
 - id: gke-tpu-7x
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml ${_TEST_PREFIX} false"
 
 - id: gke-tpu-v6e-flex
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-tpu-v6e-flex
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-tpu-v6e-flex
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -42,7 +42,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke-tpu-v6e-flex
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -33,8 +33,16 @@ timeout: 7200s
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-tpu-v6e-flex
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke-tpu-v6e
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke-tpu-v6e
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml ${_TEST_PREFIX} false"
 
 - id: gke-tpu-v6e
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -29,8 +29,16 @@ timeout: 7200s
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke-tpu-v6e
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml '${_TEST_PREFIX}' false"
 
 - id: gke-tpu-v6e
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/gke.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml '${_TEST_PREFIX}' false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/gke.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/gke.yaml ${_TEST_PREFIX} false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml '${_TEST_PREFIX}' false"
 
 - id: h4d-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml ${_TEST_PREFIX} false"
 
 - id: h4d-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -37,7 +37,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/h4d-vm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: h4d-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/h4d-vm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: h4d-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/h4d-vm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: h4d-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -50,7 +50,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/hcls.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: hcls-v6
   waitFor: ["check_for_running_build"]

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -41,8 +41,16 @@ steps:
 
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/hcls.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: hcls-v6
   waitFor: ["check_for_running_build"]

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -42,7 +42,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml '${_TEST_PREFIX}' false"
 
 - id: hcls-v6
   waitFor: ["check_for_running_build"]

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -42,7 +42,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml \"${_TEST_PREFIX}\" false"
 
 - id: hcls-v6
   waitFor: ["check_for_running_build"]

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -42,7 +42,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hcls.yaml ${_TEST_PREFIX} false"
 
 - id: hcls-v6
   waitFor: ["check_for_running_build"]

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: hpc-build-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml \"${_TEST_PREFIX}\" false"
 
 - id: hpc-build-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml '${_TEST_PREFIX}' false"
 
 - id: hpc-build-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml ${_TEST_PREFIX} false"
 
 - id: hpc-build-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -29,8 +29,16 @@ timeout: 5400s  # 1.5h
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: hpc-build-slurm-image
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: hpc-enterprise-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: hpc-enterprise-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: hpc-enterprise-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: hpc-enterprise-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -42,7 +42,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: hpc-enterprise-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -31,8 +31,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/htc-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: htc-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: htc-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: htc-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -40,7 +40,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/htc-slurm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: htc-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htc-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: htc-slurm-v6
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml '${_TEST_PREFIX}' false"
 
 - id: htcondor
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -43,7 +43,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/htcondor.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: htcondor
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/htcondor.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: htcondor
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml ${_TEST_PREFIX} false"
 
 - id: htcondor
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/htcondor.yaml \"${_TEST_PREFIX}\" false"
 
 - id: htcondor
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-a3-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-a3-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
 
 - id: ml-a3-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-a3-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a3-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a3-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -34,7 +34,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a3-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -33,8 +33,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a3-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -34,7 +34,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml ${_TEST_PREFIX} true"
 
 - id: ml-a3-megagpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -34,7 +34,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-a3-megagpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -33,8 +33,16 @@ substitutions:
 timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-a3-megagpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -34,7 +34,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-a3-megagpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a3-megagpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a3-megagpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a3-megagpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a3-megagpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a3-ultragpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a3-ultragpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a3-ultragpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a3-ultragpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: ml-a3-ultragpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a3-ultragpu-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a3-ultragpu-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a3-ultragpu-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a3-ultragpu-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-a3-ultragpu-onspot-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml ${_TEST_PREFIX} true"
 
 - id: ml-a3-ultragpu-onspot-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-a3-ultragpu-onspot-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-a3-ultragpu-onspot-jbvms
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-a3-ultragpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-a3-ultragpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
 
 - id: ml-a3-ultragpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-a3-ultragpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a3-ultragpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a3-ultragpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a3-ultragpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a3-ultragpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a4-highgpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a4-highgpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: ml-a4-highgpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a4-highgpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a4-highgpu-custom-blueprint-test
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-a4-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-a4-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-a4-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml ${_TEST_PREFIX} true"
 
 - id: ml-a4-highgpu-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: ml-a4x-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: ml-a4x-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ml-a4x-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ml-a4x-highgpu-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-g4-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-g4-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml ${_TEST_PREFIX} true"
 
 - id: ml-g4-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -31,8 +31,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are gaurding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-g4-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml '${_TEST_PREFIX}' false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml ${_TEST_PREFIX} false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml ${_TEST_PREFIX} false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ml-gke.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml \"${_TEST_PREFIX}\" false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml '${_TEST_PREFIX}' false"
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-gke.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-gke.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -29,8 +29,16 @@ substitutions:
 timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      true
 
 - id: ml-h4d-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -30,7 +30,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml ${_TEST_PREFIX} true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml '${_TEST_PREFIX}' true"
 
 - id: ml-h4d-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -30,7 +30,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml ${_TEST_PREFIX} true"
 
 - id: ml-h4d-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -30,7 +30,7 @@ timeout: 14400s  # 4hr
 steps:
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml '${_TEST_PREFIX}' true"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml \"${_TEST_PREFIX}\" true"
 
 - id: ml-h4d-onspot-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -41,7 +41,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ml-slurm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml ${_TEST_PREFIX} false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -33,7 +33,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml '${_TEST_PREFIX}' false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -32,8 +32,16 @@ timeout: 18000s  # 5hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ml-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/monitoring.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # Test monitoring dashboard and install script
 - id: monitoring

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml ${_TEST_PREFIX} false"
 
 # Test monitoring dashboard and install script
 - id: monitoring

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/monitoring.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # Test monitoring dashboard and install script
 - id: monitoring

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml \"${_TEST_PREFIX}\" false"
 
 # Test monitoring dashboard and install script
 - id: monitoring

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/monitoring.yaml '${_TEST_PREFIX}' false"
 
 # Test monitoring dashboard and install script
 - id: monitoring

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/netapp-volumes.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml '${_TEST_PREFIX}' false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/netapp-volumes.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/netapp-volumes.yaml ${_TEST_PREFIX} false"
 
 - id: ansible-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -23,7 +23,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml ${_TEST_PREFIX} false"
 
 - id: ofe-deployment
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -23,7 +23,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml '${_TEST_PREFIX}' false"
 
 - id: ofe-deployment
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -22,8 +22,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/ofe-deployment.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: ofe-deployment
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -31,7 +31,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/ofe-deployment.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: ofe-deployment
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -23,7 +23,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ofe-deployment.yaml \"${_TEST_PREFIX}\" false"
 
 - id: ofe-deployment
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml \"${_TEST_PREFIX}\" false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml ${_TEST_PREFIX} false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml '${_TEST_PREFIX}' false"
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -31,8 +31,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/packer.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/packer.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -40,7 +40,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/packer.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 # test image creation by provisioning a new VPC and using Packer to build an
 # image in it

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml ${_TEST_PREFIX} false"
 
 - id: managed-lustre-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: managed-lustre-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: managed-lustre-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml '${_TEST_PREFIX}' false"
 
 - id: managed-lustre-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: managed-lustre-slurm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml '${_TEST_PREFIX}' false"
 
 - id: managed-lustre-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -36,7 +36,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: managed-lustre-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml \"${_TEST_PREFIX}\" false"
 
 - id: managed-lustre-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -27,8 +27,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: managed-lustre-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -28,7 +28,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml ${_TEST_PREFIX} false"
 
 - id: managed-lustre-vm
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml \"${_TEST_PREFIX}\" false"
 
 - id: slinky
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slinky.yml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slinky
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slinky.yml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slinky
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml ${_TEST_PREFIX} false"
 
 - id: slinky
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slinky.yml '${_TEST_PREFIX}' false"
 
 - id: slinky
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -37,7 +37,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-flex.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-flex.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-flex.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-debian
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gcp-v6-debian
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-debian
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-debian
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-debian
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-reconfig
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-reconfig
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -37,7 +37,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-reconfig
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-reconfig
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-reconfig
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-rocky8
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-rocky8
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-rocky8
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-rocky8
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gcp-v6-rocky8
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -37,7 +37,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-job-completion
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -31,8 +31,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-ssd
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-ssd
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-ssd
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -40,7 +40,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gcp-v6-ssd
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-ssd
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-startup-scripts
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -40,7 +40,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gcp-v6-startup-scripts
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -31,8 +31,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-startup-scripts
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-startup-scripts
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -32,7 +32,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-startup-scripts
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-static
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-static
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-static
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-static.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-static
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-topology
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -37,7 +37,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-topology
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -28,8 +28,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-topology
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-topology
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -29,7 +29,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-topology
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -29,8 +29,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm6-tpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml ${_TEST_PREFIX} false"
 
 - id: slurm6-tpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -38,7 +38,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm6-tpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm6-tpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -30,7 +30,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm6-tpu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gcp-v6-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gcp-v6-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gcp-v6-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gcp-v6-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gcp-v6-ubuntu
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -38,7 +38,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml '${_TEST_PREFIX}' false"
 
 - id: slurm-gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -38,7 +38,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml ${_TEST_PREFIX} false"
 
 - id: slurm-gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -38,7 +38,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml \"${_TEST_PREFIX}\" false"
 
 - id: slurm-gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -46,7 +46,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-gke.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: slurm-gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -37,8 +37,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-gke.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-gke.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: slurm-gke
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml \"${_TEST_PREFIX}\" false"
 
 ## Test SLURM Rapid Storage
 - id: slurm-rapid-storage

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml '${_TEST_PREFIX}' false"
 
 ## Test SLURM Rapid Storage
 - id: slurm-rapid-storage

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -31,7 +31,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml ${_TEST_PREFIX} false"
 
 ## Test SLURM Rapid Storage
 - id: slurm-rapid-storage

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -30,8 +30,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 ## Test SLURM Rapid Storage
 - id: slurm-rapid-storage

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -39,7 +39,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 ## Test SLURM Rapid Storage
 - id: slurm-rapid-storage

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml '${_TEST_PREFIX}' false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml \"${_TEST_PREFIX}\" false"
 
 - id: spack-gromacs
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml ${_TEST_PREFIX} false"
 
 - id: spack-gromacs
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -35,7 +35,7 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml ${_TEST_PREFIX} false"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml '${_TEST_PREFIX}' false"
 
 - id: spack-gromacs
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -34,8 +34,16 @@ timeout: 14400s  # 4hr
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
-  name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/spack-gromacs.yaml \"${_TEST_PREFIX}\" false"
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -e
+    tools/cloud-build/check_running_build.sh \
+      "tools/cloud-build/daily-tests/builds/spack-gromacs.yaml" \
+      "${_TEST_PREFIX}" \
+      false
 
 - id: spack-gromacs
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -43,7 +43,7 @@ steps:
     tools/cloud-build/check_running_build.sh \
       "tools/cloud-build/daily-tests/builds/spack-gromacs.yaml" \
       "${_TEST_PREFIX}" \
-      false
+      true
 
 - id: spack-gromacs
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner

--- a/tools/cloud-build/daily-tests/validate_daily_test_builds.py
+++ b/tools/cloud-build/daily-tests/validate_daily_test_builds.py
@@ -46,22 +46,28 @@ def validate_build_file(file_path: Path) -> bool:
 
     for step in steps:
         if isinstance(step, dict) and step.get("id") == "check_for_running_build":
-            script = step.get("script")
-            if not script:
-                print(
-                    f"Error: 'script' not found in 'check_for_running_build' step in {file_path}",
-                    file=sys.stderr,
-                )
+            entrypoint = step.get("entrypoint")
+            args = step.get("args")
+            if not entrypoint or not args:
+                print(f"Error: 'entrypoint' or 'args' not found in 'check_for_running_build' step in {file_path}", file=sys.stderr)
                 return False
+            if entrypoint != "/bin/bash":
+                print(f"Error: Invalid 'entrypoint' in 'check_for_running_build' step in {file_path}. Expected /bin/bash, got {entrypoint}", file=sys.stderr)
+                return False
+            if not isinstance(args, list) or len(args) != 2 or args[0] != "-c":
+                print(f"Error: Invalid 'args' structure in 'check_for_running_build' step in {file_path}. Expected ['-c', '...']", file=sys.stderr)
+                return False
+                
+            script_content = args[1]
             is_onspot = "true" if "onspot" in file_path.name else "false"
-            expected_script = f"tools/cloud-build/check_running_build.sh {file_path} '${{_TEST_PREFIX}}' {is_onspot}"
-            if script != expected_script:
-                print(
-                    f"Error: Invalid 'script' in 'check_for_running_build' step in {file_path}",
-                    file=sys.stderr,
-                )
-                print(f"  Expected: {expected_script}", file=sys.stderr)
-                print(f"  Got:      {script}", file=sys.stderr)
+            
+            if "check_running_build.sh" not in script_content or \
+               str(file_path) not in script_content or \
+               "${_TEST_PREFIX}" not in script_content or \
+               is_onspot not in script_content:
+                print(f"Error: Invalid script content in 'check_for_running_build' step in {file_path}", file=sys.stderr)
+                print(f"  Expected to contain: check_running_build.sh, {file_path}, ${_TEST_PREFIX}, {is_onspot}", file=sys.stderr)
+                print(f"  Got: {script_content}", file=sys.stderr)
                 return False
             return True
 

--- a/tools/cloud-build/daily-tests/validate_daily_test_builds.py
+++ b/tools/cloud-build/daily-tests/validate_daily_test_builds.py
@@ -19,6 +19,22 @@ from pathlib import Path
 
 import yaml
 
+# List of files that use reservations
+reservation_files = [
+    "slurm-gcp-v6-static.yaml",
+    "ml-a3-megagpu-slurm-ubuntu.yaml",
+    "gke-a4x.yaml",
+    "gke-h4d.yaml",
+    "gke-a3-highgpu.yaml",
+    "ml-a3-ultragpu-slurm.yaml",
+    "ml-a3-highgpu-slurm.yaml",
+    "ml-a4x-highgpu-slurm.yaml",
+    "gke-a3-megagpu.yaml",
+    "gke-inactive-reservation.yaml",
+    "ml-a3-ultragpu-jbvms.yaml",
+    "gke-a3-ultragpu.yaml"
+]
+
 def validate_build_file(file_path: Path) -> bool:
     """Validates a daily test build file.
 
@@ -59,14 +75,14 @@ def validate_build_file(file_path: Path) -> bool:
                 return False
                 
             script_content = args[1]
-            is_onspot = "true" if "onspot" in file_path.name else "false"
+            is_onspot = "false" if file_path.name in reservation_files else "true"
             
             if "check_running_build.sh" not in script_content or \
                str(file_path) not in script_content or \
                "${_TEST_PREFIX}" not in script_content or \
                is_onspot not in script_content:
                 print(f"Error: Invalid script content in 'check_for_running_build' step in {file_path}", file=sys.stderr)
-                print(f"  Expected to contain: check_running_build.sh, {file_path}, ${_TEST_PREFIX}, {is_onspot}", file=sys.stderr)
+                print(f"  Expected to contain: check_running_build.sh, {file_path}, ${{_TEST_PREFIX}}, {is_onspot}", file=sys.stderr)
                 print(f"  Got: {script_content}", file=sys.stderr)
                 return False
             return True

--- a/tools/cloud-build/daily-tests/validate_daily_test_builds.py
+++ b/tools/cloud-build/daily-tests/validate_daily_test_builds.py
@@ -53,7 +53,8 @@ def validate_build_file(file_path: Path) -> bool:
                     file=sys.stderr,
                 )
                 return False
-            expected_script = f"tools/cloud-build/check_running_build.sh {file_path}"
+            is_onspot = "true" if "onspot" in file_path.name else "false"
+            expected_script = f"tools/cloud-build/check_running_build.sh {file_path} '${{_TEST_PREFIX}}' {is_onspot}"
             if script != expected_script:
                 print(
                     f"Error: Invalid 'script' in 'check_for_running_build' step in {file_path}",


### PR DESCRIPTION
This pull request introduces logic to enable parallel execution of integration tests in the Cluster Toolkit, specifically allowing a Pull Request (PR) test and a Daily scheduled test for the same blueprint to run concurrently without conflict .

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
