### PR TITLE
Update GKE TPU examples by removing static_node_count var

### DIFF
--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -222,7 +222,6 @@ To avoid recurring charges for the resources used, clean up the resources provis
 
 - The formula is: (`Total Chips in Topology`) / (`Chips per Machine`)
 - This value is automatically injected into your configuration during blueprint expansion.
-- For multi-node setups, a COMPACT placement policy is automatically configured.
 
 #### Example 1: *Single-Node Slice* (The default for this blueprint)
 

--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -16,12 +16,11 @@ This guide also includes a `gke-tpu-7x-job.yaml` that creates a Kubernetes Pod a
 
 - `num_slices`: The number of identical, independent **TPU slices (node pools)** to create. A TPU slice is a collection of TPU chips that are physically connected by a dedicated, ultra-low-latency network called the Inter-Chip Interconnect (ICI). This is what allows the nodes to function as a single, cohesive supercomputer. Each node pool created by this variable corresponds to one such slice.
   - **Default value is 1**. Most use-cases require this value to be `1`. This blueprint will create one GKE node pool that contains all the nodes needed for your `tpu_topology`.
-  - **Advanced Use**: This variable acts as a multiplier. For example, if you set `num_slices: 3` and `static_node_count: 2`, the blueprint will create three separate node pools (...-pool-0, ...-pool-1, ...-pool-2), each containing `2` TPU nodes. This is an advanced feature for provisioning multiple, smaller, identical slices at once.
+  - **Advanced Use**: This variable acts as a multiplier. For example, if you set `num_slices: 3`, the blueprint will create three separate node pools (...-pool-0, ...-pool-1, ...-pool-2). This is an advanced feature for provisioning multiple, smaller, identical slices at once.
 - `tpu_topology`: The TPU topology desired. Topology is the number and physical arrangement of the TPU chips in a TPU slice.
   - **What it is**: This defines the shape and total size of your TPU "supercomputer". For the 3D-interconnected TPU 7x, you must specify this in XxYxZ format (e.g., `2x2x1`).
   - **Why it matters**: The product of the dimensions (X*Y*Z) gives you the total number of chips in your slice. This number is essential for calculating the `static_node_count`.
-  - **Example**: A tpu_topology of `2x2x1` creates a 4-chip slice. If you then use a `tpu7x-standard-4t` machine type (which has `4` chips per node), you can calculate your required `static_node_count` as `1` (4 total chips / 4 chips per node).
-- `static_node_count`: The **fixed, exact number of nodes (VMs)** required to build **each individual TPU slice** (*as defined by `num_slices`*) in your `tpu_topology`. **This is the most critical parameter to set correctly**. Cloud TPU slices are created as a single, rigid hardware unit with physical, high-speed interconnects (ICI) between all nodes. This is different from standard CPU or GPU node pools. For more details please refer to the [appendix](#how-to-calculate-static_node_count)
+  - **Example**: A tpu_topology of `2x2x1` creates a 4-chip slice. If you then use a `tpu7x-standard-4t` machine type (which has `4` chips per node),then the derived `static_node_count` is `1` (4 total chips / 4 chips per node).
   - **It is an exact requirement, not a maximum**. If your topology requires 4 nodes, you must set this value to `4`. Providing a different number will cause the deployment to **fail**.
   - **It does not support autoscaling**. Because the hardware is physically interconnected, the size of the slice is fixed at creation time. There are no "*dynamic*" options.
 
@@ -81,11 +80,10 @@ This section guides you through the cluster creation process.
    - `num_slices`: the number of TPU slices (node pools) to create.
    - `machine_type`: the machine type of the TPU.
    - `tpu_topology`: the TPU placement topology for the node pool.
-   - `static_node_count`: the number of TPU nodes in each TPU slice (node pool).z
-
-    > (Note: This is calculated by dividing the total chips in the topology by the chips per machine. E.g. a `2x2x1` topology (4 chips) using `tpu7x-standard-4t` machines (4 chips) requires `static_node_count: 1`). For details refer to the [Appendix](#how-to-calculate-static_node_count).
    - `authorized_cidr`: The IP address range you want to allow to connect with the cluster.
    - `reservation`: the name of the compute engine reservation for your TPU 7x nodes.
+
+    > **Note:** The `static_node_count` is now automatically calculated from `machine_type`, `num_slices` and `tpu_topology`. It is derived using the formula: `(total_chips_in_topology / chips_per_machine)`. For further details, please refer [appendix](#node-count-calculation)
 
 6. To modify advanced settings, edit `examples/gke-tpu-7x/gke-tpu-7x.yaml`.
 7. Generate [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp) to provide access to Terraform.
@@ -220,9 +218,11 @@ To avoid recurring charges for the resources used, clean up the resources provis
 
 ## Appendix
 
-### How to Calculate `static_node_count`
+### Node Count Calculation
 
 - The formula is: (`Total Chips in Topology`) / (`Chips per Machine`)
+- This value is automatically injected into your configuration during blueprint expansion.
+- For multi-node setups, a COMPACT placement policy is automatically configured.
 
 #### Example 1: *Single-Node Slice* (The default for this blueprint)
 
@@ -248,6 +248,8 @@ This example shows how `num_slices` and `static_node_count` work together. The g
 - **Calculation**: `8 / 4 = 2`
 - **Correct value**: `static_node_count: 2`
 - **Result**: This configuration will create three separate GKE node pools, and each of those node pools will contain two nodes. The total number of TPU nodes created will be `3 * 2 = 6`.
+
+**NOTE**: You can optionally provide an explicit `static_node_count` value in your deployment file. If you do, ensure it matches the above calculation formula. The toolkit will use explicit value and skip auto-calculation. Incorrect values will cause deployment failures, so auto-derivation is recommended.
 
 ### How to Calculate the Expected Device Count after running the `gke-tpu-7x-job.yaml`
 

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -38,9 +38,6 @@ vars:
   # The TPU placement topology for pod slice node pool.
   tpu_topology:
 
-  # The number of nodes to be created in each nodepool
-  static_node_count:
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
@@ -219,7 +216,6 @@ deployment_groups:
       machine_type: $(vars.machine_type)
       auto_upgrade: true
       zones: [$(vars.zone)]
-      static_node_count: $(vars.static_node_count)
       additional_networks:
         $(concat(
           [{
@@ -294,7 +290,7 @@ deployment_groups:
         install: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
-          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-7x-pool.tpu_chips_per_node)
+          tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(gke-tpu-7x-pool.tpu_accelerator_type)
       jobset:
         install: true
@@ -337,7 +333,7 @@ deployment_groups:
     source: modules/compute/gke-job-template
     use: [checkpointing-pv, training-pv, gke-tpu-7x-pool]
     settings:
-      node_count: $(vars.static_node_count)
+      node_count: $(gke-tpu-7x-pool.node_count_static)
       security_context:  # to make sure the job have enough access to install the fio packages
       - key: runAsUser
         value: 0

--- a/examples/gke-tpu-7x/gke-tpu-7x-deployment.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-deployment.yaml
@@ -45,11 +45,6 @@ vars:
   # The physical arrangement of the TPU chips in the slice.
   tpu_topology: 2x2x1
 
-  # The number of nodes to be created in each nodepool
-  # For TPUs, static_node_count should be num of chips based on topology divided by num chips for the machine type
-  # Example: 4 chips (for 2x2x1) / 4 chips (per tpu7x-standard-4t) = 1 node
-  static_node_count: 1
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -38,9 +38,6 @@ vars:
   # The TPU placement topology for pod slice node pool.
   tpu_topology:
 
-  # The number of nodes to be created in each nodepool
-  static_node_count:
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
@@ -148,7 +145,6 @@ deployment_groups:
       machine_type: $(vars.machine_type)
       auto_upgrade: true
       zones: [$(vars.zone)]
-      static_node_count: $(vars.static_node_count)
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:
@@ -163,7 +159,7 @@ deployment_groups:
         install: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
-          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-7x-pool.tpu_chips_per_node)
+          tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(gke-tpu-7x-pool.tpu_accelerator_type)
       jobset:
         install: true

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -71,6 +71,8 @@ This section guides you through the cluster creation process, ensuring that your
    * `authorized_cidr`: The IP address range that you want to allow to connect with the cluster. This CIDR block must include the IP address of the machine to call Terraform.
    * `reservation`: the name of the compute engine reservation of TPU v6e nodes.
 
+    > **Note:** The `static_node_count` is now automatically calculated from `machine_type`, `num_slices` and `tpu_topology`. It is derived using the formula: `(total_chips_in_topology / chips_per_machine)`.
+
     To modify advanced settings, edit `examples/gke-tpu-v6e/gke-tpu-v6e.yaml`.
 
 1. To use on-demand capacity, you can remove the reservation usage by making the following changes.

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -68,7 +68,6 @@ This section guides you through the cluster creation process, ensuring that your
    * `num_slices`: the number of TPU slices to create.
    * `machine_type`: the machine type of the TPU.
    * `tpu_topology`: the TPU placement topology for pod slice node pool.
-   * `static_node_count`: the number of TPU nodes in your cluster.
    * `authorized_cidr`: The IP address range that you want to allow to connect with the cluster. This CIDR block must include the IP address of the machine to call Terraform.
    * `reservation`: the name of the compute engine reservation of TPU v6e nodes.
 
@@ -123,7 +122,7 @@ The process is nearly identical to the basic deployment.
 
 This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native system for managing quotas and job queuing. This is enabled by default in the advanced blueprint (`gke-tpu-v6e-advanced.yaml`).
 
-1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
+1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
 2. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
 
     A sample job file is provided: `kueue-job-sample.yaml`.

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -38,9 +38,6 @@ vars:
   # The TPU placement topology for pod slice node pool.
   tpu_topology:
 
-  # The number of nodes to be created in each nodepool
-  static_node_count:
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
@@ -216,7 +213,6 @@ deployment_groups:
       auto_upgrade: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
-      static_node_count: $(vars.static_node_count)
       additional_networks:
         $(concat(
           [{
@@ -294,7 +290,7 @@ deployment_groups:
         install: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
-          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-v6e-pool.tpu_chips_per_node)
+          tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(gke-tpu-v6e-pool.tpu_accelerator_type)
       jobset:
         install: true
@@ -337,7 +333,7 @@ deployment_groups:
     source: modules/compute/gke-job-template
     use: [checkpointing-pv, training-pv, gke-tpu-v6e-pool]
     settings:
-      node_count: $(vars.static_node_count)
+      node_count: $(gke-tpu-v6e-pool.node_count_static)
       security_context:  # to make sure the job have enough access to install the fio packages
       - key: runAsUser
         value: 0

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
@@ -43,11 +43,6 @@ vars:
   # The TPU placement topology for pod slice node pool.
   tpu_topology: 4x4
 
-  # The number of nodes to be created in each nodepool
-  # For TPUs, static_node_count should be num of chips based on topology divided by num chips for the machine type
-  # Reference: https://cloud.google.com/tpu/docs/v6e
-  static_node_count: 4
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -17,31 +17,31 @@ blueprint_name: gke-tpu-v6e
 vars:
   # The following variables should be over-written in the deployment.yaml file.
   # Your GCP Project ID
-  project_id: hpc-toolkit-dev
+  project_id:
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
   deployment_name: gke-tpu-v6e
 
   # The GCP Region used for this deployment.
-  region: us-central1
+  region:
 
   # The GCP Zone used for this deployment.
-  zone: us-central1-b
+  zone:
 
   # The number of TPU slices to create
-  num_slices: 1
+  num_slices:
 
   # Machine type
-  machine_type: ct6e-standard-4t
+  machine_type:
 
   # The TPU placement topology for pod slice node pool.
-  tpu_topology: 2x2
+  tpu_topology:
 
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
-  authorized_cidr: 0.0.0.0/0
+  authorized_cidr:
 
   # The name of the compute engine reservation of TPU v6e nodes
   #reservation:

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -44,7 +44,7 @@ vars:
   authorized_cidr:
 
   # The name of the compute engine reservation of TPU v6e nodes
-  #reservation:
+  reservation:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
@@ -188,10 +188,10 @@ deployment_groups:
             alias_ip_range=[]
           }]
         ))
-      # reservation_affinity:
-      #   consume_reservation_type: SPECIFIC_RESERVATION
-      #   specific_reservations:
-      #   - name: $(vars.reservation)
+      reservation_affinity:
+        consume_reservation_type: SPECIFIC_RESERVATION
+        specific_reservations:
+        - name: $(vars.reservation)
       placement_policy:
         type: COMPACT
         tpu_topology: $(vars.tpu_topology)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -17,37 +17,34 @@ blueprint_name: gke-tpu-v6e
 vars:
   # The following variables should be over-written in the deployment.yaml file.
   # Your GCP Project ID
-  project_id:
+  project_id: hpc-toolkit-dev
 
   # This should be unique across all of your Cluster
   # Toolkit Deployments.
   deployment_name: gke-tpu-v6e
 
   # The GCP Region used for this deployment.
-  region:
+  region: us-central1
 
   # The GCP Zone used for this deployment.
-  zone:
+  zone: us-central1-b
 
   # The number of TPU slices to create
-  num_slices:
+  num_slices: 1
 
   # Machine type
-  machine_type:
+  machine_type: ct6e-standard-4t
 
   # The TPU placement topology for pod slice node pool.
-  tpu_topology:
-
-  # The number of nodes to be created in each nodepool
-  static_node_count:
+  tpu_topology: 2x2
 
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
-  authorized_cidr:
+  authorized_cidr: 0.0.0.0/0
 
   # The name of the compute engine reservation of TPU v6e nodes
-  reservation:
+  #reservation:
 
   system_node_pool_disk_size_gb: 200
   v6e_node_pool_disk_size_gb: 100
@@ -176,7 +173,6 @@ deployment_groups:
       auto_upgrade: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
-      static_node_count: $(vars.static_node_count)
       additional_networks:
         $(concat(
           [{
@@ -192,10 +188,10 @@ deployment_groups:
             alias_ip_range=[]
           }]
         ))
-      reservation_affinity:
-        consume_reservation_type: SPECIFIC_RESERVATION
-        specific_reservations:
-        - name: $(vars.reservation)
+      # reservation_affinity:
+      #   consume_reservation_type: SPECIFIC_RESERVATION
+      #   specific_reservations:
+      #   - name: $(vars.reservation)
       placement_policy:
         type: COMPACT
         tpu_topology: $(vars.tpu_topology)
@@ -210,7 +206,7 @@ deployment_groups:
         enable_pathways_for_tpus: true
         config_path: $(vars.kueue_configuration_path)
         config_template_vars:
-          tpu_quota: $(vars.num_slices * vars.static_node_count * gke-tpu-v6e-pool.tpu_chips_per_node)
+          tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(gke-tpu-v6e-pool.tpu_accelerator_type)
       jobset:
         install: true


### PR DESCRIPTION
### 1. **Rationale**
This PR eliminates`static_node_count` variable from TPU example blueprints as the node count value is automatically getting derived from `machine_type`, `tpu_topology`, and `num_slices`. This reduces deployment errors and simplifies the user experience.

### 2. **Changes Done**
- Removed `static_node_count` variable from YAML files
- Updated all references to use auto-calculated `node_count_static` from the GKE module
- Updated README documentation to clarify automatic calculation and removed manual calculation examples

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
