### PR TITLE
Fix Slurm 25.05 topology.yaml parsing error

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -19,7 +19,6 @@ from itertools import chain
 from collections import defaultdict
 from dataclasses import dataclass, field
 import logging
-import os
 import math
 import json
 from pathlib import Path
@@ -756,8 +755,8 @@ def gen_topology_yaml(lkp: util.Lookup) -> Tuple[bool, TopologySummary]:
         f.write("---\n\n")
         yaml.dump(topo.render_yaml(block_is_default=block_is_default), f, sort_keys=False)
 
-    if os.path.getsize(yaml_file) % 4096 == 0:
-        with open(yaml_file, "a") as f:
+    if yaml_file.stat().st_size % 4096 == 0:
+        with yaml_file.open("a") as f:
             f.write("\n")
 
     prev_summary = TopologySummary.load(lkp)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -19,6 +19,7 @@ from itertools import chain
 from collections import defaultdict
 from dataclasses import dataclass, field
 import logging
+import os
 import math
 import json
 from pathlib import Path
@@ -754,6 +755,10 @@ def gen_topology_yaml(lkp: util.Lookup) -> Tuple[bool, TopologySummary]:
         f.write(FILE_PREAMBLE)
         f.write("---\n\n")
         yaml.dump(topo.render_yaml(block_is_default=block_is_default), f, sort_keys=False)
+
+    if os.path.getsize(yaml_file) % 4096 == 0:
+        with open(yaml_file, "a") as f:
+            f.write("\n")
 
     prev_summary = TopologySummary.load(lkp)
     return topo.summary.requires_reconfigure(prev_summary), topo.summary


### PR DESCRIPTION
## Description
This PR implements a fix for Slurm 25.05 to prevent a fatal startup failure when reading `topology.yaml` due to a page-alignment issue.

### Problem
In Slurm 25.05, the YAML parser plugin uses memory-mapped I/O to read configuration files like topology.yaml. The parser strictly requires the input buffer to be NULL-terminated. If the file size is exactly a multiple of the page size (4096 bytes), the parser reads past the mapped buffer to check for the NULL terminator, potentially accessing random data in the adjacent page and failing with EINVAL (Invalid argument).

This causes a fatal error: `fatal: Something wrong with reading /usr/local/etc/slurm/topology.yaml: Invalid argument`.

### Solution
Modified `gen_topology_yaml` in `conf.py` to check the size of the generated `cloud_topology.yaml` file. If the size is a multiple of 4096 bytes, the script appends a newline (`\n`) to the file. This ensures the file is never page-aligned, satisfying the Slurm parser without breaking the YAML validity.

### Verification
1. **Reproduction**: Verified on a live cluster running Slurm 25.05.3 by manually padding `topology.yaml` to exactly 4096 bytes. The Slurm controller failed to start with the expected `Invalid argument` error.
2. **Fix Verification**: Modified `conf.py` to force the generated file size to 4096 bytes. Verified that the fix correctly appended a newline, resulting in a 4097-byte file, and `slurmctld` started successfully.