### PR TITLE
adding new global static ip module.

### DIFF
--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -1,0 +1,49 @@
+# Global Static IP Module
+This module creates Google Cloud Global Static IP addresses.
+## Usage
+
+```hcl
+module "global_static_ip" {
+  source = "path/to/module"
+  project_id = "your-project-id"
+  ip_names   = ["ip-1", "ip-2"]
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_global_address.ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_ip_names"></a> [ip\_names](#input\_ip\_names) | List of global static IP names to create | `list(string)` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_global_ips"></a> [global\_ips](#output\_global\_ips) | A map of IP names to allocated global static IP addresses. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -66,5 +66,6 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_addresses"></a> [addresses](#output\_addresses) | A list of allocated global static IP addresses. |
 | <a name="output_global_ips"></a> [global\_ips](#output\_global\_ips) | A map of IP names to allocated global static IP addresses. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -1,8 +1,12 @@
+
 ## Description
 
 This module creates Google Cloud Global Static IP addresses.
 
 ## Example usage
+
+This module can be used to reserve global static IP addresses for use with
+external load balancers or other global resources.
 
 ```yaml
 - id: global_static_ip
@@ -12,6 +16,20 @@ This module creates Google Cloud Global Static IP addresses.
     - $(vars.deployment_name)-ip-1
     - $(vars.deployment_name)-ip-2
 ```
+
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -1,13 +1,16 @@
-# Global Static IP Module
-This module creates Google Cloud Global Static IP addresses.
-## Usage
+## Description
 
-```hcl
-module "global_static_ip" {
-  source = "path/to/module"
-  project_id = "your-project-id"
-  ip_names   = ["ip-1", "ip-2"]
-}
+This module creates Google Cloud Global Static IP addresses.
+
+## Example usage
+
+```yaml
+- id: global_static_ip
+  source: modules/network/global-static-ip
+  settings:
+    ip_names:
+    - $(vars.deployment_name)-ip-1
+    - $(vars.deployment_name)-ip-2
 ```
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -59,7 +59,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_ip_names"></a> [ip\_names](#input\_ip\_names) | List of global static IP names to create | `list(string)` | n/a | yes |
+| <a name="input_description"></a> [description](#input\_description) | Description to provide context for the global static IP addresses | `string` | `null` | no |
+| <a name="input_ip_names"></a> [ip\_names](#input\_ip\_names) | Set of global static IP names to create | `set(string)` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the global static IP addresses | `map(string)` | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/network/global-static-ip/main.tf
+++ b/modules/network/global-static-ip/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_compute_global_address" "ips" {
+  for_each = toset(var.ip_names)
+  name     = each.value
+  project  = var.project_id
+}

--- a/modules/network/global-static-ip/main.tf
+++ b/modules/network/global-static-ip/main.tf
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "global-static-ip", ghpc_role = "network" })
+}
+
 resource "google_compute_global_address" "ips" {
-  for_each = toset(var.ip_names)
-  name     = each.value
-  project  = var.project_id
+  for_each    = var.ip_names
+  name        = each.value
+  project     = var.project_id
+  description = var.description
+  labels      = local.labels
 }

--- a/modules/network/global-static-ip/metadata.yaml
+++ b/modules/network/global-static-ip/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - compute.googleapis.com
+ghpc:
+  validators: []

--- a/modules/network/global-static-ip/outputs.tf
+++ b/modules/network/global-static-ip/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "global_ips" {
+  value       = { for k, v in google_compute_global_address.ips : k => v.address }
+  description = "A map of IP names to allocated global static IP addresses."
+}

--- a/modules/network/global-static-ip/outputs.tf
+++ b/modules/network/global-static-ip/outputs.tf
@@ -16,3 +16,8 @@ output "global_ips" {
   value       = { for k, v in google_compute_global_address.ips : k => v.address }
   description = "A map of IP names to allocated global static IP addresses."
 }
+
+output "addresses" {
+  value       = [for v in google_compute_global_address.ips : v.address]
+  description = "A list of allocated global static IP addresses."
+}

--- a/modules/network/global-static-ip/variables.tf
+++ b/modules/network/global-static-ip/variables.tf
@@ -1,0 +1,22 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+variable "ip_names" {
+  description = "List of global static IP names to create"
+  type        = list(string)
+}

--- a/modules/network/global-static-ip/variables.tf
+++ b/modules/network/global-static-ip/variables.tf
@@ -16,7 +16,20 @@ variable "project_id" {
   description = "GCP Project ID"
   type        = string
 }
+
 variable "ip_names" {
-  description = "List of global static IP names to create"
-  type        = list(string)
+  description = "Set of global static IP names to create"
+  type        = set(string)
+}
+
+variable "labels" {
+  description = "Labels to apply to the global static IP addresses"
+  type        = map(string)
+  default     = {}
+}
+
+variable "description" {
+  description = "Description to provide context for the global static IP addresses"
+  type        = string
+  default     = null
 }

--- a/modules/network/global-static-ip/versions.tf
+++ b/modules/network/global-static-ip/versions.tf
@@ -1,0 +1,23 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a new module for provisioning Google Cloud Global Static IP addresses.

This module allows for the allocation of named global static IPs using Terraform's for_each pattern. It provides a standard way to manage static IP resources required by Global Load Balancers across different environments.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
