### PR TITLE
adding new module for kubernetes namespace.

### DIFF
--- a/modules/management/kubernetes-namespace/README.md
+++ b/modules/management/kubernetes-namespace/README.md
@@ -1,0 +1,83 @@
+## Description
+
+This module creates a Kubernetes namespace.
+
+## Example usage
+
+```yaml
+- id: kubernetes_namespace
+  source: modules/management/kubernetes-namespace
+  settings:
+    namespace: my-namespace
+    cluster_id: $(kubernetes_cluster.cluster_id)
+```
+
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [kubernetes_namespace_v1.ns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+| [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the cluster | `string` | `null` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | The name of the created Kubernetes namespace. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/management/kubernetes-namespace/README.md
+++ b/modules/management/kubernetes-namespace/README.md
@@ -12,19 +12,7 @@ This module creates a Kubernetes namespace.
     cluster_id: $(kubernetes_cluster.cluster_id)
 ```
 
-Copyright 2026 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC
@@ -72,7 +60,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the cluster | `string` | `null` | no |
+| <a name="input_access_token"></a> [access\_token](#input\_access\_token) | The access token for accessing the cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The full GCP resource ID of the GKE cluster in the format projects/PROJECT\_ID/locations/LOCATION/clusters/CLUSTER\_NAME | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/management/kubernetes-namespace/README.md
+++ b/modules/management/kubernetes-namespace/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module creates a Kubernetes namespace.
+This module creates a Kubernetes namespace. It configures the Kubernetes provider using either explicitly provided credentials (`cluster_endpoint`, `cluster_ca_certificate`, `access_token`) or dynamically looks them up using the `cluster_id`.
 
 ## Example usage
 

--- a/modules/management/kubernetes-namespace/main.tf
+++ b/modules/management/kubernetes-namespace/main.tf
@@ -1,0 +1,37 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+resource "kubernetes_namespace_v1" "ns" {
+  metadata {
+    name = var.namespace
+  }
+}
+locals {
+  cluster_id_parts = var.cluster_id != null ? split("/", var.cluster_id) : []
+  cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
+  cluster_location = length(local.cluster_id_parts) > 3 ? local.cluster_id_parts[3] : ""
+  kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
+}
+data "google_client_config" "default" {}
+data "google_container_cluster" "gke_cluster" {
+  name     = local.cluster_name
+  location = local.cluster_location
+  project  = local.kube_project_id
+}
+provider "kubernetes" {
+  host                   = "https://${data.google_container_cluster.gke_cluster.endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+}

--- a/modules/management/kubernetes-namespace/main.tf
+++ b/modules/management/kubernetes-namespace/main.tf
@@ -23,6 +23,12 @@ locals {
   cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
   cluster_location = length(local.cluster_id_parts) > 3 ? local.cluster_id_parts[3] : ""
   kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
+
+
+  # HYBRID LOGIC: Use passed-in variable if available, otherwise fall back to data source
+  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : "https://${data.google_container_cluster.gke_cluster.endpoint}"
+  token                  = var.access_token != null ? var.access_token : data.google_client_config.default.access_token
+  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
 }
 data "google_client_config" "default" {}
 data "google_container_cluster" "gke_cluster" {
@@ -31,7 +37,7 @@ data "google_container_cluster" "gke_cluster" {
   project  = local.kube_project_id
 }
 provider "kubernetes" {
-  host                   = "https://${data.google_container_cluster.gke_cluster.endpoint}"
-  token                  = data.google_client_config.default.access_token
-  cluster_ca_certificate = base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+  host                   = local.host
+  token                  = local.token
+  cluster_ca_certificate = local.cluster_ca_certificate
 }

--- a/modules/management/kubernetes-namespace/main.tf
+++ b/modules/management/kubernetes-namespace/main.tf
@@ -13,31 +13,10 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
+
 resource "kubernetes_namespace_v1" "ns" {
   metadata {
-    name = var.namespace
+    name   = var.namespace
+    labels = { ghpc_module = "kubernetes-namespace", ghpc_role = "management" }
   }
-}
-locals {
-  cluster_id_parts = var.cluster_id != null ? split("/", var.cluster_id) : []
-  cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
-  cluster_location = length(local.cluster_id_parts) > 3 ? local.cluster_id_parts[3] : ""
-  kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
-
-
-  # HYBRID LOGIC: Use passed-in variable if available, otherwise fall back to data source
-  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : "https://${data.google_container_cluster.gke_cluster.endpoint}"
-  token                  = var.access_token != null ? var.access_token : data.google_client_config.default.access_token
-  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
-}
-data "google_client_config" "default" {}
-data "google_container_cluster" "gke_cluster" {
-  name     = local.cluster_name
-  location = local.cluster_location
-  project  = local.kube_project_id
-}
-provider "kubernetes" {
-  host                   = local.host
-  token                  = local.token
-  cluster_ca_certificate = local.cluster_ca_certificate
 }

--- a/modules/management/kubernetes-namespace/metadata.yaml
+++ b/modules/management/kubernetes-namespace/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services: []
+ghpc:
+  validators: []

--- a/modules/management/kubernetes-namespace/metadata.yaml
+++ b/modules/management/kubernetes-namespace/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,7 @@
 
 spec:
   requirements:
-    services: []
+    services:
+    - container.googleapis.com
 ghpc:
   validators: []

--- a/modules/management/kubernetes-namespace/outputs.tf
+++ b/modules/management/kubernetes-namespace/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "namespace" {
+  value       = kubernetes_namespace_v1.ns.metadata[0].name
+  description = "The name of the created Kubernetes namespace."
+}

--- a/modules/management/kubernetes-namespace/outputs.tf
+++ b/modules/management/kubernetes-namespace/outputs.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/management/kubernetes-namespace/providers.tf
+++ b/modules/management/kubernetes-namespace/providers.tf
@@ -1,0 +1,43 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+
+locals {
+  cluster_id_parts = var.cluster_id != null ? split("/", var.cluster_id) : []
+  cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
+  cluster_location = length(local.cluster_id_parts) > 3 ? local.cluster_id_parts[3] : ""
+  kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
+
+  # HYBRID LOGIC: Use passed-in variable if available, otherwise fall back to data source
+  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : (length(data.google_container_cluster.gke_cluster) > 0 ? "https://${data.google_container_cluster.gke_cluster[0].endpoint}" : "")
+  token                  = var.access_token != null ? var.access_token : data.google_client_config.default.access_token
+  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : (length(data.google_container_cluster.gke_cluster) > 0 ? base64decode(data.google_container_cluster.gke_cluster[0].master_auth[0].cluster_ca_certificate) : null)
+}
+
+data "google_client_config" "default" {}
+
+data "google_container_cluster" "gke_cluster" {
+  count = var.cluster_endpoint != null ? 0 : 1
+
+  name     = local.cluster_name
+  location = local.cluster_location
+  project  = local.kube_project_id
+}
+
+provider "kubernetes" {
+  host                   = local.host
+  token                  = local.token
+  cluster_ca_certificate = local.cluster_ca_certificate
+}

--- a/modules/management/kubernetes-namespace/variables.tf
+++ b/modules/management/kubernetes-namespace/variables.tf
@@ -1,0 +1,24 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+variable "namespace" {
+  description = "Kubernetes namespace"
+  type        = string
+}
+variable "cluster_id" {
+  description = "An identifier for the cluster"
+  type        = string
+  default     = null
+}

--- a/modules/management/kubernetes-namespace/variables.tf
+++ b/modules/management/kubernetes-namespace/variables.tf
@@ -17,8 +17,27 @@ variable "namespace" {
   description = "Kubernetes namespace"
   type        = string
 }
+
 variable "cluster_id" {
-  description = "An identifier for the cluster"
+  description = "The full GCP resource ID of the GKE cluster in the format projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_NAME"
   type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "The endpoint of the GKE cluster. If provided, ignores data source lookup."
+  type        = string
+  default     = null
+}
+
+variable "cluster_ca_certificate" {
+  description = "The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup."
+  type        = string
+  default     = null
+}
+
+variable "access_token" {
+  description = "The access token for accessing the cluster. If provided, ignores data source lookup."
+  type        = string
+  sensitive   = true
   default     = null
 }

--- a/modules/management/kubernetes-namespace/variables.tf
+++ b/modules/management/kubernetes-namespace/variables.tf
@@ -21,6 +21,11 @@ variable "namespace" {
 variable "cluster_id" {
   description = "The full GCP resource ID of the GKE cluster in the format projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_NAME"
   type        = string
+
+  validation {
+    condition     = can(regex("^projects/[^/]+/locations/[^/]+/clusters/[^/]+$", var.cluster_id))
+    error_message = "The cluster_id must be in the format projects/PROJECT_ID/locations/LOCATION/clusters/NAME."
+  }
 }
 
 variable "cluster_endpoint" {

--- a/modules/management/kubernetes-namespace/versions.tf
+++ b/modules/management/kubernetes-namespace/versions.tf
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
adding a module for managing Kubernetes namespaces with dynamic provider config.

This module provides a standard way to create K8s namespaces. It implements a dynamic provider configuration pattern that fetches GKE cluster credentials at runtime, enabling "zero-touch" deployments where the cluster and namespace are created in a single Terraform run.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
