### PR TITLE
adding new iap-policy module.

### DIFF
--- a/modules/iam/iap-policy/README.md
+++ b/modules/iam/iap-policy/README.md
@@ -1,0 +1,68 @@
+## Description
+
+This module configures IAM policy for Identity-Aware Proxy (IAP) on a Google Cloud Backend Service.
+
+## Example usage
+
+```yaml
+- id: iap_policy
+  source: modules/iam/iap-policy
+  settings:
+    project_id: $(vars.project_id)
+    backend_service_id: "your-backend-service-id"
+    iap_members:
+    - "user:example@google.com"
+```
+
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_iap_web_backend_service_iam_member.iap_accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iap_web_backend_service_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_backend_service_id"></a> [backend\_service\_id](#input\_backend\_service\_id) | The ID of the IAP-secured Google Cloud Backend Service (usually obtained from the gke-backend-fetcher module). | `string` | n/a | yes |
+| <a name="input_iap_members"></a> [iap\_members](#input\_iap\_members) | List of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com']). | `list(string)` | `[]` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID where the backend service resides. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_backend_service_id"></a> [backend\_service\_id](#output\_backend\_service\_id) | The Backend Service ID the policy was applied to. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/iam/iap-policy/README.md
+++ b/modules/iam/iap-policy/README.md
@@ -57,7 +57,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_backend_service_id"></a> [backend\_service\_id](#input\_backend\_service\_id) | The ID of the IAP-secured Google Cloud Backend Service (usually obtained from the gke-backend-fetcher module). | `string` | n/a | yes |
-| <a name="input_iap_members"></a> [iap\_members](#input\_iap\_members) | List of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com']). | `list(string)` | `[]` | no |
+| <a name="input_iap_members"></a> [iap\_members](#input\_iap\_members) | Set of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com']). | `set(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID where the backend service resides. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/iam/iap-policy/main.tf
+++ b/modules/iam/iap-policy/main.tf
@@ -1,0 +1,21 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_iap_web_backend_service_iam_member" "iap_accessor" {
+  for_each            = toset(var.iap_members)
+  project             = var.project_id
+  web_backend_service = var.backend_service_id
+  role                = "roles/iap.httpsResourceAccessor"
+  member              = each.value
+}

--- a/modules/iam/iap-policy/main.tf
+++ b/modules/iam/iap-policy/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource "google_iap_web_backend_service_iam_member" "iap_accessor" {
-  for_each            = toset(var.iap_members)
+  for_each            = var.iap_members
   project             = var.project_id
   web_backend_service = var.backend_service_id
   role                = "roles/iap.httpsResourceAccessor"

--- a/modules/iam/iap-policy/metadata.yaml
+++ b/modules/iam/iap-policy/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - iap.googleapis.com
+ghpc:
+  validators: []

--- a/modules/iam/iap-policy/outputs.tf
+++ b/modules/iam/iap-policy/outputs.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "backend_service_id" {
+  description = "The Backend Service ID the policy was applied to."
+  value       = var.backend_service_id
+}

--- a/modules/iam/iap-policy/variables.tf
+++ b/modules/iam/iap-policy/variables.tf
@@ -1,0 +1,27 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  type        = string
+  description = "Project ID where the backend service resides."
+}
+variable "backend_service_id" {
+  type        = string
+  description = "The ID of the IAP-secured Google Cloud Backend Service (usually obtained from the gke-backend-fetcher module)."
+}
+variable "iap_members" {
+  type        = list(string)
+  description = "List of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com'])."
+  default     = []
+}

--- a/modules/iam/iap-policy/variables.tf
+++ b/modules/iam/iap-policy/variables.tf
@@ -21,7 +21,7 @@ variable "backend_service_id" {
   description = "The ID of the IAP-secured Google Cloud Backend Service (usually obtained from the gke-backend-fetcher module)."
 }
 variable "iap_members" {
-  type        = list(string)
-  description = "List of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com'])."
+  type        = set(string)
+  description = "Set of IAM members to grant the 'roles/iap.httpsResourceAccessor' role (e.g. ['user:example@google.com', 'group:admins@google.com', 'serviceAccount:sa@project.iam.gserviceaccount.com'])."
   default     = []
 }

--- a/modules/iam/iap-policy/versions.tf
+++ b/modules/iam/iap-policy/versions.tf
@@ -1,0 +1,23 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a wrapper module for configuring Identity-Aware Proxy (IAP) access policies.

This module manages IAM bindings for IAP-secured GCP Backend Services. It specifically handles the roles/iap.httpsResourceAccessor role, allowing for declarative management of web-based service access.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
