### PR TITLE
Adding new cloud run module.

### DIFF
--- a/modules/compute/cloud-run/README.md
+++ b/modules/compute/cloud-run/README.md
@@ -18,19 +18,7 @@ This module deploys a Google Cloud Run (v2) service.
     allow_unauthenticated: true
 ```
 
-Copyright 2026 Google LLC
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC
@@ -79,6 +67,8 @@ No modules.
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container listens on | `number` | `8080` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Environment variables for the container | `map(string)` | `{}` | no |
 | <a name="input_image"></a> [image](#input\_image) | Container Image URL | `string` | n/a | yes |
+| <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress traffic allowed for the service. Possible values: INGRESS\_TRAFFIC\_ALL, INGRESS\_TRAFFIC\_INTERNAL\_ONLY, INGRESS\_TRAFFIC\_INTERNAL\_LOAD\_BALANCER. | `string` | `"INGRESS_TRAFFIC_ALL"` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the Cloud Run service | `any` | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | GCP Region | `string` | n/a | yes |
 | <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Cloud Run Service Name | `string` | n/a | yes |

--- a/modules/compute/cloud-run/README.md
+++ b/modules/compute/cloud-run/README.md
@@ -1,0 +1,92 @@
+## Description
+
+This module deploys a Google Cloud Run (v2) service.
+
+## Example usage
+
+```yaml
+- id: cloud_run
+  source: modules/compute/cloud-run
+  settings:
+    project_id: $(vars.project_id)
+    region: us-central1
+    service_name: my-service
+    image: us-docker.pkg.dev/cloudrun/container/hello
+    container_port: 8080
+    env_vars:
+      KEY: "VALUE"
+    allow_unauthenticated: true
+```
+
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.48.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.48.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_cloud_run_v2_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service) | resource |
+| [google_cloud_run_v2_service_iam_member.public_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service_iam_member) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_allow_unauthenticated"></a> [allow\_unauthenticated](#input\_allow\_unauthenticated) | Whether to allow unauthenticated access | `bool` | `true` | no |
+| <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container listens on | `number` | `8080` | no |
+| <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Environment variables for the container | `map(string)` | `{}` | no |
+| <a name="input_image"></a> [image](#input\_image) | Container Image URL | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP Project ID | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | GCP Region | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Cloud Run Service Name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_service_name"></a> [service\_name](#output\_service\_name) | The Name of the Cloud Run service |
+| <a name="output_service_url"></a> [service\_url](#output\_service\_url) | The URL of the Cloud Run service |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute/cloud-run/README.md
+++ b/modules/compute/cloud-run/README.md
@@ -63,8 +63,9 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_allow_unauthenticated"></a> [allow\_unauthenticated](#input\_allow\_unauthenticated) | Whether to allow unauthenticated access | `bool` | `true` | no |
+| <a name="input_allow_unauthenticated"></a> [allow\_unauthenticated](#input\_allow\_unauthenticated) | Whether to allow unauthenticated access | `bool` | `false` | no |
 | <a name="input_container_port"></a> [container\_port](#input\_container\_port) | Port the container listens on | `number` | `8080` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Whether to enable deletion protection for the Cloud Run service | `bool` | `true` | no |
 | <a name="input_env_vars"></a> [env\_vars](#input\_env\_vars) | Environment variables for the container | `map(string)` | `{}` | no |
 | <a name="input_image"></a> [image](#input\_image) | Container Image URL | `string` | n/a | yes |
 | <a name="input_ingress"></a> [ingress](#input\_ingress) | Ingress traffic allowed for the service. Possible values: INGRESS\_TRAFFIC\_ALL, INGRESS\_TRAFFIC\_INTERNAL\_ONLY, INGRESS\_TRAFFIC\_INTERNAL\_LOAD\_BALANCER. | `string` | `"INGRESS_TRAFFIC_ALL"` | no |

--- a/modules/compute/cloud-run/main.tf
+++ b/modules/compute/cloud-run/main.tf
@@ -13,13 +13,20 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "cloud-run", ghpc_role = "compute" })
+}
+
 resource "google_cloud_run_v2_service" "default" {
   name                = var.service_name
   location            = var.region
   project             = var.project_id
   deletion_protection = false
-  ingress             = "INGRESS_TRAFFIC_ALL"
+  ingress             = var.ingress
+  labels              = local.labels
   template {
+    labels = local.labels
     containers {
       image = var.image
       ports {

--- a/modules/compute/cloud-run/main.tf
+++ b/modules/compute/cloud-run/main.tf
@@ -1,0 +1,45 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+resource "google_cloud_run_v2_service" "default" {
+  name                = var.service_name
+  location            = var.region
+  project             = var.project_id
+  deletion_protection = false
+  ingress             = "INGRESS_TRAFFIC_ALL"
+  template {
+    containers {
+      image = var.image
+      ports {
+        container_port = var.container_port
+      }
+      dynamic "env" {
+        for_each = var.env_vars
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+    }
+  }
+}
+resource "google_cloud_run_v2_service_iam_member" "public_access" {
+  count    = var.allow_unauthenticated ? 1 : 0
+  project  = google_cloud_run_v2_service.default.project
+  location = google_cloud_run_v2_service.default.location
+  name     = google_cloud_run_v2_service.default.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/modules/compute/cloud-run/main.tf
+++ b/modules/compute/cloud-run/main.tf
@@ -13,6 +13,7 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
+
 locals {
   # This label allows for billing report tracking based on module.
   labels = merge(var.labels, { ghpc_module = "cloud-run", ghpc_role = "compute" })
@@ -22,9 +23,10 @@ resource "google_cloud_run_v2_service" "default" {
   name                = var.service_name
   location            = var.region
   project             = var.project_id
-  deletion_protection = false
+  deletion_protection = var.deletion_protection
   ingress             = var.ingress
   labels              = local.labels
+
   template {
     labels = local.labels
     containers {
@@ -42,6 +44,7 @@ resource "google_cloud_run_v2_service" "default" {
     }
   }
 }
+
 resource "google_cloud_run_v2_service_iam_member" "public_access" {
   count    = var.allow_unauthenticated ? 1 : 0
   project  = google_cloud_run_v2_service.default.project

--- a/modules/compute/cloud-run/metadata.yaml
+++ b/modules/compute/cloud-run/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - run.googleapis.com
+ghpc:
+  validators: []

--- a/modules/compute/cloud-run/metadata.yaml
+++ b/modules/compute/cloud-run/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/compute/cloud-run/outputs.tf
+++ b/modules/compute/cloud-run/outputs.tf
@@ -1,0 +1,23 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+output "service_url" {
+  description = "The URL of the Cloud Run service"
+  value       = google_cloud_run_v2_service.default.uri
+}
+output "service_name" {
+  description = "The Name of the Cloud Run service"
+  value       = google_cloud_run_v2_service.default.name
+}

--- a/modules/compute/cloud-run/variables.tf
+++ b/modules/compute/cloud-run/variables.tf
@@ -44,3 +44,19 @@ variable "allow_unauthenticated" {
   type        = bool
   default     = true
 }
+
+variable "ingress" {
+  description = "Ingress traffic allowed for the service. Possible values: INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
+  type        = string
+  default     = "INGRESS_TRAFFIC_ALL"
+  validation {
+    condition     = contains(["INGRESS_TRAFFIC_ALL", "INGRESS_TRAFFIC_INTERNAL_ONLY", "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"], var.ingress)
+    error_message = "The ingress variable must be one of INGRESS_TRAFFIC_ALL, INGRESS_TRAFFIC_INTERNAL_ONLY, or INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER."
+  }
+}
+
+variable "labels" {
+  description = "Labels to apply to the Cloud Run service"
+  type        = any
+  default     = {}
+}

--- a/modules/compute/cloud-run/variables.tf
+++ b/modules/compute/cloud-run/variables.tf
@@ -1,0 +1,46 @@
+/**
+  * Copyright 2026 Google LLC
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *      http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+variable "project_id" {
+  description = "GCP Project ID"
+  type        = string
+}
+variable "region" {
+  description = "GCP Region"
+  type        = string
+}
+variable "service_name" {
+  description = "Cloud Run Service Name"
+  type        = string
+}
+variable "image" {
+  description = "Container Image URL"
+  type        = string
+}
+variable "container_port" {
+  description = "Port the container listens on"
+  type        = number
+  default     = 8080
+}
+variable "env_vars" {
+  description = "Environment variables for the container"
+  type        = map(string)
+  default     = {}
+}
+variable "allow_unauthenticated" {
+  description = "Whether to allow unauthenticated access"
+  type        = bool
+  default     = true
+}

--- a/modules/compute/cloud-run/variables.tf
+++ b/modules/compute/cloud-run/variables.tf
@@ -13,36 +13,43 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
+
 variable "project_id" {
   description = "GCP Project ID"
   type        = string
 }
+
 variable "region" {
   description = "GCP Region"
   type        = string
 }
+
 variable "service_name" {
   description = "Cloud Run Service Name"
   type        = string
 }
+
 variable "image" {
   description = "Container Image URL"
   type        = string
 }
+
 variable "container_port" {
   description = "Port the container listens on"
   type        = number
   default     = 8080
 }
+
 variable "env_vars" {
   description = "Environment variables for the container"
   type        = map(string)
   default     = {}
 }
+
 variable "allow_unauthenticated" {
   description = "Whether to allow unauthenticated access"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "ingress" {
@@ -59,4 +66,10 @@ variable "labels" {
   description = "Labels to apply to the Cloud Run service"
   type        = any
   default     = {}
+}
+
+variable "deletion_protection" {
+  description = "Whether to enable deletion protection for the Cloud Run service"
+  type        = bool
+  default     = true
 }

--- a/modules/compute/cloud-run/versions.tf
+++ b/modules/compute/cloud-run/versions.tf
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/modules/compute/cloud-run/versions.tf
+++ b/modules/compute/cloud-run/versions.tf
@@ -1,0 +1,23 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.48.0"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a new module to deploy a Cloud Run service (v2) with standard configuration options, including region, image, container port, environment variables, and optional public access (IAM role roles/run.invoker for allUsers). This module provides a standard way to deploy serverless workloads in the cluster toolkit.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
