### PR TITLE
chore: align Batch blueprints with org-wide naming convention

### DIFF
--- a/docs/batch.md
+++ b/docs/batch.md
@@ -25,9 +25,9 @@ contained in the `community` folder of the Cluster Toolkit repo and are marked a
 
 ## Example
 
-[serverless-batch.yaml](../examples/serverless-batch.yaml) contains an example
+[batch.yaml](../examples/batch.yaml) contains an example
 of how to use Google Cloud Batch with the Cluster Toolkit
-([example documentation](../examples/README.md#serverless-batchyaml--)).
+([example documentation](../examples/README.md#batchyaml-)).
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,8 +27,8 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [ml-slurm-g4-vgpu.yaml](#ml-slurm-g4-vgu-yaml-) ![community-badge] ![experimental-badge]
   * [h4d-vm.yaml](#h4d-vmyaml--) ![core-badge] ![experimental-badge]
   * [image-builder.yaml](#image-builderyaml-) ![core-badge]
-  * [serverless-batch.yaml](#serverless-batchyaml-) ![core-badge]
-  * [serverless-batch-mpi.yaml](#serverless-batch-mpiyaml-) ![core-badge]
+  * [batch.yaml](#batchyaml-) ![core-badge]
+  * [batch-mpi.yaml](#batch-mpiyaml-) ![core-badge]
   * [pfs-managed-lustre-vm.yaml](#pfs-managed-lustre-vmyaml-) ![core-badge]
   * [pfs-managed-lustre-slurm.yaml](#pfs-managed-lustre-slurmyaml-) ![core-badge]
   * [rapid-storage-slurm.yaml](#rapid-storage-slurmyaml-) ![core-badge]
@@ -563,7 +563,7 @@ timestamp for uniqueness.
 
 [console-images]: https://console.cloud.google.com/compute/images
 
-### [serverless-batch.yaml] ![core-badge]
+### [batch.yaml] ![core-badge]
 
 This example demonstrates how to use the Cluster Toolkit to set up a Google Cloud Batch job
 that mounts a Filestore instance and runs startup scripts.
@@ -578,7 +578,7 @@ job.
 To provision the cluster, please run:
 
 ```text
-./gcluster create examples/serverless-batch.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}"
+./gcluster create examples/batch.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}"
 ./gcluster deploy hello-workload
 ```
 
@@ -588,9 +588,9 @@ When you are done, clean up the resources in reverse order of creation:
 ./gcluster destroy hello-workload
 ```
 
-[serverless-batch.yaml]: ../examples/serverless-batch.yaml
+[batch.yaml]: ../examples/batch.yaml
 
-### [serverless-batch-mpi.yaml] ![core-badge]
+### [batch-mpi.yaml] ![core-badge]
 
 This blueprint demonstrates how to use Spack to run a real MPI job on Batch.
 
@@ -645,7 +645,7 @@ The blueprint contains the following:
     job has finished this folder will contain the results of the job. You can
     inspect the `rsl.out.0000` file for a summary of the job.
 
-[serverless-batch-mpi.yaml]: ../examples/serverless-batch-mpi.yaml
+[batch-mpi.yaml]: ../examples/batch-mpi.yaml
 
 ### [pfs-managed-lustre-vm.yaml] ![core-badge]
 

--- a/examples/batch-mpi.yaml
+++ b/examples/batch-mpi.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 ---
 
-blueprint_name: serverless-batch-mpi
+blueprint_name: batch-mpi
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/examples/batch.yaml
+++ b/examples/batch.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ---
-blueprint_name: serverless-batch
+blueprint_name: batch
 
 vars:
   project_id:  ## Set GCP Project ID Here ##

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -32,7 +32,7 @@ user will modify the template after running the Cluster Toolkit.
 ```
 
 See the
-[Google Cloud Batch Example](../../../../examples/README.md#serverless-batchyaml--)
+[Google Cloud Batch Example](../../../../examples/README.md#batchyaml-)
 for how to use the `batch-job-template` module with other Cluster Toolkit modules such
 as `filestore` and `startup-script`.
 
@@ -164,7 +164,7 @@ limitations under the License.
 | <a name="input_image"></a> [image](#input\_image) | DEPRECATED: Google Cloud Batch compute node image. Ignored if `instance_template` is provided. | `any` | `null` | no |
 | <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Google Cloud Batch compute node image. Ignored if `instance_template` is provided.<br/><br/>Expected Fields:<br/>name: The name of the image. Mutually exclusive with family.<br/>family: The image family to use. Mutually exclusive with name.<br/>project: The project where the image is hosted. | `map(string)` | <pre>{<br/>  "family": "hpc-rocky-linux-8",<br/>  "project": "cloud-hpc-image-public"<br/>}</pre> | no |
 | <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | Compute VM instance template self-link to be used for Google Cloud Batch compute node. If provided, a number of other variables will be ignored as noted by `Ignored if instance_template is provided` in descriptions. | `string` | `null` | no |
-| <a name="input_job_filename"></a> [job\_filename](#input\_job\_filename) | The filename of the generated job template file. Will default to `cloud-batch-<job_id>.json` if not specified | `string` | `null` | no |
+| <a name="input_job_filename"></a> [job\_filename](#input\_job\_filename) | The filename of the generated job template file. Will default to `<job_id>.yaml` if not specified | `string` | `null` | no |
 | <a name="input_job_id"></a> [job\_id](#input\_job\_id) | An id for the Google Cloud Batch job. Used for output instructions and file naming. Automatically populated by the module id if not set. If setting manually, ensure a unique value across all jobs. | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the Google Cloud Batch compute nodes. Key-value pairs. Ignored if `instance_template` is provided. | `map(string)` | n/a | yes |
 | <a name="input_log_policy"></a> [log\_policy](#input\_log\_policy) | Create a block to define log policy.<br/>When set to `CLOUD_LOGGING`, logs will be sent to Cloud Logging.<br/>When set to `PATH`, path must be added to generated template.<br/>When set to `DESTINATION_UNSPECIFIED`, logs will not be preserved. | `string` | `"CLOUD_LOGGING"` | no |

--- a/modules/scheduler/batch-job-template/variables.tf
+++ b/modules/scheduler/batch-job-template/variables.tf
@@ -40,7 +40,7 @@ variable "job_id" {
 }
 
 variable "job_filename" {
-  description = "The filename of the generated job template file. Will default to `cloud-batch-<job_id>.json` if not specified"
+  description = "The filename of the generated job template file. Will default to `<job_id>.yaml` if not specified"
   type        = string
   default     = null
 }

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -65,7 +65,7 @@ steps:
     fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    SG_EXAMPLE=examples/serverless-batch-mpi.yaml
+    SG_EXAMPLE=examples/batch-mpi.yaml
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
 
 

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -28,10 +28,10 @@ steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)
 - id: check_for_running_build
   name: gcr.io/cloud-builders/gcloud
-  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/cloud-batch.yaml"
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/batch.yaml"
 
 # Test Cloud Batch Example
-- id: cloud-batch
+- id: batch
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
@@ -52,13 +52,13 @@ steps:
     fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
-    BLUEPRINT=examples/serverless-batch.yaml
+    BLUEPRINT=examples/batch.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
-      --extra-vars="@tools/cloud-build/daily-tests/tests/cloud-batch.yml"
+      --extra-vars="@tools/cloud-build/daily-tests/tests/batch.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/tests/batch-mpi.yml
+++ b/tools/cloud-build/daily-tests/tests/batch-mpi.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: serverless-batch-mpi
+test_name: batch-mpi
 deployment_name: batch-mpi-{{ build }}
 zone: us-west4-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/serverless-batch-mpi.yaml"
+blueprint_yaml: "{{ workspace }}/examples/batch-mpi.yaml"
 network: "default"
 remote_node: "{{ deployment_name }}-batch-login"
 post_deploy_tests:

--- a/tools/cloud-build/daily-tests/tests/batch.yml
+++ b/tools/cloud-build/daily-tests/tests/batch.yml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-test_name: serverless-batch
-deployment_name: cloud-batch-{{ build }}
+test_name: batch
+deployment_name: batch-{{ build }}
 zone: us-central1-c
 workspace: /workspace
-blueprint_yaml: "{{ workspace }}/examples/serverless-batch.yaml"
+blueprint_yaml: "{{ workspace }}/examples/batch.yaml"
 network: "default"
 remote_node: "{{ deployment_name }}-batch-login"
 post_deploy_tests:


### PR DESCRIPTION
This PR removes references to "serverless" and "cloud-batch" from Google Cloud Batch blueprints, documentation, and tests. These changes are intended to align the Toolkit with the organization-wide naming convention for the Batch product.

**Key Changes**

**Blueprints & Examples:**
*   Renamed examples/serverless-batch.yaml to examples/batch.yaml.
*   Renamed examples/serverless-batch-mpi.yaml to examples/batch-mpi.yaml.
*   Updated examples/README.md to reflect these renames and updated anchor links.

**Documentation:**
*   Renamed docs/cloud-batch.md to docs/batch.md.
*   Updated modules/scheduler/batch-job-template/README.md to reference the new example paths.

**Modules:**
*   Updated modules/scheduler/batch-job-template/variables.tf to modify the default job_filename description.

**Tests:**
*   Renamed and updated Cloud Build daily test configurations (builds and test YAMLs) to use the "batch" naming scheme.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
