### PR TITLE
adding new redis module.

### DIFF
--- a/modules/database/redis/README.md
+++ b/modules/database/redis/README.md
@@ -9,9 +9,10 @@ This module deploys a Google Cloud Memorystore for Redis instance.
   source: modules/database/redis
   settings:
     project_id: "your-project-id"
+    deployment_name: "my-deployment"
     environment: "dev"
-    redis_region: "us-central1"
-    authorized_network: "projects/your-project-id/global/networks/your-network"
+    region: "us-central1"
+    network_self_link: "projects/your-project-id/global/networks/your-network"
 ```
 
 ## License
@@ -59,13 +60,18 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | The VPC network to which the instance is connected. | `string` | n/a | yes |
+| <a name="input_auth_enabled"></a> [auth\_enabled](#input\_auth\_enabled) | Indicates whether OSS Redis AUTH is enabled. | `bool` | `true` | no |
 | <a name="input_connect_mode"></a> [connect\_mode](#input\_connect\_mode) | The connection mode of the Redis instance. | `string` | `"DIRECT_PEERING"` | no |
 | <a name="input_deploy_redis"></a> [deploy\_redis](#input\_deploy\_redis) | Whether to deploy Redis. | `bool` | `true` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name. | `string` | n/a | yes |
+| <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Redis memory size in GiB. | `number` | `2` | no |
+| <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The VPC network to which the instance is connected. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to deploy to. | `string` | n/a | yes |
-| <a name="input_redis_region"></a> [redis\_region](#input\_redis\_region) | The region to deploy Redis to. | `string` | n/a | yes |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The version of Redis software. | `string` | `"REDIS_6_X"` | no |
+| <a name="input_region"></a> [region](#input\_region) | The region to deploy Redis to. | `string` | n/a | yes |
 | <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | The name of the allocated IP range for the Private Service Access. | `string` | `null` | no |
+| <a name="input_tier"></a> [tier](#input\_tier) | The service tier of the Redis instance. | `string` | `"BASIC"` | no |
 
 ## Outputs
 

--- a/modules/database/redis/README.md
+++ b/modules/database/redis/README.md
@@ -1,0 +1,77 @@
+## Description
+
+This module deploys a Google Cloud Memorystore for Redis instance.
+
+## Example usage
+
+```yaml
+- id: redis
+  source: modules/database/redis
+  settings:
+    project_id: "your-project-id"
+    environment: "dev"
+    redis_region: "us-central1"
+    authorized_network: "projects/your-project-id/global/networks/your-network"
+```
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_project_service.redis_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_redis_instance.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/redis_instance) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_authorized_network"></a> [authorized\_network](#input\_authorized\_network) | The VPC network to which the instance is connected. | `string` | n/a | yes |
+| <a name="input_connect_mode"></a> [connect\_mode](#input\_connect\_mode) | The connection mode of the Redis instance. | `string` | `"DIRECT_PEERING"` | no |
+| <a name="input_deploy_redis"></a> [deploy\_redis](#input\_deploy\_redis) | Whether to deploy Redis. | `bool` | `true` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | The environment name. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to deploy to. | `string` | n/a | yes |
+| <a name="input_redis_region"></a> [redis\_region](#input\_redis\_region) | The region to deploy Redis to. | `string` | n/a | yes |
+| <a name="input_reserved_ip_range"></a> [reserved\_ip\_range](#input\_reserved\_ip\_range) | The name of the allocated IP range for the Private Service Access. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_auth_string"></a> [auth\_string](#output\_auth\_string) | The auth string (password) of the Redis instance. |
+| <a name="output_redis_host"></a> [redis\_host](#output\_redis\_host) | The host of the Redis instance. |
+| <a name="output_redis_port"></a> [redis\_port](#output\_redis\_port) | The port of the Redis instance. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/database/redis/README.md
+++ b/modules/database/redis/README.md
@@ -65,7 +65,7 @@ No modules.
 | <a name="input_deploy_redis"></a> [deploy\_redis](#input\_deploy\_redis) | Whether to deploy Redis. | `bool` | `true` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the current deployment. | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name. | `string` | n/a | yes |
-| <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Redis memory size in GiB. | `number` | `2` | no |
+| <a name="input_memory_size_gb"></a> [memory\_size\_gb](#input\_memory\_size\_gb) | Redis memory size in GiB. Defaults to 2 GiB as a safe minimal baseline for general caching workloads. | `number` | `2` | no |
 | <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The VPC network to which the instance is connected. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID to deploy to. | `string` | n/a | yes |
 | <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | The version of Redis software. | `string` | `"REDIS_6_X"` | no |

--- a/modules/database/redis/main.tf
+++ b/modules/database/redis/main.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_service" "redis_api" {
+  count              = var.deploy_redis ? 1 : 0
+  project            = var.project_id
+  service            = "redis.googleapis.com"
+  disable_on_destroy = false
+}
+resource "google_redis_instance" "default" {
+  count              = var.deploy_redis ? 1 : 0
+  project            = var.project_id
+  name               = "xmc-redis-${var.environment}"
+  tier               = "BASIC"
+  memory_size_gb     = 2
+  region             = var.redis_region
+  redis_version      = "REDIS_6_X"
+  auth_enabled       = true
+  connect_mode       = var.connect_mode
+  reserved_ip_range  = var.reserved_ip_range
+  authorized_network = var.authorized_network
+  depends_on         = [google_project_service.redis_api]
+}

--- a/modules/database/redis/main.tf
+++ b/modules/database/redis/main.tf
@@ -23,14 +23,14 @@ resource "google_project_service" "redis_api" {
 resource "google_redis_instance" "default" {
   count              = var.deploy_redis ? 1 : 0
   project            = var.project_id
-  name               = "xmc-redis-${var.environment}"
-  tier               = "BASIC"
-  memory_size_gb     = 2
-  region             = var.redis_region
-  redis_version      = "REDIS_6_X"
-  auth_enabled       = true
+  name               = "${var.deployment_name}-redis-${var.environment}"
+  tier               = var.tier
+  memory_size_gb     = var.memory_size_gb
+  region             = var.region
+  redis_version      = var.redis_version
+  auth_enabled       = var.auth_enabled
   connect_mode       = var.connect_mode
   reserved_ip_range  = var.reserved_ip_range
-  authorized_network = var.authorized_network
+  authorized_network = var.network_self_link
   depends_on         = [google_project_service.redis_api]
 }

--- a/modules/database/redis/main.tf
+++ b/modules/database/redis/main.tf
@@ -20,10 +20,16 @@ resource "google_project_service" "redis_api" {
   service            = "redis.googleapis.com"
   disable_on_destroy = false
 }
+
+locals {
+  # Redis instance names are limited to 40 characters.
+  redis_name = substr("${var.deployment_name}-redis-${var.environment}", 0, 40)
+}
+
 resource "google_redis_instance" "default" {
   count              = var.deploy_redis ? 1 : 0
   project            = var.project_id
-  name               = "${var.deployment_name}-redis-${var.environment}"
+  name               = local.redis_name
   tier               = var.tier
   memory_size_gb     = var.memory_size_gb
   region             = var.region
@@ -32,5 +38,7 @@ resource "google_redis_instance" "default" {
   connect_mode       = var.connect_mode
   reserved_ip_range  = var.reserved_ip_range
   authorized_network = var.network_self_link
-  depends_on         = [google_project_service.redis_api]
+  labels             = { ghpc_module = "redis", ghpc_role = "database" }
+
+  depends_on = [google_project_service.redis_api]
 }

--- a/modules/database/redis/metadata.yaml
+++ b/modules/database/redis/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - redis.googleapis.com
+ghpc:
+  validators: []

--- a/modules/database/redis/outputs.tf
+++ b/modules/database/redis/outputs.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "redis_host" {
+  description = "The host of the Redis instance."
+  value       = var.deploy_redis ? google_redis_instance.default[0].host : null
+}
+output "redis_port" {
+  description = "The port of the Redis instance."
+  value       = var.deploy_redis ? google_redis_instance.default[0].port : null
+}
+output "auth_string" {
+  description = "The auth string (password) of the Redis instance."
+  value       = var.deploy_redis ? google_redis_instance.default[0].auth_string : null
+  sensitive   = true
+}

--- a/modules/database/redis/variables.tf
+++ b/modules/database/redis/variables.tf
@@ -22,7 +22,11 @@ variable "environment" {
   description = "The environment name."
   type        = string
 }
-variable "redis_region" {
+variable "deployment_name" {
+  description = "The name of the current deployment."
+  type        = string
+}
+variable "region" {
   description = "The region to deploy Redis to."
   type        = string
 }
@@ -31,7 +35,7 @@ variable "deploy_redis" {
   type        = bool
   default     = true
 }
-variable "authorized_network" {
+variable "network_self_link" {
   description = "The VPC network to which the instance is connected."
   type        = string
 }
@@ -44,4 +48,32 @@ variable "reserved_ip_range" {
   description = "The name of the allocated IP range for the Private Service Access."
   type        = string
   default     = null
+}
+
+variable "tier" {
+  description = "The service tier of the Redis instance."
+  type        = string
+  default     = "BASIC"
+  validation {
+    condition     = contains(["BASIC", "STANDARD_HA"], var.tier)
+    error_message = "The tier must be one of BASIC or STANDARD_HA."
+  }
+}
+
+variable "memory_size_gb" {
+  description = "Redis memory size in GiB."
+  type        = number
+  default     = 2
+}
+
+variable "redis_version" {
+  description = "The version of Redis software."
+  type        = string
+  default     = "REDIS_6_X"
+}
+
+variable "auth_enabled" {
+  description = "Indicates whether OSS Redis AUTH is enabled."
+  type        = bool
+  default     = true
 }

--- a/modules/database/redis/variables.tf
+++ b/modules/database/redis/variables.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to deploy to."
+  type        = string
+}
+variable "environment" {
+  description = "The environment name."
+  type        = string
+}
+variable "redis_region" {
+  description = "The region to deploy Redis to."
+  type        = string
+}
+variable "deploy_redis" {
+  description = "Whether to deploy Redis."
+  type        = bool
+  default     = true
+}
+variable "authorized_network" {
+  description = "The VPC network to which the instance is connected."
+  type        = string
+}
+variable "connect_mode" {
+  description = "The connection mode of the Redis instance."
+  type        = string
+  default     = "DIRECT_PEERING"
+}
+variable "reserved_ip_range" {
+  description = "The name of the allocated IP range for the Private Service Access."
+  type        = string
+  default     = null
+}

--- a/modules/database/redis/variables.tf
+++ b/modules/database/redis/variables.tf
@@ -18,32 +18,43 @@ variable "project_id" {
   description = "The project ID to deploy to."
   type        = string
 }
+
 variable "environment" {
   description = "The environment name."
   type        = string
 }
+
 variable "deployment_name" {
   description = "The name of the current deployment."
   type        = string
 }
+
 variable "region" {
   description = "The region to deploy Redis to."
   type        = string
 }
+
 variable "deploy_redis" {
   description = "Whether to deploy Redis."
   type        = bool
   default     = true
 }
+
 variable "network_self_link" {
   description = "The VPC network to which the instance is connected."
   type        = string
 }
+
 variable "connect_mode" {
   description = "The connection mode of the Redis instance."
   type        = string
   default     = "DIRECT_PEERING"
+  validation {
+    condition     = contains(["DIRECT_PEERING", "PRIVATE_SERVICE_ACCESS"], var.connect_mode)
+    error_message = "The connect_mode must be one of DIRECT_PEERING or PRIVATE_SERVICE_ACCESS."
+  }
 }
+
 variable "reserved_ip_range" {
   description = "The name of the allocated IP range for the Private Service Access."
   type        = string
@@ -61,7 +72,7 @@ variable "tier" {
 }
 
 variable "memory_size_gb" {
-  description = "Redis memory size in GiB."
+  description = "Redis memory size in GiB. Defaults to 2 GiB as a safe minimal baseline for general caching workloads."
   type        = number
   default     = 2
 }

--- a/modules/database/redis/versions.tf
+++ b/modules/database/redis/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a new module to provision a Google Cloud Memorystore for Redis instance. The module supports basic tier, custom memory size, region, Redis version, authentication, connect mode, and authorization on a network. It also handles enabling the Redis API.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
