### PR TITLE
[Telemetry] Refactor getModules method to use cached standard modules from firestore

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,12 +25,6 @@ import (
 	"sort"
 	"strings"
 
-	"encoding/json"
-	"net/http"
-	"path"
-
-	"time"
-
 	"github.com/agext/levenshtein"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pkg/errors"
@@ -975,60 +969,4 @@ func GetAllBpModules(bp *Blueprint) []Module {
 		modules = append(modules, *m)
 	})
 	return modules
-}
-
-// TreeResponse represents the expected JSON structure from the GitHub Git Trees API
-type TreeResponse struct {
-	Tree []struct {
-		Path string `json:"path"`
-		Type string `json:"type"`
-	} `json:"tree"`
-}
-
-// GetPredefinedModules fetches all pre-defined modules for the current toolkit version directly from the GitHub repository.
-// This ensures that even if local files are deleted or custom modules are added, the returned list strictly reflects the official release of the user's toolkit version.
-func GetPredefinedModules() []string {
-	version := GetToolkitVersion()
-
-	// Query the GitHub API for the recursive file tree of this specific version tag
-	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
-	client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-
-	resp, err := client.Get(url)
-	if err != nil {
-		return nil
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil
-	}
-
-	var treeResp TreeResponse
-	if err := json.NewDecoder(resp.Body).Decode(&treeResp); err != nil {
-		return nil
-	}
-
-	var predefinedModules []string
-	moduleSet := make(map[string]bool)
-
-	// Parse the remote tree
-	for _, item := range treeResp.Tree {
-		// We only care about files ("blob") inside the known module directories
-		if item.Type == "blob" {
-			if strings.HasPrefix(item.Path, "modules/") || strings.HasPrefix(item.Path, "community/modules/") {
-				// Identify module directories by Terraform or Packer configuration files
-				if strings.HasSuffix(item.Path, ".tf") || strings.HasSuffix(item.Path, ".pkr.hcl") {
-					moduleDir := path.Dir(item.Path)
-					if !moduleSet[moduleDir] {
-						moduleSet[moduleDir] = true
-						predefinedModules = append(predefinedModules, moduleDir)
-					}
-				}
-			}
-		}
-	}
-	return predefinedModules
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -17,15 +17,11 @@ limitations under the License.
 package config
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strings"
 	"testing"
 
 	"hpc-toolkit/pkg/modulereader"
@@ -1011,94 +1007,6 @@ func TestGetAllModules(t *testing.T) {
 			if !reflect.DeepEqual(actualIDs, tt.expected) {
 				t.Errorf("GetAllModules() returned IDs %v, want %v", actualIDs, tt.expected)
 			}
-		})
-	}
-}
-
-// mockTransport implements http.RoundTripper to intercept HTTP requests.
-type mockTransport struct {
-	roundTripFunc func(req *http.Request) (*http.Response, error)
-}
-
-// RoundTrip executes the mocked request.
-func (m *mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	return m.roundTripFunc(req)
-}
-
-func TestGetPredefinedModules(t *testing.T) {
-	// Save the original transport to restore it after tests complete
-	originalTransport := http.DefaultTransport
-	defer func() { http.DefaultTransport = originalTransport }()
-
-	tests := []struct {
-		name        string
-		mockResp    *http.Response
-		mockErr     error
-		expected    []string
-		errContains string
-	}{
-		{
-			name: "success: extracts and deduplicates tf and packer modules",
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body: io.NopCloser(bytes.NewBufferString(`{
-					"tree": [
-						{"path": "modules/network/vpc/main.tf", "type": "blob"},
-						{"path": "modules/network/vpc/variables.tf", "type": "blob"},
-						{"path": "community/modules/compute/mig/main.pkr.hcl", "type": "blob"},
-						{"path": "modules/ignore_me.txt", "type": "blob"},
-						{"path": "some_other_dir/main.tf", "type": "blob"},
-						{"path": "modules/not_a_blob/main.tf", "type": "tree"}
-					]
-				}`)),
-			},
-			// Expected to ignore "ignore_me.txt", "some_other_dir", and "not_a_blob" (since it's a tree)
-			// Expected to deduplicate the "modules/network/vpc" module.
-			expected: []string{"modules/network/vpc", "community/modules/compute/mig"},
-		},
-		{
-			name: "error: non-200 status code",
-			mockResp: &http.Response{
-				StatusCode: http.StatusNotFound,
-				Status:     "404 Not Found",
-				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "Not Found"}`)),
-			},
-		},
-		{
-			name: "error: invalid JSON",
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(`{invalid json`)),
-			},
-		},
-		{
-			name:    "error: network failure or timeout",
-			mockErr: fmt.Errorf("connection timeout"),
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// Set up the mock transport for the current test case
-			http.DefaultTransport = &mockTransport{
-				roundTripFunc: func(req *http.Request) (*http.Response, error) {
-					// Verify that the request URL contains the toolkit version
-					version := GetToolkitVersion()
-					if !strings.Contains(req.URL.String(), version) {
-						t.Errorf("Expected URL to contain version %s, got %s", version, req.URL.String())
-					}
-					return tc.mockResp, tc.mockErr
-				},
-			}
-
-			modules := GetPredefinedModules()
-
-			// reflect.DeepEqual works deterministically here because the function processes
-			// the JSON array sequentially and appends exactly in the order items appear.
-			if !reflect.DeepEqual(modules, tc.expected) {
-				t.Errorf("expected modules %v, got %v", tc.expected, modules)
-			}
-
 		})
 	}
 }

--- a/pkg/config/user_config.go
+++ b/pkg/config/user_config.go
@@ -47,7 +47,7 @@ func InitUserConfig() error {
 
 	userID := generateUniqueID()
 
-	client, err := getFirestoreClient(ctx)
+	client, err := GetFirestoreClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func SaveToFirestore() error {
 
 	userID := viper.GetString(USER_ID_KEY)
 
-	client, err := getFirestoreClient(ctx)
+	client, err := GetFirestoreClient(ctx)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func generateUniqueID() string {
 }
 
 // Helper function to initialize Firestore client
-func getFirestoreClient(ctx context.Context) (*firestore.Client, error) {
+func GetFirestoreClient(ctx context.Context) (*firestore.Client, error) {
 	var initErr error
 
 	// The block inside Do() will only be executed once globally even if multiple goroutines call it simultaneously.

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -35,7 +35,6 @@ import (
 
 var (
 	machineTypeModulePattern   = "modules.compute" // pattern for compute modules that set the machine.
-	standardModules            = config.GetPredefinedModules()
 	isGkeModulePatterns        = []string{"gke-node-pool", "gke-cluster"}
 	isSlurmModulePatterns      = []string{"schedmd-slurm-gcp-"}
 	isVmInstanceModulePatterns = []string{"vm-instance"}
@@ -203,6 +202,8 @@ func getModules(modulesList []string) string {
 	if len(modulesList) == 0 {
 		return ""
 	}
+
+	standardModules := getStandardModules()
 
 	// If standardModules is empty due to a network fetch failure, the telemetry payload will correctly report "UNVERIFIED", rather than falsely implying the blueprint had no modules.
 	if len(standardModules) == 0 {

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1031,6 +1031,70 @@ func TestGetBillingAccountId(t *testing.T) {
 	}
 }
 
+func TestGetModules(t *testing.T) {
+	// Save and restore the original function to avoid affecting other tests
+	originalGetStandardModules := getStandardModules
+	defer func() { getStandardModules = originalGetStandardModules }()
+
+	mockStandardList := []string{
+		"modules/network/vpc",
+		"community/modules/compute/mig",
+	}
+
+	tests := []struct {
+		name                string
+		input               []string
+		mockStandardModules []string
+		expected            string
+	}{
+		{
+			name:                "success: all standard modules",
+			input:               []string{"modules/network/vpc", "community/modules/compute/mig"},
+			mockStandardModules: mockStandardList,
+			expected:            "modules/network/vpc,community/modules/compute/mig",
+		},
+		{
+			name:                "success: mix of standard and custom modules",
+			input:               []string{"modules/network/vpc", "modules/my-custom-network", "community/modules/compute/mig"},
+			mockStandardModules: mockStandardList,
+			expected:            "modules/network/vpc,Custom,community/modules/compute/mig",
+		},
+		{
+			name:                "success: only custom modules",
+			input:               []string{"my/custom/module1", "my/custom/module2"},
+			mockStandardModules: mockStandardList,
+			expected:            "Custom,Custom",
+		},
+		{
+			name:                "success: empty input",
+			input:               []string{},
+			mockStandardModules: mockStandardList,
+			expected:            "",
+		},
+		{
+			name:                "error: standardModules fetch failed (UNVERIFIED)",
+			input:               []string{"modules/network/vpc", "my/custom/module"},
+			mockStandardModules: []string{}, // Simulating an empty return indicating fetch failure
+			expected:            "UNVERIFIED",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Mock the getStandardModules function for this specific test case
+			getStandardModules = func() []string {
+				return tc.mockStandardModules
+			}
+
+			result := getModules(tc.input)
+
+			if result != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
 // TestGetIsGoogler tests the full logic of the getIsGoogler method including fallbacks.
 func TestGetIsGoogler(t *testing.T) {
 	// Save the original environment variables to restore them after the tests

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -15,13 +15,10 @@
 package telemetry
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1029,97 +1026,6 @@ func TestGetBillingAccountId(t *testing.T) {
 
 			if actual != tt.expected {
 				t.Errorf("getBillingAccountId() = %q, want %q", actual, tt.expected)
-			}
-		})
-	}
-}
-
-func TestGetModules(t *testing.T) {
-	// Save and restore the original transport
-	originalTransport := http.DefaultTransport
-	defer func() { http.DefaultTransport = originalTransport }()
-
-	// Mock JSON response that config.GetPredefinedModules() will parse
-	mockJSON := `{
-		"tree": [
-			{"path": "modules/network/vpc/main.tf", "type": "blob"},
-			{"path": "community/modules/compute/mig/main.pkr.hcl", "type": "blob"}
-		]
-	}`
-
-	tests := []struct {
-		name     string
-		input    []string
-		mockResp *http.Response
-		expected string
-	}{
-		{
-			name:  "success: all standard modules",
-			input: []string{"modules/network/vpc", "community/modules/compute/mig"},
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
-			},
-			// Expected to keep original paths
-			expected: "modules/network/vpc,community/modules/compute/mig",
-		},
-		{
-			name:  "success: mix of standard and custom modules",
-			input: []string{"modules/network/vpc", "modules/my-custom-network", "community/modules/compute/mig"},
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
-			},
-			// Expected to sanitize the unknown module
-			expected: "modules/network/vpc,Custom,community/modules/compute/mig",
-		},
-		{
-			name:  "success: only custom modules",
-			input: []string{"my/custom/module1", "my/custom/module2"},
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
-			},
-			// Expected to sanitize all
-			expected: "Custom,Custom",
-		},
-		{
-			name:  "success: empty input",
-			input: []string{},
-			mockResp: &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
-			},
-			expected: "",
-		},
-		{
-			name:  "error: standardModules fetch failed (UNVERIFIED)",
-			input: []string{"modules/network/vpc", "my/custom/module"},
-			mockResp: &http.Response{
-				StatusCode: http.StatusInternalServerError,
-				Body:       io.NopCloser(bytes.NewBufferString(`{"message": "Internal Server Error"}`)),
-			},
-			expected: "UNVERIFIED",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			http.DefaultTransport = &mockTransport{
-				roundTripFunc: func(req *http.Request) (*http.Response, error) {
-					return tc.mockResp, nil
-				},
-			}
-
-			// Force re-initialization of the global variable for this specific test so it picks up the mocked HTTP response, and restore it afterwards.
-			originalModules := standardModules
-			standardModules = config.GetPredefinedModules()
-			defer func() { standardModules = originalModules }()
-
-			result := getModules(tc.input)
-
-			if result != tc.expected {
-				t.Errorf("expected %q, got %q", tc.expected, result)
 			}
 		})
 	}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -89,12 +89,12 @@ func loadReleaseMetadata() error {
 }
 
 // getStandardModules returns the cached list of official modules from Viper
-func getStandardModules() []string {
+var getStandardModules = func() []string {
 	err := loadReleaseMetadata() // Will move this function call within the root persistent pre-run in future PR to avoid calling multiple times.
-	if err != nil {
-		return []string{}
+	if err == nil && viper.IsSet("standard_modules") {
+		return viper.GetStringSlice("standard_modules")
 	}
-	return viper.GetStringSlice("standard_modules")
+	return []string{}
 }
 
 func getBpModulesList(bp config.Blueprint) []string {

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/billing/apiv1/billingpb"
+	"github.com/spf13/viper"
 	"github.com/zclconf/go-cty/cty"
 
 	billing "cloud.google.com/go/billing/apiv1"
@@ -50,6 +51,50 @@ func getEventMetadataKVPairs(sourceMetadata map[string]string) []map[string]stri
 		})
 	}
 	return eventMetadata
+}
+
+const releasesCollection = "release_metadata"
+
+// loadReleaseMetadata fetches the predefined metadata from Firestore and loads it into the global Viper registry.
+// Will move this function call within the root persistent pre-run in future PR to avoid calling multiple times.
+func loadReleaseMetadata() error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout10Sec)
+	defer cancel()
+
+	version := config.GetToolkitVersion()
+
+	// GetFirestoreClient is a singleton helper defined in user_config.go
+	client, err := config.GetFirestoreClient(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get firestore client: %v", err)
+	}
+
+	// Try to fetch the cached metadata document for this version
+	doc, err := client.Collection(releasesCollection).Doc(version).Get(ctx)
+	if err != nil {
+		// Document not found or network error.
+		// Here we would trigger the fallback to fetchGitTree() and the GitHub API.
+		return fmt.Errorf("metadata cache miss for version %s: %v", version, err)
+	}
+
+	// Merge Firestore array data into the local Viper registry
+	data := doc.Data()
+
+	// Viper will store these as []interface{} internally, which can be easily retrieved
+	viper.Set("standard_modules", data["modules"])
+	viper.Set("standard_examples", data["examples"])
+	viper.Set("standard_blueprint_names", data["blueprint_names"])
+
+	return nil
+}
+
+// getStandardModules returns the cached list of official modules from Viper
+func getStandardModules() []string {
+	err := loadReleaseMetadata() // Will move this function call within the root persistent pre-run in future PR to avoid calling multiple times.
+	if err != nil {
+		return []string{}
+	}
+	return viper.GetStringSlice("standard_modules")
 }
 
 func getBpModulesList(bp config.Blueprint) []string {

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -53,7 +53,12 @@ func getEventMetadataKVPairs(sourceMetadata map[string]string) []map[string]stri
 	return eventMetadata
 }
 
-const releasesCollection = "release_metadata"
+const (
+	releasesCollection        = "release_metadata"
+	standardModulesKey        = "standard_modules"
+	standardExamplesKey       = "standard_examples"
+	standardBlueprintNamesKey = "standard_blueprint_names"
+)
 
 // loadReleaseMetadata fetches the predefined metadata from Firestore and loads it into the global Viper registry.
 // Will move this function call within the root persistent pre-run in future PR to avoid calling multiple times.
@@ -81,9 +86,9 @@ func loadReleaseMetadata() error {
 	data := doc.Data()
 
 	// Viper will store these as []interface{} internally, which can be easily retrieved
-	viper.Set("standard_modules", data["modules"])
-	viper.Set("standard_examples", data["examples"])
-	viper.Set("standard_blueprint_names", data["blueprint_names"])
+	viper.Set(standardModulesKey, data["modules"])
+	viper.Set(standardExamplesKey, data["examples"])
+	viper.Set(standardBlueprintNamesKey, data["blueprint_names"])
 
 	return nil
 }
@@ -91,8 +96,8 @@ func loadReleaseMetadata() error {
 // getStandardModules returns the cached list of official modules from Viper
 var getStandardModules = func() []string {
 	err := loadReleaseMetadata() // Will move this function call within the root persistent pre-run in future PR to avoid calling multiple times.
-	if err == nil && viper.IsSet("standard_modules") {
-		return viper.GetStringSlice("standard_modules")
+	if err == nil && viper.IsSet(standardModulesKey) {
+		return viper.GetStringSlice(standardModulesKey)
 	}
 	return []string{}
 }


### PR DESCRIPTION
This pull request refactors the telemetry module retrieval process to rely on **cached data from Firestore for getting pre-defined (standard) modules** rather than performing live network requests to the GitHub API. This change improves the reliability and speed of the telemetry collection process by reducing external dependencies and leveraging pre-cached release metadata.

Changes:

* **Firestore Integration**: Refactored module retrieval to fetch standard modules from Firestore instead of querying the GitHub API directly.
* **Code Cleanup**: Removed obsolete GitHub API client code and associated tests in the config and telemetry packages.
* **Metadata Caching**: Implemented a new mechanism to load release metadata into the Viper registry for improved performance and reliability.