### PR TITLE
[Telemetry] Script to backfill release metadata in Firestore

### DIFF
--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -240,6 +240,11 @@ func worker(id int, version string, jobs <-chan string, results chan<- string, w
 			continue
 		}
 
+		// Inject the GITHUB_TOKEN if it exists
+		if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			log.Printf("Warning [Worker %d]: failed to fetch raw yaml %s: %v", id, rawURL, err)

--- a/tools/cache_metadata/main.go
+++ b/tools/cache_metadata/main.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -95,8 +96,17 @@ func main() {
 // fetchGitTree queries the GitHub API and decodes the JSON into a TreeResponse for the specific version.
 func fetchGitTree(version string) (*TreeResponse, error) {
 	url := fmt.Sprintf("https://api.github.com/repos/GoogleCloudPlatform/cluster-toolkit/git/trees/%s?recursive=1", version)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error creating HTTP request: %v", err)
+	}
 
-	resp, err := httpClient.Get(url)
+	// Can export and use GITHUB_TOKEN for personal authentication tokens
+	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch from GitHub API: %v", err)
 	}

--- a/tools/cache_metadata/run_backfill.sh
+++ b/tools/cache_metadata/run_backfill.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script caches metadata for all the github version releases. Used to backfill the data.
+# Cmds to run the script:
+# chmod +x tools/cache_metadata/run_backfill.sh
+# ./tools/cache_metadata/run_backfill.sh
+# If hitting Github API rate limits, can create and use a Personal Authentication token by generating and exporting it.
+# export GITHUB_TOKEN="ghp_YourGeneratedTokenHere..."
+
+set -e
+
+# Ensure we have the latest tags
+git fetch --tags
+
+# Loop through all tags matching the pattern "v*"
+for version in $(git tag -l "v*" | sort -V); do
+	echo "Running for $version..."
+	go run tools/cache_metadata/main.go -version "$version"
+done
+
+echo "Finished processing all tags."

--- a/tools/cache_metadata/run_backfill.sh
+++ b/tools/cache_metadata/run_backfill.sh
@@ -14,11 +14,14 @@
 # limitations under the License.
 
 # This script caches metadata for all the github version releases. Used to backfill the data.
-# Cmds to run the script:
+# Commands to run the script:
 # chmod +x tools/cache_metadata/run_backfill.sh
 # ./tools/cache_metadata/run_backfill.sh
 # If hitting Github API rate limits, can create and use a Personal Authentication token by generating and exporting it.
 # export GITHUB_TOKEN="ghp_YourGeneratedTokenHere..."
+
+# To collect metadata for one specific version, run the following command:
+# go run tools/cache_metadata/main.go -version <VERSION>
 
 set -e
 

--- a/tools/cache_metadata/run_backfill.sh
+++ b/tools/cache_metadata/run_backfill.sh
@@ -25,10 +25,16 @@ set -e
 # Ensure we have the latest tags
 git fetch --tags
 
+# Build the tool once
+go build -o backfill_tool tools/cache_metadata/main.go
+
 # Loop through all tags matching the pattern "v*"
 for version in $(git tag -l "v*" | sort -V); do
 	echo "Running for $version..."
-	go run tools/cache_metadata/main.go -version "$version"
+	./backfill_tool -version "$version"
 done
+
+# Clean up
+rm backfill_tool
 
 echo "Finished processing all tags."


### PR DESCRIPTION
Added a script to backfill the release metadata for all versions of Cluster Toolkit. Also include support for using a Github Personal Authentication Token if needed.

This pull request introduces **automation for backfilling release metadata for Cluster Toolkit versions**. It enhances the existing Go-based metadata tool to support GitHub personal access tokens and provides a **new shell script to iterate through all repository tags**, ensuring comprehensive data coverage in Firestore.

Changes:

* **GitHub API Authentication**: Updated the metadata caching tool to support GITHUB_TOKEN for authenticated requests to avoid API rate limits.
* **Backfill Automation**: Added a shell script to automate the process of iterating through all version tags and backfilling release metadata.