### PR TITLE
adding new kubernetes-secret module.

### DIFF
--- a/modules/security/kubernetes-secret/README.md
+++ b/modules/security/kubernetes-secret/README.md
@@ -65,8 +65,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_access_token"></a> [access\_token](#input\_access\_token) | The access token for accessing the cluster. If provided, ignores data source lookup. | `string` | `null` | no |
-| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
-| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | The cluster CA certificate of the GKE cluster. Must be base64-encoded. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint of the GKE cluster. Do not include the https:// prefix. If provided, ignores data source lookup. | `string` | `null` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The full GCP resource ID of the GKE cluster in the format projects/PROJECT\_ID/locations/LOCATION/clusters/CLUSTER\_NAME | `string` | n/a | yes |
 | <a name="input_data"></a> [data](#input\_data) | Key-value map of secret data | `map(string)` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace | `string` | n/a | yes |

--- a/modules/security/kubernetes-secret/README.md
+++ b/modules/security/kubernetes-secret/README.md
@@ -1,0 +1,80 @@
+## Description
+
+This module creates a Kubernetes secret in a specified namespace on a given GKE cluster. It automatically configures the Kubernetes provider using the GKE cluster credentials.
+
+## Example usage
+
+```yaml
+- id: k8s_secret
+  source: ./modules/security/kubernetes-secret
+  settings:
+    cluster_id: "projects/my-project/locations/us-central1/clusters/my-cluster"
+    namespace: "default"
+    secret_name: "my-secret"
+    data:
+      key1: "sensitive-value1"
+      key2: "sensitive-value2"
+```
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [kubernetes_secret_v1.secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [google_client_config.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+| [google_container_cluster.gke_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_access_token"></a> [access\_token](#input\_access\_token) | The access token for accessing the cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_ca_certificate"></a> [cluster\_ca\_certificate](#input\_cluster\_ca\_certificate) | The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_endpoint"></a> [cluster\_endpoint](#input\_cluster\_endpoint) | The endpoint of the GKE cluster. If provided, ignores data source lookup. | `string` | `null` | no |
+| <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | The full GCP resource ID of the GKE cluster in the format projects/PROJECT\_ID/locations/LOCATION/clusters/CLUSTER\_NAME | `string` | n/a | yes |
+| <a name="input_data"></a> [data](#input\_data) | Key-value map of secret data | `map(string)` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace | `string` | n/a | yes |
+| <a name="input_secret_name"></a> [secret\_name](#input\_secret\_name) | Name of the Kubernetes secret | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_secret_name"></a> [secret\_name](#output\_secret\_name) | The name of the created Kubernetes secret |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/security/kubernetes-secret/README.md
+++ b/modules/security/kubernetes-secret/README.md
@@ -1,6 +1,6 @@
 ## Description
 
-This module creates a Kubernetes secret in a specified namespace on a given GKE cluster. It automatically configures the Kubernetes provider using the GKE cluster credentials.
+This module creates a Kubernetes secret in a specified namespace on a given GKE cluster. It configures the Kubernetes provider using either explicitly provided credentials (`cluster_endpoint`, `cluster_ca_certificate`, `access_token`) or dynamically looks them up using the `cluster_id`.
 
 ## Example usage
 

--- a/modules/security/kubernetes-secret/main.tf
+++ b/modules/security/kubernetes-secret/main.tf
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "kubernetes_secret_v1" "secret" {
+  metadata {
+    name      = var.secret_name
+    namespace = var.namespace
+  }
+  data = var.data
+}
+locals {
+  cluster_id_parts = var.cluster_id != null ? split("/", var.cluster_id) : []
+  cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
+  cluster_location = length(local.cluster_id_parts) > 3 ? local.cluster_id_parts[3] : ""
+  kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
+
+  # HYBRID LOGIC: Use passed-in variable if available, otherwise fall back to data source
+  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : "https://${data.google_container_cluster.gke_cluster.endpoint}"
+  token                  = var.access_token != null ? var.access_token : data.google_client_config.default.access_token
+  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+}
+
+data "google_client_config" "default" {}
+data "google_container_cluster" "gke_cluster" {
+  name     = local.cluster_name
+  location = local.cluster_location
+  project  = local.kube_project_id
+}
+provider "kubernetes" {
+  host                   = local.host
+  token                  = local.token
+  cluster_ca_certificate = local.cluster_ca_certificate
+}

--- a/modules/security/kubernetes-secret/main.tf
+++ b/modules/security/kubernetes-secret/main.tf
@@ -18,9 +18,12 @@ resource "kubernetes_secret_v1" "secret" {
   metadata {
     name      = var.secret_name
     namespace = var.namespace
+    labels    = { ghpc_module = "kubernetes-secret", ghpc_role = "security" }
   }
+
   data = var.data
 }
+
 locals {
   cluster_id_parts = var.cluster_id != null ? split("/", var.cluster_id) : []
   cluster_name     = length(local.cluster_id_parts) > 5 ? local.cluster_id_parts[5] : ""
@@ -28,17 +31,21 @@ locals {
   kube_project_id  = length(local.cluster_id_parts) > 1 ? local.cluster_id_parts[1] : ""
 
   # HYBRID LOGIC: Use passed-in variable if available, otherwise fall back to data source
-  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : "https://${data.google_container_cluster.gke_cluster.endpoint}"
+  host                   = var.cluster_endpoint != null ? "https://${var.cluster_endpoint}" : (length(data.google_container_cluster.gke_cluster) > 0 ? "https://${data.google_container_cluster.gke_cluster[0].endpoint}" : "")
   token                  = var.access_token != null ? var.access_token : data.google_client_config.default.access_token
-  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : base64decode(data.google_container_cluster.gke_cluster.master_auth[0].cluster_ca_certificate)
+  cluster_ca_certificate = var.cluster_ca_certificate != null ? base64decode(var.cluster_ca_certificate) : (length(data.google_container_cluster.gke_cluster) > 0 ? base64decode(data.google_container_cluster.gke_cluster[0].master_auth[0].cluster_ca_certificate) : "")
 }
 
 data "google_client_config" "default" {}
+
 data "google_container_cluster" "gke_cluster" {
+  count = var.cluster_endpoint == null && var.cluster_id != null ? 1 : 0
+
   name     = local.cluster_name
   location = local.cluster_location
   project  = local.kube_project_id
 }
+
 provider "kubernetes" {
   host                   = local.host
   token                  = local.token

--- a/modules/security/kubernetes-secret/metadata.yaml
+++ b/modules/security/kubernetes-secret/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - container.googleapis.com
+ghpc:
+  validators: []

--- a/modules/security/kubernetes-secret/outputs.tf
+++ b/modules/security/kubernetes-secret/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "secret_name" {
+  description = "The name of the created Kubernetes secret"
+  value       = kubernetes_secret_v1.secret.metadata[0].name
+}

--- a/modules/security/kubernetes-secret/variables.tf
+++ b/modules/security/kubernetes-secret/variables.tf
@@ -33,13 +33,13 @@ variable "cluster_id" {
 }
 
 variable "cluster_endpoint" {
-  description = "The endpoint of the GKE cluster. If provided, ignores data source lookup."
+  description = "The endpoint of the GKE cluster. Do not include the https:// prefix. If provided, ignores data source lookup."
   type        = string
   default     = null
 }
 
 variable "cluster_ca_certificate" {
-  description = "The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup."
+  description = "The cluster CA certificate of the GKE cluster. Must be base64-encoded. If provided, ignores data source lookup."
   type        = string
   default     = null
 }

--- a/modules/security/kubernetes-secret/variables.tf
+++ b/modules/security/kubernetes-secret/variables.tf
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "namespace" {
+  description = "Kubernetes namespace"
+  type        = string
+}
+variable "secret_name" {
+  description = "Name of the Kubernetes secret"
+  type        = string
+}
+variable "data" {
+  description = "Key-value map of secret data"
+  type        = map(string)
+  sensitive   = true
+}
+variable "cluster_id" {
+  description = "The full GCP resource ID of the GKE cluster in the format projects/PROJECT_ID/locations/LOCATION/clusters/CLUSTER_NAME"
+  type        = string
+}
+
+variable "cluster_endpoint" {
+  description = "The endpoint of the GKE cluster. If provided, ignores data source lookup."
+  type        = string
+  default     = null
+}
+
+variable "cluster_ca_certificate" {
+  description = "The cluster CA certificate of the GKE cluster. If provided, ignores data source lookup."
+  type        = string
+  default     = null
+}
+
+variable "access_token" {
+  description = "The access token for accessing the cluster. If provided, ignores data source lookup."
+  type        = string
+  sensitive   = true
+  default     = null
+}

--- a/modules/security/kubernetes-secret/versions.tf
+++ b/modules/security/kubernetes-secret/versions.tf
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.10"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a new module to create a Kubernetes Secret (kubernetes_secret_v1) with dynamic provider configuration. It securely handles credentials by fetching them from a target cluster, supporting both variable-provided and data-source-fetched tokens and CA certificates.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
