### PR TITLE
adding new workload_identity_binding module.

### DIFF
--- a/modules/project/workload_identity_binding/README.md
+++ b/modules/project/workload_identity_binding/README.md
@@ -1,0 +1,72 @@
+## Description
+
+This module creates a Workload Identity binding between a Google Service Account (GSA) and a Kubernetes Service Account (KSA) in a GKE cluster.
+
+## Example usage
+
+```yaml
+- id: workload_identity_binding
+  source: modules/project/workload_identity_binding
+  settings:
+    project_id: $(vars.project_id)
+    service_account_email: $(service_account.service_account_email)
+    namespace: "my-namespace"
+    k8s_service_account_name: "my-ksa"
+```
+
+## License
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_service_account_iam_member.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The name of the Kubernetes Service Account (KSA) to bind. | `string` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where the KSA is located. | `string` | `"xmc"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID where the cluster is located. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the Google Service Account (GSA) to bind. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_iam_email"></a> [iam\_email](#output\_iam\_email) | The Workload Identity principal. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/project/workload_identity_binding/README.md
+++ b/modules/project/workload_identity_binding/README.md
@@ -53,14 +53,13 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [google_service_account_iam_member.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
-| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The name of the Kubernetes Service Account (KSA) to bind. | `string` | n/a | yes |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where the KSA is located. | `string` | `"xmc"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where the KSA is located. | `string` | `"default"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID where the cluster is located. | `string` | n/a | yes |
 | <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the Google Service Account (GSA) to bind. | `string` | n/a | yes |
 

--- a/modules/project/workload_identity_binding/README.md
+++ b/modules/project/workload_identity_binding/README.md
@@ -61,11 +61,11 @@ No modules.
 | <a name="input_k8s_service_account_name"></a> [k8s\_service\_account\_name](#input\_k8s\_service\_account\_name) | The name of the Kubernetes Service Account (KSA) to bind. | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace where the KSA is located. | `string` | `"default"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The GCP project ID where the cluster is located. | `string` | n/a | yes |
-| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email of the Google Service Account (GSA) to bind. | `string` | n/a | yes |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | The email address of the Google Service Account (GSA) to bind (e.g., user@project.iam.gserviceaccount.com). | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
-| <a name="output_iam_email"></a> [iam\_email](#output\_iam\_email) | The Workload Identity principal. |
+| <a name="output_workload_identity_principal"></a> [workload\_identity\_principal](#output\_workload\_identity\_principal) | The Workload Identity principal. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/project/workload_identity_binding/main.tf
+++ b/modules/project/workload_identity_binding/main.tf
@@ -18,7 +18,7 @@
 # and a Kubernetes Service Account (KSA).
 
 resource "google_service_account_iam_member" "main" {
-  service_account_id = var.service_account_email
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.k8s_service_account_name}]"
 }

--- a/modules/project/workload_identity_binding/main.tf
+++ b/modules/project/workload_identity_binding/main.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# This module creates a Workload Identity binding between a Google Service Account (GSA)
+# and a Kubernetes Service Account (KSA).
+data "google_project" "project" {
+  project_id = var.project_id
+}
+resource "google_service_account_iam_member" "main" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/subject/ns/${var.namespace}/sa/${var.k8s_service_account_name}"
+}

--- a/modules/project/workload_identity_binding/main.tf
+++ b/modules/project/workload_identity_binding/main.tf
@@ -16,11 +16,9 @@
 
 # This module creates a Workload Identity binding between a Google Service Account (GSA)
 # and a Kubernetes Service Account (KSA).
-data "google_project" "project" {
-  project_id = var.project_id
-}
+
 resource "google_service_account_iam_member" "main" {
-  service_account_id = "projects/${var.project_id}/serviceAccounts/${var.service_account_email}"
+  service_account_id = var.service_account_email
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principal://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/subject/ns/${var.namespace}/sa/${var.k8s_service_account_name}"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.k8s_service_account_name}]"
 }

--- a/modules/project/workload_identity_binding/metadata.yaml
+++ b/modules/project/workload_identity_binding/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - iam.googleapis.com
+ghpc:
+  validators: []

--- a/modules/project/workload_identity_binding/outputs.tf
+++ b/modules/project/workload_identity_binding/outputs.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "iam_email" {
+  description = "The Workload Identity principal."
+  value       = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.k8s_service_account_name}]"
+}

--- a/modules/project/workload_identity_binding/outputs.tf
+++ b/modules/project/workload_identity_binding/outputs.tf
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-output "iam_email" {
+output "workload_identity_principal" {
   description = "The Workload Identity principal."
   value       = "serviceAccount:${var.project_id}.svc.id.goog[${var.namespace}/${var.k8s_service_account_name}]"
 }

--- a/modules/project/workload_identity_binding/variables.tf
+++ b/modules/project/workload_identity_binding/variables.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID where the cluster is located."
+}
+variable "service_account_email" {
+  type        = string
+  description = "The email of the Google Service Account (GSA) to bind."
+}
+variable "namespace" {
+  type        = string
+  description = "The Kubernetes namespace where the KSA is located."
+  default     = "xmc"
+}
+variable "k8s_service_account_name" {
+  type        = string
+  description = "The name of the Kubernetes Service Account (KSA) to bind."
+}

--- a/modules/project/workload_identity_binding/variables.tf
+++ b/modules/project/workload_identity_binding/variables.tf
@@ -25,7 +25,7 @@ variable "service_account_email" {
 variable "namespace" {
   type        = string
   description = "The Kubernetes namespace where the KSA is located."
-  default     = "xmc"
+  default     = "default"
 }
 variable "k8s_service_account_name" {
   type        = string

--- a/modules/project/workload_identity_binding/variables.tf
+++ b/modules/project/workload_identity_binding/variables.tf
@@ -18,15 +18,18 @@ variable "project_id" {
   type        = string
   description = "The GCP project ID where the cluster is located."
 }
+
 variable "service_account_email" {
   type        = string
-  description = "The email of the Google Service Account (GSA) to bind."
+  description = "The email address of the Google Service Account (GSA) to bind (e.g., user@project.iam.gserviceaccount.com)."
 }
+
 variable "namespace" {
   type        = string
   description = "The Kubernetes namespace where the KSA is located."
   default     = "default"
 }
+
 variable "k8s_service_account_name" {
   type        = string
   description = "The name of the Kubernetes Service Account (KSA) to bind."

--- a/modules/project/workload_identity_binding/versions.tf
+++ b/modules/project/workload_identity_binding/versions.tf
@@ -1,0 +1,25 @@
+
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+  required_version = "= 1.12.2"
+}

--- a/modules/project/workload_identity_binding/versions.tf
+++ b/modules/project/workload_identity_binding/versions.tf
@@ -13,7 +13,8 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
-*/
+ */
+
 terraform {
   required_providers {
     google = {


### PR DESCRIPTION
 Adding a new module to create a Workload Identity binding between a Google Service Account (GSA) and a Kubernetes Service Account (KSA). It manages the service account IAM member role roles/iam.workloadIdentityUser with full project number pathing.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
