### PR TITLE
fix list job to use interface

### DIFF
--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -76,6 +76,10 @@ func (m *mockKubeClient) DeleteJobSet(namespace string, name string) error {
 	return m.err
 }
 
+func (m *mockKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+	return []orchestrator.JobStatus{}, m.err
+}
+
 func TestCancelCmd_MissingArgs(t *testing.T) {
 	resetSubmitCmdFlags()
 

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -31,6 +31,7 @@ func TestListWorkloadsCmd_Success(t *testing.T) {
 	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
 		g := gke.NewGKEOrchestrator()
 		g.SetExecutor(&mockCancelExecutor{}) // Use the mock from cancel_test.go if available
+		g.SetKubeClient(&mockKubeClient{namespace: "default"})
 		return g
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1851,7 +1851,7 @@ func (d *DefaultKubeClient) ListWorkloads(namespace string, workloadName string)
 
 func (d *DefaultKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
 	gvr := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
-	list, err := d.dynClient.Resource(gvr).Namespace("").List(context.TODO(), metav1.ListOptions{
+	list, err := d.dynClient.Resource(gvr).Namespace("").List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
 	if err != nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -130,45 +130,29 @@ func (g *GKEOrchestrator) ListJobs(opts orchestrator.ListOptions) ([]orchestrato
 		return nil, err
 	}
 
-	client, err := g.getDynamicClient()
-	if err != nil {
+	if _, err := g.getDynamicClient(); err != nil {
 		return nil, err
 	}
 
-	gvr := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
-
-	list, err := client.Resource(gvr).Namespace("").List(context.TODO(), metav1.ListOptions{
-		LabelSelector: "gcluster.google.com/workload",
-	})
+	list, err := g.kubeClient.ListJobSets("gcluster.google.com/workload")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list jobsets across all namespaces: %w", err)
 	}
 
-	var jobs []orchestrator.JobStatus
-	for _, item := range list.Items {
-		name := item.GetName()
-		if opts.NameContains != "" && !strings.Contains(name, opts.NameContains) {
+	var filteredJobs []orchestrator.JobStatus
+	for _, job := range list {
+		if opts.NameContains != "" && !strings.Contains(job.Name, opts.NameContains) {
 			continue
 		}
 
-		creationParams := item.GetCreationTimestamp()
-		creationTime := creationParams.Time.Format(time.RFC3339)
-
-		statusStr, completionTime := g.parseJobStatus(item.Object)
-
-		if opts.Status != "" && !strings.EqualFold(statusStr, opts.Status) {
+		if opts.Status != "" && !strings.EqualFold(job.Status, opts.Status) {
 			continue
 		}
 
-		jobs = append(jobs, orchestrator.JobStatus{
-			Name:           name,
-			Status:         statusStr,
-			CreationTime:   creationTime,
-			CompletionTime: completionTime,
-		})
+		filteredJobs = append(filteredJobs, job)
 	}
 
-	return jobs, nil
+	return filteredJobs, nil
 }
 
 // CancelJob deletes a job from the GKE cluster by name.
@@ -1353,7 +1337,7 @@ func (g *GKEOrchestrator) addVolumeOptions(opts *ManifestOptions, vols []orchest
 	}
 }
 
-func (g *GKEOrchestrator) parseJobStatus(obj map[string]interface{}) (statusStr, completionTime string) {
+func parseJobStatus(obj map[string]interface{}) (statusStr, completionTime string) {
 	statusStr = "Unknown"
 	completionTime = ""
 
@@ -1378,13 +1362,13 @@ func (g *GKEOrchestrator) parseJobStatus(obj map[string]interface{}) (statusStr,
 	}
 
 	if conditions, ok := statusMap["conditions"].([]interface{}); ok {
-		g.parseConditions(conditions, &statusStr, &completionTime)
+		parseConditions(conditions, &statusStr, &completionTime)
 	}
 
 	return
 }
 
-func (g *GKEOrchestrator) parseConditions(conditions []interface{}, statusStr *string, completionTime *string) {
+func parseConditions(conditions []interface{}, statusStr *string, completionTime *string) {
 	for _, c := range conditions {
 		cond := c.(map[string]interface{})
 		condType, _ := cond["type"].(string)
@@ -1518,7 +1502,7 @@ func (g *GKEOrchestrator) getJobStatus(name string) (string, error) {
 		return wlStatus, nil
 	}
 
-	status, _ := g.parseJobStatus(obj.Object)
+	status, _ := parseJobStatus(obj.Object)
 
 	if status == "Running" {
 		podStatus, err := g.getPodAggregatedStatus(client, ns, name)
@@ -1863,6 +1847,34 @@ func (d *DefaultKubeClient) ListWorkloads(namespace string, workloadName string)
 		matchedWorkloads = append(matchedWorkloads, item.GetName())
 	}
 	return matchedWorkloads, nil
+}
+
+func (d *DefaultKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+	gvr := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
+	list, err := d.dynClient.Resource(gvr).Namespace("").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: labelSelector,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var jobs []orchestrator.JobStatus
+	for _, item := range list.Items {
+		name := item.GetName()
+		creationParams := item.GetCreationTimestamp()
+		creationTime := creationParams.Time.Format(time.RFC3339)
+
+		statusStr, completionTime := parseJobStatus(item.Object)
+
+		jobs = append(jobs, orchestrator.JobStatus{
+			Name:           name,
+			Status:         statusStr,
+			CreationTime:   creationTime,
+			CompletionTime: completionTime,
+		})
+	}
+
+	return jobs, nil
 }
 
 func (d *DefaultExecutor) ExecuteCommand(name string, args ...string) shell.CommandResult {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -73,6 +73,10 @@ func (m *MockKubeClient) DeleteJobSet(namespace string, name string) error {
 	return m.Err
 }
 
+func (m *MockKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+	return []orchestrator.JobStatus{}, m.Err
+}
+
 func TestGenerateGKEManifest_Accelerators(t *testing.T) {
 
 	tests := []struct {
@@ -1025,8 +1029,6 @@ func TestGenerateGKEManifest_Verbose_TPU(t *testing.T) {
 }
 
 func TestParseJobStatus_CompletionTime(t *testing.T) {
-	orc := &GKEOrchestrator{}
-
 	tests := []struct {
 		name               string
 		obj                map[string]interface{}
@@ -1114,7 +1116,7 @@ func TestParseJobStatus_CompletionTime(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotStatus, gotCompletionTime := orc.parseJobStatus(tt.obj)
+			gotStatus, gotCompletionTime := parseJobStatus(tt.obj)
 			if gotStatus != tt.wantStatus {
 				t.Errorf("parseJobStatus() gotStatus = %v, want %v", gotStatus, tt.wantStatus)
 			}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -34,6 +34,7 @@ type KubeClient interface {
 	GetJobNamespace(workloadName string) (string, error)
 	ListWorkloads(namespace string, workloadName string) ([]string, error)
 	DeleteJobSet(namespace string, name string) error
+	ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error)
 }
 
 // DefaultKubeClient implements KubeClient using the actual dynamic client.


### PR DESCRIPTION
This pull request refactors the ListJobs logic within the GKE orchestrator to utilize the KubeClient interface. By abstracting the Kubernetes API interactions, the PR enables proper mocking and improves the testability of job-related CLI commands

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
