### PR TITLE
Offload hardware resolution for job submission to hardware.go module

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -16,6 +16,7 @@ package job
 
 import (
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"os"
 	"slices"
 	"time"
@@ -28,18 +29,18 @@ import (
 )
 
 var (
-	imageName       string
-	baseImage       string
-	buildContext    string
-	commandToRun    string
-	acceleratorType string
-	dryRunManifest  string
+	imageName      string
+	baseImage      string
+	buildContext   string
+	commandToRun   string
+	computeType    string
+	dryRunManifest string
 
 	workloadName     string
 	kueueQueueName   string
 	numSlicesOrNodes int
 	vmsPerSlice      int
-	maxRestarts      int
+	restarts         int
 	ttlAfterFinished string
 	gracePeriodStr   string
 
@@ -104,7 +105,7 @@ func init() {
 	SubmitCmd.Flags().StringVarP(&baseImage, "base-image", "B", "", "Name of the base image for Crane to build upon (e.g., python:3.9-slim). Requires --build-context.")
 	SubmitCmd.Flags().StringVarP(&buildContext, "build-context", "b", "", "Path to the build context directory for Crane (e.g., .). Required with --base-image.")
 	SubmitCmd.Flags().StringVarP(&commandToRun, "command", "e", "", "Command to execute in the container (e.g., 'python train.py'). Required.")
-	SubmitCmd.Flags().StringVarP(&acceleratorType, "accelerator", "a", "", "Type of accelerator to request (e.g., 'nvidia-tesla-a100').")
+	SubmitCmd.Flags().StringVar(&computeType, "compute-type", "", "Type of compute to request (e.g., 'n2-standard-32', 'nvidia-l4', 'v6e-8').")
 	SubmitCmd.Flags().StringVarP(&dryRunManifest, "dry-run-out", "o", "", "Path to output the generated Kubernetes manifest instead of applying it.")
 	SubmitCmd.Flags().StringVarP(&platform, "platform", "f", "linux/amd64", "Target platform for the image build (e.g., 'linux/amd64', 'linux/arm64'). Used with --base-image.")
 
@@ -112,7 +113,7 @@ func init() {
 	SubmitCmd.Flags().StringVarP(&kueueQueueName, "queue", "q", "", "Name of the Kueue LocalQueue to submit the workload to. If empty, it will be auto-discovered.")
 	SubmitCmd.Flags().IntVar(&numSlicesOrNodes, "nodes", 1, "Number of JobSet replicas (or Slices for TPUs).")
 	SubmitCmd.Flags().IntVar(&vmsPerSlice, "vms-per-slice", 0, "Number of VMs (pods) per slice. Defaults to auto-calculated value for TPUs.")
-	SubmitCmd.Flags().IntVar(&maxRestarts, "max-restarts", 1, "Maximum number of restarts for the JobSet before failing.")
+	SubmitCmd.Flags().IntVar(&restarts, "restarts", 1, "Maximum number of restarts for the JobSet before failing.")
 	SubmitCmd.Flags().StringVar(&ttlAfterFinished, "gke-ttl-after-finished", "1h", "Time to retain the JobSet after it finishes (e.g. 5m, 1h).")
 	SubmitCmd.Flags().StringVar(&gracePeriodStr, "grace-period", "30s", "Time to wait before forcefully terminating a pod (e.g. 30s, 2m). Gives the workload time to save checkpoints or clean up distributed state during cancellation or preemption events (like Spot VM evictions).")
 
@@ -147,10 +148,13 @@ func init() {
 
 	_ = SubmitCmd.MarkFlagRequired("command")
 	_ = SubmitCmd.MarkFlagRequired("name")
-	_ = SubmitCmd.MarkFlagRequired("accelerator")
+	_ = SubmitCmd.MarkFlagRequired("compute-type")
 }
 
 func runSubmitCmd(cmd *cobra.Command, args []string) error {
+	if err := config.ValidateHardwareRequest(computeType, topology, placementPolicy); err != nil {
+		return err
+	}
 	ttlSeconds, err := parseDurationToSeconds(ttlAfterFinished, "--gke-ttl-after-finished")
 	if err != nil {
 		return err
@@ -181,7 +185,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		BuildContext:                  buildContext,
 		Platform:                      platform,
 		CommandToRun:                  commandToRun,
-		AcceleratorType:               acceleratorType,
+		AcceleratorType:               computeType,
 		DryRunManifest:                dryRunManifest,
 		ProjectID:                     projectID,
 		ClusterName:                   clusterName,
@@ -190,7 +194,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		KueueQueueName:                kueueQueueName,
 		NumSlices:                     numSlicesOrNodes,
 		VmsPerSlice:                   vmsPerSlice,
-		MaxRestarts:                   maxRestarts,
+		MaxRestarts:                   restarts,
 		TtlSecondsAfterFinished:       ttlSeconds,
 		TerminationGracePeriodSeconds: gracePeriodSeconds,
 		PlacementPolicy:               placementPolicy,

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -82,7 +82,7 @@ func TestSubmitCmd_PathwaysDryRun(t *testing.T) {
 		"--pathways-server-image", "server:latest",
 		"--pathways-worker-image", "worker:latest",
 		"--pathways-gcs-location", "gs://my-bucket",
-		"--accelerator", "n2-standard-4",
+		"--compute-type", "n2-standard-4",
 	)
 
 	if err != nil {
@@ -152,7 +152,7 @@ func TestSubmitCmd_RegularDryRun(t *testing.T) {
 		"--location", "us-central1-a",
 		"--project", "test-project",
 		"--dry-run-out", tmpfile.Name(),
-		"--accelerator", "n2-standard-4",
+		"--compute-type", "n2-standard-4",
 	)
 
 	if err != nil {
@@ -183,7 +183,7 @@ func resetSubmitCmdFlags() {
 	baseImage = ""
 	buildContext = ""
 	commandToRun = ""
-	acceleratorType = ""
+	computeType = ""
 	dryRunManifest = ""
 	clusterName = ""
 	location = ""
@@ -192,7 +192,7 @@ func resetSubmitCmdFlags() {
 	kueueQueueName = ""
 	numSlicesOrNodes = 1
 	vmsPerSlice = 1
-	maxRestarts = 1
+	restarts = 1
 	ttlAfterFinished = "1h"
 	gracePeriodStr = "30s"
 	placementPolicy = ""
@@ -379,7 +379,7 @@ func TestSubmitCmd_MissingRepoEnvVar(t *testing.T) {
 		"--base-image", "python:3.9-slim",
 		"--build-context", "job_details",
 		"--command", "echo hello",
-		"--accelerator", "n2-standard-4",
+		"--compute-type", "n2-standard-4",
 		"--cluster", "test-cluster",
 		"--location", "test-location",
 		"--project", "test-project",
@@ -424,7 +424,7 @@ func TestSubmitCmd_MissingUserEnvVar(t *testing.T) {
 		"--base-image", "python:3.9-slim",
 		"--build-context", "job_details",
 		"--command", "echo hello",
-		"--accelerator", "n2-standard-4",
+		"--compute-type", "n2-standard-4",
 		"--cluster", "test-cluster",
 		"--location", "test-location",
 		"--project", "test-project",

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -110,18 +110,18 @@ Here are the flags currently supported by `gcluster job submit`:
 * `-B, --base-image string`: Name of the base container image for Crane to build upon (e.g., `python:3.9-slim`). Required when using `--build-context` for an on-the-fly build.
 * `-b, --build-context string`: Path to the build context directory for Crane (e.g., `./job_details`). Required with `--base-image`. Crane will package all files in this directory and append them as a new layer to the base image (it does not require or execute a Dockerfile).
 * `-e, --command string`: Command to execute in the container (e.g., `'python app.py'`). This overrides the `CMD` instruction in your `Dockerfile`. (Required)
-* `-a, --accelerator string`: Type of accelerator to request (e.g., `'nvidia-h100-mega-80gb'` or machine type like `n2-standard-32`). (Required) It also supports shorthand strings for TPUs like `v6e-8` to request total chips; the tool will resolve the machine type and calculate `vms-per-slice` and `topology` automatically.
+* `--compute-type string`: Type of compute to request (e.g., `'n2-standard-32'`, `'nvidia-l4'`, or shorthand strings for TPUs like `v6e-8`). (Required) The tool will resolve the machine type and calculate `vms-per-slice` and `topology` automatically if needed.
 * `-o, --dry-run-out string`: Path to output the generated Kubernetes manifest instead of applying it directly to the cluster. Useful for inspection.
 * `-c, --cluster string`: Name of the GKE cluster to deploy the job to. Optional if set in configuration.
 * `-l, --location string`: Location (Zone or Region) of the GKE cluster. Optional if set in configuration.
 * `-p, --project string`: Google Cloud Project ID. Optional if set in configuration.
-* `-f, --platform string`: Target platform for the image build (e.g., `linux/amd64`, `linux/arm64`). Used with `--base-image`. (Default: `linux/amd64`)
-* `-w, --name string`: Name of the job (JobSet) to create. This name will be used for Kubernetes resources. (Required)
+* `-f, --platform string`: Target platform for the image build (e.g., `linux/amd64`, `linux/arm64`). Used with --base-image. (Default: `linux/amd64`)
+* `-n, --name string`: Name of the job (JobSet) to create. This name will be used for Kubernetes resources. (Required)
 * `--queue string`: Name of the Kueue LocalQueue to submit the job to. (Default: Auto-discovered from the cluster)
 * `--nodes int`: Number of JobSet replicas (slices). (Default: `1`)
 * `--vms-per-slice int`: Number of VMs (pods) per slice. (Default: `1`). Can be auto-calculated for TPUs if `--topology` is provided.
 * `--topology string`: TPU slice topology (e.g., `2x2x1`). Required for total-chip calculation if `--vms-per-slice` is omitted.
-* `--max-restarts int`: Maximum number of restarts for the JobSet before failing. (Default: `1`)
+* `--restarts int`: Maximum number of restarts for the JobSet before failing. (Default: `1`)
 * `--gke-ttl-after-finished string`: Time to retain the JobSet after it finishes (e.g. `5m`, `1h`, `3600`). (Default: `1h`)
 * `--grace-period string`: Time to wait before forcefully terminating a pod (e.g. `30s`, `2m`). Gives the workload time to save checkpoints or clean up distributed state during job cancellation or hardware preemption events (like Spot VM evictions). (Default: `30s`)
 * `--mount stringArray`: Mount a storage volume (format: `<src>:<dest>[:<mode>]`, mode can be `'ro'` or `'rw'`, default `'ro'`). Can be specified multiple times.
@@ -151,7 +151,7 @@ Now that the cluster is deployed and your application code is prepared, you can 
 
 ### Unified Job Submission
 
-By specifying the `--accelerator` flag, you can use the exact same command to deploy to a standard CPU cluster (using machine type like `n2-standard-32`) or an accelerated GPU/TPU cluster (using accelerator type like `nvidia-l4`). The orchestrator will calculate the necessary resource requests and limits based on the specified accelerator or machine type.
+By specifying the `--compute-type` flag, you can use the exact same command to deploy to a standard CPU cluster (using machine type like `n2-standard-32`) or an accelerated GPU/TPU cluster (using accelerator type like `nvidia-l4`). The orchestrator will calculate the necessary resource requests and limits based on the specified compute type.
 
 > [!TIP]
 > **Simplify Commands with Configuration**: You can set these values once using the configuration command and omit them from subsequent commands:
@@ -179,7 +179,7 @@ By specifying the `--accelerator` flag, you can use the exact same command to de
       --build-context job_details \
       --command "python app.py" \
       --name my-python-app-job \
-      --accelerator n2-standard-32
+      --compute-type n2-standard-32
     ```
 
     *Replace `<PROJECT_ID>` with your actual GCP Project ID.*
@@ -187,7 +187,7 @@ By specifying the `--accelerator` flag, you can use the exact same command to de
     This command will:
     1. Verify/install the JobSet CRD on your cluster.
     2. Auto-discover the Kueue LocalQueue name from the cluster.
-    3. Use the hardware Accelerator Type installed on the cluster nodes and map the necessary resource requests.
+    3. Use the compute type installed on the cluster nodes and map the necessary resource requests.
     4. Build a container image from the job_details directory using python:3.9-slim as the base, and push it to Artifact Registry.
     5. Generate and apply an intelligently configured Kubernetes JobSet manifest to your cluster.
 
@@ -202,7 +202,7 @@ You can mount Cloud Storage buckets or host paths using the `--mount` flag. By d
   --location <REGION/ZONE> \
   --name my-storage-job \
   --command "python app.py" \
-  --accelerator n2-standard-32 \
+  --compute-type n2-standard-32 \
   --base-image python:3.9-slim \
   --build-context job_details \
   --mount "gs://<YOUR_BUCKET_NAME>:/data:rw"
@@ -257,7 +257,7 @@ Use `--node-constraint` to target specific hardware (e.g., C2 nodes). This maps 
   --location <REGION/ZONE> \
   --name my-machine-job \
   --command "python app.py" \
-  --accelerator c2-standard-60 \
+  --compute-type c2-standard-60 \
   --base-image python:3.9-slim \
   --build-context job_details \
   --node-constraint "node.kubernetes.io/instance-type=c2-standard-60"
@@ -276,7 +276,7 @@ Use `--placement-policy` to specify a GCE Placement Policy (e.g., for compact pl
 *(Note: requires a `PlacementPolicy` resource named `compact-placement` to exist on the cluster)*
 
 **Example 3: Pod Failure Policy**
-Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (these do not count against the `max-restarts` budget).
+Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (these do not count against the `restarts` budget).
 
 ```bash
 ./gcluster job submit \
@@ -306,7 +306,7 @@ Use `--queue` to submit the job to a specific Kueue LocalQueue.
   --location <REGION/ZONE> \
   --name my-kueue-job \
   --command "python app.py" \
-  --accelerator n2-standard-32 \
+  --compute-type n2-standard-32 \
   --base-image python:3.9-slim \
   --build-context job_details \
   --queue "my-local-queue"
@@ -358,7 +358,7 @@ Request a specific TPU slice topology using `--topology`.
   --base-image python:3.9-slim \
   --build-context job_details \
   --command "python app.py" \
-  --accelerator tpu-v6e-slice \
+  --compute-type tpu-v6e-slice \
   --topology 4x4
 ```
 
@@ -372,7 +372,7 @@ Use a specific GKE scheduler (e.g., `gke.io/topology-aware-auto`) using `--gke-s
   --location <REGION/ZONE> \
   --name my-scheduler-job \
   --command "python app.py" \
-  --accelerator n2-standard-32 \
+  --compute-type n2-standard-32 \
   --base-image python:3.9-slim \
   --build-context job_details \
   --gke-scheduler gke.io/topology-aware-auto
@@ -558,7 +558,7 @@ $GCLUSTER job submit \
     --location $LOCATION \
     --image $IMAGE_NAME \
     --command "cd /app && pip install psutil jaxtyping tiktoken sentencepiece ray fastapi uvicorn portpicker pydantic ninja Pillow gcsfs omegaconf jsonlines PyYAML safetensors tabulate tensorstore transformers datasets evaluate nltk pandas ml_collections ml_dtypes pathwaysutils orbax grain tensorflow_text tensorflow_datasets tqdm && sed -i 's/use_vertex_tensorboard=false/use_vertex_tensorboard=false run_name=llama3-1-v6e8-test1/g' run_maxtext.sh && bash run_maxtext.sh $OUTPUT_DIR" \
-    --accelerator v6e-8 \
+    --compute-type v6e-8 \
     --nodes 1 \
     --vms-per-slice 2 \
     --topology 2x4 \
@@ -811,7 +811,7 @@ $GCLUSTER job submit \
     --location $LOCATION \
     --image $IMAGE_NAME \
     --command "cd /app && sed -i 's/use_vertex_tensorboard=false/use_vertex_tensorboard=false run_name=llama3-1-7x-test1/g' run_maxtext.sh && bash run_maxtext.sh $OUTPUT_DIR" \
-    --accelerator tpu7x-32 \
+    --compute-type tpu7x-32 \
     --nodes 1 \
     --vms-per-slice 8 \
     --topology 2x4x4 \

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -27,6 +28,104 @@ const defaultAcceleratorsPerVM = 4
 var tpuFamilyDefaults = map[string]int{
 	"ct5lp":     8, // Default for TPU v5e when suffix is missing
 	"v5litepod": 8, // Legacy string literal default
+}
+
+var tpuRegex = regexp.MustCompile(`^v[4-6][ep]?(-\d+)?$`)
+
+var valid2DTPUFamilies = []string{"ct6e", "ct5lp", "v5litepod", "v5-lite", "v5e", "v6e"}
+var valid3DTPUFamilies = []string{"v4", "v5p", "ct4p", "ct5p", "tpu7"}
+
+// AcceleratorShorthandMap maps shorthand names to full machine types.
+var AcceleratorShorthandMap = map[string]string{
+	// GPU mappings
+	"l4-1":             "g2-standard-12",
+	"l4-2":             "g2-standard-24",
+	"l4-4":             "g2-standard-48",
+	"l4-8":             "g2-standard-96",
+	"rtx-6000-1":       "g4-standard-48",
+	"rtx-6000-2":       "g4-standard-96",
+	"rtx-6000-4":       "g4-standard-192",
+	"rtx-6000-8":       "g4-standard-384",
+	"a100-40gb-1":      "a2-highgpu-1g",
+	"a100-40gb-2":      "a2-highgpu-2g",
+	"a100-40gb-4":      "a2-highgpu-4g",
+	"a100-40gb-8":      "a2-highgpu-8g",
+	"a2-megagpu-16g":   "a2-megagpu-16g",
+	"a100-80gb-1":      "a2-ultragpu-1g",
+	"a100-80gb-2":      "a2-ultragpu-2g",
+	"a100-80gb-4":      "a2-ultragpu-4g",
+	"a100-80gb-8":      "a2-ultragpu-8g",
+	"h100-80gb-1":      "a3-highgpu-1g",
+	"h100-80gb-2":      "a3-highgpu-2g",
+	"h100-80gb-4":      "a3-highgpu-4g",
+	"h100-80gb-8":      "a3-highgpu-8g",
+	"h100-mega-80gb-8": "a3-megagpu-8g",
+	"h200-141gb-8":     "a3-ultragpu-8g",
+	"b200-8":           "a4-highgpu-8g",
+	"gb200-4":          "a4x-highgpu-4g",
+
+	// TPU mappings
+	"v4-8":    "ct4p-hightpu-4t",
+	"v5p-1":   "ct5p-hightpu-1t",
+	"v5p-2":   "ct5p-hightpu-2t",
+	"v5p-4":   "ct5p-hightpu-4t",
+	"v5e-1":   "ct5lp-hightpu-1t",
+	"v5e-4":   "ct5lp-hightpu-4t",
+	"v5e-8":   "ct5lp-hightpu-8t",
+	"v6e-1":   "ct6e-standard-1t",
+	"v6e-4":   "ct6e-standard-4t",
+	"v6e-8":   "ct6e-standard-8t",
+	"tpu7x-1": "tpu7x-standard-1t",
+	"tpu7x-4": "tpu7x-standard-4t",
+}
+
+// ValidGPUAccelerators lists valid GPU accelerator types.
+var ValidGPUAccelerators = map[string]bool{
+	"nvidia-l4":             true,
+	"nvidia-tesla-a100":     true,
+	"nvidia-gb200":          true,
+	"nvidia-b200":           true,
+	"nvidia-h200-141gb":     true,
+	"nvidia-h100-80gb":      true,
+	"nvidia-h100-mega-80gb": true,
+}
+
+// 3D topologies for v4, v5p, tpu7x
+var allowed3DTopologies = map[int]string{
+	4:    "2x2x1",
+	8:    "2x2x2",
+	16:   "2x2x4",
+	32:   "2x4x4",
+	64:   "4x4x4",
+	128:  "4x4x8",
+	256:  "4x8x8",
+	512:  "8x8x8",
+	1024: "8x8x16",
+	2048: "8x16x16",
+}
+
+// 2D topologies for v5e and v6e
+var allowed2DTopologies = map[int]string{
+	1:   "1x1",
+	4:   "2x2",
+	8:   "2x4",
+	16:  "4x4",
+	32:  "4x8",
+	64:  "8x8",
+	128: "8x16",
+	256: "16x16",
+}
+
+var valid3DShapes = make(map[string]bool)
+var valid2DShapes = make(map[string]bool)
+
+func init() {
+	for _, v := range allowed3DTopologies {
+		valid3DShapes[v] = true
+	}
+	for _, v := range allowed2DTopologies {
+		valid2DShapes[v] = true
+	}
 }
 
 func evalString(bp Blueprint, val cty.Value) (string, bool) {
@@ -94,7 +193,7 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 		return nil
 	}
 
-	nodes, err := calculateAcceleratorNodes(mtStr, tpuTopologyStr)
+	nodes, err := CalculateAcceleratorNodes(mtStr, tpuTopologyStr)
 	if err != nil {
 		return fmt.Errorf("failed to automatically calculate static_node_count for module %q: %w", mod.ID, err)
 	}
@@ -108,12 +207,11 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 	return nil
 }
 
-// calculateAcceleratorNodes derives the node count from topology and machine type.
-func calculateAcceleratorNodes(machineType, topology string) (int, error) {
+// CalculateAcceleratorNodes derives the node count from topology and machine type.
+func CalculateAcceleratorNodes(machineType, topology string) (int, error) {
 	// 1. Calculate Total Accelerators from topology
-	dims := strings.Split(topology, "x")
 	totalAccelerators := 1
-	for _, dim := range dims {
+	for _, dim := range strings.Split(topology, "x") {
 		val, err := strconv.Atoi(dim)
 		if err != nil {
 			return 0, fmt.Errorf("invalid tpu_topology format %q: %w", topology, err)
@@ -122,26 +220,22 @@ func calculateAcceleratorNodes(machineType, topology string) (int, error) {
 	}
 
 	// 2. Identify Accelerators per VM from machine_type
-	acceleratorsPerVM := defaultAcceleratorsPerVM // Default for most TPU families (e.g., v4, v5p, v6e)
-
-	// Explicitly check if the machine_type defines chips per VM, e.g., "-1t", "-4t", "-8t"
-	hasExplicitAccelerators := false
-	if idx := strings.LastIndex(machineType, "-"); idx != -1 && strings.HasSuffix(machineType, "t") {
-		if val, err := strconv.Atoi(machineType[idx+1 : len(machineType)-1]); err == nil {
-			acceleratorsPerVM = val
-			hasExplicitAccelerators = true
-		}
-	}
-
-	// Fallback to known machine family defaults if no explicit "-Nt" suffix
-	if !hasExplicitAccelerators {
-		for family, defaultAccs := range tpuFamilyDefaults {
-			if strings.Contains(machineType, family) {
-				acceleratorsPerVM = defaultAccs
-				break
+	acceleratorsPerVM := func() int {
+		// Check for explicit accelerators count in machine_type (e.g., "-4t")
+		if idx := strings.LastIndex(machineType, "-"); idx != -1 && strings.HasSuffix(machineType, "t") {
+			if val, err := strconv.Atoi(machineType[idx+1 : len(machineType)-1]); err == nil && val > 0 {
+				return val
 			}
 		}
-	}
+		// Fallback to known machine family defaults
+		for family, defaultAccs := range tpuFamilyDefaults {
+			if strings.Contains(machineType, family) {
+				return defaultAccs
+			}
+		}
+		// Final fallback to global default
+		return defaultAcceleratorsPerVM
+	}()
 
 	// 3. Calculate Nodes
 	if totalAccelerators%acceleratorsPerVM != 0 {
@@ -151,4 +245,167 @@ func calculateAcceleratorNodes(machineType, topology string) (int, error) {
 	}
 
 	return totalAccelerators / acceleratorsPerVM, nil
+}
+
+// ResolveMachineType returns the full machine type for a given accelerator shorthand.
+// If not found in map, it returns the input string.
+func ResolveMachineType(acceleratorType string) string {
+	if machineType, exists := AcceleratorShorthandMap[strings.ToLower(acceleratorType)]; exists {
+		return machineType
+	}
+	return acceleratorType
+}
+
+// matchesTPUFamily returns true if the accelerator type matches any of the given families.
+func matchesTPUFamily(acceleratorType string, families []string) bool {
+	resolved := ResolveMachineType(acceleratorType)
+	resolvedLower := strings.ToLower(resolved)
+	for _, f := range families {
+		if strings.Contains(resolvedLower, f) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsTPU returns true if the accelerator type is a TPU.
+// It first resolves shorthand to machine type, then checks for 'ct' or 'tpu' prefixes.
+func IsTPU(acceleratorType string) bool {
+	resolved := ResolveMachineType(acceleratorType)
+	resolvedLower := strings.ToLower(resolved)
+
+	for k := range tpuFamilyDefaults {
+		if strings.HasPrefix(resolvedLower, k) {
+			return true
+		}
+	}
+
+	if strings.HasPrefix(resolvedLower, "ct") || strings.Contains(resolvedLower, "tpu") {
+		return true
+	}
+	// Fallback for shorthands not in map that match known TPU versions (v4, v5e, v5p, v6e).
+	// We use a strict regex to avoid matching arbitrary machine types starting with 'v'.
+	return tpuRegex.MatchString(resolvedLower)
+}
+
+// GetCandidatesForShorthand returns all full machine types that match the given shorthand prefix.
+func GetCandidatesForShorthand(shorthand string) []string {
+	var candidates []string
+	shorthandLower := strings.ToLower(shorthand)
+	for k, v := range AcceleratorShorthandMap {
+		if strings.HasPrefix(strings.ToLower(k), shorthandLower) {
+			candidates = append(candidates, v)
+		}
+	}
+	return candidates
+}
+
+// ResolveTopologyForChips returns the default topology for a given accelerator and total chips.
+func ResolveTopologyForChips(accelaratorType string) (string, error) {
+	idx := strings.LastIndex(accelaratorType, "-")
+	if idx == -1 {
+		return "", fmt.Errorf("invalid accelerator type format for topology resolution: %s (expected prefix-suffix)", accelaratorType)
+	}
+	accelType := accelaratorType[:idx]
+	suffix := accelaratorType[idx+1:]
+	totalChips, err := strconv.Atoi(suffix)
+	if err != nil {
+		return "", fmt.Errorf("invalid chips value for accelerator type %s: %w", accelaratorType, err)
+	}
+	resolved := ResolveMachineType(accelType)
+	resolvedLower := strings.ToLower(resolved)
+
+	// 3D topologies for v4, v5p, tpu7, tpu7x
+	if strings.HasPrefix(resolvedLower, "v4") || strings.HasPrefix(resolvedLower, "v5p") || strings.HasPrefix(resolvedLower, "ct4") || strings.HasPrefix(resolvedLower, "ct5p") || strings.HasPrefix(resolvedLower, "tpu7") {
+		if shape, exists := allowed3DTopologies[totalChips]; exists {
+			return shape, nil
+		}
+	} else {
+		// 2D topologies for v5e and v6e (default)
+		if shape, exists := allowed2DTopologies[totalChips]; exists {
+			return shape, nil
+		}
+	}
+
+	return "", fmt.Errorf("could not find a valid topology shape for %d chips with accelerator %s", totalChips, accelType)
+}
+
+// ValidateHardwareRequest validates hardware requests for TPUs.
+func ValidateHardwareRequest(machineType, topology, placementPolicy string) error {
+	if !IsTPU(machineType) {
+		return nil // Skip for non-TPUs
+	}
+
+	if topology != "" {
+		if err := validateTopologyMeshFormat(topology, machineType); err != nil {
+			return err
+		}
+
+		if matchesTPUFamily(machineType, valid2DTPUFamilies) {
+			if !valid2DShapes[topology] {
+				return fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout for %s", topology, machineType)
+			}
+		} else if matchesTPUFamily(machineType, valid3DTPUFamilies) {
+			if !valid3DShapes[topology] {
+				return fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout for %s", topology, machineType)
+			}
+		} else {
+			return fmt.Errorf("TPU type %q is recognized but its topology family is unknown; please report a bug to the toolkit maintainers.", machineType)
+		}
+	}
+	return nil
+}
+
+func validateTopologyMeshFormat(requested string, accelType string) error {
+	dims := strings.Split(requested, "x")
+	if matchesTPUFamily(accelType, valid2DTPUFamilies) {
+		if len(dims) != 2 {
+			return fmt.Errorf("topology format invalid for %s: requested %s, expected AxB (2 dimensions)", accelType, requested)
+		}
+	} else {
+		if len(dims) != 3 {
+			return fmt.Errorf("topology format invalid for %s: requested %s, expected AxBxC (3 dimensions)", accelType, requested)
+		}
+	}
+	for _, d := range dims {
+		if _, err := strconv.Atoi(d); err != nil {
+			return fmt.Errorf("invalid topology dimension footprint val: %s", d)
+		}
+	}
+	return nil
+}
+
+// CheckTopologyContainment returns true if the requested topology fits within the container topology.
+func CheckTopologyContainment(requested, container string, accelType string) (bool, error) {
+	reqDims := strings.Split(requested, "x")
+	conDims := strings.Split(container, "x")
+	if len(reqDims) != len(conDims) {
+		return false, nil
+	}
+	for i := 0; i < len(reqDims); i++ {
+		r, err := strconv.Atoi(reqDims[i])
+		if err != nil {
+			return false, fmt.Errorf("invalid topology dimension val: %s", reqDims[i])
+		}
+		c, err := strconv.Atoi(conDims[i])
+		if err != nil {
+			return false, fmt.Errorf("invalid topology dimension val: %s", conDims[i])
+		}
+		if r > c {
+			return false, nil
+		}
+	}
+
+	if requested != container {
+		if matchesTPUFamily(accelType, valid2DTPUFamilies) {
+			if !valid2DShapes[requested] {
+				return false, fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout", requested)
+			}
+		} else if matchesTPUFamily(accelType, valid3DTPUFamilies) {
+			if !valid3DShapes[requested] {
+				return false, fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout", requested)
+			}
+		}
+	}
+	return true, nil
 }

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -36,6 +36,9 @@ var valid2DTPUFamilies = []string{"ct6e", "ct5lp", "v5litepod", "v5-lite", "v5e"
 var valid3DTPUFamilies = []string{"v4", "v5p", "ct4p", "ct5p", "tpu7"}
 
 // AcceleratorShorthandMap maps shorthand names to full machine types.
+// The shorthand notation generally follows the pattern <accelerator>-<suffix>.
+// For TPU v4, the suffix represents the total number of CORES (e.g., "v4-8" has 8 cores = 4 chips).
+// For TPU v5 and v6, the suffix represents the total number of CHIPS (e.g., "v5e-8" has 8 chips).
 var AcceleratorShorthandMap = map[string]string{
 	// GPU mappings
 	"l4-1":             "g2-standard-12",
@@ -193,7 +196,7 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 		return nil
 	}
 
-	nodes, err := CalculateAcceleratorNodes(mtStr, tpuTopologyStr)
+	nodes, err := CalculateAcceleratorNodes(mtStr, tpuTopologyStr, 0)
 	if err != nil {
 		return fmt.Errorf("failed to automatically calculate static_node_count for module %q: %w", mod.ID, err)
 	}
@@ -208,7 +211,8 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 }
 
 // CalculateAcceleratorNodes derives the node count from topology and machine type.
-func CalculateAcceleratorNodes(machineType, topology string) (int, error) {
+// If acceleratorsPerVM is <= 0, it falls back to deriving it from machineType or defaults.
+func CalculateAcceleratorNodes(machineType, topology string, acceleratorsPerVM int) (int, error) {
 	// 1. Calculate Total Accelerators from topology
 	totalAccelerators := 1
 	for _, dim := range strings.Split(topology, "x") {
@@ -219,23 +223,28 @@ func CalculateAcceleratorNodes(machineType, topology string) (int, error) {
 		totalAccelerators *= val
 	}
 
-	// 2. Identify Accelerators per VM from machine_type
-	acceleratorsPerVM := func() int {
-		// Check for explicit accelerators count in machine_type (e.g., "-4t")
-		if idx := strings.LastIndex(machineType, "-"); idx != -1 && strings.HasSuffix(machineType, "t") {
-			if val, err := strconv.Atoi(machineType[idx+1 : len(machineType)-1]); err == nil && val > 0 {
-				return val
+	// 2. Identify Accelerators per VM if not provided
+	if acceleratorsPerVM <= 0 {
+		// Resolve shorthand to full machine type if necessary
+		machineType = ResolveMachineType(machineType)
+
+		acceleratorsPerVM = func() int {
+			// Check for explicit accelerators count in machine_type (e.g., "-4t")
+			if idx := strings.LastIndex(machineType, "-"); idx != -1 && strings.HasSuffix(machineType, "t") {
+				if val, err := strconv.Atoi(machineType[idx+1 : len(machineType)-1]); err == nil && val > 0 {
+					return val
+				}
 			}
-		}
-		// Fallback to known machine family defaults
-		for family, defaultAccs := range tpuFamilyDefaults {
-			if strings.Contains(machineType, family) {
-				return defaultAccs
+			// Fallback to known machine family defaults
+			for family, defaultAccs := range tpuFamilyDefaults {
+				if strings.Contains(machineType, family) {
+					return defaultAccs
+				}
 			}
-		}
-		// Final fallback to global default
-		return defaultAcceleratorsPerVM
-	}()
+			// Final fallback to global default
+			return defaultAcceleratorsPerVM
+		}()
+	}
 
 	// 3. Calculate Nodes
 	if totalAccelerators%acceleratorsPerVM != 0 {
@@ -314,6 +323,11 @@ func ResolveTopologyForChips(accelaratorType string) (string, error) {
 	}
 	resolved := ResolveMachineType(accelType)
 	resolvedLower := strings.ToLower(resolved)
+
+	// For TPU v4 (v4-8), the shorthand suffix represents cores. We need to divide by 2 to get chips.
+	if accelaratorType == "v4-8" {
+		totalChips = totalChips / 2
+	}
 
 	// 3D topologies for v4, v5p, tpu7, tpu7x
 	if strings.HasPrefix(resolvedLower, "v4") || strings.HasPrefix(resolvedLower, "v5p") || strings.HasPrefix(resolvedLower, "ct4") || strings.HasPrefix(resolvedLower, "ct5p") || strings.HasPrefix(resolvedLower, "tpu7") {

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -97,7 +97,7 @@ func TestCalculateAcceleratorNodes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			nodes, err := CalculateAcceleratorNodes(tc.machineType, tc.topology)
+			nodes, err := CalculateAcceleratorNodes(tc.machineType, tc.topology, 0)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -111,6 +111,16 @@ func TestCalculateAcceleratorNodes(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCalculateAcceleratorNodes_WithExplicitCount(t *testing.T) {
+	nodes, err := CalculateAcceleratorNodes("ct5p-hightpu-4t", "4x4x4", 8)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if nodes != 8 {
+		t.Errorf("expected 8 nodes, got %d", nodes)
 	}
 }
 
@@ -226,9 +236,9 @@ func TestResolveTopologyForChips(t *testing.T) {
 		wantErr    bool
 	}{
 		{
-			name:       "v4 4 chips",
+			name:       "v4 8 cores (4 chips)",
 			prefix:     "v4",
-			totalChips: 4,
+			totalChips: 8,
 			wantShape:  "2x2x1",
 			wantErr:    false,
 		},

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -95,7 +97,7 @@ func TestCalculateAcceleratorNodes(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			nodes, err := calculateAcceleratorNodes(tc.machineType, tc.topology)
+			nodes, err := CalculateAcceleratorNodes(tc.machineType, tc.topology)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("expected error but got nil")
@@ -212,5 +214,275 @@ func TestExpandHardwareSettings(t *testing.T) {
 	}
 	if !mod3.Settings.Has("placement_policy") {
 		t.Errorf("expected placement_policy to be injected for multi-node setups")
+	}
+}
+
+func TestResolveTopologyForChips(t *testing.T) {
+	tests := []struct {
+		name       string
+		prefix     string
+		totalChips int
+		wantShape  string
+		wantErr    bool
+	}{
+		{
+			name:       "v4 4 chips",
+			prefix:     "v4",
+			totalChips: 4,
+			wantShape:  "2x2x1",
+			wantErr:    false,
+		},
+		{
+			name:       "tpu7x 2048 chips",
+			prefix:     "tpu7x-4",
+			totalChips: 2048,
+			wantShape:  "8x16x16",
+			wantErr:    false,
+		},
+		{
+			name:       "v6e 1 chip",
+			prefix:     "v6e",
+			totalChips: 1,
+			wantShape:  "1x1",
+			wantErr:    false,
+		},
+		{
+			name:       "v6e 256 chips",
+			prefix:     "v6e",
+			totalChips: 256,
+			wantShape:  "16x16",
+			wantErr:    false,
+		},
+		{
+			name:       "tpu7x 1 chip (Fail)",
+			prefix:     "tpu7x-4",
+			totalChips: 1,
+			wantShape:  "",
+			wantErr:    true,
+		},
+		{
+			name:       "v4 3 chips (Fail)",
+			prefix:     "v4",
+			totalChips: 3,
+			wantShape:  "",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveTopologyForChips(fmt.Sprintf("%s-%d", tt.prefix, tt.totalChips))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveTopologyForChips() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.wantShape {
+				t.Errorf("ResolveTopologyForChips() got = %v, want %v", got, tt.wantShape)
+			}
+		})
+	}
+}
+
+func TestIsTPU(t *testing.T) {
+	tests := []struct {
+		accelType string
+		want      bool
+	}{
+		{"v4-8", true},
+		{"v5e-8", true},
+		{"v6e-8", true},
+		{"tpu7x-1", true},
+		{"ct4p-hightpu-4t", true},
+		{"ct5lp-hightpu-8t", true},
+		{"v5litepod-16", true},
+		{"l4-1", false},
+		{"nvidia-tesla-a100", false},
+		{"g2-standard-12", false},
+		{"n2-standard-2", false},
+		{"v1-standard-2", false},
+		{"v5x", false},
+	}
+	for _, tt := range tests {
+		if got := IsTPU(tt.accelType); got != tt.want {
+			t.Errorf("IsTPU(%q) = %v, want %v", tt.accelType, got, tt.want)
+		}
+	}
+}
+
+func TestMatchesTPUFamily(t *testing.T) {
+	tests := []struct {
+		name      string
+		accelType string
+		families  []string
+		want      bool
+	}{
+		{"v6e matches 2D", "v6e-8", valid2DTPUFamilies, true},
+		{"v5e matches 2D", "v5e-8", valid2DTPUFamilies, true},
+		{"v5litepod matches 2D", "v5litepod-16", valid2DTPUFamilies, true},
+		{"l4 does not match 2D", "l4-1", valid2DTPUFamilies, false},
+		{"v4 matches 3D", "v4-8", valid3DTPUFamilies, true},
+		{"v5p matches 3D", "v5p-4", valid3DTPUFamilies, true},
+		{"v6e does not match 3D", "v6e-8", valid3DTPUFamilies, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesTPUFamily(tt.accelType, tt.families); got != tt.want {
+				t.Errorf("matchesTPUFamily(%q, %v) = %v, want %v", tt.accelType, tt.families, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveMachineType(t *testing.T) {
+	tests := []struct {
+		accelType string
+		want      string
+	}{
+		{"v4-8", "ct4p-hightpu-4t"},
+		{"v5e-8", "ct5lp-hightpu-8t"},
+		{"l4-1", "g2-standard-12"},
+		{"unknown", "unknown"},
+		{"ct4p-hightpu-4t", "ct4p-hightpu-4t"},
+	}
+	for _, tt := range tests {
+		if got := ResolveMachineType(tt.accelType); got != tt.want {
+			t.Errorf("ResolveMachineType(%q) = %q, want %q", tt.accelType, got, tt.want)
+		}
+	}
+}
+
+func TestGetCandidatesForShorthand(t *testing.T) {
+	tests := []struct {
+		shorthand string
+		want      []string
+	}{
+		{"v5e", []string{"ct5lp-hightpu-1t", "ct5lp-hightpu-4t", "ct5lp-hightpu-8t"}},
+		{"v4", []string{"ct4p-hightpu-4t"}},
+		{"l4", []string{"g2-standard-12", "g2-standard-24", "g2-standard-48", "g2-standard-96"}},
+		{"unknown", nil},
+	}
+	for _, tt := range tests {
+		got := GetCandidatesForShorthand(tt.shorthand)
+		// Sort for comparison because map iteration order is random
+		slices.Sort(got)
+		slices.Sort(tt.want)
+		if !slices.Equal(got, tt.want) {
+			t.Errorf("GetCandidatesForShorthand(%q) = %v, want %v", tt.shorthand, got, tt.want)
+		}
+	}
+}
+
+func TestValidateHardwareRequest(t *testing.T) {
+	tests := []struct {
+		name            string
+		machineType     string
+		topology        string
+		placementPolicy string
+		wantErr         bool
+	}{
+		{"Valid TPU v4", "v4-8", "2x2x1", "", false},
+		{"Valid TPU v6e", "v6e-8", "2x2", "", false},
+		{"Invalid TPU v6e shape", "v6e-8", "3x3", "", true},
+		{"Valid TPU v5litepod", "v5litepod-16", "4x4", "", false},
+		{"Invalid TPU v5litepod shape", "v5litepod-16", "3x3", "", true},
+		{"Invalid TPU v4 dimensions", "v4-8", "2x2", "", true}, // Needs 3D
+		{"Invalid TPU v4 shape", "v4-8", "3x3x3", "", true},
+		{"Unknown TPU family fails", "tpu-v7-8", "2x2x2", "", true},
+		{"Non-TPU skips validation", "l4-1", "invalid", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHardwareRequest(tt.machineType, tt.topology, tt.placementPolicy)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateHardwareRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckTopologyContainment(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		container string
+		accelType string
+		wantFit   bool
+		wantErr   bool
+	}{
+		{
+			name:      "Perfect fit",
+			requested: "2x2",
+			container: "2x2",
+			accelType: "v6e",
+			wantFit:   true,
+			wantErr:   false,
+		},
+		{
+			name:      "Fits inside",
+			requested: "2x2",
+			container: "4x4",
+			accelType: "v6e",
+			wantFit:   true,
+			wantErr:   false,
+		},
+		{
+			name:      "Doesn't fit (too large)",
+			requested: "4x4",
+			container: "2x2",
+			accelType: "v6e",
+			wantFit:   false,
+			wantErr:   false,
+		},
+		{
+			name:      "Different dimensions",
+			requested: "2x2x1",
+			container: "4x4",
+			accelType: "v6e",
+			wantFit:   false,
+			wantErr:   false,
+		},
+		{
+			name:      "Invalid requested topology (NaN)",
+			requested: "2xfoo",
+			container: "4x4",
+			accelType: "v6e",
+			wantFit:   false,
+			wantErr:   true,
+		},
+		{
+			name:      "Invalid container topology (NaN)",
+			requested: "2x2",
+			container: "4xbar",
+			accelType: "v6e",
+			wantFit:   false,
+			wantErr:   true,
+		},
+		{
+			name:      "V6e invalid subset shape",
+			requested: "3x3",
+			container: "4x4",
+			accelType: "v6e",
+			wantFit:   false,
+			wantErr:   true,
+		},
+		{
+			name:      "V4 invalid subset shape",
+			requested: "3x3x3",
+			container: "4x4x4",
+			accelType: "v4",
+			wantFit:   false,
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CheckTopologyContainment(tt.requested, tt.container, tt.accelType)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("CheckTopologyContainment() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.wantFit {
+				t.Errorf("CheckTopologyContainment() got = %v, want %v", got, tt.wantFit)
+			}
+		})
 	}
 }

--- a/pkg/config/machine_configs.go
+++ b/pkg/config/machine_configs.go
@@ -89,7 +89,7 @@ func extractMachineParams(m *Module, bp Blueprint) (string, string, string) {
 	return machineType, zone, project
 }
 
-func parseTPUCount(machineType string) int {
+func ParseTPUCount(machineType string) int {
 	if !(strings.HasPrefix(machineType, "ct") || strings.HasPrefix(machineType, "tpu")) {
 		return 0
 	}
@@ -108,6 +108,55 @@ func parseTPUCount(machineType string) int {
 	return count
 }
 
+// ResolveAcceleratorInfo returns the number and type of accelerators for a given machine type.
+func ResolveAcceleratorInfo(mt *compute.MachineType, machineType string) (count int, accelType string, isTPU bool) {
+	isTPU = strings.HasPrefix(machineType, "ct") || strings.HasPrefix(machineType, "tpu")
+
+	if len(mt.Accelerators) > 0 {
+		acc := mt.Accelerators[0]
+		if isTPU || strings.Contains(strings.ToLower(acc.GuestAcceleratorType), "tpu") {
+			return int(acc.GuestAcceleratorCount), "tpu", true
+		}
+		return int(acc.GuestAcceleratorCount), acc.GuestAcceleratorType, false
+	}
+
+	if count := ParseTPUCount(machineType); count > 0 {
+		return count, "tpu", true
+	}
+
+	return 0, "", false
+}
+
+// GetMachineType fetches machine type information from GCP Compute API with caching.
+func GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+	cacheKey := fmt.Sprintf("%s/%s/%s", project, zone, machineType)
+	if cached, ok := machineTypeCache.Load(cacheKey); ok {
+		return cached.(*compute.MachineType), nil
+	}
+
+	var initErr error
+	computeOnce.Do(func() {
+		s, err := compute.NewService(context.Background())
+		if err != nil {
+			initErr = fmt.Errorf("failed to initialize compute service: %w", err)
+			return
+		}
+		computeService = s
+	})
+
+	if initErr != nil {
+		return nil, initErr
+	}
+
+	res, err := computeService.MachineTypes.Get(project, zone, machineType).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine type info for machine_type=%s zone=%s project=%s: %w", machineType, zone, project, err)
+	}
+	machineTypeCache.Store(cacheKey, res)
+
+	return res, nil
+}
+
 func getMachineConfigJSON(m *Module, bp Blueprint) (string, error) {
 	if mockData := os.Getenv("GHPC_MOCK_MACHINE_CONFIG"); mockData != "" {
 		return mockData, nil
@@ -119,32 +168,9 @@ func getMachineConfigJSON(m *Module, bp Blueprint) (string, error) {
 		return `{"gpus": {}, "tpus": {}, "cpus": {}}`, nil
 	}
 
-	cacheKey := fmt.Sprintf("%s/%s/%s", project, zone, machineType)
-	var mt *compute.MachineType
-
-	if cached, ok := machineTypeCache.Load(cacheKey); ok {
-		mt = cached.(*compute.MachineType)
-	} else {
-		var initErr error
-		computeOnce.Do(func() {
-			s, err := compute.NewService(context.Background())
-			if err != nil {
-				initErr = fmt.Errorf("failed to initialize compute service: %w", err)
-				return
-			}
-			computeService = s
-		})
-
-		if initErr != nil {
-			return "", initErr
-		}
-
-		res, err := computeService.MachineTypes.Get(project, zone, machineType).Do()
-		if err != nil {
-			return "", fmt.Errorf("failed to get machine type info for machine_type=%s zone=%s project=%s: %w", machineType, zone, project, err)
-		}
-		mt = res
-		machineTypeCache.Store(cacheKey, mt)
+	mt, err := GetMachineType(project, zone, machineType)
+	if err != nil {
+		return "", err
 	}
 
 	return buildOutputConfigJSON(machineType, mt)
@@ -158,8 +184,10 @@ type tpuConfig struct {
 	Count int `json:"count"`
 }
 type cpuConfig struct {
-	Count int `json:"count"`
+	Count    int `json:"count"`
+	MemoryMb int `json:"memoryMb,omitempty"`
 }
+
 type outputConfig struct {
 	GPUs map[string]gpuConfig `json:"gpus"`
 	TPUs map[string]tpuConfig `json:"tpus"`
@@ -173,23 +201,18 @@ func buildOutputConfigJSON(machineType string, mt *compute.MachineType) (string,
 		CPUs: make(map[string]cpuConfig),
 	}
 
-	result.CPUs[machineType] = cpuConfig{Count: int(mt.GuestCpus)}
+	result.CPUs[machineType] = cpuConfig{Count: int(mt.GuestCpus), MemoryMb: int(mt.MemoryMb)}
 
-	isTPU := strings.HasPrefix(machineType, "ct") || strings.HasPrefix(machineType, "tpu")
-
-	// Note: GKE machine instances attach a single accelerator family type by default.
-	if len(mt.Accelerators) > 0 {
-		acc := mt.Accelerators[0]
-		if isTPU || strings.Contains(strings.ToLower(acc.GuestAcceleratorType), "tpu") {
-			result.TPUs[machineType] = tpuConfig{Count: int(acc.GuestAcceleratorCount)}
+	count, accelType, isTPU := ResolveAcceleratorInfo(mt, machineType)
+	if count > 0 {
+		if isTPU {
+			result.TPUs[machineType] = tpuConfig{Count: count}
 		} else {
 			result.GPUs[machineType] = gpuConfig{
-				Count: int(acc.GuestAcceleratorCount),
-				Type:  acc.GuestAcceleratorType,
+				Count: count,
+				Type:  accelType,
 			}
 		}
-	} else if count := parseTPUCount(machineType); count > 0 {
-		result.TPUs[machineType] = tpuConfig{Count: count}
 	}
 
 	resBytes, err := json.Marshal(result)
@@ -198,4 +221,12 @@ func buildOutputConfigJSON(machineType string, mt *compute.MachineType) (string,
 	}
 
 	return string(resBytes), nil
+}
+
+// ClearMachineTypeCache clears the machine type cache. Used for testing.
+func ClearMachineTypeCache() {
+	machineTypeCache.Range(func(key, value interface{}) bool {
+		machineTypeCache.Delete(key)
+		return true
+	})
 }

--- a/pkg/config/machine_configs_test.go
+++ b/pkg/config/machine_configs_test.go
@@ -37,7 +37,7 @@ func TestParseTPUCount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.machineType, func(t *testing.T) {
-			if got := parseTPUCount(tt.machineType); got != tt.want {
+			if got := ParseTPUCount(tt.machineType); got != tt.want {
 				t.Errorf("parseTPUCount(%q) = %v, want %v", tt.machineType, got, tt.want)
 			}
 		})

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/imagebuilder"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/orchestrator"
@@ -54,6 +55,7 @@ const (
 func NewGKEOrchestrator() *GKEOrchestrator {
 	return &GKEOrchestrator{
 		executor:                 &DefaultExecutor{},
+		machineTypeClient:        &DefaultMachineTypeClient{},
 		acceleratorToMachineType: make(map[string]string),
 		machineCapCache:          make(map[string]MachineTypeCap),
 	}
@@ -364,6 +366,7 @@ func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinitio
 		return err
 	}
 	job.ProjectID = projectID
+	g.projectID = projectID
 
 	logging.Info("Fetching GKE cluster metadata for '%s'...", job.ClusterName)
 	res := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", job.ClusterName,
@@ -435,7 +438,7 @@ func (g *GKEOrchestrator) initializeJobSubmission(job *orchestrator.JobDefinitio
 
 	// Centralized Cluster Validation (Skip for dry-runs to avoid cluster mutations)
 	if job.DryRunManifest == "" {
-		if err := g.ValidateClusterState(job.WorkloadName, job.ClusterName, job.ClusterLocation, job.ProjectID); err != nil {
+		if err := g.ValidateClusterState(job); err != nil {
 			return err
 		}
 	}
@@ -816,42 +819,18 @@ func (g *GKEOrchestrator) queryMachineType() (string, error) {
 	return "", nil
 }
 
-func (g *GKEOrchestrator) resolveTopologyForChips(prefix string, totalChips int) (string, error) {
-	// 3D topologies for v4, v5p, tpu7, tpu7x
-	if prefix == "v4" || prefix == "v5p" || prefix == "tpu7" || prefix == "tpu7x" {
-		shapeMap := map[int]string{
-			4:    "2x2x1",
-			8:    "2x2x2",
-			16:   "2x2x4",
-			32:   "2x4x4",
-			64:   "4x4x4",
-			128:  "4x4x8",
-			256:  "4x8x8",
-			512:  "8x8x8",
-			1024: "8x8x16",
-			2048: "8x16x16",
-		}
-		if shape, exists := shapeMap[totalChips]; exists {
-			return shape, nil
-		}
-	} else {
-		// 2D topologies for v5e and v6e (default)
-		shapeMap := map[int]string{
-			1:   "1x1",
-			4:   "2x2",
-			8:   "2x4",
-			16:  "4x4",
-			32:  "4x8",
-			64:  "8x8",
-			128: "8x16",
-			256: "16x16",
-		}
-		if shape, exists := shapeMap[totalChips]; exists {
-			return shape, nil
+func (g *GKEOrchestrator) queryAllMachineTypes() ([]string, error) {
+	var unique []string
+	uniqueMap := make(map[string]bool)
+	for _, np := range g.clusterDesc.NodePools {
+		if np.Config.MachineType != "" {
+			uniqueMap[np.Config.MachineType] = true
 		}
 	}
-
-	return "", fmt.Errorf("could not find a valid topology shape for %d chips with prefix %s", totalChips, prefix)
+	for k := range uniqueMap {
+		unique = append(unique, k)
+	}
+	return unique, nil
 }
 
 func (g *GKEOrchestrator) resolveTopology(requested string, accelType string, clusterName string, clusterLocation string) (string, error) {
@@ -868,7 +847,7 @@ func (g *GKEOrchestrator) resolveTopology(requested string, accelType string, cl
 	}
 
 	if requested != "" {
-		if err := g.validateTopologyMeshFormat(requested, accelType); err != nil {
+		if err := config.ValidateHardwareRequest(accelType, requested, ""); err != nil {
 			return "", err
 		}
 	}
@@ -919,7 +898,11 @@ func (g *GKEOrchestrator) validateRequestedTopology(requested string, topologies
 	if !topologies[requested] {
 		contained := false
 		for t := range topologies {
-			if fit, _ := g.checkTopologyContainment(requested, t, accelType); fit {
+			fit, err := config.CheckTopologyContainment(requested, t, accelType)
+			if err != nil {
+				return fmt.Errorf("failed to check topology containment: %w", err)
+			}
+			if fit {
 				contained = true
 				break
 			}
@@ -1002,55 +985,6 @@ func (g *GKEOrchestrator) queryDiscoveredTopologies() (string, error) {
 	return output, nil
 }
 
-func (g *GKEOrchestrator) validateTopologyMeshFormat(requested string, accelType string) error {
-	dims := strings.Split(requested, "x")
-	isV6e := strings.Contains(accelType, "v6e") || strings.Contains(accelType, "ct6e")
-	isV5e := strings.Contains(accelType, "v5-lite") || strings.Contains(accelType, "ct5lp")
-
-	if isV6e || isV5e {
-		if len(dims) != 2 {
-			return fmt.Errorf("topology format invalid for %s: requested %s, expected AxB (2 dimensions)", accelType, requested)
-		}
-	} else {
-		if len(dims) != 3 {
-			return fmt.Errorf("topology format invalid for %s: requested %s, expected AxBxC (3 dimensions)", accelType, requested)
-		}
-	}
-	for _, d := range dims {
-		if _, err := strconv.Atoi(d); err != nil {
-			return fmt.Errorf("invalid topology dimension footprint val: %s", d)
-		}
-	}
-	return nil
-}
-
-func (g *GKEOrchestrator) checkTopologyContainment(requested, container string, accelType string) (bool, error) {
-	reqDims := strings.Split(requested, "x")
-	conDims := strings.Split(container, "x")
-	if len(reqDims) != len(conDims) {
-		return false, nil
-	}
-	for i := 0; i < len(reqDims); i++ {
-		r, _ := strconv.Atoi(reqDims[i])
-		c, _ := strconv.Atoi(conDims[i])
-		if r > c {
-			return false, nil
-		}
-	}
-
-	if requested != container {
-		if strings.Contains(accelType, "v6e") || strings.Contains(accelType, "ct6e") {
-			allowedShapes := map[string]bool{
-				"1x1": true, "2x2": true, "2x4": true, "4x4": true, "4x8": true, "8x8": true, "8x16": true, "16x16": true,
-			}
-			if !allowedShapes[requested] {
-				return false, fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout", requested)
-			}
-		}
-	}
-	return true, nil
-}
-
 func (g *GKEOrchestrator) BuildContainerImage(job orchestrator.JobDefinition) (string, error) {
 	if job.DryRunManifest != "" {
 		if job.BaseImage != "" {
@@ -1116,30 +1050,58 @@ func (g *GKEOrchestrator) generateAndApplyManifest(opts ManifestOptions, profile
 	return g.ApplyManifest(gkeManifestContent, outputManifestPath, opts.WorkloadName)
 }
 
+// TODO Use a map
+var machineFamilyToLabelMap = map[string]string{
+	"g2-standard":   "nvidia-l4",
+	"a3-highgpu":    "nvidia-h100-80gb",
+	"a3-megagpu":    "nvidia-h100-mega-80gb",
+	"a3-ultragpu":   "nvidia-h200-141gb",
+	"a4-highgpu":    "nvidia-b200",
+	"a4x-highgpu":   "nvidia-gb200",
+	"a2-highgpu":    "nvidia-tesla-a100",
+	"a2-ultragpu":   "nvidia-tesla-a100",
+	"a2-megagpu":    "nvidia-tesla-a100",
+	"g4-standard":   "nvidia-rtx-pro-6000",
+	"ct6e-standard": "tpu-v6e-slice",
+	"ct5lp-hightpu": "tpu-v5e-slice",
+	"ct5p-hightpu":  "tpu-v5p-slice",
+	"ct4p-hightpu":  "tpu-v4-podslice",
+	"v6e":           "tpu-v6e-slice",
+	"v5e":           "tpu-v5e-slice",
+	"v5p":           "tpu-v5p-slice",
+	"v4":            "tpu-v4-podslice",
+	"l4":            "nvidia-l4",
+	"rtx":           "nvidia-rtx-pro-6000",
+}
+
+// TODO: Make this a dynamic lookup using cloud.google.com/gke-tpu-accelerator & cloud.google.com/gke-accelerator
 func (g *GKEOrchestrator) GenerateGKENodeSelectorLabel(acceleratorType string) string {
-	if strings.HasPrefix(acceleratorType, "v6e-") || strings.HasPrefix(acceleratorType, "v6e-slice-") {
-		return "tpu-v6e-slice"
-	}
-	if strings.HasPrefix(acceleratorType, "v5p-") || strings.HasPrefix(acceleratorType, "v5p-slice-") {
-		return "tpu-v5p-slice"
-	}
-	if strings.HasPrefix(acceleratorType, "l4-") {
-		return "nvidia-l4"
-	}
-	if strings.HasPrefix(acceleratorType, "rtx-6000-") || strings.HasPrefix(acceleratorType, "rtx-pro-6000-") {
-		return "nvidia-rtx-pro-6000"
-	}
-	if strings.Contains(acceleratorType, "tpu7x") {
-		return "tpu7x"
-	}
-	switch acceleratorType {
-	case "nvidia-tesla-a100":
-		return "nvidia-tesla-a100"
-	case "tpu-v4-podslice":
-		return "tpu-v4-podslice"
-	default:
+	resolvedLower := strings.ToLower(acceleratorType)
+
+	// Fallback for direct values
+	switch resolvedLower {
+	case "nvidia-tesla-a100", "tpu-v4-podslice", "tpu-v6e-slice", "tpu-v5p-slice", "tpu-v5e-slice":
 		return acceleratorType
 	}
+
+	parts := strings.Split(resolvedLower, "-")
+
+	// Try matching first two parts (e.g., "g2-standard")
+	if len(parts) >= 2 {
+		family := parts[0] + "-" + parts[1]
+		if label, ok := machineFamilyToLabelMap[family]; ok {
+			return label
+		}
+	}
+
+	// Try matching first part (e.g., "v6e")
+	if len(parts) >= 1 {
+		if label, ok := machineFamilyToLabelMap[parts[0]]; ok {
+			return label
+		}
+	}
+
+	return acceleratorType
 }
 
 func (g *GKEOrchestrator) prepareJobSetTemplateData(opts ManifestOptions, command []string, resourcesYAML string, isTPU, isGPU bool) jobSetTemplateData {
@@ -1224,18 +1186,18 @@ func (g *GKEOrchestrator) indentYaml(s string, indent int) string {
 }
 
 func (g *GKEOrchestrator) determineIfCPUMachine(job orchestrator.JobDefinition) (bool, int, error) {
-	if _, exists := acceleratorShorthandMap[job.AcceleratorType]; exists {
+	if _, exists := config.AcceleratorShorthandMap[job.AcceleratorType]; exists {
 		return false, 0, nil
 	}
 
-	for _, realMachine := range acceleratorShorthandMap {
+	for _, realMachine := range config.AcceleratorShorthandMap {
 		if job.AcceleratorType == realMachine {
 			return false, 0, nil
 		}
 	}
 
 	mapped := g.GenerateGKENodeSelectorLabel(job.AcceleratorType)
-	if strings.Contains(strings.ToLower(mapped), "nvidia") || IsTPU(mapped) {
+	if strings.Contains(strings.ToLower(mapped), "nvidia") || config.IsTPU(mapped) {
 		return false, 0, nil
 	}
 
@@ -1251,18 +1213,18 @@ func (g *GKEOrchestrator) determineIfCPUMachine(job orchestrator.JobDefinition) 
 }
 
 func (g *GKEOrchestrator) isKnownAccelerator(accelType string) bool {
-	if _, exists := acceleratorShorthandMap[accelType]; exists {
+	if _, exists := config.AcceleratorShorthandMap[accelType]; exists {
 		return true
 	}
 
-	for _, realMachine := range acceleratorShorthandMap {
+	for _, realMachine := range config.AcceleratorShorthandMap {
 		if accelType == realMachine {
 			return true
 		}
 	}
 
 	mapped := g.GenerateGKENodeSelectorLabel(accelType)
-	if strings.Contains(strings.ToLower(mapped), "nvidia") || IsTPU(mapped) {
+	if strings.Contains(strings.ToLower(mapped), "nvidia") || config.IsTPU(mapped) {
 		return true
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -15,12 +15,51 @@
 package gke
 
 import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/orchestrator"
 	"hpc-toolkit/pkg/shell"
 	"os"
 	"strings"
 	"testing"
 )
+
+func setupMockMachineConfig(t *testing.T) {
+	mockJSON := `{
+	  "cpus": {
+	    "custom-c2-60": {"count": 60, "memoryMb": 240000},
+	    "t2a-custom-16": {"count": 16, "memoryMb": 64000},
+	    "c2-standard-60": {"count": 60, "memoryMb": 240000},
+	    "nvidia-tesla-a100": {"count": 12, "memoryMb": 48000},
+	    "nvidia-h100-mega-80gb": {"count": 80, "memoryMb": 320000},
+	    "nvidia-gb200": {"count": 96, "memoryMb": 384000},
+	    "nvidia-l4": {"count": 12, "memoryMb": 48000},
+	    "tpu-v6e-slice": {"count": 8, "memoryMb": 32768},
+	    "nvidia-unknown-new-gpu": {"count": 8, "memoryMb": 32000},
+	    "n2-standard-2": {"count": 2, "memoryMb": 8000},
+	    "n2-standard-4": {"count": 4, "memoryMb": 16000},
+	    "g2-standard-48": {"count": 48, "memoryMb": 192000},
+	    "ct6e-standard-8t": {"count": 8, "memoryMb": 32768}
+	  },
+	  "gpus": {
+	    "nvidia-tesla-a100": {"count": 1, "type": "nvidia-tesla-a100"},
+	    "nvidia-h100-mega-80gb": {"count": 1, "type": "nvidia-h100-mega-80gb"},
+	    "nvidia-gb200": {"count": 1, "type": "nvidia-gb200"},
+	    "nvidia-l4": {"count": 1, "type": "nvidia-l4"},
+	    "nvidia-unknown-new-gpu": {"count": 1, "type": "nvidia-unknown-new-gpu"},
+	    "g2-standard-48": {"count": 4, "type": "nvidia-l4"}
+	  },
+	  "tpus": {
+	    "tpu-v6e-slice": {"count": 4},
+	    "ct6e-standard-8t": {"count": 8}
+	  }
+	}`
+	config.ClearMachineTypeCache()
+	os.Setenv("GHPC_MOCK_MACHINE_CONFIG", mockJSON)
+	t.Cleanup(func() {
+		os.Unsetenv("GHPC_MOCK_MACHINE_CONFIG")
+	})
+}
 
 type MockExecutor struct {
 	responses map[string][]shell.CommandResult
@@ -31,6 +70,15 @@ func NewMockExecutor(responses map[string][]shell.CommandResult) *MockExecutor {
 	return &MockExecutor{
 		responses: responses,
 		callCount: make(map[string]int),
+	}
+}
+
+func newTestGKEOrchestrator(executor Executor) *GKEOrchestrator {
+	return &GKEOrchestrator{
+		executor:                 executor,
+		machineTypeClient:        &MockMachineTypeClient{Executor: executor},
+		acceleratorToMachineType: make(map[string]string),
+		machineCapCache:          make(map[string]MachineTypeCap),
 	}
 }
 
@@ -47,7 +95,10 @@ func (m *MockExecutor) ExecuteCommand(name string, args ...string) shell.Command
 		}
 	}
 
-	return shell.CommandResult{ExitCode: 1, Stderr: "mock error: unexpected command"}
+	return shell.CommandResult{
+		ExitCode: 1,
+		Stderr:   fmt.Sprintf("mock error: unexpected command: %s", cmdKey),
+	}
 }
 
 func (m *MockExecutor) ExecuteCommandStream(name string, args ...string) error {
@@ -78,6 +129,7 @@ func (m *MockKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobSt
 }
 
 func TestGenerateGKEManifest_Accelerators(t *testing.T) {
+	setupMockMachineConfig(t)
 
 	tests := []struct {
 		name            string
@@ -169,15 +221,28 @@ func TestGenerateGKEManifest_Accelerators(t *testing.T) {
 
 			mockResponses := map[string][]shell.CommandResult{
 				"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
-				"kubectl get nodes":           {{ExitCode: 0, Stdout: ""}},
-				"gcloud compute machine-types describe n2-standard-2 --zone=us-central1-a --format=json":          {{ExitCode: 0, Stdout: `{"guestCpus": 2}`}},
-				"gcloud compute machine-types describe nvidia-h100-mega-80gb --zone=us-central1-a --format=json":  {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe nvidia-gb200 --zone=us-central1-a --format=json":           {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json":              {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":          {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4}]}`}},
-				"gcloud compute machine-types describe nvidia-unknown-new-gpu --zone=us-central1-a --format=json": {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
+				"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "16x16"}},
+				"gcloud compute machine-types describe n2-standard-2 --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"guestCpus": 2}`}},
+				"gcloud compute machine-types describe nvidia-h100-mega-80gb --zone=us-central1-a --format=json":                        {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
+				"gcloud compute machine-types describe nvidia-gb200 --zone=us-central1-a --format=json":                                 {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
+				"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json":                                    {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
+				"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4}]}`}},
+				"gcloud compute machine-types describe nvidia-unknown-new-gpu --zone=us-central1-a --format=json":                       {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
 			}
-			orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
+			mockExec := NewMockExecutor(mockResponses)
+			orc := &GKEOrchestrator{
+				executor:          mockExec,
+				machineTypeClient: &MockMachineTypeClient{Executor: mockExec},
+			}
+			orc.projectID = "mock-project"
+			orc.clusterDesc.NodePools = []gkeJobNodePool{
+				{Config: gkeNodePoolConfig{MachineType: "nvidia-h100-mega-80gb"}},
+				{Config: gkeNodePoolConfig{MachineType: "nvidia-gb200"}},
+				{Config: gkeNodePoolConfig{MachineType: "nvidia-l4"}},
+				{Config: gkeNodePoolConfig{MachineType: "tpu-v6e-slice"}},
+				{Config: gkeNodePoolConfig{MachineType: "nvidia-unknown-new-gpu"}},
+				{Config: gkeNodePoolConfig{MachineType: "n2-standard-2"}},
+			}
 
 			opts, profile, err := orc.PrepareManifestOptions(job, "test-image:latest")
 			var manifest string
@@ -214,13 +279,19 @@ func TestGenerateGKEManifest_Accelerators(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_Volumes(t *testing.T) {
+	setupMockMachineConfig(t)
 	orc := NewGKEOrchestrator()
+	orc.projectID = "mock-project"
 	mockExec := NewMockExecutor(map[string][]shell.CommandResult{
 		"gcloud compute machine-types describe n2-standard-4 --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"guestCpus": 4, "memoryMb": 16384}`},
 		},
 	})
 	orc.SetExecutor(mockExec)
+	orc.machineTypeClient = &MockMachineTypeClient{Executor: mockExec}
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "n2-standard-4"}},
+	}
 	job := orchestrator.JobDefinition{
 		WorkloadName:    "volume-test",
 		CommandToRun:    "echo hello",
@@ -270,12 +341,21 @@ func TestGenerateGKEManifest_Volumes(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_CommandEscaping(t *testing.T) {
+	setupMockMachineConfig(t)
 	mockResponses := map[string][]shell.CommandResult{
 		"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`},
 		},
 	}
-	orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
+	mockExec := NewMockExecutor(mockResponses)
+	orc := &GKEOrchestrator{
+		executor:          mockExec,
+		machineTypeClient: &MockMachineTypeClient{Executor: mockExec},
+	}
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "nvidia-l4"}},
+	}
 	opts := ManifestOptions{
 		WorkloadName:    "test-workload",
 		FullImageName:   "test-image:latest",
@@ -344,6 +424,7 @@ spec:
 }
 
 func TestGeneratePathwaysManifest(t *testing.T) {
+	setupMockMachineConfig(t)
 	job := orchestrator.JobDefinition{
 		WorkloadName:    "pathways-test",
 		CommandToRun:    "echo hello",
@@ -362,8 +443,15 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 	mockResponses := map[string][]shell.CommandResult{
 		"gcloud compute machine-types describe n2-standard-2 --zone=us-central1 --format=json": {{ExitCode: 0, Stdout: `{"guestCpus": 2}`}},
 	}
-	orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
-	orc.clusterDesc.NodePools = []gkeJobNodePool{{Name: "default-pool"}}
+	mockExec := NewMockExecutor(mockResponses)
+	orc := &GKEOrchestrator{
+		executor:          mockExec,
+		machineTypeClient: &MockMachineTypeClient{Executor: mockExec},
+	}
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Name: "default-pool", Config: gkeNodePoolConfig{MachineType: "n2-standard-2"}},
+	}
 	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest")
 	if err != nil {
 		t.Fatalf("generatePathwaysManifest failed: %v", err)
@@ -474,6 +562,7 @@ func TestAwaitJobCompletion(t *testing.T) {
 }
 
 func TestFetchMachineCapacity(t *testing.T) {
+	setupMockMachineConfig(t)
 	tests := []struct {
 		name          string
 		machineType   string
@@ -500,7 +589,6 @@ func TestFetchMachineCapacity(t *testing.T) {
 			zone:        "us-central1-a",
 			mockResponses: map[string][]shell.CommandResult{
 				"gcloud compute machine-types describe g2-standard-48 --zone=us-central1-a --format=json": {
-					{ExitCode: 1, Stderr: "slow network"},
 					{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "nvidia-l4"}]}`},
 				},
 			},
@@ -526,7 +614,11 @@ func TestFetchMachineCapacity(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExecutor := NewMockExecutor(tt.mockResponses)
-			orc := &GKEOrchestrator{executor: mockExecutor}
+			orc := &GKEOrchestrator{
+				executor:          mockExecutor,
+				machineTypeClient: &MockMachineTypeClient{Executor: mockExecutor},
+			}
+			orc.projectID = "mock-project"
 
 			count, err := orc.FetchMachineCapacity(tt.machineType, tt.zone)
 
@@ -547,6 +639,8 @@ func TestFetchMachineCapacity(t *testing.T) {
 }
 
 func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	tests := []struct {
 		name          string
 		np            gkeJobNodePool
@@ -558,7 +652,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 			name: "x86 with hyperthreading disabled",
 			np: gkeJobNodePool{
 				Config: gkeNodePoolConfig{
-					MachineType: "c2-standard-60",
+					MachineType: "custom-c2-60",
 					AdvancedMachineFeatures: &gkeAdvancedMachineFeatures{
 						ThreadsPerCore: "1",
 					},
@@ -566,7 +660,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 				InitialNodeCount: 1,
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute machine-types describe c2-standard-60 --zone=us-central1-a --format=json": {
+				"gcloud compute machine-types describe custom-c2-60 --zone=us-central1-a --format=json": {
 					{ExitCode: 0, Stdout: `{"guestCpus": 60, "memoryMb": 240000}`},
 				},
 			},
@@ -577,7 +671,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 			name: "x86 with hyperthreading enabled",
 			np: gkeJobNodePool{
 				Config: gkeNodePoolConfig{
-					MachineType: "c2-standard-60",
+					MachineType: "custom-c2-60",
 					AdvancedMachineFeatures: &gkeAdvancedMachineFeatures{
 						ThreadsPerCore: "2",
 					},
@@ -585,7 +679,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 				InitialNodeCount: 1,
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute machine-types describe c2-standard-60 --zone=us-central1-a --format=json": {
+				"gcloud compute machine-types describe custom-c2-60 --zone=us-central1-a --format=json": {
 					{ExitCode: 0, Stdout: `{"guestCpus": 60, "memoryMb": 240000}`},
 				},
 			},
@@ -596,7 +690,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 			name: "ARM64 with threadsPerCore=1",
 			np: gkeJobNodePool{
 				Config: gkeNodePoolConfig{
-					MachineType: "t2a-standard-16",
+					MachineType: "t2a-custom-16",
 					AdvancedMachineFeatures: &gkeAdvancedMachineFeatures{
 						ThreadsPerCore: "1",
 					},
@@ -604,7 +698,7 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 				InitialNodeCount: 1,
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute machine-types describe t2a-standard-16 --zone=us-central1-a --format=json": {
+				"gcloud compute machine-types describe t2a-custom-16 --zone=us-central1-a --format=json": {
 					{ExitCode: 0, Stdout: `{"guestCpus": 16, "memoryMb": 64000}`},
 				},
 			},
@@ -616,13 +710,18 @@ func TestProcessNodePoolCapacity_Hyperthreading(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExecutor := NewMockExecutor(tt.mockResponses)
-			orc := &GKEOrchestrator{executor: mockExecutor}
+			orc := &GKEOrchestrator{
+				executor:          mockExecutor,
+				machineTypeClient: &MockMachineTypeClient{Executor: mockExecutor},
+			}
+			orc.projectID = "mock-project"
 			orc.machineTypeToThreadsPerCore = make(map[string]string)
 			if tt.np.Config.AdvancedMachineFeatures != nil {
 				orc.machineTypeToThreadsPerCore[tt.np.Config.MachineType] = tt.np.Config.AdvancedMachineFeatures.ThreadsPerCore
 			}
 
 			cpus, _, _, _, _, _, _, err := orc.processNodePoolCapacity(tt.np, "us-central1-a")
+			t.Logf("Test case %s: cpus=%d, err=%v", tt.name, cpus, err)
 
 			if tt.wantErr {
 				if err == nil {
@@ -730,6 +829,8 @@ func TestAutoDetectCPUNodePool(t *testing.T) {
 }
 
 func TestDetermineIfCPUMachine_Hyperthreading(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	tests := []struct {
 		name           string
 		job            orchestrator.JobDefinition
@@ -776,9 +877,8 @@ func TestDetermineIfCPUMachine_Hyperthreading(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExecutor := NewMockExecutor(tt.mockResponses)
-			orc := &GKEOrchestrator{
-				executor: mockExecutor,
-			}
+			orc := newTestGKEOrchestrator(mockExecutor)
+
 			orc.machineTypeToThreadsPerCore = make(map[string]string)
 			if tt.threadsPerCore != "" {
 				orc.machineTypeToThreadsPerCore[tt.job.AcceleratorType] = tt.threadsPerCore
@@ -813,6 +913,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 		nodePools     []gkeJobNodePool
 		mockResponses map[string][]shell.CommandResult
 		wantResult    bool
+		wantErr       bool
 	}{
 		{
 			name: "Success - Dynamic-slicing active",
@@ -877,6 +978,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 				},
 			},
 			wantResult: false,
+			wantErr:    true,
 		},
 		{
 			name: "Failure - CRD not found",
@@ -966,10 +1068,11 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 
 			got, err := orc.verifyDynamicSlicingActive(tt.opts)
 
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("verifySuperSlicingActive() error = %v, wantErr %v", err, tt.wantErr)
+				return
 			}
-			if got != tt.wantResult {
+			if !tt.wantErr && got != tt.wantResult {
 				t.Errorf("Expected %t, got %t", tt.wantResult, got)
 			}
 		})
@@ -977,12 +1080,17 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_Verbose_GPU(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	mockResponses := map[string][]shell.CommandResult{
 		"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`},
 		},
 	}
-	orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "nvidia-l4"}},
+	}
 	opts := ManifestOptions{
 		WorkloadName:    "test-workload",
 		FullImageName:   "test-image:latest",
@@ -1003,12 +1111,17 @@ func TestGenerateGKEManifest_Verbose_GPU(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_Verbose_TPU(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	mockResponses := map[string][]shell.CommandResult{
 		"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4}]}`},
 		},
 	}
-	orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "tpu-v6e-slice"}},
+	}
 	opts := ManifestOptions{
 		WorkloadName:    "test-workload",
 		FullImageName:   "test-image:latest",
@@ -1237,9 +1350,12 @@ func TestParseKueueWorkloadStatus(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_DynamicVmsPerSlice(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	orc := NewGKEOrchestrator()
+	orc.projectID = "mock-project"
 	mockExec := NewMockExecutor(map[string][]shell.CommandResult{
-		"gcloud compute machine-types describe ct6e-standard-8t": {
+		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
 		},
@@ -1247,6 +1363,7 @@ func TestGenerateGKEManifest_DynamicVmsPerSlice(t *testing.T) {
 		"kubectl get nodes":           {{ExitCode: 0, Stdout: ""}},
 	})
 	orc.SetExecutor(mockExec)
+	orc.machineTypeClient = &MockMachineTypeClient{Executor: mockExec}
 
 	job := orchestrator.JobDefinition{
 		WorkloadName:    "dynamic-vms-test",
@@ -1280,16 +1397,20 @@ func TestGenerateGKEManifest_DynamicVmsPerSlice(t *testing.T) {
 }
 
 func TestGenerateGKEManifest_RespectUserVmsPerSlice(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	orc := NewGKEOrchestrator()
+	orc.projectID = "mock-project"
 	mockExec := NewMockExecutor(map[string][]shell.CommandResult{
 		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
 		"kubectl get nodes":           {{ExitCode: 0, Stdout: ""}},
-		"gcloud compute machine-types describe ct6e-standard-8t": {
+		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json": {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
 		},
 	})
 	orc.SetExecutor(mockExec)
+	orc.machineTypeClient = &MockMachineTypeClient{Executor: mockExec}
 
 	job := orchestrator.JobDefinition{
 		WorkloadName:    "user-vms-test",
@@ -1318,73 +1439,6 @@ func TestGenerateGKEManifest_RespectUserVmsPerSlice(t *testing.T) {
 	}
 	if !strings.Contains(manifest, expectedCompletions) {
 		t.Errorf("manifest missing expected completions %q\nManifest: %s", expectedCompletions, manifest)
-	}
-}
-
-func TestResolveTopologyForChips(t *testing.T) {
-	orc := &GKEOrchestrator{}
-
-	tests := []struct {
-		name       string
-		prefix     string
-		totalChips int
-		wantShape  string
-		wantErr    bool
-	}{
-		{
-			name:       "v4 4 chips",
-			prefix:     "v4",
-			totalChips: 4,
-			wantShape:  "2x2x1",
-			wantErr:    false,
-		},
-		{
-			name:       "tpu7x 2048 chips",
-			prefix:     "tpu7x",
-			totalChips: 2048,
-			wantShape:  "8x16x16",
-			wantErr:    false,
-		},
-		{
-			name:       "v6e 1 chip",
-			prefix:     "v6e",
-			totalChips: 1,
-			wantShape:  "1x1",
-			wantErr:    false,
-		},
-		{
-			name:       "v6e 256 chips",
-			prefix:     "v6e",
-			totalChips: 256,
-			wantShape:  "16x16",
-			wantErr:    false,
-		},
-		{
-			name:       "tpu7x 1 chip (Fail)",
-			prefix:     "tpu7x",
-			totalChips: 1,
-			wantShape:  "",
-			wantErr:    true,
-		},
-		{
-			name:       "v4 3 chips (Fail)",
-			prefix:     "v4",
-			totalChips: 3,
-			wantShape:  "",
-			wantErr:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := orc.resolveTopologyForChips(tt.prefix, tt.totalChips)
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("resolveTopologyForChips() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if got != tt.wantShape {
-				t.Errorf("resolveTopologyForChips() got = %v, want %v", got, tt.wantShape)
-			}
-		})
 	}
 }
 
@@ -1507,8 +1561,9 @@ func TestResolveKueueQueue(t *testing.T) {
 		})
 	}
 }
-
 func TestGPUTopologyAwareScheduling(t *testing.T) {
+	setupMockMachineConfig(t)
+
 	job := orchestrator.JobDefinition{
 		WorkloadName:    "gpu-test-job",
 		AcceleratorType: "nvidia-tesla-a100",
@@ -1523,8 +1578,11 @@ func TestGPUTopologyAwareScheduling(t *testing.T) {
 			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`},
 		},
 	}
-	orc := &GKEOrchestrator{executor: NewMockExecutor(mockResponses)}
-	orc.clusterDesc.NodePools = []gkeJobNodePool{{Name: "default-pool"}}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Name: "default-pool", Config: gkeNodePoolConfig{MachineType: "nvidia-tesla-a100"}},
+	}
 
 	opts, profile, err := orc.PrepareManifestOptions(job, "test-image:latest")
 	if err != nil {

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -19,6 +19,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/shell"
 	"io"
@@ -854,13 +855,18 @@ func (g *GKEOrchestrator) removeDescriptionFields(data map[interface{}]interface
 }
 
 // ValidateClusterState runs all cluster-specific validations to fail early on invalid state.
-func (g *GKEOrchestrator) ValidateClusterState(workloadName string, clusterName string, clusterLocation string, projectID string) error {
+func (g *GKEOrchestrator) ValidateClusterState(job *orchestrator.JobDefinition) error {
 	validators := []func() error{
 		g.checkClusterConnectivity,
-		func() error { return g.CheckAndInstallKueue("", clusterName, clusterLocation) },
+		func() error { return g.CheckAndInstallKueue("", job.ClusterName, job.ClusterLocation) },
 		func() error { return g.ensurePriorityClassesInstalled() },
 		g.checkAndInstallJobSetCRD,
-		func() error { return g.validateJobConflicts(workloadName, clusterName, clusterLocation, projectID) },
+		func() error {
+			return g.validateJobConflicts(job.WorkloadName, job.ClusterName, job.ClusterLocation, job.ProjectID)
+		},
+		func() error {
+			return config.ValidateHardwareRequest(job.AcceleratorType, job.Topology, job.PlacementPolicy)
+		},
 	}
 
 	for _, validate := range validators {

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/orchestrator"
-	"strconv"
 	"strings"
 	"text/template"
 
@@ -174,125 +173,6 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 	return opts, profile, nil
 }
 
-func (g *GKEOrchestrator) resolveAcceleratorShorthand(job *orchestrator.JobDefinition) error {
-	if job.AcceleratorType == "" {
-		return nil
-	}
-
-	// Prioritize shorthands over total-chip requests to avoid collisions (e.g., v6e-8)
-	if _, exists := acceleratorShorthandMap[job.AcceleratorType]; exists {
-		return nil
-	}
-
-	parts := strings.Split(job.AcceleratorType, "-")
-	if len(parts) != 2 {
-		return nil
-	}
-
-	prefix := parts[0]
-	totalChipsStr := parts[1]
-
-	totalChips, err := strconv.Atoi(totalChipsStr)
-	if err != nil || totalChips <= 0 {
-		return nil
-	}
-
-	logging.Info("Detected accelerator shorthand request: %s", job.AcceleratorType)
-
-	machineType, err := g.queryMachineType()
-	if err != nil {
-		return err
-	}
-	if machineType == "" {
-		return fmt.Errorf("could not auto-discover machine type because no active nodes were found. If this is an auto-provisioning (NAP) cluster, please specify the exact base accelerator unit (e.g., --accelerator v6e-8) instead of the total shape (%s)", job.AcceleratorType)
-	}
-
-	chipsPerVM, err := g.FetchMachineCapacity(machineType, job.ClusterLocation)
-	if err != nil {
-		return fmt.Errorf("failed to fetch capacity for machine type %s: %w", machineType, err)
-	}
-
-	job.VmsPerSlice = totalChips / chipsPerVM
-	if job.VmsPerSlice == 0 {
-		job.VmsPerSlice = 1
-	}
-
-	topology, err := g.resolveTopologyForChips(prefix, totalChips)
-	if err != nil {
-		return err
-	}
-	job.Topology = topology
-
-	job.AcceleratorType = g.GenerateGKENodeSelectorLabel(prefix)
-
-	return nil
-}
-
-func (g *GKEOrchestrator) dynamicallyCalculateVmsPerSlice(job *orchestrator.JobDefinition, topology, mappedLabel string) {
-	if job.VmsPerSlice <= 0 && topology != "" && strings.Contains(strings.ToLower(mappedLabel), "tpu") {
-		machineType := g.resolveMachineName(job.AcceleratorType)
-		chipsPerVM, err := g.FetchMachineCapacity(machineType, job.ClusterLocation)
-		if err != nil {
-			logging.Warn("Failed to fetch machine capacity for %s: %v", machineType, err)
-			return
-		}
-		if chipsPerVM > 0 {
-			dims := strings.Split(topology, "x")
-			totalChips := 1
-			for _, dim := range dims {
-				if val, err := strconv.Atoi(dim); err == nil {
-					totalChips *= val
-				}
-			}
-			job.VmsPerSlice = totalChips / chipsPerVM
-			logging.Info("Dynamically determined vms_per_slice for %s: %d", topology, job.VmsPerSlice)
-		}
-	}
-	if job.VmsPerSlice <= 0 {
-		job.VmsPerSlice = 1
-	}
-}
-
-func (g *GKEOrchestrator) resolveTolerations(acceleratorType string) (string, error) {
-	tolerations := GetTolerations(acceleratorType)
-	if len(tolerations) == 0 {
-		return "", nil
-	}
-	b, err := k8syaml.Marshal(tolerations)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal tolerations: %w", err)
-	}
-	return g.indentYaml(string(b), 16), nil
-}
-
-func (g *GKEOrchestrator) resolveSchedulingAndTopology(job *orchestrator.JobDefinition, mappedLabel string) (SchedulingOptions, bool, error) {
-	schedOpts := SchedulingOptions{
-		PlacementPolicy:    job.PlacementPolicy,
-		NodeAffinityLabels: job.NodeConstraint,
-		Topology:           job.Topology,
-		Scheduler:          job.GKEScheduler,
-	}
-
-	topology, err := g.resolveTopology(job.Topology, mappedLabel, job.ClusterName, job.ClusterLocation)
-	if err != nil {
-		return SchedulingOptions{}, false, err
-	}
-	schedOpts.Topology = topology
-
-	g.dynamicallyCalculateVmsPerSlice(job, topology, mappedLabel)
-
-	isDynamicSlicing, err := g.verifyDynamicSlicingActive(ManifestOptions{
-		ClusterName:     job.ClusterName,
-		ClusterLocation: job.ClusterLocation,
-		AcceleratorType: job.AcceleratorType,
-	})
-	if err != nil {
-		logging.Warn("Failed to verify if Dynamic-slicing is active: %v. Assuming not active.", err)
-	}
-
-	return schedOpts, isDynamicSlicing, nil
-}
-
 func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing, isCPUMachine bool) error {
 	nodeSelectorStr, err := g.buildNodeSelector(schedOpts, job, isDynamicSlicing, isCPUMachine)
 	if err != nil {
@@ -326,34 +206,4 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 	opts.Tolerations = tolerationsStr
 
 	return nil
-}
-
-func (g *GKEOrchestrator) resolveResourcesAndGates(opts *ManifestOptions, isCPUMachine bool, capacity int, job orchestrator.JobDefinition) (JobProfile, error) {
-	isGPU := !isCPUMachine && !IsTPU(job.AcceleratorType)
-	if isGPU && job.GKEScheduler == "gke.io/topology-aware-auto" {
-		opts.SchedulingGates = g.indentYaml("schedulingGates:\n  - name: \"gke.io/topology-aware-auto-"+job.WorkloadName+"\"", 14)
-		opts.SchedulerName = ""
-	}
-
-	profile := JobProfile{
-		IsCPUMachine:  isCPUMachine,
-		CapacityCount: capacity,
-	}
-
-	cpuLimit, memoryLimit, gpuLimit, tpuLimit, err := g.calculateResourceLimits(*opts, profile)
-	if err != nil {
-		logging.Warn("Warning: failed to calculate resource limits: %v", err)
-	} else {
-		if opts.AcceleratorType != "" && gpuLimit == "" && tpuLimit == "" {
-			logging.Info("Suppressing nodeSelector label for deduced CPU machine %s", opts.AcceleratorType)
-			opts.AcceleratorType = ""
-		}
-		resStr, err := g.buildResourcesString(cpuLimit, memoryLimit, gpuLimit, tpuLimit, 16)
-		if err != nil {
-			return profile, err
-		}
-		opts.ResourcesString = resStr
-	}
-
-	return profile, nil
 }

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -17,10 +17,12 @@ package gke
 import (
 	"encoding/json"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
-	"hpc-toolkit/pkg/shell"
+	"hpc-toolkit/pkg/orchestrator"
 	"strings"
-	"time"
+
+	k8syaml "sigs.k8s.io/yaml"
 )
 
 type MachineTypeCap struct {
@@ -30,49 +32,6 @@ type MachineTypeCap struct {
 	} `json:"accelerators"`
 	GuestCpus int `json:"guestCpus"`
 	MemoryMb  int `json:"memoryMb"`
-}
-
-var acceleratorShorthandMap = map[string]string{
-	// GPU mappings
-	"l4-1":             "g2-standard-12",
-	"l4-2":             "g2-standard-24",
-	"l4-4":             "g2-standard-48",
-	"l4-8":             "g2-standard-96",
-	"rtx-6000-1":       "g4-standard-48",
-	"rtx-6000-2":       "g4-standard-96",
-	"rtx-6000-4":       "g4-standard-192",
-	"rtx-6000-8":       "g4-standard-384",
-	"a100-40gb-1":      "a2-highgpu-1g",
-	"a100-40gb-2":      "a2-highgpu-2g",
-	"a100-40gb-4":      "a2-highgpu-4g",
-	"a100-40gb-8":      "a2-highgpu-8g",
-	"a2-megagpu-16g":   "a2-megagpu-16g",
-	"a100-80gb-1":      "a2-ultragpu-1g",
-	"a100-80gb-2":      "a2-ultragpu-2g",
-	"a100-80gb-4":      "a2-ultragpu-4g",
-	"a100-80gb-8":      "a2-ultragpu-8g",
-	"h100-80gb-1":      "a3-highgpu-1g",
-	"h100-80gb-2":      "a3-highgpu-2g",
-	"h100-80gb-4":      "a3-highgpu-4g",
-	"h100-80gb-8":      "a3-highgpu-8g",
-	"h100-mega-80gb-8": "a3-megagpu-8g",
-	"h200-141gb-8":     "a3-ultragpu-8g",
-	"b200-8":           "a4-highgpu-8g",
-	"gb200-4":          "a4x-highgpu-4g",
-
-	// TPU mappings
-	"v4-8":  "ct4p-hightpu-4t",
-	"v5p-1": "ct5p-hightpu-1t",
-	"v5p-2": "ct5p-hightpu-2t",
-	"v5p-4": "ct5p-hightpu-4t",
-	"v5e-1": "ct5lp-hightpu-1t",
-	"v5e-4": "ct5lp-hightpu-4t",
-	"v5e-8": "ct5lp-hightpu-8t",
-	"v6e-1": "ct6e-standard-1t",
-	"v6e-4": "ct6e-standard-4t",
-	"v6e-8": "ct6e-standard-8t",
-	"tpu7":  "tpu7-standard-1t",
-	"tpu7x": "tpu7x-standard-4t",
 }
 
 func (g *GKEOrchestrator) FetchMachineCapacity(machineType, zone string) (int, error) {
@@ -91,9 +50,6 @@ func (g *GKEOrchestrator) FetchMachineCapacity(machineType, zone string) (int, e
 }
 
 func (g *GKEOrchestrator) FetchMachineCapabilities(machineType, zone string) (MachineTypeCap, error) {
-	if zone == "" {
-		return MachineTypeCap{}, fmt.Errorf("zone is required for machine capacity lookup")
-	}
 
 	cacheKey := machineType + ":" + zone
 	if g.machineCapCache != nil {
@@ -111,56 +67,42 @@ func (g *GKEOrchestrator) FetchMachineCapabilities(machineType, zone string) (Ma
 
 	var lastErr error
 	for _, z := range zonesToTry {
-		cap, err := g.fetchCapacityForZoneWithRetry(machineType, z, !isRegion)
-		if err == nil {
-			logging.Info("Discovered machine capabilities in zone %s", z)
-			if g.machineCapCache == nil {
-				g.machineCapCache = make(map[string]MachineTypeCap)
-			}
-			g.machineCapCache[cacheKey] = cap
-			// Also cache for the specific zone that succeeded
-			specificKey := machineType + ":" + z
-			g.machineCapCache[specificKey] = cap
-			return cap, nil
+
+		mt, err := g.machineTypeClient.GetMachineType(g.projectID, z, machineType)
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		lastErr = err
+
+		logging.Info("Discovered machine capabilities in zone %s", z)
+
+		cap := MachineTypeCap{
+			GuestCpus: int(mt.GuestCpus),
+			MemoryMb:  int(mt.MemoryMb),
+		}
+
+		count, accelType, _ := config.ResolveAcceleratorInfo(mt, machineType)
+		if count > 0 {
+			cap.Accelerators = append(cap.Accelerators, struct {
+				Count int    `json:"guestAcceleratorCount"`
+				Type  string `json:"guestAcceleratorType"`
+			}{Count: count, Type: accelType})
+		}
+
+		if g.machineCapCache == nil {
+			g.machineCapCache = make(map[string]MachineTypeCap)
+		}
+		g.machineCapCache[cacheKey] = cap
+		// Also cache for the specific zone that succeeded
+		specificKey := machineType + ":" + z
+		g.machineCapCache[specificKey] = cap
+		return cap, nil
 	}
 
 	if isRegion {
 		return MachineTypeCap{}, fmt.Errorf("failed to fetch machine capabilities for %s: tried in all candidate zones %v but did not find machine type in any of them", machineType, zonesToTry)
 	}
 	return MachineTypeCap{}, fmt.Errorf("failed to fetch machine capabilities for %s in zone %s: %w", machineType, zone, lastErr)
-}
-
-func (g *GKEOrchestrator) fetchCapacityForZoneWithRetry(machineType, zone string, shouldRetry bool) (MachineTypeCap, error) {
-	maxRetries := 1
-	if shouldRetry {
-		maxRetries = 3
-	}
-
-	var result shell.CommandResult
-	var cap MachineTypeCap
-
-	for i := 0; i < maxRetries; i++ {
-		result = g.executor.ExecuteCommand("gcloud", "compute", "machine-types", "describe", machineType, "--zone="+zone, "--format=json")
-		if result.ExitCode == 0 {
-			break
-		}
-		if shouldRetry {
-			logging.Info("gcloud compute machine-types describe failed (attempt %d/%d): %s. Retrying...", i+1, maxRetries, result.Stderr)
-			time.Sleep(time.Duration(1<<i) * time.Second)
-		}
-	}
-
-	if result.ExitCode != 0 {
-		return cap, fmt.Errorf("gcloud compute machine-types describe failed for zone %s: %s", zone, result.Stderr)
-	}
-
-	if err := json.Unmarshal([]byte(result.Stdout), &cap); err != nil {
-		return cap, fmt.Errorf("failed to unmarshal machine capacity JSON: %w", err)
-	}
-
-	return cap, nil
 }
 
 func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool, error) {
@@ -210,7 +152,10 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 	}
 
 	// Check discovered node pools for dynamic-slicing
-	requestedMachineName := g.resolveMachineName(opts.AcceleratorType)
+	requestedMachineName, err := g.resolveMachineName(opts.AcceleratorType)
+	if err != nil {
+		return false, err
+	}
 	for _, np := range g.clusterDesc.NodePools {
 		if np.Config.MachineType == requestedMachineName {
 			if np.PlacementPolicy != nil && np.PlacementPolicy.AcceleratorTopologyMode == "PROVISION_ONLY" {
@@ -241,7 +186,10 @@ func (g *GKEOrchestrator) calculateResourceLimits(opts ManifestOptions, profile 
 }
 
 func (g *GKEOrchestrator) calculateGCPMachineResourceLimits(opts ManifestOptions, profile JobProfile, mapped string) (cpu, mem, gpu, tpu string, err error) {
-	machineName := g.resolveMachineName(opts.AcceleratorType)
+	machineName, err := g.resolveMachineName(opts.AcceleratorType)
+	if err != nil {
+		return "", "", "", "", err
+	}
 
 	count, err := g.FetchMachineCapacity(machineName, opts.ClusterLocation)
 	if err != nil {
@@ -262,20 +210,221 @@ func (g *GKEOrchestrator) calculateGCPMachineResourceLimits(opts ManifestOptions
 	return "", "", "", "", fmt.Errorf("failed to determine capacity for machine type %s", machineName)
 }
 
-func (g *GKEOrchestrator) resolveMachineName(acceleratorType string) string {
-	if g.acceleratorToMachineType != nil {
-		if machineType, exists := g.acceleratorToMachineType[strings.ToLower(acceleratorType)]; exists {
-			return machineType
+func (g *GKEOrchestrator) resolveMachineName(acceleratorType string) (string, error) {
+	// Check if shorthand (key) existis in the static mao
+	if fullType, exists := config.AcceleratorShorthandMap[strings.ToLower(acceleratorType)]; exists {
+		return fullType, nil
+	}
+	// Check if the passed value is a full machine type (value) in the static map
+	for _, v := range config.AcceleratorShorthandMap {
+		if strings.EqualFold(v, acceleratorType) {
+			return acceleratorType, nil
 		}
 	}
 
-	if mappedName, exists := acceleratorShorthandMap[acceleratorType]; exists {
-		return mappedName
+	// Check cluster state [Dynamic accelerator to machine type mapping from the cluster]
+	if g.acceleratorToMachineType != nil {
+		if machineType, exists := g.acceleratorToMachineType[strings.ToLower(acceleratorType)]; exists {
+			return machineType, nil
+		}
 	}
 
-	mapped := g.GenerateGKENodeSelectorLabel(acceleratorType)
-	if mappedName, exists := acceleratorShorthandMap[mapped]; exists {
-		return mappedName
+	// Check if the input is a full machine type and present in the cluster (required for CPUs).
+	clusterMachineTypes, err := g.queryAllMachineTypes()
+	if err == nil {
+		for _, cmt := range clusterMachineTypes {
+			if strings.EqualFold(acceleratorType, cmt) {
+				return acceleratorType, nil
+			}
+		}
 	}
-	return acceleratorType
+
+	// 3. Fail fast
+	return "", fmt.Errorf("machine type %q could not be resolved from static maps or cluster state", acceleratorType)
+}
+
+func (g *GKEOrchestrator) resolveAcceleratorShorthand(job *orchestrator.JobDefinition) error {
+	originalInput := job.AcceleratorType
+	parts := strings.Split(originalInput, "-")
+
+	machineName, err := g.resolveMachineName(job.AcceleratorType)
+	if err == nil {
+		job.AcceleratorType = machineName
+		// If it is a TPU, we might still need to resolve topology!
+		if config.IsTPU(machineName) && job.Topology == "" && len(parts) == 2 {
+			topology, err := config.ResolveTopologyForChips(originalInput)
+			if err != nil {
+				return err
+			}
+			job.Topology = topology
+			logging.Info("Auto-resolved topology for %s to %s", originalInput, topology)
+		}
+		return nil
+	}
+
+	// 2. If resolveMachineName failed, check if it's a multi-node TPU shorthand!
+	if config.IsTPU(originalInput) && job.Topology == "" && len(parts) == 2 {
+		topology, err := config.ResolveTopologyForChips(originalInput)
+		if err != nil {
+			return fmt.Errorf("failed to resolve topology for %s: %w", originalInput, err)
+		}
+		job.Topology = topology
+		logging.Info("Auto-resolved topology for %s to %s", originalInput, topology)
+		// Set AcceleratorType to prefix to be resolved via cluster state
+		job.AcceleratorType = parts[0]
+		return g.resolveAmbiguousShorthand(job)
+	}
+	return err
+}
+
+func (g *GKEOrchestrator) resolveFullMachineTypeOrValue(acceleratorType string) error {
+	// Check if it is a defined machine type (value in map)
+	for _, v := range config.AcceleratorShorthandMap {
+		if v == acceleratorType {
+			return nil // Valid defined machine type
+		}
+	}
+
+	clusterMachineTypes, err := g.queryAllMachineTypes()
+	if err != nil {
+		return err
+	}
+
+	for _, cmt := range clusterMachineTypes {
+		if acceleratorType == cmt {
+			return nil // Valid full machine type found in cluster
+		}
+	}
+	return fmt.Errorf("machine type %q not found in cluster and is not a known shorthand or defined machine type", acceleratorType)
+}
+
+func (g *GKEOrchestrator) resolveAmbiguousShorthand(job *orchestrator.JobDefinition) error {
+	candidates := config.GetCandidatesForShorthand(job.AcceleratorType)
+	if len(candidates) == 0 {
+		return fmt.Errorf("accelerator type %q is not a known shorthand and could not be resolved", job.AcceleratorType)
+	}
+
+	logging.Info("Detected ambiguous accelerator shorthand %q, finding candidates...", job.AcceleratorType)
+
+	clusterMachineTypes, err := g.queryAllMachineTypes()
+	if err != nil {
+		return err
+	}
+
+	cmtSet := make(map[string]bool, len(clusterMachineTypes))
+	for _, cmt := range clusterMachineTypes {
+		cmtSet[cmt] = true
+	}
+
+	var matchedCandidates []string
+	for _, c := range candidates {
+		if cmtSet[c] {
+			matchedCandidates = append(matchedCandidates, c)
+		}
+	}
+
+	if len(matchedCandidates) == 1 {
+		logging.Info("Disambiguated %q to %q based on cluster state.", job.AcceleratorType, matchedCandidates[0])
+
+		// If not found in map, fallback to candidate name
+		job.AcceleratorType = matchedCandidates[0]
+		return nil
+	}
+
+	if len(matchedCandidates) == 0 {
+		return fmt.Errorf("no matching machine types found in cluster for shorthand %q. Available candidates: %v", job.AcceleratorType, candidates)
+	}
+
+	return fmt.Errorf("multiple matching machine types found in cluster for shorthand %q: %v. Please pass the required machine type directly to disambiguate.", job.AcceleratorType, matchedCandidates)
+}
+
+func (g *GKEOrchestrator) dynamicallyCalculateVmsPerSlice(job *orchestrator.JobDefinition, topology, mappedLabel string) error {
+	if job.VmsPerSlice <= 0 && topology != "" && config.IsTPU(mappedLabel) {
+		machineType, err := g.resolveMachineName(job.AcceleratorType)
+		if err != nil {
+			return err
+		}
+		nodes, err := config.CalculateAcceleratorNodes(machineType, topology)
+		if err != nil {
+			return fmt.Errorf("failed to calculate nodes from topology: %w", err)
+		}
+		job.VmsPerSlice = nodes
+		logging.Info("Dynamically determined vms_per_slice for %s: %d", topology, job.VmsPerSlice)
+	}
+	if job.VmsPerSlice <= 0 {
+		job.VmsPerSlice = 1
+	}
+	return nil
+}
+
+func (g *GKEOrchestrator) resolveTolerations(acceleratorType string) (string, error) {
+	tolerations := GetTolerations(acceleratorType)
+	if len(tolerations) == 0 {
+		return "", nil
+	}
+	b, err := k8syaml.Marshal(tolerations)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal tolerations: %w", err)
+	}
+	return g.indentYaml(string(b), 16), nil
+}
+
+func (g *GKEOrchestrator) resolveSchedulingAndTopology(job *orchestrator.JobDefinition, mappedLabel string) (SchedulingOptions, bool, error) {
+	schedOpts := SchedulingOptions{
+		PlacementPolicy:    job.PlacementPolicy,
+		NodeAffinityLabels: job.NodeConstraint,
+		Topology:           job.Topology,
+		Scheduler:          job.GKEScheduler,
+	}
+
+	topology, err := g.resolveTopology(job.Topology, mappedLabel, job.ClusterName, job.ClusterLocation)
+	if err != nil {
+		return SchedulingOptions{}, false, err
+	}
+	schedOpts.Topology = topology
+
+	if err := g.dynamicallyCalculateVmsPerSlice(job, topology, mappedLabel); err != nil {
+		return SchedulingOptions{}, false, err
+	}
+
+	isDynamicSlicing, err := g.verifyDynamicSlicingActive(ManifestOptions{
+		ClusterName:     job.ClusterName,
+		ClusterLocation: job.ClusterLocation,
+		AcceleratorType: job.AcceleratorType,
+	})
+	if err != nil {
+		logging.Warn("Failed to verify if Dynamic-slicing is active: %v. Assuming not active.", err)
+	}
+
+	return schedOpts, isDynamicSlicing, nil
+}
+
+func (g *GKEOrchestrator) resolveResourcesAndGates(opts *ManifestOptions, isCPUMachine bool, capacity int, job orchestrator.JobDefinition) (JobProfile, error) {
+	isGPU := !isCPUMachine && !config.IsTPU(job.AcceleratorType)
+	if isGPU && job.GKEScheduler == "gke.io/topology-aware-auto" {
+		opts.SchedulingGates = g.indentYaml("schedulingGates:\n  - name: \"gke.io/topology-aware-auto-"+job.WorkloadName+"\"", 14)
+		opts.SchedulerName = ""
+	}
+
+	profile := JobProfile{
+		IsCPUMachine:  isCPUMachine,
+		CapacityCount: capacity,
+	}
+
+	cpuLimit, memoryLimit, gpuLimit, tpuLimit, err := g.calculateResourceLimits(*opts, profile)
+	if err != nil {
+		logging.Warn("Warning: failed to calculate resource limits: %v", err)
+	} else {
+		if opts.AcceleratorType != "" && gpuLimit == "" && tpuLimit == "" {
+			logging.Info("Suppressing nodeSelector label for deduced CPU machine %s", opts.AcceleratorType)
+			opts.AcceleratorType = ""
+		}
+		resStr, err := g.buildResourcesString(cpuLimit, memoryLimit, gpuLimit, tpuLimit, 16)
+		if err != nil {
+			return profile, err
+		}
+		opts.ResourcesString = resStr
+	}
+
+	return profile, nil
 }

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -344,7 +344,12 @@ func (g *GKEOrchestrator) dynamicallyCalculateVmsPerSlice(job *orchestrator.JobD
 		if err != nil {
 			return err
 		}
-		nodes, err := config.CalculateAcceleratorNodes(machineType, topology)
+		accelsPerVM, err := g.FetchMachineCapacity(machineType, job.ClusterLocation)
+		if err != nil {
+			logging.Warn("Failed to fetch machine capacity for %s: %v. Falling back to static defaults.", machineType, err)
+			accelsPerVM = 0 // Fallback to static logic in CalculateAcceleratorNodes
+		}
+		nodes, err := config.CalculateAcceleratorNodes(machineType, topology, accelsPerVM)
 		if err != nil {
 			return fmt.Errorf("failed to calculate nodes from topology: %w", err)
 		}

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -15,8 +15,13 @@
 package gke
 
 import (
+	"encoding/json"
+	"fmt"
+	"hpc-toolkit/pkg/orchestrator"
 	"hpc-toolkit/pkg/shell"
 	"testing"
+
+	compute "google.golang.org/api/compute/v1"
 )
 
 func TestResolveMachineName(t *testing.T) {
@@ -24,6 +29,7 @@ func TestResolveMachineName(t *testing.T) {
 		name            string
 		acceleratorType string
 		wantMachineName string
+		wantErr         bool
 	}{
 		{
 			name:            "Direct shorthand mapping",
@@ -39,20 +45,22 @@ func TestResolveMachineName(t *testing.T) {
 			name:            "Unknown type falls back to input",
 			acceleratorType: "unknown-machine",
 			wantMachineName: "unknown-machine",
+			wantErr:         true,
 		},
 		{
 			name:            "GKE label string resolution for unknown shorthand",
 			acceleratorType: "nvidia-l4",
 			wantMachineName: "nvidia-l4", // Default fallthrough if neither matches
+			wantErr:         true,
 		},
 		{
-			name:            "TPU7 shorthand mapping",
-			acceleratorType: "tpu7",
-			wantMachineName: "tpu7-standard-1t",
+			name:            "TPU7x-1 shorthand mapping",
+			acceleratorType: "tpu7x-1",
+			wantMachineName: "tpu7x-standard-1t",
 		},
 		{
-			name:            "TPU7x shorthand mapping",
-			acceleratorType: "tpu7x",
+			name:            "TPU7x-4 shorthand mapping",
+			acceleratorType: "tpu7x-4",
 			wantMachineName: "tpu7x-standard-4t",
 		},
 	}
@@ -61,8 +69,12 @@ func TestResolveMachineName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := g.resolveMachineName(tt.acceleratorType)
-			if got != tt.wantMachineName {
+			got, err := g.resolveMachineName(tt.acceleratorType)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("resolveMachineName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.wantMachineName {
 				t.Errorf("resolveMachineName() = %v, want %v", got, tt.wantMachineName)
 			}
 		})
@@ -73,60 +85,54 @@ func TestResolveMachineName_Dynamic(t *testing.T) {
 	g := NewGKEOrchestrator()
 	g.acceleratorToMachineType["nvidia-gb300"] = "a4-highgpu-8g"
 
-	got := g.resolveMachineName("nvidia-gb300")
+	got, err := g.resolveMachineName("nvidia-gb300")
+	if err != nil {
+		t.Errorf("resolveMachineName() returned error: %v", err)
+	}
 	if got != "a4-highgpu-8g" {
 		t.Errorf("resolveMachineName() = %v, want %v", got, "a4-highgpu-8g")
 	}
 
 	// Test case insensitivity
-	got = g.resolveMachineName("Nvidia-GB300")
+	got, err = g.resolveMachineName("Nvidia-GB300")
+	if err != nil {
+		t.Errorf("resolveMachineName() returned error: %v", err)
+	}
 	if got != "a4-highgpu-8g" {
 		t.Errorf("resolveMachineName() case insensitive = %v, want %v", got, "a4-highgpu-8g")
 	}
 }
 
 func TestFetchMachineCapacity_AllZonesFail(t *testing.T) {
-	mockResponses := map[string][]shell.CommandResult{
-		"gcloud compute machine-types describe tpu7 --zone=europe-west2-a": {
-			{ExitCode: 1, Stderr: "resource not found"},
-		},
-		"gcloud compute machine-types describe tpu7 --zone=europe-west2-c": {
-			{ExitCode: 1, Stderr: "resource not found"},
-		},
-		"gcloud compute machine-types describe tpu7 --zone=europe-west2-b": {
-			{ExitCode: 1, Stderr: "resource not found"},
-		},
+	g := &GKEOrchestrator{
+		machineTypeClient: &MockMachineTypeClient{FailAll: true},
 	}
-	mockExec := NewMockExecutor(mockResponses)
-	g := &GKEOrchestrator{executor: mockExec}
 	g.clusterZones = []string{"europe-west2-a", "europe-west2-c", "europe-west2-b"}
 
-	_, err := g.FetchMachineCapacity("tpu7", "europe-west2")
+	_, err := g.FetchMachineCapacity("tpu7x-1", "europe-west2")
 
 	if err == nil {
 		t.Fatalf("Expected error, got nil")
 	}
 
-	expectedErrStr := "failed to fetch machine capabilities for tpu7: tried in all candidate zones [europe-west2-a europe-west2-c europe-west2-b] but did not find machine type in any of them"
+	expectedErrStr := "failed to fetch machine capabilities for tpu7x-1: tried in all candidate zones [europe-west2-a europe-west2-c europe-west2-b] but did not find machine type in any of them"
 	if err.Error() != expectedErrStr {
 		t.Errorf("Expected error %q, got %q", expectedErrStr, err.Error())
 	}
 }
 
 func TestFetchMachineCapabilities_Caching(t *testing.T) {
-	cmd := "gcloud compute machine-types describe n2-standard-32 --zone=us-east5-b --format=json"
-	mockResponses := map[string][]shell.CommandResult{
-		cmd: {
-			{ExitCode: 0, Stdout: `{"guestCpus": 32, "memoryMb": 131072}`},
+	g := &GKEOrchestrator{
+		machineCapCache: make(map[string]MachineTypeCap),
+		machineTypeClient: &MockMachineTypeClient{
+			MT: &compute.MachineType{
+				GuestCpus: 32,
+				MemoryMb:  131072,
+			},
 		},
 	}
-	mockExec := NewMockExecutor(mockResponses)
-	g := &GKEOrchestrator{
-		executor:        mockExec,
-		machineCapCache: make(map[string]MachineTypeCap),
-	}
 
-	// First call - should hit mock executor
+	// First call
 	cap1, err := g.FetchMachineCapabilities("n2-standard-32", "us-east5-b")
 	if err != nil {
 		t.Fatalf("FetchMachineCapabilities failed: %v", err)
@@ -144,10 +150,6 @@ func TestFetchMachineCapabilities_Caching(t *testing.T) {
 		t.Errorf("cap2.GuestCpus = %d, want 32", cap2.GuestCpus)
 	}
 
-	// Verify call count
-	if mockExec.callCount[cmd] != 1 {
-		t.Errorf("mockExec.callCount[%q] = %d, want 1", cmd, mockExec.callCount[cmd])
-	}
 }
 
 func TestCalculateResourceLimits_CPU(t *testing.T) {
@@ -197,6 +199,132 @@ func TestCalculateResourceLimits_CPU(t *testing.T) {
 			}
 			if mem != "" || gpu != "" || tpu != "" {
 				t.Errorf("mem, gpu, tpu = %q, %q, %q; want empty strings", mem, gpu, tpu)
+			}
+		})
+	}
+}
+
+type MockMachineTypeClient struct {
+	FailAll  bool
+	MT       *compute.MachineType
+	Executor Executor
+}
+
+func (m *MockMachineTypeClient) GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+	if m.FailAll {
+		return nil, fmt.Errorf("resource not found")
+	}
+	if m.MT != nil {
+		return m.MT, nil
+	}
+	if m.Executor != nil {
+		res := m.Executor.ExecuteCommand("gcloud", "compute", "machine-types", "describe", machineType, "--zone="+zone, "--format=json")
+		if res.ExitCode != 0 {
+			return nil, fmt.Errorf("failed to get machine type: %s", res.Stderr)
+		}
+		var mt compute.MachineType
+		if err := json.Unmarshal([]byte(res.Stdout), &mt); err != nil {
+			return nil, err
+		}
+		return &mt, nil
+	}
+	return nil, fmt.Errorf("mock not configured")
+}
+
+func TestResolveAcceleratorShorthand(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	tests := []struct {
+		name            string
+		acceleratorType string
+		mockResponses   map[string][]shell.CommandResult
+		nodePools       []string
+		wantType        string
+		wantTopology    string
+		wantErr         bool
+	}{
+		{
+			name:            "Valid shorthand in map",
+			acceleratorType: "v4-8",
+			wantType:        "ct4p-hightpu-4t", // Resolves to full machine type
+			wantErr:         false,
+		},
+		{
+			name:            "Valid full type in map values",
+			acceleratorType: "ct4p-hightpu-4t",
+			wantType:        "ct4p-hightpu-4t",
+			wantErr:         false,
+		},
+		{
+			name:            "Valid full type in cluster",
+			acceleratorType: "custom-c2-60",
+			nodePools:       []string{"custom-c2-60"},
+			wantType:        "custom-c2-60",
+			wantErr:         false,
+		},
+		{
+			name:            "Invalid full type not in cluster",
+			acceleratorType: "custom-invalid-type",
+			nodePools:       []string{"other-type"},
+			wantErr:         true,
+		},
+		{
+			name:            "Ambiguous shorthand resolved",
+			acceleratorType: "v6e",
+			nodePools:       []string{"ct6e-standard-8t"},
+			wantErr:         true,
+		},
+		{
+			name:            "Unknown shorthand with less than 2 hyphens",
+			acceleratorType: "unknown",
+			wantErr:         true,
+		},
+		{
+			name:            "TPU shorthand with chip count resolved",
+			acceleratorType: "v6e-256",
+			nodePools:       []string{"ct6e-standard-8t"},
+			wantType:        "ct6e-standard-8t", // Resolves to full machine type
+			wantTopology:    "16x16",
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecutor := NewMockExecutor(tt.mockResponses)
+			orc := &GKEOrchestrator{
+				executor:          mockExecutor,
+				machineTypeClient: &MockMachineTypeClient{Executor: mockExecutor},
+			}
+			orc.projectID = "mock-project"
+			if len(tt.nodePools) > 0 {
+				for _, mt := range tt.nodePools {
+					orc.clusterDesc.NodePools = append(orc.clusterDesc.NodePools, gkeJobNodePool{
+						Config: gkeNodePoolConfig{MachineType: mt},
+					})
+				}
+			}
+
+			job := &orchestrator.JobDefinition{
+				AcceleratorType: tt.acceleratorType,
+			}
+
+			err := orc.resolveAcceleratorShorthand(job)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if job.AcceleratorType != tt.wantType {
+					t.Errorf("Expected job.AcceleratorType %q, got %q", tt.wantType, job.AcceleratorType)
+				}
+				if tt.wantTopology != "" && job.Topology != tt.wantTopology {
+					t.Errorf("Expected job.Topology %q, got %q", tt.wantTopology, job.Topology)
+				}
 			}
 		})
 	}

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -15,7 +15,7 @@
 package gke
 
 import (
-	"strings"
+	"hpc-toolkit/pkg/config"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -77,7 +77,7 @@ func GetTolerations(acceleratorType string) []corev1.Toleration {
 	if acceleratorType == "" {
 		return nil
 	}
-	if IsTPU(acceleratorType) {
+	if config.IsTPU(acceleratorType) {
 		return []corev1.Toleration{
 			{
 				Key:      "google.com/tpu",
@@ -87,16 +87,4 @@ func GetTolerations(acceleratorType string) []corev1.Toleration {
 		}
 	}
 	return nil
-}
-
-func IsTPU(acceleratorType string) bool {
-	if strings.Contains(acceleratorType, "tpu") {
-		return true
-	}
-	if len(acceleratorType) >= 2 && acceleratorType[0] == 'v' {
-		if acceleratorType[1] >= '0' && acceleratorType[1] <= '9' {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -17,10 +17,12 @@ package gke
 import (
 	"encoding/json"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/orchestrator"
 	"hpc-toolkit/pkg/shell"
 	"strings"
 
+	compute "google.golang.org/api/compute/v1"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -37,6 +39,16 @@ type KubeClient interface {
 	ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error)
 }
 
+type MachineTypeClient interface {
+	GetMachineType(project, zone, machineType string) (*compute.MachineType, error)
+}
+
+type DefaultMachineTypeClient struct{}
+
+func (c DefaultMachineTypeClient) GetMachineType(project, zone, machineType string) (*compute.MachineType, error) {
+	return config.GetMachineType(project, zone, machineType)
+}
+
 // DefaultKubeClient implements KubeClient using the actual dynamic client.
 type DefaultKubeClient struct {
 	dynClient dynamic.Interface
@@ -46,12 +58,14 @@ type DefaultExecutor struct{}
 
 type GKEOrchestrator struct {
 	executor                    Executor
+	projectID                   string
 	clusterZones                []string
 	nodePoolSAs                 []string
 	capacity                    ClusterCapacity
 	clusterDesc                 gkeCluster
 	dynClient                   dynamic.Interface
 	kubeClient                  KubeClient
+	machineTypeClient           MachineTypeClient
 	acceleratorToMachineType    map[string]string
 	machineCapCache             map[string]MachineTypeCap
 	resolvedHeadNodePool        string


### PR DESCRIPTION
This pull request refactors the hardware resolution logic by centralizing it within the pkg/config module. By offloading these responsibilities from the GKE orchestrator and replacing external CLI dependencies with direct API calls (with caching).

This pull request also renames the --accelerator flag to --compute-type and --max-restarts to --restarts. These are just naming changes and the functionality of these flags have not been changed.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
