### PR TITLE
adding new module spanner in cluster toolkit.

### DIFF
--- a/modules/database/spanner/README.md
+++ b/modules/database/spanner/README.md
@@ -36,13 +36,13 @@ limitations under the License.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.0 |
 
 ## Modules
 
@@ -52,7 +52,6 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
-| [google_project_service.spanner_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_spanner_database.db](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database) | resource |
 | [google_spanner_database_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database_iam_member) | resource |
 | [google_spanner_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_instance) | resource |

--- a/modules/database/spanner/README.md
+++ b/modules/database/spanner/README.md
@@ -1,0 +1,79 @@
+# Spanner Module
+This module handles Spanner instance and database creation in Cluster Toolkit.
+## Usage
+
+```hcl
+module "spanner_db" {
+  source = "./modules/database/spanner"
+
+  project_id    = var.project_id
+  instance_name = "my-instance"
+  databases = {
+    "my-db" = {
+      name = "actual-db-name"
+    }
+  }
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_project_service.spanner_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_spanner_database.db](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database) | resource |
+| [google_spanner_database_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_database_iam_member) | resource |
+| [google_spanner_instance.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/spanner_instance) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_config"></a> [config](#input\_config) | The name of the instance's configuration. | `string` | `"regional-us-central1"` | no |
+| <a name="input_databases"></a> [databases](#input\_databases) | A map of databases to create. Keys are logical names. | <pre>map(object({<br/>    name                = string<br/>    deletion_protection = optional(bool, true)<br/>    iam_members = optional(list(object({<br/>      role   = string<br/>      member = string<br/>    })), [])<br/>  }))</pre> | `{}` | no |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | The descriptive name for this instance as it appears in UIs. | `string` | `"Spanner Instance"` | no |
+| <a name="input_edition"></a> [edition](#input\_edition) | The edition of the Spanner instance (e.g., ENTERPRISE, ENTERPRISE\_PLUS, or STANDARD). | `string` | `"STANDARD"` | no |
+| <a name="input_instance_name"></a> [instance\_name](#input\_instance\_name) | Name of the Spanner instance. | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to apply to the Spanner instance. | `map(string)` | `{}` | no |
+| <a name="input_processing_units"></a> [processing\_units](#input\_processing\_units) | The number of processing units allocated to this instance. | `number` | `100` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID for Spanner instance. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_database_ids"></a> [database\_ids](#output\_database\_ids) | A map from logical database name to the actual created database ID. |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | The name of the Spanner instance. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/database/spanner/main.tf
+++ b/modules/database/spanner/main.tf
@@ -15,14 +15,8 @@
  */
 
 
-resource "google_project_service" "spanner_api" {
-  project            = var.project_id
-  service            = "spanner.googleapis.com"
-  disable_on_destroy = false
-}
-
 resource "google_spanner_instance" "main" {
-  project          = google_project_service.spanner_api.project
+  project          = var.project_id
   name             = var.instance_name
   config           = var.config
   display_name     = var.display_name
@@ -33,7 +27,7 @@ resource "google_spanner_instance" "main" {
 
 resource "google_spanner_database" "db" {
   for_each            = var.databases
-  project             = google_project_service.spanner_api.project
+  project             = var.project_id
   instance            = google_spanner_instance.main.name
   name                = each.value.name
   deletion_protection = each.value.deletion_protection
@@ -60,7 +54,7 @@ locals {
 
 resource "google_spanner_database_iam_member" "member" {
   for_each = { for iam in local.db_iam_members : iam.key => iam }
-  project  = google_project_service.spanner_api.project
+  project  = var.project_id
   instance = google_spanner_instance.main.name
   database = google_spanner_database.db[each.value.database].name
   role     = each.value.role

--- a/modules/database/spanner/main.tf
+++ b/modules/database/spanner/main.tf
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+resource "google_project_service" "spanner_api" {
+  project            = var.project_id
+  service            = "spanner.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_spanner_instance" "main" {
+  project          = google_project_service.spanner_api.project
+  name             = var.instance_name
+  config           = var.config
+  display_name     = var.display_name
+  processing_units = var.processing_units
+  labels           = local.labels
+  edition          = var.edition
+}
+
+resource "google_spanner_database" "db" {
+  for_each            = var.databases
+  project             = google_project_service.spanner_api.project
+  instance            = google_spanner_instance.main.name
+  name                = each.value.name
+  deletion_protection = each.value.deletion_protection
+}
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "spanner", ghpc_role = "database" })
+}
+
+locals {
+  # Flatten IAM members
+  db_iam_members = flatten([
+    for db_key, db in var.databases : [
+      for iam in db.iam_members : {
+        database = db_key
+        role     = iam.role
+        member   = iam.member
+        key      = "${db_key}-${iam.role}-${iam.member}"
+      }
+    ]
+  ])
+}
+
+resource "google_spanner_database_iam_member" "member" {
+  for_each = { for iam in local.db_iam_members : iam.key => iam }
+  project  = google_project_service.spanner_api.project
+  instance = google_spanner_instance.main.name
+  database = google_spanner_database.db[each.value.database].name
+  role     = each.value.role
+  member   = each.value.member
+}

--- a/modules/database/spanner/metadata.yaml
+++ b/modules/database/spanner/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services:
+    - spanner.googleapis.com
+ghpc:
+  validators: []

--- a/modules/database/spanner/outputs.tf
+++ b/modules/database/spanner/outputs.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+output "instance_name" {
+  description = "The name of the Spanner instance."
+  value       = google_spanner_instance.main.name
+}
+
+output "database_ids" {
+  description = "A map from logical database name to the actual created database ID."
+  value       = { for k, db in google_spanner_database.db : k => db.name }
+}

--- a/modules/database/spanner/variables.tf
+++ b/modules/database/spanner/variables.tf
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+variable "project_id" {
+  type        = string
+  description = "Project ID for Spanner instance."
+}
+
+variable "instance_name" {
+  type        = string
+  description = "Name of the Spanner instance."
+}
+
+variable "config" {
+  type        = string
+  description = "The name of the instance's configuration."
+  default     = "regional-us-central1"
+}
+
+variable "display_name" {
+  type        = string
+  description = "The descriptive name for this instance as it appears in UIs."
+  default     = "Spanner Instance"
+}
+
+variable "processing_units" {
+  type        = number
+  description = "The number of processing units allocated to this instance."
+  default     = 100
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "Labels to apply to the Spanner instance."
+  default     = {}
+}
+
+variable "edition" {
+  type        = string
+  description = "The edition of the Spanner instance (e.g., ENTERPRISE, ENTERPRISE_PLUS, or STANDARD)."
+  default     = "STANDARD"
+}
+
+variable "databases" {
+  type = map(object({
+    name                = string
+    deletion_protection = optional(bool, true)
+    iam_members = optional(list(object({
+      role   = string
+      member = string
+    })), [])
+  }))
+  description = "A map of databases to create. Keys are logical names."
+  default     = {}
+}

--- a/modules/database/spanner/versions.tf
+++ b/modules/database/spanner/versions.tf
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+  required_version = "= 1.12.2"
+}

--- a/modules/database/spanner/versions.tf
+++ b/modules/database/spanner/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
   }
   required_version = "= 1.12.2"


### PR DESCRIPTION
Adding a Spanner module for instance, database, and IAM management.

This module provides a standardized way to provision Google Cloud Spanner infrastructure. It supports the creation of Spanner instances and multiple databases within a single declarative block, including automated IAM configuration for database-level access.

Key Changes:

Instance Provisioning: Supports configurable processing units, regional configurations, and instance editions.
Multi-Database Management: Uses a map-based variable to provision multiple databases with individual deletion protection settings.
Automated IAM: Includes logic to flatten and apply IAM member bindings across all created databases, specifically for the roles/spanner.databaseUser role.
Service Enablement: Ensures the spanner.googleapis.com API is enabled in the target project before resource creation.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
