### PR TITLE
adding new scripting module gke-backend-fetcher under community folder.

### DIFF
--- a/community/modules/scripts/gke-backend-fetcher/README.md
+++ b/community/modules/scripts/gke-backend-fetcher/README.md
@@ -1,5 +1,16 @@
 ## Description
 This module fetches the BackendService associated with a GKE Ingress service. It uses a Python script to query the GKE cluster and return the backend service name and ID.
+
+### Software Requirements
+
+* Python 3 (with `json` support)
+* `gcloud` CLI
+* `kubectl` CLI
+
+### Permissions
+
+* Active authentication with permissions to view GKE clusters and Compute backend services.
+
 ### Example
 
 ```yaml

--- a/community/modules/scripts/gke-backend-fetcher/README.md
+++ b/community/modules/scripts/gke-backend-fetcher/README.md
@@ -1,0 +1,74 @@
+## Description
+This module fetches the BackendService associated with a GKE Ingress service. It uses a Python script to query the GKE cluster and return the backend service name and ID.
+### Example
+
+```yaml
+  - id: fetch_http_backend
+    source: community/modules/scripts/gke-backend-fetcher
+    settings:
+      project_id: $(vars.project_id)
+      cluster_name: my-cluster
+      location: us-central1
+      namespace: default
+      service_name: http-service
+      service_port: "8080"
+```
+
+## License
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_external"></a> [external](#provider\_external) | >= 2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [external_external.backend_fetcher](https://registry.terraform.io/providers/hashicorp/external/latest/docs/data-sources/external) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Location (zone or region) of the GKE cluster. | `string` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace where the Ingress is deployed. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID where the GKE cluster and Ingress reside. | `string` | n/a | yes |
+| <a name="input_service_name"></a> [service\_name](#input\_service\_name) | Name of the Kubernetes Service the BackendService is backing (e.g. 'http-service'). | `string` | n/a | yes |
+| <a name="input_service_port"></a> [service\_port](#input\_service\_port) | Port of the Kubernetes Service (e.g. '8080'). | `string` | n/a | yes |
+| <a name="input_timeout_seconds"></a> [timeout\_seconds](#input\_timeout\_seconds) | Maximum time to wait for the backend service to be provisioned (in seconds). | `number` | `600` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_backend_service_id"></a> [backend\_service\_id](#output\_backend\_service\_id) | The dynamically assigned ID of the Google Cloud BackendService. |
+| <a name="output_backend_service_name"></a> [backend\_service\_name](#output\_backend\_service\_name) | The dynamically assigned name of the Google Cloud BackendService. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
+++ b/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
@@ -17,30 +17,47 @@ import sys
 import json
 import subprocess
 import time
-import os
+import shutil
+
+def check_dependencies():
+    missing = []
+    if not shutil.which("gcloud"):
+        missing.append("gcloud")
+    if not shutil.which("kubectl"):
+        missing.append("kubectl")
+    
+    if missing:
+        sys.stderr.write(f"{{\"error\": \"Missing required host dependencies: {', '.join(missing)}. Please install them and ensure they are in your PATH.\"}}\n")
+        sys.exit(1)
+
 def main():
+    check_dependencies()
+
     try:
         input_data = json.loads(sys.stdin.read())
     except Exception as e:
         sys.stderr.write(f"{{\"error\": \"Failed to read stdin: {e}\"}}\n")
         sys.exit(1)
+
     project_id = input_data.get('project_id')
     cluster_name = input_data.get('cluster_name')
     location = input_data.get('location')
     namespace = input_data.get('namespace')
     service_name = input_data.get('service_name')
     service_port = str(input_data.get('service_port'))
-    timeout_seconds = int(input_data.get('timeout_seconds', '120'))
+    timeout_seconds = int(input_data.get('timeout_seconds', '600'))
+
     # Configure kubectl
     subprocess.run([
         'gcloud', 'container', 'clusters', 'get-credentials', cluster_name,
         '--project', project_id, '--region', location
-    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
     pattern = f"-{namespace}-{service_name}-{service_port}-"
-    start_time = time.time()
+    initial_start_time = time.time()
     backend_filter = ""
     
-    while (time.time() - start_time) < timeout_seconds:
+    while (time.time() - initial_start_time) < timeout_seconds:
         try:
             res = subprocess.run(['kubectl', 'get', 'ingress', '-n', namespace, '-o', 'json'], capture_output=True, text=True)
             if res.returncode == 0:
@@ -54,7 +71,7 @@ def main():
                     except json.JSONDecodeError:
                         continue
                     
-                    matching_backends = [k for k in backends.keys() if pattern in k]
+                    matching_backends = [k for k in backends.keys() if pattern in k or f"k8s-be-{service_port}--" in k]
                     
                     if len(matching_backends) == 1:
                         backend_filter = f"name~^{matching_backends[0]}"
@@ -69,13 +86,15 @@ def main():
             pass
             
         time.sleep(10)
+
     if not backend_filter:
         sys.stderr.write(f"{{\"error\": \"Timeout waiting for backend service annotation for {service_name}:{service_port}\"}}\n")
         sys.exit(1)
-    start_time = time.time()
+
     backend_service_id = ""
     real_backend_name = ""
-    while (time.time() - start_time) < timeout_seconds:
+
+    while (time.time() - initial_start_time) < timeout_seconds:
         try:
             res = subprocess.run([
                 'gcloud', 'compute', 'backend-services', 'list',
@@ -95,12 +114,15 @@ def main():
             pass
             
         time.sleep(10)
+
     if not backend_service_id:
         sys.stderr.write("{\"error\": \"Timeout fetching GCP backend service ID\"}\n")
         sys.exit(1)
+
     sys.stdout.write(json.dumps({
         "backend_service_id": str(backend_service_id),
         "backend_service_name": real_backend_name
     }) + "\n")
+
 if __name__ == "__main__":
     main()

--- a/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
+++ b/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import json
+import subprocess
+import time
+import os
+def main():
+    try:
+        input_data = json.loads(sys.stdin.read())
+    except Exception as e:
+        sys.stderr.write(f"{{\"error\": \"Failed to read stdin: {e}\"}}\n")
+        sys.exit(1)
+    project_id = input_data.get('project_id')
+    cluster_name = input_data.get('cluster_name')
+    location = input_data.get('location')
+    namespace = input_data.get('namespace')
+    service_name = input_data.get('service_name')
+    service_port = str(input_data.get('service_port'))
+    timeout_seconds = int(input_data.get('timeout_seconds', '120'))
+    # Configure kubectl
+    subprocess.run([
+        'gcloud', 'container', 'clusters', 'get-credentials', cluster_name,
+        '--project', project_id, '--region', location
+    ], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    pattern = f"-{namespace}-{service_name}-{service_port}-"
+    start_time = time.time()
+    backend_filter = ""
+    
+    while (time.time() - start_time) < timeout_seconds:
+        try:
+            res = subprocess.run(['kubectl', 'get', 'ingress', '-n', namespace, '-o', 'json'], capture_output=True, text=True)
+            if res.returncode == 0:
+                ingresses = json.loads(res.stdout).get('items', [])
+                for ingress in ingresses:
+                    annotations = ingress.get('metadata', {}).get('annotations', {})
+                    backends_str = annotations.get('ingress.kubernetes.io/backends', '{}')
+                    
+                    try:
+                        backends = json.loads(backends_str)
+                    except json.JSONDecodeError:
+                        continue
+                    
+                    matching_backends = [k for k in backends.keys() if pattern in k]
+                    
+                    if len(matching_backends) == 1:
+                        backend_filter = f"name~^{matching_backends[0]}"
+                        break
+                    elif len(matching_backends) > 1:
+                        sys.stderr.write(f"{{\"error\": \"Multiple backend services found for {service_name}:{service_port}\"}}\n")
+                        sys.exit(1)
+            
+            if backend_filter:
+                break
+        except Exception:
+            pass
+            
+        time.sleep(10)
+    if not backend_filter:
+        sys.stderr.write(f"{{\"error\": \"Timeout waiting for backend service annotation for {service_name}:{service_port}\"}}\n")
+        sys.exit(1)
+    start_time = time.time()
+    backend_service_id = ""
+    real_backend_name = ""
+    while (time.time() - start_time) < timeout_seconds:
+        try:
+            res = subprocess.run([
+                'gcloud', 'compute', 'backend-services', 'list',
+                '--project', project_id, f'--filter={backend_filter}', '--format=json'
+            ], capture_output=True, text=True)
+            
+            if res.returncode == 0:
+                services = json.loads(res.stdout)
+                if len(services) == 1:
+                    backend_service_id = services[0].get('id')
+                    real_backend_name = services[0].get('name')
+                    break
+                elif len(services) > 1:
+                    sys.stderr.write(f"{{\"error\": \"Multiple GCP backend services matched filter {backend_filter}\"}}\n")
+                    sys.exit(1)
+        except Exception:
+            pass
+            
+        time.sleep(10)
+    if not backend_service_id:
+        sys.stderr.write("{\"error\": \"Timeout fetching GCP backend service ID\"}\n")
+        sys.exit(1)
+    sys.stdout.write(json.dumps({
+        "backend_service_id": str(backend_service_id),
+        "backend_service_name": real_backend_name
+    }) + "\n")
+if __name__ == "__main__":
+    main()

--- a/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
+++ b/community/modules/scripts/gke-backend-fetcher/fetch_backend.py
@@ -50,7 +50,7 @@ def main():
     # Configure kubectl
     subprocess.run([
         'gcloud', 'container', 'clusters', 'get-credentials', cluster_name,
-        '--project', project_id, '--region', location
+        '--project', project_id, '--location', location
     ], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
     pattern = f"-{namespace}-{service_name}-{service_port}-"

--- a/community/modules/scripts/gke-backend-fetcher/main.tf
+++ b/community/modules/scripts/gke-backend-fetcher/main.tf
@@ -1,0 +1,28 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+data "external" "backend_fetcher" {
+  program = ["python3", "${path.module}/fetch_backend.py"]
+  query = {
+    project_id      = var.project_id
+    cluster_name    = var.cluster_name
+    location        = var.location
+    namespace       = var.namespace
+    service_name    = var.service_name
+    service_port    = var.service_port
+    timeout_seconds = var.timeout_seconds
+  }
+}

--- a/community/modules/scripts/gke-backend-fetcher/metadata.yaml
+++ b/community/modules/scripts/gke-backend-fetcher/metadata.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+spec:
+  requirements:
+    services: []
+ghpc:
+  validators: []

--- a/community/modules/scripts/gke-backend-fetcher/metadata.yaml
+++ b/community/modules/scripts/gke-backend-fetcher/metadata.yaml
@@ -14,6 +14,8 @@
 
 spec:
   requirements:
-    services: []
+    services:
+    - compute.googleapis.com
+    - container.googleapis.com
 ghpc:
   validators: []

--- a/community/modules/scripts/gke-backend-fetcher/outputs.tf
+++ b/community/modules/scripts/gke-backend-fetcher/outputs.tf
@@ -1,0 +1,25 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+output "backend_service_id" {
+  value       = data.external.backend_fetcher.result["backend_service_id"]
+  description = "The dynamically assigned ID of the Google Cloud BackendService."
+}
+
+output "backend_service_name" {
+  value       = data.external.backend_fetcher.result["backend_service_name"]
+  description = "The dynamically assigned name of the Google Cloud BackendService."
+}

--- a/community/modules/scripts/gke-backend-fetcher/variables.tf
+++ b/community/modules/scripts/gke-backend-fetcher/variables.tf
@@ -1,0 +1,51 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "Project ID where the GKE cluster and Ingress reside."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the GKE cluster."
+}
+
+variable "location" {
+  type        = string
+  description = "Location (zone or region) of the GKE cluster."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace where the Ingress is deployed."
+}
+
+variable "service_name" {
+  type        = string
+  description = "Name of the Kubernetes Service the BackendService is backing (e.g. 'http-service')."
+}
+
+variable "service_port" {
+  type        = string
+  description = "Port of the Kubernetes Service (e.g. '8080')."
+}
+
+variable "timeout_seconds" {
+  type        = number
+  description = "Maximum time to wait for the backend service to be provisioned (in seconds)."
+  default     = 600
+}

--- a/community/modules/scripts/gke-backend-fetcher/versions.tf
+++ b/community/modules/scripts/gke-backend-fetcher/versions.tf
@@ -1,0 +1,26 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    external = {
+      source  = "hashicorp/external"
+      version = ">= 2.0"
+    }
+  }
+
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a new module to dynamically discover GCP Backend Service IDs from GKE Ingress.

When a GKE Ingress controller creates a Global Load Balancer, it generates Backend Services with dynamic, non-deterministic names. This makes it difficult to reference these backends in declarative Terraform code (e.g., for applying Identity-Aware Proxy policies).

This module introduces a Python-based utility that queries the GKE cluster's ingress annotations to resolve the mapping between a Kubernetes Service/Port and the corresponding Google Cloud Backend Service ID.

Key Changes:

External Data Provider: Utilizes the Terraform external provider to execute a specialized Python discovery script.
Python Logic: Implements a robust polling loop with a configurable timeout to wait for the GKE Ingress controller to successfully provision the cloud resources and update the ingress annotations.
Credential Handling: The script automatically handles gcloud container clusters get-credentials to ensure kubectl context is available for the lookup.
Output: Provides the backend_service_id and backend_service_name as standard Terraform outputs for consumption by downstream IAM/IAP modules.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
