### PR TITLE
adding a new helm-upgrade module under community folder.

### DIFF
--- a/community/modules/management/helm-upgrade/README.md
+++ b/community/modules/management/helm-upgrade/README.md
@@ -1,0 +1,71 @@
+
+## Description
+This community script module manages Helm chart deployment lifecycles inside a GKE cluster using the raw `helm` CLI binary via a `local-exec` provisioner block.
+It utilizes the **`helm upgrade --install`** flag sequence, meaning it is fully capable of both **installing new charts** for the first time, as well as **upgrading active charts** during multi-stage deployment configurations.
+
+### Production-Ready Dynamic Authentication
+The module handles its own cluster authentication on-the-fly by executing `gcloud container clusters get-credentials` at the start of the provisioner shell block. It does not rely on pre-cached host machine credentials, making it 100% self-sufficient and safe to use inside clean automated CI/CD pipelines (such as Cloud Build).
+
+## Requirements
+The host machine running Terraform must have the following tools available in its `PATH`:
+
+* `gcloud` (Google Cloud SDK)
+* `helm` (Helm CLI binary)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [null_resource.helm_upgrade](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_chart_name"></a> [chart\_name](#input\_chart\_name) | Name of the Helm chart to install or upgrade. | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of the GKE cluster. | `string` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Location (region or zone) of the GKE cluster. | `string` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to install the release into. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID of the GKE cluster. | `string` | n/a | yes |
+| <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Name of the Helm release. | `string` | n/a | yes |
+| <a name="input_set_values"></a> [set\_values](#input\_set\_values) | List of key-value pairs to set in the helm chart. | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | n/a | yes |
+| <a name="input_values_yaml"></a> [values\_yaml](#input\_values\_yaml) | List of paths to values.yaml files to pass to helm upgrade. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_completed"></a> [completed](#output\_completed) | Indicator that the Helm upgrade completed. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/management/helm-upgrade/README.md
+++ b/community/modules/management/helm-upgrade/README.md
@@ -1,4 +1,3 @@
-
 ## Description
 This community script module manages Helm chart deployment lifecycles inside a GKE cluster using the raw `helm` CLI binary via a `local-exec` provisioner block.
 It utilizes the **`helm upgrade --install`** flag sequence, meaning it is fully capable of both **installing new charts** for the first time, as well as **upgrading active charts** during multi-stage deployment configurations.
@@ -6,11 +5,30 @@ It utilizes the **`helm upgrade --install`** flag sequence, meaning it is fully 
 ### Production-Ready Dynamic Authentication
 The module handles its own cluster authentication on-the-fly by executing `gcloud container clusters get-credentials` at the start of the provisioner shell block. It does not rely on pre-cached host machine credentials, making it 100% self-sufficient and safe to use inside clean automated CI/CD pipelines (such as Cloud Build).
 
-## Requirements
+> [!IMPORTANT]
+> **Lifecycle Warning (No Destroy Cleanup)**: Because this module utilizes shell execution hooks outside the standard declarative Terraform state tracking, removing this module block from your blueprint will remove the reference from the state file, but **it will not uninstall the chart release from your cluster**. If you permanently retire this module, you must run `helm uninstall <release_name> --namespace <namespace>` manually via the CLI shell to clear the namespace.
+
+### Software Requirements
 The host machine running Terraform must have the following tools available in its `PATH`:
 
 * `gcloud` (Google Cloud SDK)
 * `helm` (Helm CLI binary)
+
+### Example
+
+```yaml
+  - id: upgrade_my_chart
+    source: community/modules/management/helm-upgrade
+    settings:
+      project_id: $(vars.project_id)
+      cluster_name: my-gke-cluster
+      location: us-central1
+      release_name: my-app
+      chart_name: ./charts/my-app
+      namespace: default
+```
+
+## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC
@@ -60,8 +78,8 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to install the release into. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID of the GKE cluster. | `string` | n/a | yes |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Name of the Helm release. | `string` | n/a | yes |
-| <a name="input_set_values"></a> [set\_values](#input\_set\_values) | List of key-value pairs to set in the helm chart. | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | n/a | yes |
-| <a name="input_values_yaml"></a> [values\_yaml](#input\_values\_yaml) | List of paths to values.yaml files to pass to helm upgrade. | `list(string)` | n/a | yes |
+| <a name="input_set_values"></a> [set\_values](#input\_set\_values) | List of key-value pairs to set in the helm chart. | `any` | `[]` | no |
+| <a name="input_values_yaml"></a> [values\_yaml](#input\_values\_yaml) | List of paths to values.yaml files to pass to helm upgrade. | `any` | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/management/helm-upgrade/README.md
+++ b/community/modules/management/helm-upgrade/README.md
@@ -78,8 +78,8 @@ No modules.
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to install the release into. | `string` | n/a | yes |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID of the GKE cluster. | `string` | n/a | yes |
 | <a name="input_release_name"></a> [release\_name](#input\_release\_name) | Name of the Helm release. | `string` | n/a | yes |
-| <a name="input_set_values"></a> [set\_values](#input\_set\_values) | List of key-value pairs to set in the helm chart. | `any` | `[]` | no |
-| <a name="input_values_yaml"></a> [values\_yaml](#input\_values\_yaml) | List of paths to values.yaml files to pass to helm upgrade. | `any` | `[]` | no |
+| <a name="input_set_values"></a> [set\_values](#input\_set\_values) | List of key-value pairs to set in the helm chart. | `list(object({ name = string, value = any }))` | `[]` | no |
+| <a name="input_values_yaml"></a> [values\_yaml](#input\_values\_yaml) | List of paths to values.yaml files to pass to helm upgrade. | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/community/modules/management/helm-upgrade/main.tf
+++ b/community/modules/management/helm-upgrade/main.tf
@@ -16,15 +16,21 @@
 
 resource "null_resource" "helm_upgrade" {
   triggers = {
-    values = yamlencode(var.set_values)
+    release_name = var.release_name
+    chart_name   = var.chart_name
+    namespace    = var.namespace
+    values_yaml  = join(",", var.values_yaml)
+    set_values   = yamlencode(var.set_values)
   }
+
   provisioner "local-exec" {
     command = <<EOT
-      gcloud container clusters get-credentials ${var.cluster_name} --project ${var.project_id} --region ${var.location}
-      helm upgrade --install ${var.release_name} ${var.chart_name} \
-        --namespace ${var.namespace} --create-namespace \
-        ${join(" ", [for f in var.values_yaml : "--values ${f}"])} \
+      gcloud container clusters get-credentials "${var.cluster_name}" --project "${var.project_id}" --region "${var.location}"
+      helm upgrade --install "${var.release_name}" "${var.chart_name}" \
+        --namespace "${var.namespace}" --create-namespace \
+        ${join(" ", [for f in var.values_yaml : "--values \"${f}\""])} \
         ${join(" ", [for v in var.set_values : "--set '${v.name}=${v.value}'"])}
     EOT
   }
+
 }

--- a/community/modules/management/helm-upgrade/main.tf
+++ b/community/modules/management/helm-upgrade/main.tf
@@ -1,0 +1,30 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+resource "null_resource" "helm_upgrade" {
+  triggers = {
+    values = yamlencode(var.set_values)
+  }
+  provisioner "local-exec" {
+    command = <<EOT
+      gcloud container clusters get-credentials ${var.cluster_name} --project ${var.project_id} --region ${var.location}
+      helm upgrade --install ${var.release_name} ${var.chart_name} \
+        --namespace ${var.namespace} --create-namespace \
+        ${join(" ", [for f in var.values_yaml : "--values ${f}"])} \
+        ${join(" ", [for v in var.set_values : "--set '${v.name}=${v.value}'"])}
+    EOT
+  }
+}

--- a/community/modules/management/helm-upgrade/main.tf
+++ b/community/modules/management/helm-upgrade/main.tf
@@ -21,11 +21,15 @@ resource "null_resource" "helm_upgrade" {
     namespace    = var.namespace
     values_yaml  = join(",", var.values_yaml)
     set_values   = yamlencode(var.set_values)
+    project_id   = var.project_id
+    cluster_name = var.cluster_name
+    location     = var.location
   }
 
   provisioner "local-exec" {
     command = <<EOT
-      gcloud container clusters get-credentials "${var.cluster_name}" --project "${var.project_id}" --region "${var.location}"
+      set -e
+      gcloud container clusters get-credentials "${var.cluster_name}" --project "${var.project_id}" --location "${var.location}"
       helm upgrade --install "${var.release_name}" "${var.chart_name}" \
         --namespace "${var.namespace}" --create-namespace \
         ${join(" ", [for f in var.values_yaml : "--values \"${f}\""])} \

--- a/community/modules/management/helm-upgrade/metadata.yaml
+++ b/community/modules/management/helm-upgrade/metadata.yaml
@@ -1,4 +1,4 @@
-# Copyright 2026 "Google LLC"
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,8 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
 
-name: helm-upgrade
-description: Upgrades or installs a Helm chart on a Kubernetes cluster using local CLI.
-category: management
-provider: local
+spec:
+  requirements:
+    services:
+    - container.googleapis.com
+ghpc:
+  validators: []

--- a/community/modules/management/helm-upgrade/metadata.yaml
+++ b/community/modules/management/helm-upgrade/metadata.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: helm-upgrade
+description: Upgrades or installs a Helm chart on a Kubernetes cluster using local CLI.
+category: management
+provider: local

--- a/community/modules/management/helm-upgrade/outputs.tf
+++ b/community/modules/management/helm-upgrade/outputs.tf
@@ -1,0 +1,20 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+output "completed" {
+  description = "Indicator that the Helm upgrade completed."
+  value       = true
+}

--- a/community/modules/management/helm-upgrade/outputs.tf
+++ b/community/modules/management/helm-upgrade/outputs.tf
@@ -17,4 +17,5 @@
 output "completed" {
   description = "Indicator that the Helm upgrade completed."
   value       = true
+  depends_on  = [null_resource.helm_upgrade]
 }

--- a/community/modules/management/helm-upgrade/variables.tf
+++ b/community/modules/management/helm-upgrade/variables.tf
@@ -46,14 +46,13 @@ variable "namespace" {
 }
 
 variable "values_yaml" {
-  type        = list(string)
+  type        = any
   description = "List of paths to values.yaml files to pass to helm upgrade."
+  default     = []
 }
 
 variable "set_values" {
-  type = list(object({
-    name  = string
-    value = string
-  }))
+  type        = any
   description = "List of key-value pairs to set in the helm chart."
+  default     = []
 }

--- a/community/modules/management/helm-upgrade/variables.tf
+++ b/community/modules/management/helm-upgrade/variables.tf
@@ -1,0 +1,59 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+
+variable "project_id" {
+  type        = string
+  description = "Project ID of the GKE cluster."
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the GKE cluster."
+}
+
+variable "location" {
+  type        = string
+  description = "Location (region or zone) of the GKE cluster."
+}
+
+variable "release_name" {
+  type        = string
+  description = "Name of the Helm release."
+}
+
+variable "chart_name" {
+  type        = string
+  description = "Name of the Helm chart to install or upgrade."
+}
+
+variable "namespace" {
+  type        = string
+  description = "Kubernetes namespace to install the release into."
+}
+
+variable "values_yaml" {
+  type        = list(string)
+  description = "List of paths to values.yaml files to pass to helm upgrade."
+}
+
+variable "set_values" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "List of key-value pairs to set in the helm chart."
+}

--- a/community/modules/management/helm-upgrade/variables.tf
+++ b/community/modules/management/helm-upgrade/variables.tf
@@ -46,13 +46,13 @@ variable "namespace" {
 }
 
 variable "values_yaml" {
-  type        = any
+  type        = list(string)
   description = "List of paths to values.yaml files to pass to helm upgrade."
   default     = []
 }
 
 variable "set_values" {
-  type        = any
+  type        = list(object({ name = string, value = any }))
   description = "List of key-value pairs to set in the helm chart."
   default     = []
 }

--- a/community/modules/management/helm-upgrade/versions.tf
+++ b/community/modules/management/helm-upgrade/versions.tf
@@ -1,0 +1,26 @@
+/**
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.0"
+    }
+  }
+  required_version = "= 1.12.2"
+}


### PR DESCRIPTION
Adding a community module for managing Helm chart lifecycles using the Helm CLI.

This module provides a standardized way to deploy and upgrade Helm charts on GKE by wrapping the helm upgrade --install command within a local-exec provisioner.

While the native Terraform Helm provider is preferred for standard resource management, this CLI-based module is specifically designed for complex orchestration scenarios where direct control over the Helm binary is required or where "zero-touch" dynamic authentication is a priority.

Key Changes:

Dynamic Authentication: The module manages its own cluster connection on-the-fly by executing gcloud container clusters get-credentials at the beginning of the provisioner block. This ensures it is self-sufficient in clean CI/CD environments like Cloud Build.
Unified Lifecycle: Utilizes the --install flag to handle both new installations and version upgrades in a single declarative block.
Flexible Configuration: Supports both local file-based overrides (values_yaml) and dynamic key-value pairs (set_values).
Trigger-based Updates: Uses Terraform triggers to ensure the local-exec block re-runs whenever the set_values configuration is modified.

Requirements:
The host environment executing Terraform must have the gcloud (Google Cloud SDK) and helm CLI binaries installed and available in the system PATH.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
