### PR TITLE
fix: Update wait-for-startup-status.sh to allow for transient lookup failures.

### DIFF
--- a/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
+++ b/community/modules/scripts/wait-for-startup/scripts/wait-for-startup-status.sh
@@ -67,6 +67,7 @@ STARTUP_SCRIPT_SERVICE_FINISHED_LINE="Finished google-startup-scripts.service - 
 
 NON_FATAL_ERRORS=(
 	"Internal error"
+	"SERIAL_PORT_OUTPUT_IN_PROGRESS"
 )
 
 until [[ now -gt deadline ]]; do
@@ -90,7 +91,7 @@ until [[ now -gt deadline ]]; do
 		fi
 	}
 	if [[ -n "${ser_log}" ]]; then break; fi
-	sleep 5
+	sleep 15
 	now=$(date +%s)
 done
 


### PR DESCRIPTION
This pull request improves the startup script monitoring process.
* Error Handling: Added SERIAL_PORT_OUTPUT_IN_PROGRESS to the list of non-fatal errors to prevent premature script termination.
* Polling Interval: Increased the sleep duration between polling attempts from 5 seconds to 15 seconds to improve stability.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
