### PR TITLE
[Telemetry]  Start collecting Telemetry data by adding a new "telemetry" command to GCluster CLI!

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,9 @@ If developing on a mac, a workaround is to install GNU tooling by installing
 
 To help improve Cluster Toolkit, feature usage statistics are collected and sent to Google. You can opt-out at any time by executing the following command:
 
+    ```shell
     ./gcluster telemetry off
+    ```
 
 Cluster Toolkit telemetry overall is handled in accordance with the [Google Privacy Policy](https://policies.google.com/privacy). When you use Cluster Toolkit to interact with or utilize GCP Services, your information is handled in accordance with the [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice).
 

--- a/README.md
+++ b/README.md
@@ -443,9 +443,9 @@ If developing on a mac, a workaround is to install GNU tooling by installing
 
 To help improve Cluster Toolkit, feature usage statistics are collected and sent to Google. You can opt-out at any time by executing the following command:
 
-    ```shell
-    ./gcluster telemetry off
-    ```
+```shell
+./gcluster telemetry off
+```
 
 Cluster Toolkit telemetry overall is handled in accordance with the [Google Privacy Policy](https://policies.google.com/privacy). When you use Cluster Toolkit to interact with or utilize GCP Services, your information is handled in accordance with the [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice).
 

--- a/README.md
+++ b/README.md
@@ -439,6 +439,14 @@ it is not supported for Toolkit development due to GNU specific shell scripts.
 If developing on a mac, a workaround is to install GNU tooling by installing
 `coreutils` and `findutils` from a package manager such as homebrew or conda.
 
+## Privacy notice
+
+To help improve Cluster Toolkit, feature usage statistics are collected and sent to Google. You can opt-out at any time by executing the following command:
+
+    ./gcluster telemetry off
+
+Cluster Toolkit telemetry overall is handled in accordance with the [Google Privacy Policy](https://policies.google.com/privacy). When you use Cluster Toolkit to interact with or utilize GCP Services, your information is handled in accordance with the [Google Cloud Privacy Notice](https://cloud.google.com/terms/cloud-privacy-notice).
+
 ### Contributing
 
 Please refer to the [contributing file](CONTRIBUTING.md) in our GitHub

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var (
 var (
 	InstallationMode   string // Toolkit installation mode like "SOURCE", "BINARY", etc.
 	telemetryCollector *telemetry.Collector
-	userConfigPresent  bool = false
+	userConfigExists   bool = false
 )
 
 var (
@@ -74,7 +74,7 @@ func init() {
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		if err := config.InitUserConfig(); err == nil {
 			telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
-			userConfigPresent = true
+			userConfigExists = true
 		}
 		initColor()
 		initDependencies(cmd)
@@ -134,7 +134,7 @@ Commit info: {{index .Annotations "commitInfo"}}
 		}
 	}
 
-	if config.IsTelemetryEnabled() && userConfigPresent {
+	if config.IsTelemetryEnabled() && userConfigExists {
 		telemetryCollector.Execute(exitCode)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/shell"
+	"hpc-toolkit/pkg/telemetry"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,7 +47,9 @@ var (
 )
 
 var (
-	InstallationMode string // Toolkit installation mode like "SOURCE", "BINARY", etc.
+	InstallationMode   string // Toolkit installation mode like "SOURCE", "BINARY", etc.
+	telemetryCollector *telemetry.Collector
+	userConfigPresent  bool = false
 )
 
 var (
@@ -69,6 +72,10 @@ func init() {
 	addDependenciesFlags(rootCmd.PersistentFlags())
 	addColorFlag(rootCmd.PersistentFlags())
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		if err := config.InitUserConfig(); err == nil {
+			telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
+			userConfigPresent = true
+		}
 		initColor()
 		initDependencies(cmd)
 	}
@@ -113,7 +120,25 @@ Commit info: {{index .Annotations "commitInfo"}}
 		rootCmd.SetVersionTemplate(tmpl)
 	}
 
-	return rootCmd.Execute()
+	err := rootCmd.Execute()
+
+	// Capture Error Code
+	exitCode := 0
+	if err != nil {
+		exitCode = 1 // Default generic error code
+
+		// Attempt to unwrap the specific exit code from the error
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		}
+	}
+
+	if config.IsTelemetryEnabled() && userConfigPresent {
+		telemetryCollector.Execute(exitCode)
+	}
+
+	return err
 }
 
 // checkGitHashMismatch will compare the hash of the git repository vs the git

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,12 +72,12 @@ func init() {
 	addDependenciesFlags(rootCmd.PersistentFlags())
 	addColorFlag(rootCmd.PersistentFlags())
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+		initColor()
+		initDependencies(cmd)
 		if err := config.InitUserConfig(); err == nil {
 			telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
 			userConfigExists = true
 		}
-		initColor()
-		initDependencies(cmd)
 	}
 
 	rootCmd.AddCommand(cluster.ClusterCmd)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -17,10 +17,14 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"hpc-toolkit/pkg/config"
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
@@ -28,6 +32,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/storage/filesystem"
+	"github.com/spf13/cobra"
 	. "gopkg.in/check.v1"
 )
 
@@ -246,4 +251,109 @@ func initTestRepo(path string) (repo *git.Repository, initHash plumbing.Hash, er
 	}
 	_, err = commit("Last")
 	return
+}
+
+func TestExecute_TelemetryAndErrorHandling(t *testing.T) {
+	// Isolate the config directory for tests to prevent modifying the real user config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	t.Setenv("APPDATA", tempDir) // For Windows compatibility
+	t.Setenv("HOME", tempDir)    // For macOS/Linux compatibility
+
+	// Ensure config is initialized and telemetry is explicitly turned OFF
+	// to prevent actual network/telemetry calls during unit tests.
+	_ = config.InitUserConfig()
+	_ = config.SetTelemetry(false)
+
+	// Create a real *exec.ExitError for testing the exit code unwrapping logic
+	execCmd := exec.Command("false")
+	exitErr := execCmd.Run()
+
+	tests := []struct {
+		name        string
+		setupCmd    func() *cobra.Command
+		expectError bool
+		expectedErr error
+	}{
+		{
+			name: "Successful command execution",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{
+					Use: "dummy-success",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return nil // No error
+					},
+				}
+			},
+			expectError: false,
+		},
+		{
+			name: "Generic error execution",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{
+					Use: "dummy-error",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return errors.New("generic error")
+					},
+				}
+			},
+			expectError: true,
+			expectedErr: errors.New("generic error"),
+		},
+		{
+			name: "ExitError execution",
+			setupCmd: func() *cobra.Command {
+				return &cobra.Command{
+					Use: "dummy-exit-error",
+					RunE: func(cmd *cobra.Command, args []string) error {
+						return exitErr // Should unwrap to a specific exit code internally
+					},
+				}
+			},
+			expectError: true,
+			expectedErr: exitErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset global state initialized by PersistentPreRun to ensure clean slates
+			userConfigExists = false
+			telemetryCollector = nil
+
+			// Inject a dummy command to trigger specific error cases
+			dummyCmd := tt.setupCmd()
+			rootCmd.AddCommand(dummyCmd)
+
+			// Set args to invoke the dummy command
+			rootCmd.SetArgs([]string{dummyCmd.Use})
+
+			// Invoke the package-level Execute function
+			err := Execute()
+
+			// 1. Verify Error Handling Passthrough
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected an error but got nil")
+				} else if err.Error() != tt.expectedErr.Error() {
+					t.Errorf("Expected error '%v', got '%v'", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+
+			// 2. Verify PersistentPreRun Initialization Logic
+			if !userConfigExists {
+				t.Errorf("Expected userConfigExists to be true, got false. PersistentPreRun did not execute.")
+			}
+			if telemetryCollector == nil {
+				t.Errorf("Expected telemetryCollector to be initialized, got nil.")
+			}
+
+			// Cleanup dummy command for the next iteration
+			rootCmd.RemoveCommand(dummyCmd)
+		})
+	}
 }

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -1,0 +1,54 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(telemetryCmd)
+}
+
+var telemetryCmd = &cobra.Command{
+	Use:   "telemetry [on|off]",
+	Short: "Enable or disable telemetry",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var enabled bool
+
+		switch strings.ToLower(args[0]) {
+		case "on", "true", "yes", "enable":
+			enabled = true
+			logging.Info("Telemetry has been turned on.")
+		case "off", "false", "no", "disable":
+			enabled = false
+			logging.Info("Telemetry has been turned off.")
+		default:
+			return fmt.Errorf("invalid argument %q: use 'on' or 'off'", args[0])
+		}
+
+		if err := config.SetTelemetry(enabled); err != nil {
+			return err
+		}
+
+		return nil
+	},
+}

--- a/cmd/telemetry.go
+++ b/cmd/telemetry.go
@@ -37,16 +37,20 @@ var telemetryCmd = &cobra.Command{
 		switch strings.ToLower(args[0]) {
 		case "on", "true", "yes", "enable":
 			enabled = true
-			logging.Info("Telemetry has been turned on.")
 		case "off", "false", "no", "disable":
 			enabled = false
-			logging.Info("Telemetry has been turned off.")
 		default:
 			return fmt.Errorf("invalid argument %q: use 'on' or 'off'", args[0])
 		}
 
 		if err := config.SetTelemetry(enabled); err != nil {
 			return err
+		}
+
+		if enabled {
+			logging.Info("Telemetry has been turned on.")
+		} else {
+			logging.Info("Telemetry has been turned off.")
 		}
 
 		return nil

--- a/cmd/telemetry_test.go
+++ b/cmd/telemetry_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"hpc-toolkit/pkg/config"
+)
+
+func TestTelemetryCmd_Logic(t *testing.T) {
+	// Isolate the config directory for tests to prevent modifying the real user config file
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	t.Setenv("APPDATA", tempDir) // For Windows compatibility
+	t.Setenv("HOME", tempDir)    // For macOS/Linux compatibility
+
+	// Initialize the user config to set defaults within the temporary directory
+	err := config.InitUserConfig()
+	if err != nil {
+		t.Fatalf("Failed to initialize user config for tests: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+		expected    bool
+	}{
+		{
+			name:        "Enable using 'on'",
+			args:        []string{"on"},
+			expectError: false,
+			expected:    true,
+		},
+		{
+			name:        "Enable using 'TRUE' (case-insensitive)",
+			args:        []string{"TRUE"},
+			expectError: false,
+			expected:    true,
+		},
+		{
+			name:        "Enable using 'enable'",
+			args:        []string{"enable"},
+			expectError: false,
+			expected:    true,
+		},
+		{
+			name:        "Disable using 'off'",
+			args:        []string{"off"},
+			expectError: false,
+			expected:    false,
+		},
+		{
+			name:        "Disable using 'False' (case-insensitive)",
+			args:        []string{"False"},
+			expectError: false,
+			expected:    false,
+		},
+		{
+			name:        "Disable using 'disable'",
+			args:        []string{"disable"},
+			expectError: false,
+			expected:    false,
+		},
+		{
+			name:        "Invalid argument",
+			args:        []string{"invalid"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Call RunE directly to bypass Cobra's global execution state in loops
+			err := telemetryCmd.RunE(telemetryCmd, tt.args)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+
+				// Verify the configuration was actually updated as expected
+				if config.IsTelemetryEnabled() != tt.expected {
+					t.Errorf("Expected telemetry enabled to be %v, got %v", tt.expected, config.IsTelemetryEnabled())
+				}
+			}
+		})
+	}
+}
+
+func TestTelemetryCmd_ArgsValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectError bool
+	}{
+		{
+			name:        "Valid args",
+			args:        []string{"on"},
+			expectError: false,
+		},
+		{
+			name:        "No arguments",
+			args:        []string{},
+			expectError: true,
+		},
+		{
+			name:        "Too many arguments",
+			args:        []string{"on", "off"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Directly test Cobra's ExactArgs(1) validation configured on the command
+			err := telemetryCmd.Args(telemetryCmd, tt.args)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces a **Telemetry framework to the GCluster CLI** to improve feature usage tracking. It modifies the root command lifecycle to initialize telemetry collection and report execution results, while providing users with a dedicated CLI command to manage their telemetry preferences. The changes also include robust error handling to ensure exit codes are correctly captured and reported.

Changes:

* **Telemetry Framework Integration**: Integrated a telemetry collector into the root command execution flow to capture command usage and exit status.
* **New CLI Command**: Added a 'telemetry' command allowing users to toggle telemetry reporting on or off.
* **Error Handling**: Updated the root command execution to capture and unwrap exit codes from errors, ensuring accurate telemetry reporting.
* **Documentation**: Added a privacy notice to the README detailing telemetry collection and opt-out instructions.

**KINDLY NOTE THAT TELEMETRY DATA IS GOING TO COLLECTED (MARKED AS TEST) AFTER THIS PR IS MERGED TO MAIN BRANCH.**