### PR TITLE
Fix zero-capacity calculation for Regional GKE Node Pools in Kueue

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -508,11 +508,7 @@ func (g *GKEOrchestrator) processNodePoolCapacity(np gkeJobNodePool, location st
 		sa = ""
 	}
 
-	nodeCount := np.InitialNodeCount
-	if np.Autoscaling.Enabled && np.Autoscaling.MaxNodeCount > nodeCount {
-		nodeCount = np.Autoscaling.MaxNodeCount
-	}
-
+	nodeCount := g.getNodeCount(np)
 	nodeLabels = make(map[string]string)
 
 	if nodeCount == 0 {
@@ -558,6 +554,28 @@ func (g *GKEOrchestrator) processNodePoolCapacity(np gkeJobNodePool, location st
 	}
 
 	return cpus, memMb, gpus, tpus, flavor, nodeLabels, sa, nil
+}
+
+func (g *GKEOrchestrator) getNodeCount(np gkeJobNodePool) int {
+	numZones := len(g.clusterZones)
+	if numZones == 0 {
+		numZones = 1
+	}
+
+	nodeCount := np.InitialNodeCount * numZones
+	if np.Autoscaling.Enabled {
+		var maxNodes int
+		if np.Autoscaling.TotalMaxNodeCount > 0 {
+			maxNodes = np.Autoscaling.TotalMaxNodeCount
+		} else {
+			maxNodes = np.Autoscaling.MaxNodeCount * numZones
+		}
+
+		if maxNodes > nodeCount {
+			nodeCount = maxNodes
+		}
+	}
+	return nodeCount
 }
 
 func (g *GKEOrchestrator) processAccelerators(accelerators []gkeAccelerator, nodeCount int, machineType string) (gpus, tpus int, flavor string, nodeLabels map[string]string, err error) {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1612,3 +1612,73 @@ func TestGPUTopologyAwareScheduling(t *testing.T) {
 		t.Errorf("Rendered manifest unexpectedly contains schedulerName")
 	}
 }
+
+func TestGetNodeCount(t *testing.T) {
+	tests := []struct {
+		name      string
+		locations []string
+		np        gkeJobNodePool
+		expected  int
+	}{
+		{
+			name:      "Autoscaling disabled, zonal",
+			locations: []string{"zone-1"},
+			np: gkeJobNodePool{
+				InitialNodeCount: 5,
+				Autoscaling: gkeAutoscaling{
+					Enabled: false,
+				},
+			},
+			expected: 5,
+		},
+		{
+			name:      "Autoscaling disabled, regional",
+			locations: []string{"zone-1", "zone-2", "zone-3"},
+			np: gkeJobNodePool{
+				InitialNodeCount: 5,
+				Autoscaling: gkeAutoscaling{
+					Enabled: false,
+				},
+			},
+			expected: 15,
+		},
+		{
+			name:      "Autoscaling enabled, uses TotalMaxNodeCount",
+			locations: []string{"zone-1", "zone-2", "zone-3"},
+			np: gkeJobNodePool{
+				InitialNodeCount: 5,
+				Autoscaling: gkeAutoscaling{
+					Enabled:           true,
+					MaxNodeCount:      10,
+					TotalMaxNodeCount: 20,
+				},
+			},
+			expected: 20,
+		},
+		{
+			name:      "Autoscaling enabled, falls back to MaxNodeCount (regional)",
+			locations: []string{"zone-1", "zone-2"},
+			np: gkeJobNodePool{
+				InitialNodeCount: 5,
+				Autoscaling: gkeAutoscaling{
+					Enabled:           true,
+					MaxNodeCount:      10,
+					TotalMaxNodeCount: 0,
+				},
+			},
+			expected: 20,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orc := &GKEOrchestrator{
+				clusterZones: tt.locations,
+			}
+			result := orc.getNodeCount(tt.np)
+			if result != tt.expected {
+				t.Errorf("getNodeCount() = %d, expected %d", result, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -204,9 +204,10 @@ type gkeNodePoolConfig struct {
 }
 
 type gkeAutoscaling struct {
-	Enabled      bool `json:"enabled"`
-	MinNodeCount int  `json:"minNodeCount"`
-	MaxNodeCount int  `json:"maxNodeCount"`
+	Enabled           bool `json:"enabled"`
+	MinNodeCount      int  `json:"minNodeCount"`
+	MaxNodeCount      int  `json:"maxNodeCount"`
+	TotalMaxNodeCount int  `json:"totalMaxNodeCount"`
 }
 
 type gkePlacementPolicy struct {


### PR DESCRIPTION
### Problem
When `gcluster` auto-configures Kueue, it inspects the cluster's node pools to calculate the total available capacity (CPUs, Memory, GPUs, TPUs). For regional GKE clusters `with locationPolicy: ANY`, the autoscaling limits are exposed via the `totalMaxNodeCount` field in the GKE API. The orchestrator was previously only checking for `maxNodeCount` (used in zonal clusters). Because `maxNodeCount` is not populated for regional pools, `gcluster` incorrectly calculated a capacity of `0` nodes, resulting in empty Kueue `ClusterQueues` that rejected all submitted workloads.

### Solution:
- Updated the internal `gkeAutoscaling` JSON unmarshaling struct in `types.go` to include the `totalMaxNodeCount` field.
- Modified the `processNodePoolCapacity` function in `gke_job_orchestrator.go` to safely check for and use `TotalMaxNodeCount` if `MaxNodeCount` is `0` or absent.