### PR TITLE
Correctly evaluate Docker credentials prerequisite state

### DIFF
--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -188,6 +188,37 @@ func checkK8sDependencies(state *PrereqState, missing *[]missingPrereq) {
 	}
 }
 
+// isDockerCredsConfigured checks if Docker is configured to use gcloud credentials for the required registries.
+func isDockerCredsConfigured(region string) bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	configPath := filepath.Join(homeDir, ".docker", "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false
+	}
+
+	var config struct {
+		CredHelpers map[string]string `json:"credHelpers"`
+		CredsStore  string            `json:"credsStore"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return false
+	}
+
+	if config.CredsStore == "gcloud" {
+		return true
+	}
+
+	if config.CredHelpers["gcr.io"] != "gcloud" {
+		return false
+	}
+	pkgDevReg := fmt.Sprintf("%s-docker.pkg.dev", region)
+	return config.CredHelpers[pkgDevReg] == "gcloud"
+}
+
 // EnsurePrerequisites checks all necessary gcloud and kubectl prerequisites.
 func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string) error {
 	if dryRunManifest != "" {
@@ -228,8 +259,8 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 	checkK8sDependencies(&state, &missing)
 
 	// Check Docker creds
-	if !state.DockerCredsConfigured {
-		region := shell.ExtractRegion(location)
+	region := shell.ExtractRegion(location)
+	if !isDockerCredsConfigured(region) {
 		missing = append(missing, missingPrereq{
 			name: "Docker Credentials",
 			commands: []string{
@@ -237,6 +268,7 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 				fmt.Sprintf("gcloud auth configure-docker %s-docker.pkg.dev --quiet", region),
 			},
 		})
+	} else {
 		state.DockerCredsConfigured = true
 	}
 

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -190,11 +190,15 @@ func checkK8sDependencies(state *PrereqState, missing *[]missingPrereq) {
 
 // isDockerCredsConfigured checks if Docker is configured to use gcloud credentials for the required registries.
 func isDockerCredsConfigured(region string) bool {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return false
+	configDir := os.Getenv("DOCKER_CONFIG")
+	if configDir == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return false
+		}
+		configDir = filepath.Join(homeDir, ".docker")
 	}
-	configPath := filepath.Join(homeDir, ".docker", "config.json")
+	configPath := filepath.Join(configDir, "config.json")
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		return false
@@ -205,6 +209,7 @@ func isDockerCredsConfigured(region string) bool {
 		CredsStore  string            `json:"credsStore"`
 	}
 	if err := json.Unmarshal(data, &config); err != nil {
+		logging.Error("Failed to unmarshal Docker config from %s: %v", configPath, err)
 		return false
 	}
 
@@ -261,12 +266,13 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 	// Check Docker creds
 	region := shell.ExtractRegion(location)
 	if !isDockerCredsConfigured(region) {
+		cmds := []string{"gcloud auth configure-docker gcr.io --quiet"}
+		if region != "" {
+			cmds = append(cmds, fmt.Sprintf("gcloud auth configure-docker %s-docker.pkg.dev --quiet", region))
+		}
 		missing = append(missing, missingPrereq{
-			name: "Docker Credentials",
-			commands: []string{
-				"gcloud auth configure-docker gcr.io --quiet",
-				fmt.Sprintf("gcloud auth configure-docker %s-docker.pkg.dev --quiet", region),
-			},
+			name:     "Docker Credentials",
+			commands: cmds,
 		})
 	} else {
 		state.DockerCredsConfigured = true

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -320,11 +320,105 @@ func TestEnsureApplicationDefaultCredentials_Failure(t *testing.T) {
 	}
 }
 
+func TestIsDockerCredsConfigured(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	dockerDir := filepath.Join(tempDir, ".docker")
+	configPath := filepath.Join(dockerDir, "config.json")
+
+	tests := []struct {
+		name          string
+		configContent string
+		shouldExist   bool
+		region        string
+		expected      bool
+	}{
+		{
+			name:        "No config file",
+			shouldExist: false,
+			region:      "us-central1",
+			expected:    false,
+		},
+		{
+			name:          "Corrupted config file",
+			configContent: "invalid",
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      false,
+		},
+		{
+			name:          "CredsStore set to gcloud",
+			configContent: `{"credsStore": "gcloud"}`,
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      true,
+		},
+		{
+			name:          "CredHelpers configured correctly",
+			configContent: `{"credHelpers": {"gcr.io": "gcloud", "us-central1-docker.pkg.dev": "gcloud"}}`,
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      true,
+		},
+		{
+			name:          "CredHelpers missing gcr.io",
+			configContent: `{"credHelpers": {"us-central1-docker.pkg.dev": "gcloud"}}`,
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      false,
+		},
+		{
+			name:          "CredHelpers missing regional registry",
+			configContent: `{"credHelpers": {"gcr.io": "gcloud"}}`,
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      false,
+		},
+		{
+			name:          "CredHelpers wrong helper",
+			configContent: `{"credHelpers": {"gcr.io": "desktop", "us-central1-docker.pkg.dev": "gcloud"}}`,
+			shouldExist:   true,
+			region:        "us-central1",
+			expected:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !tt.shouldExist {
+				os.Remove(configPath)
+			} else {
+				if err := os.MkdirAll(dockerDir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(configPath, []byte(tt.configContent), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got := isDockerCredsConfigured(tt.region)
+			if got != tt.expected {
+				t.Errorf("isDockerCredsConfigured() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestEnsurePrerequisites_DockerCreds(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
 	origExecuteCommand := shell.ExecuteCommand
 	defer func() { shell.ExecuteCommand = origExecuteCommand }()
 
 	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
+		if name == "gcloud" && len(args) > 1 && args[0] == "auth" && args[1] == "list" {
+			return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
+		}
+		if name == "gcloud" && len(args) > 1 && args[0] == "services" && args[1] == "list" {
+			return shell.CommandResult{ExitCode: 0, Stdout: "artifactregistry.googleapis.com"}
+		}
 		return shell.CommandResult{ExitCode: 0}
 	}
 


### PR DESCRIPTION
### The Problem
When submitting a job via `gcluster job submit`, the prerequisite check for Docker credentials was getting stuck in a broken state. 
If the user's Docker credentials were not configured, the code would correctly flag the missing prerequisite and populate the `missing` array. It would then update the in-memory state flag (`state.DockerCredsConfigured = true`). However, because the missing array was not empty, the function immediately returned an error and exited before saving the updated state to disk (`~/.gcluster/job_prereq_state.json`). 

  Furthermore, there was no actual logic to dynamically check the user's system to see if the credentials had been configured; it relied entirely on that state file flag. This meant the CLI could never detect if the user had actually run the `gcloud auth configure-docker` commands.

### The Solution
1. Introduced a new function, `isDockerCredsConfigured(region string)`, which actively evaluates the user's system state.
2. The function parses `~/.docker/config.json` and verifies that the `gcloud` credential helper is configured globally via `credsStore`, or specifically for both `"gcr.io"` and `"<region>-docker.pkg.dev"` via `credHelpers`.
3. Updated the `ensurePrerequisites` method to rely on this new dynamic check rather than the flawed state-flag mutation.

### How to Test
1. Remove the `gcloud` credential helpers from your `~/.docker/config.json`.
2. Clear your local state file: `rm ~/.gcluster/job_prereq_state.json`.
3. Run a job submission. Ensure it fails with the correct prompt to run `gcloud auth configure-docker`.
4. Run the suggested `gcloud auth configure-docker ...` commands.
5. Re-run the job submission. The prerequisite check will now pass.