### PR TITLE
Refactoring node flags

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -38,8 +38,8 @@ var (
 
 	workloadName     string
 	kueueQueueName   string
-	numSlicesOrNodes int
-	vmsPerSlice      int
+	numNodes         int
+	numSlices        int
 	restarts         int
 	ttlAfterFinished string
 	gracePeriodStr   string
@@ -111,8 +111,8 @@ func init() {
 
 	SubmitCmd.Flags().StringVarP(&workloadName, "name", "n", "", "Name of the workload to create. Required.")
 	SubmitCmd.Flags().StringVarP(&kueueQueueName, "queue", "q", "", "Name of the Kueue LocalQueue to submit the workload to. If empty, it will be auto-discovered.")
-	SubmitCmd.Flags().IntVar(&numSlicesOrNodes, "nodes", 1, "Number of JobSet replicas (or Slices for TPUs).")
-	SubmitCmd.Flags().IntVar(&vmsPerSlice, "vms-per-slice", 0, "Number of VMs (pods) per slice. Defaults to auto-calculated value for TPUs.")
+	SubmitCmd.Flags().IntVar(&numNodes, "num-nodes", 1, "The number of nodes to use per group/slice. Defaults to 1 for CPU/GPU, or auto-calculated for TPUs.")
+	SubmitCmd.Flags().IntVar(&numSlices, "num-slices", 1, "The number of independent groups/slices to use.")
 	SubmitCmd.Flags().IntVar(&restarts, "restarts", 1, "Maximum number of restarts for the JobSet before failing.")
 	SubmitCmd.Flags().StringVar(&ttlAfterFinished, "gke-ttl-after-finished", "1h", "Time to retain the JobSet after it finishes (e.g. 5m, 1h).")
 	SubmitCmd.Flags().StringVar(&gracePeriodStr, "grace-period", "30s", "Time to wait before forcefully terminating a pod (e.g. 30s, 2m). Gives the workload time to save checkpoints or clean up distributed state during cancellation or preemption events (like Spot VM evictions).")
@@ -179,6 +179,10 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		awaitJobCompletion = true
 	}
 
+	if config.IsTPU(computeType) && cmd.Flags().Changed("num-nodes") {
+		return fmt.Errorf("--num-nodes cannot be used with TPU jobs (it is calculated automatically from topology)")
+	}
+
 	jobDef := orchestrator.JobDefinition{
 		ImageName:                     imageName,
 		BaseImage:                     baseImage,
@@ -192,8 +196,8 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		ClusterLocation:               location,
 		WorkloadName:                  workloadName,
 		KueueQueueName:                kueueQueueName,
-		NumSlices:                     numSlicesOrNodes,
-		VmsPerSlice:                   vmsPerSlice,
+		NumSlices:                     numSlices,
+		VmsPerSlice:                   numNodes,
 		MaxRestarts:                   restarts,
 		TtlSecondsAfterFinished:       ttlSeconds,
 		TerminationGracePeriodSeconds: gracePeriodSeconds,

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -178,6 +178,46 @@ func TestSubmitCmd_RegularDryRun(t *testing.T) {
 	}
 }
 
+func TestSubmitCmd_TPUWithNumNodes_Fails(t *testing.T) {
+	resetSubmitCmdFlags()
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp:         time.Now(),
+			LastCheckedProjectID:         "test-project",
+			GCloudSDKInstalled:           true,
+			GCloudAuthenticated:          true,
+			ADCConfigured:                true,
+			KubectlInstalled:             true,
+			GKEGCloudAuthPluginInstalled: true,
+			DockerCredsConfigured:        true,
+		},
+	}
+
+	output, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "tpu-fail-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--cluster", "test-cluster",
+		"--location", "us-central1-a",
+		"--project", "test-project",
+		"--compute-type", "v6e-8", // TPU type
+		"--num-nodes", "2", // Explicitly set!
+	)
+
+	if err == nil {
+		t.Fatalf("expected error when passing --num-nodes for TPU job, but got nil")
+	}
+
+	expectedErr := "--num-nodes cannot be used with TPU jobs"
+	if !strings.Contains(output, expectedErr) && !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error message to contain %q, got output: %q, err: %v", expectedErr, output, err)
+	}
+}
+
 func resetSubmitCmdFlags() {
 	imageName = ""
 	baseImage = ""
@@ -190,8 +230,8 @@ func resetSubmitCmdFlags() {
 	projectID = ""
 	workloadName = ""
 	kueueQueueName = ""
-	numSlicesOrNodes = 1
-	vmsPerSlice = 1
+	numNodes = 1
+	numSlices = 1
 	restarts = 1
 	ttlAfterFinished = "1h"
 	gracePeriodStr = "30s"

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -110,7 +110,7 @@ Here are the flags currently supported by `gcluster job submit`:
 * `-B, --base-image string`: Name of the base container image for Crane to build upon (e.g., `python:3.9-slim`). Required when using `--build-context` for an on-the-fly build.
 * `-b, --build-context string`: Path to the build context directory for Crane (e.g., `./job_details`). Required with `--base-image`. Crane will package all files in this directory and append them as a new layer to the base image (it does not require or execute a Dockerfile).
 * `-e, --command string`: Command to execute in the container (e.g., `'python app.py'`). This overrides the `CMD` instruction in your `Dockerfile`. (Required)
-* `--compute-type string`: Type of compute to request (e.g., `'n2-standard-32'`, `'nvidia-l4'`, or shorthand strings for TPUs like `v6e-8`). (Required) The tool will resolve the machine type and calculate `vms-per-slice` and `topology` automatically if needed.
+* `--compute-type string`: Type of compute to request (e.g., `'n2-standard-32'`, `'nvidia-l4'`, or shorthand strings for TPUs like `v6e-8`). (Required) The tool will resolve the machine type and calculate `num-nodes` and `topology` automatically if needed.
 * `-o, --dry-run-out string`: Path to output the generated Kubernetes manifest instead of applying it directly to the cluster. Useful for inspection.
 * `-c, --cluster string`: Name of the GKE cluster to deploy the job to. Optional if set in configuration.
 * `-l, --location string`: Location (Zone or Region) of the GKE cluster. Optional if set in configuration.
@@ -118,9 +118,9 @@ Here are the flags currently supported by `gcluster job submit`:
 * `-f, --platform string`: Target platform for the image build (e.g., `linux/amd64`, `linux/arm64`). Used with --base-image. (Default: `linux/amd64`)
 * `-n, --name string`: Name of the job (JobSet) to create. This name will be used for Kubernetes resources. (Required)
 * `--queue string`: Name of the Kueue LocalQueue to submit the job to. (Default: Auto-discovered from the cluster)
-* `--nodes int`: Number of JobSet replicas (slices). (Default: `1`)
-* `--vms-per-slice int`: Number of VMs (pods) per slice. (Default: `1`). Can be auto-calculated for TPUs if `--topology` is provided.
-* `--topology string`: TPU slice topology (e.g., `2x2x1`). Required for total-chip calculation if `--vms-per-slice` is omitted.
+* `--num-slices int`: Number of independent groups/slices to use. (Default: `1`).
+* `--num-nodes int`: Number of nodes to use per group/slice. (Default: `1`). Auto-calculated for TPUs based on topology.
+* `--topology string`: TPU slice topology (e.g., `2x2x1`).
 * `--restarts int`: Maximum number of restarts for the JobSet before failing. (Default: `1`)
 * `--gke-ttl-after-finished string`: Time to retain the JobSet after it finishes (e.g. `5m`, `1h`, `3600`). (Default: `1h`)
 * `--grace-period string`: Time to wait before forcefully terminating a pod (e.g. `30s`, `2m`). Gives the workload time to save checkpoints or clean up distributed state during job cancellation or hardware preemption events (like Spot VM evictions). (Default: `30s`)
@@ -190,6 +190,24 @@ By specifying the `--compute-type` flag, you can use the exact same command to d
     3. Use the compute type installed on the cluster nodes and map the necessary resource requests.
     4. Build a container image from the job_details directory using python:3.9-slim as the base, and push it to Artifact Registry.
     5. Generate and apply an intelligently configured Kubernetes JobSet manifest to your cluster.
+
+* **Example for Multi-Slice GPU Job:**
+    If you want to run a job across multiple groups of GPU nodes (e.g., 2 groups of 4 nodes each), you can use `--num-slices` and `--num-nodes`:
+
+    ```bash
+    ./gcluster job submit \
+      --project <PROJECT_ID> \
+      --cluster <CLUSTER_NAME> \
+      --location <REGION/ZONE> \
+      --image us-docker.pkg.dev/my-project/my-repo/my-image:latest \
+      --command "python train.py" \
+      --name my-gpu-job \
+      --compute-type l4-1 \
+      --num-slices 2 \
+      --num-nodes 4
+    ```
+
+    *This creates a JobSet with 2 replicas, each having 4 pods, totaling 8 nodes.*
 
 ### 7.1 Example: Submit Job with Persistent Storage (Mounting Bucket)
 
@@ -559,8 +577,7 @@ $GCLUSTER job submit \
     --image $IMAGE_NAME \
     --command "cd /app && pip install psutil jaxtyping tiktoken sentencepiece ray fastapi uvicorn portpicker pydantic ninja Pillow gcsfs omegaconf jsonlines PyYAML safetensors tabulate tensorstore transformers datasets evaluate nltk pandas ml_collections ml_dtypes pathwaysutils orbax grain tensorflow_text tensorflow_datasets tqdm && sed -i 's/use_vertex_tensorboard=false/use_vertex_tensorboard=false run_name=llama3-1-v6e8-test1/g' run_maxtext.sh && bash run_maxtext.sh $OUTPUT_DIR" \
     --compute-type v6e-8 \
-    --nodes 1 \
-    --vms-per-slice 2 \
+    --num-slices 1 \
     --topology 2x4 \
     --priority medium \
     --service-account workload-identity-k8s-sa
@@ -812,8 +829,7 @@ $GCLUSTER job submit \
     --image $IMAGE_NAME \
     --command "cd /app && sed -i 's/use_vertex_tensorboard=false/use_vertex_tensorboard=false run_name=llama3-1-7x-test1/g' run_maxtext.sh && bash run_maxtext.sh $OUTPUT_DIR" \
     --compute-type tpu7x-32 \
-    --nodes 1 \
-    --vms-per-slice 8 \
+    --num-slices 1 \
     --topology 2x4x4 \
     --priority medium \
     --service-account workload-identity-k8s-sa

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1396,52 +1396,6 @@ func TestGenerateGKEManifest_DynamicVmsPerSlice(t *testing.T) {
 	}
 }
 
-func TestGenerateGKEManifest_RespectUserVmsPerSlice(t *testing.T) {
-	setupMockMachineConfig(t)
-
-	orc := NewGKEOrchestrator()
-	orc.projectID = "mock-project"
-	mockExec := NewMockExecutor(map[string][]shell.CommandResult{
-		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
-		"kubectl get nodes":           {{ExitCode: 0, Stdout: ""}},
-		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json": {
-			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
-			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`},
-		},
-	})
-	orc.SetExecutor(mockExec)
-	orc.machineTypeClient = &MockMachineTypeClient{Executor: mockExec}
-
-	job := orchestrator.JobDefinition{
-		WorkloadName:    "user-vms-test",
-		CommandToRun:    "echo hello",
-		ClusterLocation: "us-central1-a",
-		AcceleratorType: "v6e-8",
-		Topology:        "16x16",
-		VmsPerSlice:     1, // Explicitly set to 1
-	}
-
-	opts, profile, err := orc.PrepareManifestOptions(job, "test-image:latest")
-	if err != nil {
-		t.Fatalf("prepareManifestOptions failed: %v", err)
-	}
-
-	manifest, err := orc.GenerateGKEManifest(opts, profile)
-	if err != nil {
-		t.Fatalf("GenerateGKEManifest failed: %v", err)
-	}
-
-	expectedParallelism := "parallelism: 1"
-	expectedCompletions := "completions: 1"
-
-	if !strings.Contains(manifest, expectedParallelism) {
-		t.Errorf("manifest missing expected parallelism %q\nManifest: %s", expectedParallelism, manifest)
-	}
-	if !strings.Contains(manifest, expectedCompletions) {
-		t.Errorf("manifest missing expected completions %q\nManifest: %s", expectedCompletions, manifest)
-	}
-}
-
 func TestConfigureClusterEnvironment_AutoCreateQueues(t *testing.T) {
 	pipeRead, pipeWrite, err := os.Pipe()
 	if err != nil {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -339,7 +339,7 @@ func (g *GKEOrchestrator) resolveAmbiguousShorthand(job *orchestrator.JobDefinit
 }
 
 func (g *GKEOrchestrator) dynamicallyCalculateVmsPerSlice(job *orchestrator.JobDefinition, topology, mappedLabel string) error {
-	if job.VmsPerSlice <= 0 && topology != "" && config.IsTPU(mappedLabel) {
+	if config.IsTPU(mappedLabel) && topology != "" {
 		machineType, err := g.resolveMachineName(job.AcceleratorType)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR refactors node and slice related flags for job submission to remove ambiguity and make it easy to map flags to GKE and SLURM orchestrators.

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-8b83c318-7fff-22a0-0653-cc98941d4a47"><div dir="ltr" style="margin-left:0pt;" align="left">
CLI Flag | Concept | GKE (JobSet) Mapping | SLURM Mapping
-- | -- | -- | --
--num-slices | Number of independent groups/slices | replicas | N/A
--num-nodes | Number of VMs per group/slice | parallelism | --nodes (-N)

</div></b><meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-8b83c318-7fff-22a0-0653-cc98941d4a47"><div dir="ltr" style="margin-left:0pt;" align="left">


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
