### PR TITLE
Allow parallel containers for TPU7x

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -44,6 +44,8 @@ var (
 	ttlAfterFinished string
 	gracePeriodStr   string
 
+	gkeDisableParallelContainers bool
+
 	placementPolicy string
 	nodeConstraint  map[string]string
 
@@ -116,6 +118,7 @@ func init() {
 	SubmitCmd.Flags().IntVar(&restarts, "restarts", 1, "Maximum number of restarts for the JobSet before failing.")
 	SubmitCmd.Flags().StringVar(&ttlAfterFinished, "gke-ttl-after-finished", "1h", "Time to retain the JobSet after it finishes (e.g. 5m, 1h).")
 	SubmitCmd.Flags().StringVar(&gracePeriodStr, "grace-period", "30s", "Time to wait before forcefully terminating a pod (e.g. 30s, 2m). Gives the workload time to save checkpoints or clean up distributed state during cancellation or preemption events (like Spot VM evictions).")
+	SubmitCmd.Flags().BoolVar(&gkeDisableParallelContainers, "gke-disable-parallel-containers", false, "Disable parallel containers for TPU v7/v7x on GKE.")
 
 	SubmitCmd.Flags().StringVar(&placementPolicy, "placement-policy", "", "Name of the GKE placement policy to use.")
 	SubmitCmd.Flags().StringToStringVar(&nodeConstraint, "node-constraint", nil, "Key=value pairs for node labels to target specific nodes. Maps to nodeSelector in GKE, and to SLURM's --constraint.")
@@ -210,6 +213,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		Topology:                      topology,
 		GKEScheduler:                  gkeScheduler,
 		AwaitJobCompletion:            awaitJobCompletion,
+		UseParallelContainers:         !gkeDisableParallelContainers,
 		Timeout:                       timeoutStr,
 		PriorityClassName:             priorityClassName,
 		IsPathwaysJob:                 isPathwaysJob,

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -124,6 +124,7 @@ Here are the flags currently supported by `gcluster job submit`:
 * `--restarts int`: Maximum number of restarts for the JobSet before failing. (Default: `1`)
 * `--gke-ttl-after-finished string`: Time to retain the JobSet after it finishes (e.g. `5m`, `1h`, `3600`). (Default: `1h`)
 * `--grace-period string`: Time to wait before forcefully terminating a pod (e.g. `30s`, `2m`). Gives the workload time to save checkpoints or clean up distributed state during job cancellation or hardware preemption events (like Spot VM evictions). (Default: `30s`)
+* `--gke-disable-parallel-containers`: Disable parallel containers for TPU v7/v7x on GKE. (Default: `false`)
 * `--mount stringArray`: Mount a storage volume (format: `<src>:<dest>[:<mode>]`, mode can be `'ro'` or `'rw'`, default `'ro'`). Can be specified multiple times.
 * `--pathways`: If present, gcluster will generate a manifest for a Pathways job.
 * `--pathways-gcs-location string`: Please provide the GCS location to store Pathways artifacts. This flag is required when using --pathways.
@@ -833,6 +834,23 @@ $GCLUSTER job submit \
     --topology 2x4x4 \
     --priority medium \
     --service-account workload-identity-k8s-sa
+```
+
+To disable parallel containers and use a single container per VM, add the `--gke-disable-parallel-containers` flag:
+
+```bash
+$GCLUSTER job submit \
+    --name maxtext-llama3-1-final-tpu7x-32 \
+    --cluster $CLUSTER_NAME \
+    --location $LOCATION \
+    --image $IMAGE_NAME \
+    --command "cd /app && sed -i 's/use_vertex_tensorboard=false/use_vertex_tensorboard=false run_name=llama3-1-7x-test1/g' run_maxtext.sh && bash run_maxtext.sh $OUTPUT_DIR" \
+    --compute-type tpu7x-32 \
+    --nodes 1 \
+    --topology 2x4x4 \
+    --priority medium \
+    --service-account workload-identity-k8s-sa \
+    --gke-disable-parallel-containers
 ```
 
 ### 10.2 Build and Submit

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1173,9 +1173,25 @@ func (g *GKEOrchestrator) prepareJobSetTemplateData(opts ManifestOptions, comman
 		workerArgsList = strings.Fields(opts.Pathways.WorkerArgs)
 	}
 
+	var containers []ContainerData
+	if opts.ParallelContainers > 1 {
+		for i := 0; i < opts.ParallelContainers; i++ {
+			containers = append(containers, ContainerData{
+				Name:          fmt.Sprintf("workload-container-%d", i+1),
+				ResourcesYAML: resourcesYAML,
+			})
+		}
+	} else {
+		containers = append(containers, ContainerData{
+			Name:          "workload-container",
+			ResourcesYAML: resourcesYAML,
+		})
+	}
+
 	return jobSetTemplateData{
 		WorkloadName:                  opts.WorkloadName,
 		ClusterName:                   opts.ClusterName,
+		Containers:                    containers,
 		ProjectID:                     opts.ProjectID,
 		KueueQueueName:                opts.KueueQueueName,
 		TtlSecondsAfterFinished:       opts.TtlSecondsAfterFinished,

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1456,6 +1456,61 @@ func TestGenerateGKEManifest_RespectUserNumNodes(t *testing.T) {
 	}
 }
 
+func TestGenerateGKEManifest_ParallelContainers(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	orc := NewGKEOrchestrator()
+	orc.projectID = "mock-project"
+	mockExec := NewMockExecutor(map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"kubectl get nodes":           {{ExitCode: 0, Stdout: ""}},
+		"gcloud compute machine-types describe tpu7x-standard-4t --zone=us-central1-a --format=json": {
+			{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v7x-slice"}]}`},
+		},
+	})
+	orc.SetExecutor(mockExec)
+	orc.machineTypeClient = &MockMachineTypeClient{Executor: mockExec}
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:          "parallel-container-test",
+		CommandToRun:          "echo hello",
+		ClusterLocation:       "us-central1-a",
+		ComputeType:           "tpu7x-4", // Resolves to tpu7x-standard-4t
+		Topology:              "2x2x1",   // 4 chips
+		UseParallelContainers: true,      // Enable parallel containers
+	}
+
+	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Verify that we have two containers!
+	if !strings.Contains(manifest, "name: workload-container-1") {
+		t.Errorf("manifest missing expected container name %q\nManifest: %s", "workload-container-1", manifest)
+	}
+	if !strings.Contains(manifest, "name: workload-container-2") {
+		t.Errorf("manifest missing expected container name %q\nManifest: %s", "workload-container-2", manifest)
+	}
+
+	// Verify that resources are split!
+	// Total chips = 4. Parallel containers = 2. So each should get 2 chips!
+	expectedResources := "google.com/tpu: \"2\""
+	if strings.Count(manifest, expectedResources) != 2 {
+		t.Errorf("expected %d occurrences of %q, got %d\nManifest: %s", 2, expectedResources, strings.Count(manifest, expectedResources), manifest)
+	}
+}
+
 func TestConfigureClusterEnvironment_AutoCreateQueues(t *testing.T) {
 	pipeRead, pipeWrite, err := os.Pipe()
 	if err != nil {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -20,6 +20,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/orchestrator"
+	"strconv"
 	"strings"
 
 	k8syaml "sigs.k8s.io/yaml"
@@ -190,6 +191,13 @@ func (g *GKEOrchestrator) calculateResourceLimits(opts ManifestOptions, profile 
 	cpuLim, memLim, gpuLim, tpuLim, err := g.calculateGCPMachineResourceLimits(opts, profile, mapped)
 	if err != nil {
 		return "", "", "", "", fmt.Errorf("cluster resolution failed for %s: %w", opts.ComputeType, err)
+	}
+	if opts.ParallelContainers > 1 && tpuLim != "" {
+		tpuInt, err := strconv.Atoi(tpuLim)
+		if err != nil {
+			return "", "", "", "", fmt.Errorf("failed to parse tpu limit %q: %w", tpuLim, err)
+		}
+		tpuLim = strconv.Itoa(tpuInt / opts.ParallelContainers)
 	}
 	return cpuLim, memLim, gpuLim, tpuLim, nil
 }
@@ -414,6 +422,11 @@ func (g *GKEOrchestrator) resolveResourcesAndGates(opts *ManifestOptions, isCPUM
 	profile := JobProfile{
 		IsCPUMachine:  isCPUMachine,
 		CapacityCount: capacity,
+	}
+
+	opts.ParallelContainers = 1
+	if job.UseParallelContainers && config.IsTPU(job.MachineType) && strings.Contains(job.MachineType, "tpu7") {
+		opts.ParallelContainers = 2
 	}
 
 	cpuLimit, memoryLimit, gpuLimit, tpuLimit, err := g.calculateResourceLimits(*opts, profile)

--- a/pkg/orchestrator/gke/templates/jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/jobset.tmpl
@@ -59,16 +59,17 @@ spec:
 {{- end }}
               restartPolicy: Never
               containers:
-              - name: workload-container
-                image: {{.FullImageName}}
+              {{- range .Containers }}
+              - name: {{ .Name }}
+                image: {{ $.FullImageName }}
                 command:
-                {{- range .Command }}
+                {{- range $.Command }}
                 - {{ printf "%q" . }}
                 {{- end }}
-{{.ResourcesYAML}}
+{{ .ResourcesYAML }}
                 env:
-                {{- if .Verbose }}
-                {{- if .IsTPU }}
+                {{- if $.Verbose }}
+                {{- if $.IsTPU }}
                 - name: TPU_STDERR_LOG_LEVEL
                   value: "0"
                 - name: TPU_MIN_LOG_LEVEL
@@ -77,15 +78,16 @@ spec:
                   value: "0"
                 - name: TPU_VMODULE
                   value: "real_program_continuator=1"
-                {{- else if .IsGPU }}
+                {{- else if $.IsGPU }}
                 - name: NCCL_DEBUG
                   value: "INFO"
                 {{- end }}
                 {{- end }}
-{{- if .VolumeMountsYAML }}
+{{- if $.VolumeMountsYAML }}
                 volumeMounts:
-{{.VolumeMountsYAML}}
+{{ $.VolumeMountsYAML }}
 {{- end }}
+              {{- end }}
 {{- if .VolumesYAML }}
               volumes:
 {{.VolumesYAML}}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -140,6 +140,7 @@ type ManifestOptions struct {
 	KueueQueueName                string
 	NumSlices                     int
 	NodesPerSlice                 int
+	ParallelContainers            int
 	MaxRestarts                   int
 	TtlSecondsAfterFinished       int
 	TerminationGracePeriodSeconds int
@@ -245,9 +246,15 @@ type JobSetStatus struct {
 	} `json:"status"`
 }
 
+type ContainerData struct {
+	Name          string
+	ResourcesYAML string
+}
+
 type jobSetTemplateData struct {
 	WorkloadName                  string
 	ClusterName                   string
+	Containers                    []ContainerData
 	ProjectID                     string
 	KueueQueueName                string
 	TtlSecondsAfterFinished       int

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -74,13 +74,14 @@ type JobDefinition struct {
 	PodFailurePolicy   map[string]interface{}
 	RestartOnExitCodes []int
 
-	ImagePullSecrets   string
-	ServiceAccountName string
-	Topology           string
-	GKEScheduler       string
-	AwaitJobCompletion bool
-	Timeout            string
-	PriorityClassName  string
+	ImagePullSecrets      string
+	ServiceAccountName    string
+	Topology              string
+	GKEScheduler          string
+	AwaitJobCompletion    bool
+	UseParallelContainers bool
+	Timeout               string
+	PriorityClassName     string
 
 	// Pathways-specific fields
 	IsPathwaysJob bool


### PR DESCRIPTION
PR enables TPU 7x GKE job submission to create two parallel containers by default. 

Also, added a flag `--gke-disable-parallel-container` to disable this feature if required.

Highlights
* Parallel Container Support: Enabled the creation of two parallel containers by default for TPU v7 and v7x GKE job submissions to improve workload efficiency.
* New Configuration Flag: Introduced the --gke-disable-parallel-containers flag, allowing users to opt-out of the parallel container feature if necessary.
* Resource Management: Updated resource calculation logic to correctly split TPU resources across parallel containers.
* Documentation Updates: Updated the job guide to include the new flag and provided usage examples for disabling parallel containers.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
