### PR TITLE
Output variables and introduce Kueue/Jobset overrides

### DIFF
--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -213,7 +213,7 @@ limitations under the License.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
@@ -223,7 +223,7 @@ limitations under the License.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 7.2 |
 | <a name="provider_http"></a> [http](#provider\_http) | ~> 3.0 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
@@ -232,7 +232,7 @@ limitations under the License.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_configure_kueue"></a> [configure\_kueue](#module\_configure\_kueue) | ./helm_install | n/a |
 | <a name="module_install_asapd_lite"></a> [install\_asapd\_lite](#module\_install\_asapd\_lite) | ./helm_install | n/a |
 | <a name="module_install_gib"></a> [install\_gib](#module\_install\_gib) | ./helm_install | n/a |
@@ -245,7 +245,7 @@ limitations under the License.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [terraform_data.gib_validations](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.initial_gib_version](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
 | [terraform_data.jobset_validations](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
@@ -258,15 +258,15 @@ limitations under the License.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_apply_manifests"></a> [apply\_manifests](#input\_apply\_manifests) | A list of manifests to apply to the GKE cluster using helm\_install. For more details on the underlying deployment mechanism, see the [helm\_install module](helm\_install/README.md). The `enable` input acts as a FF to apply a manifest or not. By default it is always set to `true`. | <pre>list(object({<br/>    name             = optional(string, null)<br/>    enable           = optional(bool, true)<br/>    content          = optional(string, null)<br/>    source           = optional(string, null)<br/>    template_vars    = optional(map(any), null)<br/>    wait_for_rollout = optional(bool, true)<br/>    namespace        = optional(string, null)<br/>  }))</pre> | `[]` | no |
 | <a name="input_asapd_lite"></a> [asapd\_lite](#input\_asapd\_lite) | Install the asapd-lite daemonset for A4X-Max Bare Metal. | <pre>object({<br/>    install              = optional(bool, false)<br/>    config_path          = optional(string, null)<br/>    config_template_vars = optional(map(any), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_cluster_id"></a> [cluster\_id](#input\_cluster\_id) | An identifier for the gke cluster resource with format projects/<project\_id>/locations/<region>/clusters/<name>. | `string` | n/a | yes |
 | <a name="input_gib"></a> [gib](#input\_gib) | Install the NCCL gIB plugin | <pre>object({<br/>    install = bool<br/>    path    = string<br/>    template_vars = object({<br/>      image   = optional(string, "us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib")<br/>      version = string<br/>      node_affinity = optional(any, {<br/>        requiredDuringSchedulingIgnoredDuringExecution = {<br/>          nodeSelectorTerms = [{<br/>            matchExpressions = [{<br/>              key      = "cloud.google.com/gke-gpu",<br/>              operator = "In",<br/>              values   = ["true"]<br/>            }]<br/>          }]<br/>        }<br/>      })<br/>      accelerator_count = number<br/>      max_unavailable   = optional(string, "50%")<br/>    })<br/>  })</pre> | <pre>{<br/>  "install": false,<br/>  "path": "",<br/>  "template_vars": {<br/>    "accelerator_count": 0,<br/>    "version": ""<br/>  }<br/>}</pre> | no |
 | <a name="input_gke_cluster_exists"></a> [gke\_cluster\_exists](#input\_gke\_cluster\_exists) | A static flag that signals to downstream modules that a cluster has been created. | `bool` | `false` | no |
 | <a name="input_gpu_operator"></a> [gpu\_operator](#input\_gpu\_operator) | Install [GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) which uses the [Kubernetes operator](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) to automate the management of all NVIDIA software components needed to provision GPU. | <pre>object({<br/>    install = optional(bool, false)<br/>    version = optional(string, "v25.3.0")<br/>  })</pre> | `{}` | no |
-| <a name="input_jobset"></a> [jobset](#input\_jobset) | Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit. | <pre>object({<br/>    install = optional(bool, false)<br/>    version = optional(string, "0.10.1")<br/>  })</pre> | `{}` | no |
-| <a name="input_kueue"></a> [kueue](#input\_kueue) | Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. A configuration yaml/template file can be provided with config\_path to be applied right after kueue installation. If a template file provided, its variables can be set to config\_template\_vars. | <pre>object({<br/>    # ATTENTION: If you update the KUEUE's default version below, please also update the corresponding<br/>    # defaultKueueVersion constant in pkg/orchestrator/gke/infra_manager.go. (note the 'v' prefix there)<br/>    version                  = optional(string, "0.17.1")<br/>    install                  = optional(bool, false)<br/>    config_path              = optional(string, null)<br/>    config_template_vars     = optional(map(any), null)<br/>    enable_pathways_for_tpus = optional(bool, false)<br/>  })</pre> | `{}` | no |
+| <a name="input_jobset"></a> [jobset](#input\_jobset) | Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit. | <pre>object({<br/>    install           = optional(bool, false)<br/>    version           = optional(string, "0.10.1")<br/>    controller_cpu    = optional(number, null)<br/>    controller_memory = optional(string, null)<br/>  })</pre> | `{}` | no |
+| <a name="input_kueue"></a> [kueue](#input\_kueue) | Install and configure [Kueue](https://kueue.sigs.k8s.io/docs/overview/) workload scheduler. A configuration yaml/template file can be provided with config\_path to be applied right after kueue installation. If a template file provided, its variables can be set to config\_template\_vars. | <pre>object({<br/>    # ATTENTION: If you update the KUEUE's default version below, please also update the corresponding<br/>    # defaultKueueVersion constant in pkg/orchestrator/gke/infra_manager.go. (note the 'v' prefix there)<br/>    version                  = optional(string, "0.17.1")<br/>    install                  = optional(bool, false)<br/>    config_path              = optional(string, null)<br/>    config_template_vars     = optional(map(any), null)<br/>    enable_pathways_for_tpus = optional(bool, false)<br/><br/>    # Kueue controller resources overrides:<br/>    controller_cpu      = optional(number, null)<br/>    controller_memory   = optional(string, null)<br/>    controller_replicas = optional(number, null)<br/><br/>    # Validation section (imported from other modules):<br/>    enable_slice_controller   = optional(bool, false)<br/>    machine_type              = optional(string, null)<br/>    accelerator_topology_mode = optional(string, null)<br/>  })</pre> | `{}` | no |
 | <a name="input_module_id"></a> [module\_id](#input\_module\_id) | The ID of the module as defined in the blueprint. Injected by ghpc. | `string` | `"kubectl-apply"` | no |
 | <a name="input_nvidia_dra_driver"></a> [nvidia\_dra\_driver](#input\_nvidia\_dra\_driver) | Installs [Nvidia DRA driver](https://github.com/NVIDIA/k8s-dra-driver-gpu) which supports Dynamic Resource Allocation for NVIDIA GPUs in Kubernetes | <pre>object({<br/>    install          = optional(bool, false)<br/>    version          = optional(string, "v25.3.0")<br/>    accelerator_type = optional(string, "nvidia-gb200")<br/>  })</pre> | `{}` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The project ID that hosts the gke cluster. | `string` | n/a | yes |

--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -33,6 +33,13 @@ locals {
   ]))
   configure_kueue = local.install_kueue && (try(var.kueue.config_path, "") != "" || try(var.kueue.enable_pathways_for_tpus, false))
 
+  kueue_controller_cpu      = try(var.kueue.controller_cpu, null)
+  kueue_controller_memory   = try(var.kueue.controller_memory, null)
+  kueue_controller_replicas = try(var.kueue.controller_replicas, null)
+
+  jobset_controller_cpu    = try(var.jobset.controller_cpu, null)
+  jobset_controller_memory = try(var.jobset.controller_memory, null)
+
   webhook_wait_duration = "60s"
 
   asapd_lite_config_content = (
@@ -185,7 +192,20 @@ module "install_kueue" {
   namespace        = "kueue-system"
   create_namespace = true
   values_yaml = [
-    file("${path.module}/kueue/kueue-helm-values.yaml")
+    file("${path.module}/kueue/kueue-helm-values.yaml"),
+    yamlencode({
+      controllerManager = merge(
+        local.kueue_controller_replicas != null ? { replicas = local.kueue_controller_replicas } : {},
+        local.kueue_controller_cpu != null || local.kueue_controller_memory != null ? {
+          resources = {
+            requests = merge(
+              local.kueue_controller_cpu != null ? { cpu = local.kueue_controller_cpu } : {},
+              local.kueue_controller_memory != null ? { memory = local.kueue_controller_memory } : {}
+            )
+          }
+        } : {}
+      )
+    })
   ]
 
   dependencies = var.system_node_pool_id != null ? [var.system_node_pool_id] : []
@@ -233,7 +253,19 @@ module "install_jobset" {
   namespace        = "jobset-system"
   create_namespace = true
   values_yaml = [
-    file("${path.module}/jobset/jobset-helm-values.yaml")
+    file("${path.module}/jobset/jobset-helm-values.yaml"),
+    yamlencode({
+      controller = merge(
+        local.jobset_controller_cpu != null || local.jobset_controller_memory != null ? {
+          resources = {
+            requests = merge(
+              local.jobset_controller_cpu != null ? { cpu = local.jobset_controller_cpu } : {},
+              local.jobset_controller_memory != null ? { memory = local.jobset_controller_memory } : {}
+            )
+          }
+        } : {}
+      )
+    })
   ]
   depends_on = [var.gke_cluster_exists, module.configure_kueue]
 }

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -129,6 +129,16 @@ variable "kueue" {
     config_path              = optional(string, null)
     config_template_vars     = optional(map(any), null)
     enable_pathways_for_tpus = optional(bool, false)
+
+    # Kueue controller resources overrides:
+    controller_cpu      = optional(number, null)
+    controller_memory   = optional(string, null)
+    controller_replicas = optional(number, null)
+
+    # Validation section (imported from other modules):
+    enable_slice_controller   = optional(bool, false)
+    machine_type              = optional(string, null)
+    accelerator_topology_mode = optional(string, null)
   })
   default = {}
 }
@@ -142,8 +152,10 @@ variable "gke_cluster_exists" {
 variable "jobset" {
   description = "Install [Jobset](https://github.com/kubernetes-sigs/jobset) which manages a group of K8s [jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/) as a unit."
   type = object({
-    install = optional(bool, false)
-    version = optional(string, "0.10.1")
+    install           = optional(bool, false)
+    version           = optional(string, "0.10.1")
+    controller_cpu    = optional(number, null)
+    controller_memory = optional(string, null)
   })
   default = {}
 }


### PR DESCRIPTION
## Objective
Provide more flexibility for scaling Kueue and Jobset controllers and prepare the module logic for advanced topology validations.

## Changes
- **Controller Overrides:** Introduced new input variables in the `kubectl-apply` module allowing users to explicitly override `controller_cpu`, `controller_memory`, and `controller_replicas` for Kueue, and `controller_cpu` and `controller_memory` for Jobset.
- **Helm Values:** Wired these new inputs into the respective Helm `values_yaml` generation in `main.tf`.
- **Validation Prep:** Exposed variables like `enable_slice_controller`, `machine_type`, and `accelerator_topology_mode` to ensure downstream modules can perform topology validations.
