### PR TITLE
Revert cache-metadata.yml to resolve conflicts

### DIFF
--- a/.github/workflows/cache-metadata.yml
+++ b/.github/workflows/cache-metadata.yml
@@ -1,0 +1,65 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Cache Release Metadata for Telemetry
+
+on:
+  push:
+    tags:
+    - 'v*' # Triggers on any tag starting with 'v'
+
+jobs:
+  update-firestore-cache:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write' # Required for Workload Identity Federation
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: 'projects/266450182917/locations/global/workloadIdentityPools/github-pool/providers/github-provider'
+        service_account: 'cache-metadata@hpc-toolkit-gsc.iam.gserviceaccount.com'
+
+    - name: Extract Tag Name
+      id: extract_tag
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+    - name: Populate Firestore Cache (with up to 3 retries)
+      run: |
+        for i in 1 2 3; do
+          echo "Attempt $i..."
+          if go run tools/cache_metadata/main.go -version ${{ env.VERSION }}; then
+            echo "Success!"
+            exit 0
+          fi
+
+          echo "Attempt $i failed."
+          if [ $i -lt 3 ]; then
+            echo "Waiting 10 seconds before retrying..."
+            sleep 10
+          fi
+        done
+
+        echo "All 3 attempts failed. Aborting."
+        exit 1


### PR DESCRIPTION
[PR ](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5589) removed `.github/workflows/cache-metadata.yml`. We need to revert that change to resolve merge conflicts in Main to Develop [PR](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5613).