### PR TITLE
Fix zone extraction

### DIFF
--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -290,7 +290,7 @@ limitations under the License.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.24.0 |
@@ -299,7 +299,7 @@ limitations under the License.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 7.2 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.24.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
@@ -307,7 +307,7 @@ limitations under the License.
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_dranet_version_compare"></a> [dranet\_version\_compare](#module\_dranet\_version\_compare) | ../../internal/semver_compare | n/a |
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../internal/gpu-definition | n/a |
 | <a name="module_gpu_direct_version_compare"></a> [gpu\_direct\_version\_compare](#module\_gpu\_direct\_version\_compare) | ../../internal/semver_compare | n/a |
@@ -317,7 +317,7 @@ limitations under the License.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
 | [null_resource.enable_tcpx_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.enable_tcpxo_in_workload](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -330,7 +330,7 @@ limitations under the License.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_accelerator_topology_mode"></a> [accelerator\_topology\_mode](#input\_accelerator\_topology\_mode) | The accelerator topology mode for the resource policy. It accepts values like `PROVISION_ONLY` or `AUTO_CONNECT`. Note that `enable_queued_provisioning` (DWS) is not supported when `accelerator_topology_mode` is set to `PROVISION_ONLY`. | `string` | `null` | no |
 | <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for GKE, if any. Providing additional networks adds additional node networks to the node pool | <pre>list(object({<br/>    network            = string<br/>    subnetwork         = string<br/>    subnetwork_project = string<br/>    network_ip         = string<br/>    nic_type           = string<br/>    stack_type         = string<br/>    queue_count        = number<br/>    access_config = list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    }))<br/>    ipv6_access_config = list(object({<br/>      network_tier = string<br/>    }))<br/>    alias_ip_range = list(object({<br/>      ip_cidr_range         = string<br/>      subnetwork_range_name = string<br/>    }))<br/>  }))</pre> | `[]` | no |
 | <a name="input_auto_repair"></a> [auto\_repair](#input\_auto\_repair) | Whether the nodes will be automatically repaired. | `bool` | `true` | no |
@@ -391,7 +391,7 @@ limitations under the License.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_accelerator_topology_mode"></a> [accelerator\_topology\_mode](#output\_accelerator\_topology\_mode) | The accelerator topology mode for the resource policy. |
 | <a name="output_allocatable_cpu_per_node"></a> [allocatable\_cpu\_per\_node](#output\_allocatable\_cpu\_per\_node) | Number of CPUs available for scheduling pods on each node. |
 | <a name="output_allocatable_gpu_per_node"></a> [allocatable\_gpu\_per\_node](#output\_allocatable\_gpu\_per\_node) | Number of GPUs available for scheduling pods on each node. |

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -94,17 +94,12 @@ locals {
   is_valid_reservation = (length(local.verified_specific_reservations) > 0 && length(local.verified_specific_reservations) == length(toset(var.zones != null ? var.zones : []))) || !var.is_reservation_active
 
   # Build the list of reservation names when var.is_reservation_active is true
-  active_reservation_values = [
+  active_reservation_values = distinct([
     for r in local.verified_specific_reservations :
-    "projects/${r.project}/zones/${basename(r.zone)}/reservations/${r.name}${try(local.input_reservation_suffixes[0], "")}"
-  ]
+    "projects/${r.project}/reservations/${r.name}${try(local.input_reservation_suffixes[0], "")}"
+  ])
 
-  default_reservation_values = local.input_specific_reservations_count == 0 ? [] : (
-    length(var.zones != null ? var.zones : []) > 0 ? [
-      for z in toset(var.zones != null ? var.zones : []) :
-      "projects/${local.input_reservation_projects[0]}/zones/${z}/reservations/${local.input_reservation_names[0]}${try(local.input_reservation_suffixes[0], "")}"
-      ] : [
-      "projects/${local.input_reservation_projects[0]}/reservations/${local.input_reservation_names[0]}${try(local.input_reservation_suffixes[0], "")}"
-    ]
-  )
+  default_reservation_values = local.input_specific_reservations_count == 0 ? [] : [
+    "projects/${local.input_reservation_projects[0]}/reservations/${local.input_reservation_names[0]}${try(local.input_reservation_suffixes[0], "")}"
+  ]
 }

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -96,7 +96,7 @@ locals {
   # Build the list of reservation names when var.is_reservation_active is true
   active_reservation_values = [
     for r in local.verified_specific_reservations :
-    "projects/${r.project}/zones/${r.zone}/reservations/${r.name}${try(local.input_reservation_suffixes[0], "")}"
+    "projects/${r.project}/zones/${basename(r.zone)}/reservations/${r.name}${try(local.input_reservation_suffixes[0], "")}"
   ]
 
   default_reservation_values = local.input_specific_reservations_count == 0 ? [] : (


### PR DESCRIPTION
`google_compute_reservation` data source could contain zone as a fully qualified string. This leads to wrong reservation string to be constructed. Adding `basename` fixes this issue and extracts the last part only.