### PR TITLE
correct the nodeselector mapping

### DIFF
--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -26,19 +26,19 @@ import (
 const defaultAcceleratorsPerVM = 4
 
 var tpuFamilyDefaults = map[string]int{
-	"ct5lp":     8, // Default for TPU v5e when suffix is missing
+	"ct5lp":     8, // Default for TPU v5litepod when suffix is missing
 	"v5litepod": 8, // Legacy string literal default
 }
 
 var tpuRegex = regexp.MustCompile(`^v[4-6][ep]?(-\d+)?$`)
 
-var valid2DTPUFamilies = []string{"ct6e", "ct5lp", "v5litepod", "v5-lite", "v5e", "v6e"}
+var valid2DTPUFamilies = []string{"ct6e", "ct5lp", "v5litepod", "v5-lite", "v6e"}
 var valid3DTPUFamilies = []string{"v4", "v5p", "ct4p", "ct5p", "tpu7"}
 
 // AcceleratorShorthandMap maps shorthand names to full machine types.
 // The shorthand notation generally follows the pattern <accelerator>-<suffix>.
 // For TPU v4, the suffix represents the total number of CORES (e.g., "v4-8" has 8 cores = 4 chips).
-// For TPU v5 and v6, the suffix represents the total number of CHIPS (e.g., "v5e-8" has 8 chips).
+// For TPU v5 and v6, the suffix represents the total number of CHIPS (e.g., "v5litepod-8" has 8 chips).
 var AcceleratorShorthandMap = map[string]string{
 	// GPU mappings
 	"l4-1":             "g2-standard-12",
@@ -68,18 +68,17 @@ var AcceleratorShorthandMap = map[string]string{
 	"gb200-4":          "a4x-highgpu-4g",
 
 	// TPU mappings
-	"v4-8":    "ct4p-hightpu-4t",
-	"v5p-1":   "ct5p-hightpu-1t",
-	"v5p-2":   "ct5p-hightpu-2t",
-	"v5p-4":   "ct5p-hightpu-4t",
-	"v5e-1":   "ct5lp-hightpu-1t",
-	"v5e-4":   "ct5lp-hightpu-4t",
-	"v5e-8":   "ct5lp-hightpu-8t",
-	"v6e-1":   "ct6e-standard-1t",
-	"v6e-4":   "ct6e-standard-4t",
-	"v6e-8":   "ct6e-standard-8t",
-	"tpu7x-1": "tpu7x-standard-1t",
-	"tpu7x-4": "tpu7x-standard-4t",
+	"v4-8":        "ct4p-hightpu-4t",
+	"v5p-1":       "ct5p-hightpu-1t",
+	"v5p-2":       "ct5p-hightpu-2t",
+	"v5p-4":       "ct5p-hightpu-4t",
+	"v5litepod-1": "ct5lp-hightpu-1t",
+	"v5litepod-4": "ct5lp-hightpu-4t",
+	"v5litepod-8": "ct5lp-hightpu-8t",
+	"v6e-1":       "ct6e-standard-1t",
+	"v6e-4":       "ct6e-standard-4t",
+	"v6e-8":       "ct6e-standard-8t",
+	"tpu7x":       "tpu7x-standard-4t",
 }
 
 // ValidGPUAccelerators lists valid GPU accelerator types.
@@ -107,7 +106,7 @@ var allowed3DTopologies = map[int]string{
 	2048: "8x16x16",
 }
 
-// 2D topologies for v5e and v6e
+// 2D topologies for v5litepod and v6e
 var allowed2DTopologies = map[int]string{
 	1:   "1x1",
 	4:   "2x2",
@@ -321,7 +320,7 @@ func IsTPU(acceleratorType string) bool {
 	if strings.HasPrefix(resolvedLower, "ct") || strings.Contains(resolvedLower, "tpu") {
 		return true
 	}
-	// Fallback for shorthands not in map that match known TPU versions (v4, v5e, v5p, v6e).
+	// Fallback for shorthands not in map that match known TPU versions (v4, v5litepod, v5p, v6e).
 	// We use a strict regex to avoid matching arbitrary machine types starting with 'v'.
 	return tpuRegex.MatchString(resolvedLower)
 }
@@ -358,13 +357,13 @@ func ResolveTopologyForChips(accelaratorType string) (string, error) {
 		totalChips = totalChips / 2
 	}
 
-	// 3D topologies for v4, v5p, tpu7, tpu7x
+	// 3D topologies for v4, v5p, tpu7x
 	if strings.HasPrefix(resolvedLower, "v4") || strings.HasPrefix(resolvedLower, "v5p") || strings.HasPrefix(resolvedLower, "ct4") || strings.HasPrefix(resolvedLower, "ct5p") || strings.HasPrefix(resolvedLower, "tpu7") {
 		if shape, exists := allowed3DTopologies[totalChips]; exists {
 			return shape, nil
 		}
 	} else {
-		// 2D topologies for v5e and v6e (default)
+		// 2D topologies for v5litepod and v6e (default)
 		if shape, exists := allowed2DTopologies[totalChips]; exists {
 			return shape, nil
 		}

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -66,13 +66,6 @@ func TestCalculateAcceleratorNodes(t *testing.T) {
 			expectErr:     false,
 		},
 		{
-			name:          "v7x 1 chip per VM test",
-			machineType:   "tpu7x-standard-1t",
-			topology:      "1x1x1",
-			expectedNodes: 1, // 1 / 1
-			expectErr:     false,
-		},
-		{
 			name:          "v7x 4 chip per VM test",
 			machineType:   "tpu7x-standard-4t",
 			topology:      "4x4x4",
@@ -331,7 +324,7 @@ func TestResolveTopologyForChips(t *testing.T) {
 		},
 		{
 			name:       "tpu7x 2048 chips",
-			prefix:     "tpu7x-4",
+			prefix:     "tpu7x",
 			totalChips: 2048,
 			wantShape:  "8x16x16",
 			wantErr:    false,
@@ -352,7 +345,7 @@ func TestResolveTopologyForChips(t *testing.T) {
 		},
 		{
 			name:       "tpu7x 1 chip (Fail)",
-			prefix:     "tpu7x-4",
+			prefix:     "tpu7x",
 			totalChips: 1,
 			wantShape:  "",
 			wantErr:    true,
@@ -385,9 +378,9 @@ func TestIsTPU(t *testing.T) {
 		want      bool
 	}{
 		{"v4-8", true},
-		{"v5e-8", true},
+		{"v5litepod-8", true},
 		{"v6e-8", true},
-		{"tpu7x-1", true},
+		{"tpu7x", true},
 		{"ct4p-hightpu-4t", true},
 		{"ct5lp-hightpu-8t", true},
 		{"v5litepod-16", true},
@@ -413,7 +406,7 @@ func TestMatchesTPUFamily(t *testing.T) {
 		want      bool
 	}{
 		{"v6e matches 2D", "v6e-8", valid2DTPUFamilies, true},
-		{"v5e matches 2D", "v5e-8", valid2DTPUFamilies, true},
+		{"v5litepod matches 2D", "v5litepod-8", valid2DTPUFamilies, true},
 		{"v5litepod matches 2D", "v5litepod-16", valid2DTPUFamilies, true},
 		{"l4 does not match 2D", "l4-1", valid2DTPUFamilies, false},
 		{"v4 matches 3D", "v4-8", valid3DTPUFamilies, true},
@@ -435,7 +428,7 @@ func TestResolveMachineType(t *testing.T) {
 		want      string
 	}{
 		{"v4-8", "ct4p-hightpu-4t"},
-		{"v5e-8", "ct5lp-hightpu-8t"},
+		{"v5litepod-8", "ct5lp-hightpu-8t"},
 		{"l4-1", "g2-standard-12"},
 		{"unknown", "unknown"},
 		{"ct4p-hightpu-4t", "ct4p-hightpu-4t"},
@@ -452,7 +445,7 @@ func TestGetCandidatesForShorthand(t *testing.T) {
 		shorthand string
 		want      []string
 	}{
-		{"v5e", []string{"ct5lp-hightpu-1t", "ct5lp-hightpu-4t", "ct5lp-hightpu-8t"}},
+		{"v5litepod", []string{"ct5lp-hightpu-1t", "ct5lp-hightpu-4t", "ct5lp-hightpu-8t"}},
 		{"v4", []string{"ct4p-hightpu-4t"}},
 		{"l4", []string{"g2-standard-12", "g2-standard-24", "g2-standard-48", "g2-standard-96"}},
 		{"unknown", nil},

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1106,13 +1106,14 @@ var machineFamilyToLabelMap = map[string]string{
 	"a2-megagpu":    "nvidia-tesla-a100",
 	"g4-standard":   "nvidia-rtx-pro-6000",
 	"ct6e-standard": "tpu-v6e-slice",
-	"ct5lp-hightpu": "tpu-v5e-slice",
+	"ct5lp-hightpu": "tpu-v5-lite-podslice",
 	"ct5p-hightpu":  "tpu-v5p-slice",
 	"ct4p-hightpu":  "tpu-v4-podslice",
 	"v6e":           "tpu-v6e-slice",
-	"v5e":           "tpu-v5e-slice",
+	"v5litepod":     "tpu-v5-lite-podslice",
 	"v5p":           "tpu-v5p-slice",
 	"v4":            "tpu-v4-podslice",
+	"tpu7x":         "tpu7x",
 	"l4":            "nvidia-l4",
 	"rtx":           "nvidia-rtx-pro-6000",
 }
@@ -1123,7 +1124,7 @@ func (g *GKEOrchestrator) GenerateGKENodeSelectorLabel(acceleratorType string) s
 
 	// Fallback for direct values
 	switch resolvedLower {
-	case "nvidia-tesla-a100", "tpu-v4-podslice", "tpu-v6e-slice", "tpu-v5p-slice", "tpu-v5e-slice":
+	case "nvidia-tesla-a100", "tpu-v4-podslice", "tpu-v6e-slice", "tpu-v5p-slice", "tpu-v5-lite-podslice":
 		return acceleratorType
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1475,9 +1475,9 @@ func TestGenerateGKEManifest_ParallelContainers(t *testing.T) {
 		WorkloadName:          "parallel-container-test",
 		CommandToRun:          "echo hello",
 		ClusterLocation:       "us-central1-a",
-		ComputeType:           "tpu7x-4", // Resolves to tpu7x-standard-4t
-		Topology:              "2x2x1",   // 4 chips
-		UseParallelContainers: true,      // Enable parallel containers
+		ComputeType:           "tpu7x", // Resolves to tpu7x-standard-4t
+		Topology:              "2x2x1", // 4 chips
+		UseParallelContainers: true,    // Enable parallel containers
 	}
 
 	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -54,13 +54,8 @@ func TestResolveMachineName(t *testing.T) {
 			wantErr:         true,
 		},
 		{
-			name:            "TPU7x-1 shorthand mapping",
-			acceleratorType: "tpu7x-1",
-			wantMachineName: "tpu7x-standard-1t",
-		},
-		{
-			name:            "TPU7x-4 shorthand mapping",
-			acceleratorType: "tpu7x-4",
+			name:            "TPU7x shorthand mapping",
+			acceleratorType: "tpu7x",
 			wantMachineName: "tpu7x-standard-4t",
 		},
 	}


### PR DESCRIPTION
This PR Node Selector Mapping Updates: Updated the machine family to label mapping to correctly associate TPU v5e slices and added a new entry for tpu7x support. Edited the accelerator map to accept tpu7x instead of tpu7x-4 as an accelerator type. 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
