### PR TITLE
improvement(job submission): Enhance topology validation for 3D topologies

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -155,9 +155,6 @@ func init() {
 }
 
 func runSubmitCmd(cmd *cobra.Command, args []string) error {
-	if err := config.ValidateHardwareRequest(computeType, topology, placementPolicy); err != nil {
-		return err
-	}
 	ttlSeconds, err := parseDurationToSeconds(ttlAfterFinished, "--gke-ttl-after-finished")
 	if err != nil {
 		return err

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -32,6 +32,16 @@ var tpuFamilyDefaults = map[string]int{
 
 var tpuRegex = regexp.MustCompile(`^v[4-6][ep]?(-\d+)?$`)
 
+type tpu3DConstraints struct {
+	maxCubes int
+}
+
+var tpu3DConstraintsMap = map[string]tpu3DConstraints{
+	"ct4":   {maxCubes: 64},
+	"ct5p":  {maxCubes: 140},
+	"tpu7x": {maxCubes: 144},
+}
+
 var valid2DTPUFamilies = []string{"ct6e", "ct5lp", "v5litepod", "v5-lite", "v6e"}
 var valid3DTPUFamilies = []string{"v4", "v5p", "ct4p", "ct5p", "tpu7"}
 
@@ -92,8 +102,8 @@ var ValidGPUAccelerators = map[string]bool{
 	"nvidia-h100-mega-80gb": true,
 }
 
-// 3D topologies for v4, v5p, tpu7x
-var allowed3DTopologies = map[int]string{
+// 3D topologies for v4, v5p
+var common3DTopologies = map[int]string{
 	4:    "2x2x1",
 	8:    "2x2x2",
 	16:   "2x2x4",
@@ -118,13 +128,9 @@ var allowed2DTopologies = map[int]string{
 	256: "16x16",
 }
 
-var valid3DShapes = make(map[string]bool)
 var valid2DShapes = make(map[string]bool)
 
 func init() {
-	for _, v := range allowed3DTopologies {
-		valid3DShapes[v] = true
-	}
 	for _, v := range allowed2DTopologies {
 		valid2DShapes[v] = true
 	}
@@ -237,9 +243,6 @@ func CalculateAcceleratorNodes(machineType, topology string, acceleratorsPerVM i
 
 	// 2. Identify Accelerators per VM if not provided
 	if acceleratorsPerVM <= 0 {
-		// Resolve shorthand to full machine type if necessary
-		machineType = ResolveMachineType(machineType)
-
 		acceleratorsPerVM = func() int {
 			// Check for explicit accelerators count in machine_type (e.g., "-4t")
 			if idx := strings.LastIndex(machineType, "-"); idx != -1 && strings.HasSuffix(machineType, "t") {
@@ -278,11 +281,9 @@ func ResolveMachineType(acceleratorType string) string {
 }
 
 // matchesTPUFamily returns true if the accelerator type matches any of the given families.
-func matchesTPUFamily(acceleratorType string, families []string) bool {
-	resolved := ResolveMachineType(acceleratorType)
-	resolvedLower := strings.ToLower(resolved)
+func matchesTPUFamily(machineType string, families []string) bool {
 	for _, f := range families {
-		if strings.Contains(resolvedLower, f) {
+		if strings.Contains(machineType, f) {
 			return true
 		}
 	}
@@ -321,65 +322,81 @@ func GetCandidatesForShorthand(shorthand string) []string {
 	return candidates
 }
 
-// ResolveTopologyForChips returns the default topology for a given accelerator and total chips.
-func ResolveTopologyForChips(accelaratorType string) (string, error) {
-	idx := strings.LastIndex(accelaratorType, "-")
-	if idx == -1 {
-		return "", fmt.Errorf("invalid accelerator type format for topology resolution: %s (expected prefix-suffix)", accelaratorType)
+func parseShorthand(accelaratorType string) (size int, err error) {
+	if strings.Count(accelaratorType, "-") != 1 {
+		return 0, fmt.Errorf("invalid accelerator type format for topology resolution: %s (expected prefix-suffix)", accelaratorType)
 	}
-	accelType := accelaratorType[:idx]
-	suffix := accelaratorType[idx+1:]
-	totalChips, err := strconv.Atoi(suffix)
+	if strings.HasPrefix(accelaratorType, "tpu7x") {
+		return 0, fmt.Errorf("for TPU7x, topology should be passed explicitly via --topology flag. It cannot be passed as chip count via compute-type as a suffix (%q). Please use --topology=AxBxC", accelaratorType)
+	}
+
+	parts := strings.Split(accelaratorType, "-")
+	suffix := parts[1]
+	size, err = strconv.Atoi(suffix)
 	if err != nil {
-		return "", fmt.Errorf("invalid chips value for accelerator type %s: %w", accelaratorType, err)
+		if strings.Contains(suffix, "x") {
+			return 0, fmt.Errorf("only total chip count can be passed via compute-type as a suffix (%q). Use --topology flag with full topology string instead", accelaratorType)
+		}
+		return 0, fmt.Errorf("invalid chips value for accelerator type %s: %w", accelaratorType, err)
 	}
-	resolved := ResolveMachineType(accelType)
-	resolvedLower := strings.ToLower(resolved)
 
 	// For TPU v4 (v4-8), the shorthand suffix represents cores. We need to divide by 2 to get chips.
 	if accelaratorType == "v4-8" {
-		totalChips = totalChips / 2
+		size = size / 2
 	}
 
-	// 3D topologies for v4, v5p, tpu7x
-	if strings.HasPrefix(resolvedLower, "v4") || strings.HasPrefix(resolvedLower, "v5p") || strings.HasPrefix(resolvedLower, "ct4") || strings.HasPrefix(resolvedLower, "ct5p") || strings.HasPrefix(resolvedLower, "tpu7") {
-		if shape, exists := allowed3DTopologies[totalChips]; exists {
-			return shape, nil
+	return size, nil
+}
+
+// ResolveTopologyForChips returns the default topology for a given accelerator and total chips.
+func ResolveTopologyForChips(computeType string, machineType string) (string, error) {
+	totalChips, err := parseShorthand(computeType)
+	if err != nil {
+		return "", err
+	}
+
+	// Validate size based on family
+	isPowerOf2 := totalChips >= 1 && (totalChips&(totalChips-1)) == 0 && totalChips != 2
+	if matchesTPUFamily(machineType, valid2DTPUFamilies) {
+		if !(isPowerOf2) {
+			return "", fmt.Errorf("invalid size %d in compute-type %q. Valid sizes are powers of 2, except 2", totalChips, computeType)
 		}
-	} else {
-		// 2D topologies for v5litepod and v6e (default)
 		if shape, exists := allowed2DTopologies[totalChips]; exists {
 			return shape, nil
 		}
+	} else if matchesTPUFamily(machineType, valid3DTPUFamilies) {
+		isMultipleOf64 := totalChips >= 64 && totalChips%64 == 0
+		if !(isPowerOf2 || isMultipleOf64) {
+			return "", fmt.Errorf("invalid size %d in compute-type %q. Valid sizes are powers of 2, or multiples of 64", totalChips, computeType)
+		}
+		if shape, exists := common3DTopologies[totalChips]; exists {
+			return shape, nil
+		}
 	}
 
-	return "", fmt.Errorf("could not find a valid topology shape for %d chips with accelerator %s", totalChips, accelType)
+	return "", fmt.Errorf("could not find a valid topology shape for %d chips with accelerator %s", totalChips, computeType)
 }
 
 // ValidateHardwareRequest validates hardware requests for TPUs.
-func ValidateHardwareRequest(machineType, topology, placementPolicy string) error {
+func ValidateHardwareRequest(machineType, topology string) error {
 	if !IsTPU(machineType) {
 		return nil // Skip for non-TPUs
 	}
 
-	if topology != "" {
-		if err := validateTopologyMeshFormat(topology, machineType); err != nil {
-			return err
-		}
-
-		if matchesTPUFamily(machineType, valid2DTPUFamilies) {
-			if !valid2DShapes[topology] {
-				return fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout for %s", topology, machineType)
-			}
-		} else if matchesTPUFamily(machineType, valid3DTPUFamilies) {
-			if !valid3DShapes[topology] {
-				return fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout for %s", topology, machineType)
-			}
-		} else {
-			return fmt.Errorf("TPU type %q is recognized but its topology family is unknown; please report a bug to the toolkit maintainers.", machineType)
-		}
+	if err := validateTopologyMeshFormat(topology, machineType); err != nil {
+		return err
 	}
-	return nil
+
+	if matchesTPUFamily(machineType, valid2DTPUFamilies) {
+		if !valid2DShapes[topology] {
+			return fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout for %s", topology, machineType)
+		}
+		return nil
+	} else if matchesTPUFamily(machineType, valid3DTPUFamilies) {
+		return validate3DTopology(topology, machineType)
+	} else {
+		return fmt.Errorf("TPU type %q is recognized but its topology family is unknown; please report a bug to the toolkit maintainers.", machineType)
+	}
 }
 
 func validateTopologyMeshFormat(requested string, accelType string) error {
@@ -398,6 +415,53 @@ func validateTopologyMeshFormat(requested string, accelType string) error {
 			return fmt.Errorf("invalid topology dimension footprint val: %s", d)
 		}
 	}
+	return nil
+}
+
+func isValid3DDimension(x int) bool {
+	return x >= 4 && x%4 == 0
+}
+
+func validate3DTopology(topology string, machineType string) error {
+	for _, v := range common3DTopologies {
+		if topology == v {
+			return nil
+		}
+	}
+
+	dims := strings.Split(topology, "x")
+	a, _ := strconv.Atoi(dims[0])
+	b, _ := strconv.Atoi(dims[1])
+	c, _ := strconv.Atoi(dims[2])
+
+	if !isValid3DDimension(a) || !isValid3DDimension(b) || !isValid3DDimension(c) {
+		return fmt.Errorf("topology %s dimensions must be >= 4 and multiples of 4 (unless it is a common base topology)", topology)
+	}
+
+	maxCubes := 0
+	found := false
+
+	for prefix, constraints := range tpu3DConstraintsMap {
+		if strings.HasPrefix(machineType, prefix) {
+			maxCubes = constraints.maxCubes
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("unknown 3D TPU family for machine type %s", machineType)
+	}
+
+	cubes := (a / 4) * (b / 4) * (c / 4)
+	if cubes > maxCubes {
+		return fmt.Errorf("topology %s exceeds max cubes limit of %d (current: %d)", topology, maxCubes, cubes)
+	}
+
+	if !(a <= b && b <= c) {
+		return fmt.Errorf("topology %s dimensions must be in non-decreasing order (A <= B <= C)", topology)
+	}
+
 	return nil
 }
 
@@ -422,16 +486,5 @@ func CheckTopologyContainment(requested, container string, accelType string) (bo
 		}
 	}
 
-	if requested != container {
-		if matchesTPUFamily(accelType, valid2DTPUFamilies) {
-			if !valid2DShapes[requested] {
-				return false, fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout", requested)
-			}
-		} else if matchesTPUFamily(accelType, valid3DTPUFamilies) {
-			if !valid3DShapes[requested] {
-				return false, fmt.Errorf("requested carve footprint layout %s is not an authorized topology subset layout", requested)
-			}
-		}
-	}
 	return true, nil
 }

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -312,8 +312,8 @@ func TestResolveTopologyForChips(t *testing.T) {
 			name:       "tpu7x 2048 chips",
 			prefix:     "tpu7x",
 			totalChips: 2048,
-			wantShape:  "8x16x16",
-			wantErr:    false,
+			wantShape:  "",
+			wantErr:    true,
 		},
 		{
 			name:       "v6e 1 chip",
@@ -347,7 +347,8 @@ func TestResolveTopologyForChips(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ResolveTopologyForChips(fmt.Sprintf("%s-%d", tt.prefix, tt.totalChips))
+			resolvedMachineType := ResolveMachineType(tt.prefix)
+			got, err := ResolveTopologyForChips(fmt.Sprintf("%s-%d", tt.prefix, tt.totalChips), resolvedMachineType)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ResolveTopologyForChips() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -449,25 +450,29 @@ func TestGetCandidatesForShorthand(t *testing.T) {
 
 func TestValidateHardwareRequest(t *testing.T) {
 	tests := []struct {
-		name            string
-		machineType     string
-		topology        string
-		placementPolicy string
-		wantErr         bool
+		name        string
+		machineType string
+		topology    string
+		wantErr     bool
 	}{
-		{"Valid TPU v4", "v4-8", "2x2x1", "", false},
-		{"Valid TPU v6e", "v6e-8", "2x2", "", false},
-		{"Invalid TPU v6e shape", "v6e-8", "3x3", "", true},
-		{"Valid TPU v5litepod", "v5litepod-16", "4x4", "", false},
-		{"Invalid TPU v5litepod shape", "v5litepod-16", "3x3", "", true},
-		{"Invalid TPU v4 dimensions", "v4-8", "2x2", "", true}, // Needs 3D
-		{"Invalid TPU v4 shape", "v4-8", "3x3x3", "", true},
-		{"Unknown TPU family fails", "tpu-v7-8", "2x2x2", "", true},
-		{"Non-TPU skips validation", "l4-1", "invalid", "", false},
+		{"Valid TPU v4", "ct4p-hightpu-4t", "2x2x1", false},
+		{"Valid TPU v6e", "v6e-8", "2x2", false},
+		{"Invalid TPU v6e shape", "v6e-8", "3x3", true},
+		{"Valid TPU v5litepod", "v5litepod-16", "4x4", false},
+		{"Invalid TPU v5litepod shape", "v5litepod-16", "3x3", true},
+		{"Invalid TPU v4 dimensions", "ct4p-hightpu-4t", "2x2", true}, // Needs 3D
+		{"Invalid TPU v4 shape", "ct4p-hightpu-4t", "3x3x3", true},
+		{"Unknown TPU family fails", "tpu-v7-8", "2x2x2", true},
+		{"Non-TPU skips validation", "l4-1", "invalid", false},
+		{"Valid non-standard v4 shape", "ct4p-hightpu-4t", "4x4x12", false},
+		{"Valid non-standard v5p shape", "ct5p-hightpu-4t", "4x4x12", false},
+		{"Invalid v5p shape (unsorted)", "ct5p-hightpu-4t", "4x12x4", true},
+		{"Invalid v4 shape (unsorted)", "ct4p-hightpu-4t", "4x12x4", true},
+		{"Topology exceeding max cubes", "ct4p-hightpu-4t", "16x16x32", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateHardwareRequest(tt.machineType, tt.topology, tt.placementPolicy)
+			err := ValidateHardwareRequest(tt.machineType, tt.topology)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateHardwareRequest() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -533,20 +538,28 @@ func TestCheckTopologyContainment(t *testing.T) {
 			wantErr:   true,
 		},
 		{
-			name:      "V6e invalid subset shape",
+			name:      "V6e invalid subset shape (fits geometrically)",
 			requested: "3x3",
 			container: "4x4",
 			accelType: "v6e",
-			wantFit:   false,
-			wantErr:   true,
+			wantFit:   true,
+			wantErr:   false,
 		},
 		{
-			name:      "V4 invalid subset shape",
+			name:      "V4 invalid subset shape (fits geometrically)",
 			requested: "3x3x3",
 			container: "4x4x4",
 			accelType: "v4",
-			wantFit:   false,
-			wantErr:   true,
+			wantFit:   true,
+			wantErr:   false,
+		},
+		{
+			name:      "V4 valid non-standard subset shape",
+			requested: "4x4x12",
+			container: "4x4x16",
+			accelType: "v4",
+			wantFit:   true,
+			wantErr:   false,
 		},
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -862,10 +862,7 @@ func (g *GKEOrchestrator) queryAllMachineTypes() ([]string, error) {
 	return unique, nil
 }
 
-func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (string, error) {
-	if !config.IsTPU(job.MachineType) {
-		return "", nil // Rejects GPU topologies implicitly
-	}
+func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (string, bool, error) {
 
 	if g.topologyCache == nil {
 		g.topologyCache = make(map[string]string)
@@ -873,29 +870,42 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 
 	cacheKey := job.Topology + ":" + job.MachineType
 	if val, ok := g.topologyCache[cacheKey]; ok {
-		return val, nil
+		isDyn, err := g.verifyDynamicSlicingActive(ManifestOptions{
+			ClusterName:     job.ClusterName,
+			ClusterLocation: job.ClusterLocation,
+			ComputeType:     job.ComputeType,
+		})
+		if err != nil {
+			logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
+		}
+		return val, isDyn, nil
 	}
 
-	top, handled, err := g.resolveDynamicSlicingTopology(job)
+	top, dynSlicing, err := g.resolveDynamicSlicingTopology(job)
 	if err != nil {
-		return "", err
+		return "", dynSlicing, err
 	}
-	if handled {
+	if dynSlicing {
 		g.topologyCache[cacheKey] = top
-		return top, nil
+		return top, dynSlicing, nil
 	}
 
-	if job.Topology != "" {
-		if err := config.ValidateHardwareRequest(job.MachineType, job.Topology, ""); err != nil {
-			return "", err
+	if job.Topology == "" {
+		topo, err := config.ResolveTopologyForChips(job.ComputeType, job.MachineType)
+		if err == nil {
+			logging.Info("Auto-resolved topology %s for shorthand %s", topo, job.ComputeType)
+			job.Topology = topo
+		} else {
+			if !strings.Contains(err.Error(), "invalid accelerator type format") {
+				return "", false, err
+			}
 		}
 	}
 
 	logging.Info("Auto-discovering Topology for %s...", job.MachineType)
-
 	output, err := g.queryDiscoveredTopologies()
 	if err != nil {
-		return "", err
+		return "", false, err
 	}
 
 	topologies := g.parseTopologies(output)
@@ -904,7 +914,7 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 	if err == nil {
 		g.topologyCache[cacheKey] = res
 	}
-	return res, err
+	return res, false, err
 }
 
 func (g *GKEOrchestrator) selectTopology(requested string, topologies map[string]bool, accelType string) (string, error) {
@@ -968,11 +978,15 @@ func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDef
 		return "", false, nil
 	}
 
-	if active, _ := g.verifyDynamicSlicingActive(ManifestOptions{
+	active, err := g.verifyDynamicSlicingActive(ManifestOptions{
 		ClusterName:     job.ClusterName,
 		ClusterLocation: job.ClusterLocation,
 		ComputeType:     job.ComputeType,
-	}); active {
+	})
+	if err != nil {
+		logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
+	}
+	if active {
 		logging.Info("Dynamic-slicing detected. Skipping strict physical state queries for topology.")
 		if job.Topology != "" {
 			dims := strings.Split(job.Topology, "x")

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -188,7 +188,7 @@ func (g *GKEOrchestrator) calculateResourceLimits(opts ManifestOptions, profile 
 
 	mapped := g.GenerateGKENodeSelectorLabel(opts.ComputeType)
 
-	cpuLim, memLim, gpuLim, tpuLim, err := g.calculateGCPMachineResourceLimits(opts, profile, mapped)
+	cpuLim, memLim, gpuLim, tpuLim, err := g.calculateGCPMachineResourceLimits(opts, mapped)
 	if err != nil {
 		return "", "", "", "", fmt.Errorf("cluster resolution failed for %s: %w", opts.ComputeType, err)
 	}
@@ -202,7 +202,7 @@ func (g *GKEOrchestrator) calculateResourceLimits(opts ManifestOptions, profile 
 	return cpuLim, memLim, gpuLim, tpuLim, nil
 }
 
-func (g *GKEOrchestrator) calculateGCPMachineResourceLimits(opts ManifestOptions, profile JobProfile, mapped string) (cpu, mem, gpu, tpu string, err error) {
+func (g *GKEOrchestrator) calculateGCPMachineResourceLimits(opts ManifestOptions, mapped string) (cpu, mem, gpu, tpu string, err error) {
 	machineName := opts.MachineType
 
 	count, err := g.FetchMachineCapacity(machineName, opts.ClusterLocation)
@@ -271,7 +271,6 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 	// 1. Try to resolve as full machine type or direct shorthand match
 	machineName, err = g.resolveMachineName(job.ComputeType)
 	if err != nil {
-		// 2. If resolveMachineName failed, check if it's a multi-node TPU shorthand!
 		prefix := parts[0]
 		candidates := config.GetCandidatesForShorthand(prefix)
 		if len(candidates) == 0 {
@@ -284,38 +283,33 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 		}
 	}
 	job.MachineType = machineName
-
 	isDynamicSlicing := false
 	if config.IsTPU(machineName) {
+		// Validate topology shape before resolving/discovering
+		if job.Topology != "" {
+			if err := config.ValidateHardwareRequest(job.MachineType, job.Topology); err != nil {
+				return JobProfile{}, isDynamicSlicing, err
+			}
+		}
+
 		// 3. Resolve Topology
-		topology, err := g.resolveTopology(job)
+		topology, isDynamicSlicing, err := g.resolveTopology(job)
 		if err != nil {
-			return JobProfile{}, false, err
+			return JobProfile{}, isDynamicSlicing, err
 		}
 		job.Topology = topology
 
 		// 4. Calculate VMs per slice
 		err = g.dynamicallyCalculateNodesPerSlice(job)
 		if err != nil {
-			return JobProfile{}, false, err
-		}
-
-		// 6. Verify dynamic slicing (super-slicing)
-		isDynamicSlicing, err = g.verifyDynamicSlicingActive(ManifestOptions{
-			ClusterName:     job.ClusterName,
-			ClusterLocation: job.ClusterLocation,
-			ComputeType:     job.ComputeType,
-		})
-		if err != nil {
-			logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
-			isDynamicSlicing = false
+			return JobProfile{}, isDynamicSlicing, err
 		}
 	}
 
 	// 5. Determine if CPU machine
 	isCPUMachine, capacity, err := g.determineIfCPUMachine(job)
 	if err != nil {
-		return JobProfile{}, false, err
+		return JobProfile{}, isDynamicSlicing, err
 	}
 
 	return JobProfile{

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -235,12 +235,7 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 		wantTopology    string
 		wantErr         bool
 	}{
-		{
-			name:            "Valid shorthand in map",
-			acceleratorType: "v4-8",
-			wantType:        "ct4p-hightpu-4t", // Resolves to full machine type
-			wantErr:         false,
-		},
+
 		{
 			name:            "Valid full type in map values",
 			acceleratorType: "ct4p-hightpu-4t",
@@ -264,6 +259,27 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 			wantErr:         true,
 		},
 		{
+			name:            "Valid shorthand in map",
+			acceleratorType: "v4-8",
+			nodePools:       []string{"ct4p-hightpu-4t"},
+			wantType:        "ct4p-hightpu-4t",
+			wantTopology:    "2x2x1",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get nodes -o jsonpath": {{ExitCode: 0, Stdout: "2x2x1\n"}},
+			},
+			wantErr: false,
+		},
+		{
+			name:            "Valid shorthand in map fails with conflicting cluster topology",
+			acceleratorType: "v4-8",
+			nodePools:       []string{"ct4p-hightpu-4t"},
+			wantType:        "ct4p-hightpu-4t",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get nodes -o jsonpath": {{ExitCode: 0, Stdout: "16x16\n"}},
+			},
+			wantErr: true,
+		},
+		{
 			name:            "Ambiguous shorthand resolved",
 			acceleratorType: "v6e",
 			nodePools:       []string{"ct6e-standard-8t"},
@@ -282,6 +298,29 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 			wantType:        "ct6e-standard-8t", // Resolves to full machine type
 			wantTopology:    "16x16",
 			wantErr:         false,
+		},
+		{
+			name:            "TPU shorthand with invalid size (not power of 2)",
+			acceleratorType: "v6e-12",
+			wantErr:         true,
+		},
+		{
+			name:            "TPU shorthand with topology suffix fails",
+			acceleratorType: "v6e-4x4",
+			wantErr:         true,
+		},
+		{
+			name:            "TPU shorthand with valid size >= 16",
+			acceleratorType: "v6e-32",
+			nodePools:       []string{"ct6e-standard-8t"},
+			wantType:        "ct6e-standard-8t",
+			wantTopology:    "4x8",
+			wantErr:         false,
+		},
+		{
+			name:            "TPU7x shorthand fails with explicit topology requirement",
+			acceleratorType: "tpu7x-32",
+			wantErr:         true,
 		},
 	}
 


### PR DESCRIPTION
This PR enhances topology validation for 3D topology TPUs.
Also, centralizes TPU topology validation and cleans up hardware configuration logic.

Key Changes:
* Enhanced Validation: Updated the logic of 3D topology resolution from a static map matching to instead validating via rules to allow for all possible topologies to be passed.
* Centralized Validation: Moved ValidateHardwareRequest from submit.go (CLI) to resource_resolver.go (orchestrator). This ensures validation runs on fully resolved machine names.
* Hardware Logic Cleanup: Updated ValidateHardwareRequest in hardware.go to expect resolved names, removed an unused placementPolicy parameter, and fixed a fall-through bug for valid 2D topologies.
* Test Updates: Updated hardware_test.go to use full machine names (e.g., ct4p-hightpu-4t) in test cases to match the new validation flow.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
