### PR TITLE
Add A4x daily test for integrating with custom image

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1619,14 +1619,6 @@ class Lookup:
 
     @cached_property
     def hostname(self):
-        # Fallback to metadata server if socket.gethostname() returns 'localhost'
-        # (which happens on some nodes like Blackwell during early boot).
-        try:
-            name = instance_metadata("name")
-            if name and name != "localhost":
-                return name
-        except Exception:
-            pass
         return socket.gethostname()
 
     @cached_property

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -1619,6 +1619,14 @@ class Lookup:
 
     @cached_property
     def hostname(self):
+        # Fallback to metadata server if socket.gethostname() returns 'localhost'
+        # (which happens on some nodes like Blackwell during early boot).
+        try:
+            name = instance_metadata("name")
+            if name and name != "localhost":
+                return name
+        except Exception:
+            pass
         return socket.gethostname()
 
     @cached_property

--- a/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml
@@ -1,0 +1,397 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+
+blueprint_name: a4xc
+
+vars:
+  test_name: a4xc
+  deployment_name: # supply deployment name
+  project_id: # supply project ID
+  region: # supply region
+  zone: # supply zone
+  a4x_cluster_size: # supply cluster size
+  instance_image_project: # supply instance image project
+  instance_image_family: # supply instance image family
+  # Cluster env settings
+  net0_range: 192.168.0.0/19
+  net1_range: 192.168.64.0/19
+  rdma_net_range: 192.168.128.0/18
+  # Cluster Settings
+  disk_size_gb: 100
+  local_ssd_mountpoint: /mnt/localssd
+  instance_image:
+    project: $(vars.instance_image_project)
+    family: $(vars.instance_image_family)
+  a4x_reservation_name: # supply reservation name
+  base_network_name: $(vars.deployment_name)
+
+deployment_groups:
+- group: cluster-env
+  modules:
+  - id: a4x-slurm-net-0
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.base_network_name)-net-0
+      mtu: 8896
+      enable_internal_traffic: false
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-sub-0
+        subnet_region: $(vars.region)
+        subnet_ip: $(vars.net0_range)
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-0
+        ranges: [$(vars.net0_range)]
+        allow:
+        - protocol: tcp
+        - protocol: udp
+        - protocol: icmp
+
+  - id: a4x-slurm-net-1
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.base_network_name)-net-1
+      mtu: 8896
+      enable_internal_traffic: false
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-sub-1
+        subnet_region: $(vars.region)
+        subnet_ip: $(vars.net1_range)
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal-1
+        ranges: [$(vars.net1_range)]
+        allow:
+        - protocol: tcp
+        - protocol: udp
+        - protocol: icmp
+
+  - id: a4x-slurm-rdma-net
+    source: modules/network/gpu-rdma-vpc
+    settings:
+      network_name: $(vars.base_network_name)-rdma-net
+      network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
+      network_routing_mode: REGIONAL
+      subnetworks_template:
+        name_prefix: $(vars.deployment_name)-mrdma-sub
+        count: 4
+        ip_range: $(vars.rdma_net_range)
+        region: $(vars.region)
+
+  - id: gcs_bucket
+    source: modules/file-system/cloud-storage-bucket
+    settings:
+      enable_hierarchical_namespace: true
+      local_mount: /gcs
+      random_suffix: true
+      mount_options: "implicit_dirs,\
+                      metadata_cache_negative_ttl_secs=0,\
+                      metadata_cache_ttl_secs=-1,\
+                      stat_cache_max_size_mb=-1,\
+                      type_cache_max_size_mb=-1,\
+                      dir_mode=777,\
+                      file_mode=777,\
+                      allow_other"
+
+  - id: gcs_checkpoints
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      remote_mount: $(gcs_bucket.gcs_bucket_name)
+      local_mount: /gcs-checkpoints
+      fs_type: gcsfuse
+      mount_options: "profile=aiml-checkpointing,\
+                      cache_dir=/mnt/localssd,\
+                      dir_mode=777,\
+                      file_mode=777,\
+                      allow_other"
+
+  - id: gcs_training_data
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      remote_mount: $(gcs_bucket.gcs_bucket_name)
+      local_mount: /gcs-training-data
+      fs_type: gcsfuse
+      mount_options: "profile=aiml-training,\
+                      dir_mode=777,\
+                      file_mode=777,\
+                      allow_other"
+
+  - id: gcs_model_serving
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      remote_mount: $(gcs_bucket.gcs_bucket_name)
+      local_mount: /gcs-model-serving
+      fs_type: gcsfuse
+      mount_options: "profile=aiml-serving,\
+                      cache_dir=/mnt/localssd,\
+                      dir_mode=777,\
+                      file_mode=777,\
+                      allow_other"
+
+  - id: a4x_startup
+    source: modules/scripts/startup-script
+    settings:
+      local_ssd_filesystem:
+        mountpoint: $(vars.local_ssd_mountpoint)
+        permissions: "1777"
+      docker:
+        enabled: true
+        world_writable: true
+        daemon_config: |
+          {
+            "data-root": "$(vars.local_ssd_mountpoint)/docker"
+          }
+      runners:
+      - $(gcs_checkpoints.client_install_runner)
+      - $(gcs_checkpoints.mount_runner)
+      - $(gcs_training_data.client_install_runner)
+      - $(gcs_training_data.mount_runner)
+      - $(gcs_model_serving.client_install_runner)
+      - $(gcs_model_serving.mount_runner)
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
+      - type: shell
+        destination: ensure_etc_hostname_created.sh
+        content: |
+          #!/bin/bash
+          hostname -s | sudo tee /etc/hostname > /dev/null
+      - type: data
+        destination: /etc/slurm/plugstack.conf.d/pyxis.conf
+        content: |
+          optional /usr/lib/aarch64-linux-gnu/slurm/spank_pyxis.so
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
+          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
+          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
+      - type: shell
+        destination: install-dcgm.sh
+        content: |
+          #!/bin/bash
+          set -ex -o pipefail
+          URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-keyring_1.1-1_all.deb"
+
+          echo "Downloading keyring from $URL"
+          curl -s -o /tmp/cuda-keyring_1.1-1_all.deb $URL
+          dpkg -i /tmp/cuda-keyring_1.1-1_all.deb
+          rm /tmp/cuda-keyring_1.1-1_all.deb
+
+          apt-get update -y
+          apt-get install -y \
+              datacenter-gpu-manager-4-cuda13 \
+              datacenter-gpu-manager-4-dev \
+              datacenter-gpu-manager-4-core
+
+          apt-mark hold \
+              datacenter-gpu-manager-4-cuda13 \
+              datacenter-gpu-manager-4-dev \
+              datacenter-gpu-manager-4-core
+      - type: ansible-local
+        destination: enable_dcgm.yml
+        content: |
+          ---
+          - name: Enable NVIDIA DCGM on GPU nodes
+            hosts: all
+            become: true
+            vars:
+              enable_ops_agent: true
+              enable_nvidia_dcgm: true
+            tasks:
+            # - name: Ensure datacenter-gpu-manager is installed
+            #   ansible.builtin.apt:
+            #     name: datacenter-gpu-manager
+            #     state: present
+            #     update_cache: yes
+            #   when: enable_nvidia_dcgm
+            - name: Update Ops Agent configuration
+              ansible.builtin.blockinfile:
+                path: /etc/google-cloud-ops-agent/config.yaml
+                insertafter: EOF
+                block: |
+                  metrics:
+                    receivers:
+                      dcgm:
+                        type: dcgm
+                    service:
+                      pipelines:
+                        dcgm:
+                          receivers:
+                            - dcgm
+              notify:
+              - Restart Google Cloud Ops Agent
+            handlers:
+            - name: Restart Google Cloud Ops Agent
+              ansible.builtin.service:
+                name: google-cloud-ops-agent.service
+                state: "{{ 'restarted' if enable_ops_agent else 'stopped' }}"
+                enabled: "{{ enable_ops_agent }}"
+            post_tasks:
+            - name: Enable Google Cloud Ops Agent
+              ansible.builtin.service:
+                name: google-cloud-ops-agent.service
+                state: "{{ 'started' if enable_ops_agent else 'stopped' }}"
+                enabled: "{{ enable_ops_agent }}"
+            - name: Enable NVIDIA DCGM
+              ansible.builtin.service:
+                name: nvidia-dcgm.service
+                state: "{{ 'started' if enable_nvidia_dcgm else 'stopped' }}"
+                enabled: "{{ enable_nvidia_dcgm }}"
+            # Enable persistenced service
+            - name: Enable nvidia-persistenced
+              ansible.builtin.service:
+                name: nvidia-persistenced.service
+                state: started
+                enabled: true
+
+- group: cluster
+  modules:
+  - id: a4x_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [a4x-slurm-net-0, a4x_startup]
+    settings:
+      bandwidth_tier: gvnic_enabled
+      guest_accelerator:
+      - type: nvidia-gb200
+        count: 4
+      machine_type: a4x-highgpu-4g
+      enable_public_ips: true
+      node_count_static: $(vars.a4x_cluster_size)
+      node_count_dynamic_max: 0
+      enable_placement: true
+      accelerator_topology: 1x72
+      disk_type: hyperdisk-balanced
+      instance_image_custom: true
+      on_host_maintenance: TERMINATE
+      reservation_name: $(vars.a4x_reservation_name)
+      advanced_machine_features:
+        threads_per_core: null
+      node_conf:
+        CoresPerSocket: 70
+        SocketsPerBoard: 2
+        ThreadsPerCore: 1
+      additional_networks:
+        $(concat(
+          [{
+            network=null,
+            subnetwork=a4x-slurm-net-1.subnetwork_self_link,
+            subnetwork_project=vars.project_id,
+            nic_type="GVNIC",
+            queue_count=null,
+            network_ip="",
+            stack_type=null,
+            access_config=[],
+            ipv6_access_config=[],
+            alias_ip_range=[]
+          }],
+          a4x-slurm-rdma-net.subnetwork_interfaces
+        ))
+
+  - id: a4x_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use:
+    - a4x_nodeset
+    settings:
+      exclusive: false
+      partition_name: a4x
+      is_default: true
+      partition_conf:
+        OverSubscribe: EXCLUSIVE
+        ResumeTimeout: 3600
+        SuspendTimeout: 600
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use:
+    - a4x-slurm-net-0
+    settings:
+      region: $(vars.region)
+      zone: $(vars.zone)
+      enable_login_public_ips: true
+      instance_image_custom: true
+      disk_type: hyperdisk-balanced
+      machine_type: c4a-standard-4
+
+  - id: controller_startup
+    source: modules/scripts/startup-script
+    settings:
+      runners:
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
+          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
+          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
+      - type: shell
+        destination: stage_scripts.sh
+        content: |
+          #!/bin/bash
+          SLURM_ROOT=/opt/apps/adm/slurm
+          PARTITION_NAME=$(a4x_partition.partitions[0].partition_name)
+          mkdir -m 0755 -p "${SLURM_ROOT}/scripts"
+          # enable a GPU health check that runs at the completion of all jobs on A4X nodes
+          mkdir -p "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d"
+          # ln -s "/slurm/scripts/tools/gpu-test" "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d/gpu-test.epilog_slurmd"
+          # enable the use of password-free sudo within Slurm jobs on all compute nodes
+          # feature is restricted to users with OS Admin Login IAM role
+          # https://cloud.google.com/iam/docs/understanding-roles#compute.osAdminLogin
+          mkdir -p "${SLURM_ROOT}/prolog_slurmd.d"
+          mkdir -p "${SLURM_ROOT}/epilog_slurmd.d"
+          curl -s -o "${SLURM_ROOT}/scripts/sudo-oslogin" \
+              https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/sudo-oslogin
+          chmod 0755 "${SLURM_ROOT}/scripts/sudo-oslogin"
+          ln -s "${SLURM_ROOT}/scripts/sudo-oslogin" "${SLURM_ROOT}/prolog_slurmd.d/sudo-oslogin.prolog_slurmd"
+          # ln -s "${SLURM_ROOT}/scripts/sudo-oslogin" "${SLURM_ROOT}/epilog_slurmd.d/sudo-oslogin.epilog_slurmd"
+          curl -s -o "${SLURM_ROOT}/scripts/imex_prolog" \
+              https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/imex_prolog
+          chmod 0755 "${SLURM_ROOT}/scripts/imex_prolog"
+          ln -s "${SLURM_ROOT}/scripts/imex_prolog" "${SLURM_ROOT}/prolog_slurmd.d/imex_prolog.prolog_slurmd"
+          curl -s -o "${SLURM_ROOT}/scripts/imex_epilog" \
+              https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/imex_epilog
+          chmod 0755 "${SLURM_ROOT}/scripts/imex_epilog"
+          ln -s "${SLURM_ROOT}/scripts/imex_epilog" "${SLURM_ROOT}/epilog_slurmd.d/imex_epilog.epilog_slurmd"
+
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - a4x_partition
+    - a4x-slurm-net-0
+    - gcs_bucket
+    - slurm_login
+    settings:
+      enable_controller_public_ips: true
+      machine_type: c4a-highcpu-16
+      disk_type: hyperdisk-balanced
+      instance_image_custom: true
+      cloud_parameters:
+        prolog_flags: Alloc,DeferBatch,NoHold
+        switch_type: switch/nvidia_imex
+      controller_state_disk: null
+      controller_startup_script: $(controller_startup.startup_script)
+      compute_startup_scripts_timeout: 600
+      enable_external_prolog_epilog: true

--- a/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml
@@ -214,12 +214,6 @@ deployment_groups:
               enable_ops_agent: true
               enable_nvidia_dcgm: true
             tasks:
-            # - name: Ensure datacenter-gpu-manager is installed
-            #   ansible.builtin.apt:
-            #     name: datacenter-gpu-manager
-            #     state: present
-            #     update_cache: yes
-            #   when: enable_nvidia_dcgm
             - name: Update Ops Agent configuration
               ansible.builtin.blockinfile:
                 path: /etc/google-cloud-ops-agent/config.yaml
@@ -355,7 +349,6 @@ deployment_groups:
           mkdir -m 0755 -p "${SLURM_ROOT}/scripts"
           # enable a GPU health check that runs at the completion of all jobs on A4X nodes
           mkdir -p "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d"
-          # ln -s "/slurm/scripts/tools/gpu-test" "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d/gpu-test.epilog_slurmd"
           # enable the use of password-free sudo within Slurm jobs on all compute nodes
           # feature is restricted to users with OS Admin Login IAM role
           # https://cloud.google.com/iam/docs/understanding-roles#compute.osAdminLogin
@@ -365,7 +358,7 @@ deployment_groups:
               https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/sudo-oslogin
           chmod 0755 "${SLURM_ROOT}/scripts/sudo-oslogin"
           ln -s "${SLURM_ROOT}/scripts/sudo-oslogin" "${SLURM_ROOT}/prolog_slurmd.d/sudo-oslogin.prolog_slurmd"
-          # ln -s "${SLURM_ROOT}/scripts/sudo-oslogin" "${SLURM_ROOT}/epilog_slurmd.d/sudo-oslogin.epilog_slurmd"
+          ln -s "${SLURM_ROOT}/scripts/sudo-oslogin" "${SLURM_ROOT}/epilog_slurmd.d/sudo-oslogin.epilog_slurmd"
           curl -s -o "${SLURM_ROOT}/scripts/imex_prolog" \
               https://raw.githubusercontent.com/GoogleCloudPlatform/slurm-gcp/master/tools/prologs-epilogs/imex_prolog
           chmod 0755 "${SLURM_ROOT}/scripts/imex_prolog"

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- slurm6
+- m.schedmd-slurm-gcp-v6-controller
+- m.schedmd-slurm-gcp-v6-login
+- m.schedmd-slurm-gcp-v6-nodeset
+- m.schedmd-slurm-gcp-v6-partition
+- m.startup-script
+- m.vpc
+- m.cloud-storage-bucket
+- m.gpu-rdma-vpc
+- m.pre-existing-network-storage
+
+substitutions:
+  _TEST_PREFIX: "" # Default to no prefix
+
+timeout: 14400s  # 4hr
+steps:
+- id: check_for_running_build
+  name: gcr.io/cloud-builders/gcloud
+  script: "tools/cloud-build/check_running_build.sh tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml"
+
+- id: ml-a4x-highgpu-custom-blueprint-test
+  name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
+  entrypoint: /bin/bash
+  env:
+  - "ANSIBLE_HOST_KEY_CHECKING=false"
+  - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
+  args:
+  - -c
+  - |
+    set -x -e
+    cd /workspace
+    if [ "${_TEST_PREFIX}" == "daily-" ]; then
+        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
+        unzip -o gcluster-bundle.zip
+        # Grant execution permissions to the binary
+        chmod +x gcluster
+    else
+        make
+    fi
+    BUILD_ID_FULL=$BUILD_ID
+    BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
+    REGION=us-west8
+    ZONE=us-west8-a
+
+    BLUEPRINT="/workspace/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml"
+
+    bash tools/add_ttl_label.sh $${BLUEPRINT}
+    sed -i 's/test_name: a4xc/test_name: a4xc'"$${BUILD_ID_SHORT}"'/' $${BLUEPRINT}
+    python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
+
+    ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
+      --extra-vars="test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
+      --extra-vars="region=$${REGION} zone=$${ZONE} "\
+      --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \
+      --extra-vars="instance_image_family=$${CUSTOM_IMAGE_FAMILY}" \
+      --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-custom-blueprint-test.yml"
+  secretEnv: ['GCLUSTER_GCS_PATH', 'CUSTOM_IMAGE_PROJECT', 'CUSTOM_IMAGE_FAMILY']
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
+    env: 'GCLUSTER_GCS_PATH'
+  - versionName: projects/${PROJECT_ID}/secrets/custom-image-project-a4x/versions/latest
+    env: 'CUSTOM_IMAGE_PROJECT'
+  - versionName: projects/${PROJECT_ID}/secrets/custom-image-family-a4x/versions/latest
+    env: 'CUSTOM_IMAGE_FAMILY'

--- a/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-custom-blueprint-test.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-custom-blueprint-test.yml
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+test_name: "a4xc{{ build }}"
+deployment_name: a4xc-{{ build }}
+slurm_cluster_name: "a4xc{{ build[0:4] }}"
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a4x-custom-image-blueprint.yaml"
+login_node: "a4xc{{ build }}-slurm-login-001"
+controller_node: "a4xc{{ build }}-controller"
+network: "{{ test_name }}-1"
+sub_network: "{{ deployment_name }}-sub-0"
+post_deploy_tests:
+- test-validation/test-mounts.yml
+- test-validation/test-partitions.yml
+- test-validation/test-default-partition.yml
+- test-validation/test-enroot.yml
+- test-validation/test-gpus-slurm.yml
+post_destroy_tasks:
+- post-destroy-tasks/delete-image.yml
+custom_vars:
+  gpu_partition: a4x
+  gpu_count: 4
+  partitions:
+  - a4x
+  mounts:
+  - /home
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"
+  a4x_reservation_name: "nvidia-gb200-uyrez5en64cu7"
+  a4x_cluster_size: 2
+  instance_image_project: "{{ instance_image_project }}"
+  instance_image_family: "{{ instance_image_family}}"
+  base_network_name: "{{ test_name }}"


### PR DESCRIPTION
This PR introduces new Slurm cluster blueprints tailored for A4x GPU instances on Google Cloud.

Successful daily test: https://pantheon.corp.google.com/cloud-build/builds/a5e5c54d-a240-479c-ab44-a3f9bd5bcf94?project=hpc-toolkit-dev&e=13802955&mods=monitoring_api_prod

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
