### PR TITLE
Handle empty `machine_type` in TPU reservations

### DIFF
--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -77,7 +77,10 @@ locals {
   # Compare two maps by counting the keys that mismatch.
   # Know that in map comparison the order of keys does not matter. That is {NVME: x, SCSI: y} and {SCSI: y, NVME: x} are equal
   # As of this writing, there is only one reservation supported by the Node Pool API. So, directly accessing it from the list
-  specific_reservation_requirement_violations = length(local.reservation_vm_properties) == 0 ? [] : [for k, v in local.nodepool_vm_properties : k if v != local.reservation_vm_properties[0][k]]
+  specific_reservation_requirement_violations = length(local.reservation_vm_properties) == 0 ? [] : [
+    for k, v in local.nodepool_vm_properties : k
+    if v != local.reservation_vm_properties[0][k] && try(local.reservation_vm_properties[0][k] != "", true)
+  ]
 
   specific_reservation_requirement_violation_messages = {
     "machine_type" : <<-EOT


### PR DESCRIPTION
### **Problem**
When using TPU reservations, the `machine_type` (and potentially other properties) in the reservation definitions can sometimes be empty. The module's validation logic previously compared the node pool's VM properties directly against the reservation's properties. If the reservation property was an empty string but the node pool property was not, it incorrectly flagged this as a reservation requirement violation, preventing successful provisioning or causing false validation errors.

### **Solution**
Updated the `specific_reservation_requirement_violations` logic in `modules/compute/gke-node-pool/reservation_definitions.tf` to ignore property mismatch checks when the value coming from the reservation (`local.reservation_vm_properties`) is an empty string. This ensures that empty reservation properties, such as those sometimes encountered with TPU reservations, do not trigger false validation violations.