### PR TITLE
fix: Add tpu_topology conditional logic for TPU flex start 

### DIFF
--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -197,7 +197,15 @@ func injectCompactPlacementPolicy(mod *Module, tpuTopologyStr string) {
 	}
 	ppMap["type"] = cty.StringVal("COMPACT")
 	if tpuTopologyStr != "" {
-		ppMap["tpu_topology"] = cty.StringVal(tpuTopologyStr)
+		if origTopo, ok := ppMap["tpu_topology"]; ok {
+			if _, isExpr := IsExpressionValue(origTopo); isExpr {
+				// Keep the original expression to avoid breaking validators
+			} else {
+				ppMap["tpu_topology"] = cty.StringVal(tpuTopologyStr)
+			}
+		} else {
+			ppMap["tpu_topology"] = cty.StringVal(tpuTopologyStr)
+		}
 	}
 	mod.Settings = mod.Settings.With("placement_policy", cty.ObjectVal(ppMap))
 }
@@ -222,6 +230,13 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 
 	if !IsTPU(mtStr) {
 		return nil
+	}
+
+	if mod.Settings.Has("enable_flex_start") {
+		val, err := bp.Eval(mod.Settings.Get("enable_flex_start"))
+		if err == nil && val.Type() == cty.Bool && val.True() {
+			return nil
+		}
 	}
 
 	nodes, err := CalculateAcceleratorNodes(mtStr, tpuTopologyStr, 0)

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -183,33 +183,6 @@ func extractTopologyFromWorkloadPolicy(bp Blueprint, mod *Module) (string, bool)
 	return "", false
 }
 
-func injectCompactPlacementPolicy(mod *Module, tpuTopologyStr string) {
-	var ppMap map[string]cty.Value
-	if mod.Settings.Has("placement_policy") {
-		ppRaw := mod.Settings.Get("placement_policy")
-		if ppRaw.Type().IsObjectType() {
-			ppMap = ppRaw.AsValueMap()
-		} else {
-			ppMap = make(map[string]cty.Value)
-		}
-	} else {
-		ppMap = make(map[string]cty.Value)
-	}
-	ppMap["type"] = cty.StringVal("COMPACT")
-	if tpuTopologyStr != "" {
-		if origTopo, ok := ppMap["tpu_topology"]; ok {
-			if _, isExpr := IsExpressionValue(origTopo); isExpr {
-				// Keep the original expression to avoid breaking validators
-			} else {
-				ppMap["tpu_topology"] = cty.StringVal(tpuTopologyStr)
-			}
-		} else {
-			ppMap["tpu_topology"] = cty.StringVal(tpuTopologyStr)
-		}
-	}
-	mod.Settings = mod.Settings.With("placement_policy", cty.ObjectVal(ppMap))
-}
-
 // expandHardwareSettings automatically infers missing hardware settings
 // such as static_node_count for TPUs based on machine_type and tpu_topology.
 func expandHardwareSettings(bp Blueprint, mod *Module) error {
@@ -234,7 +207,7 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 
 	if mod.Settings.Has("enable_flex_start") {
 		val, err := bp.Eval(mod.Settings.Get("enable_flex_start"))
-		if err == nil && val.Type() == cty.Bool && val.True() {
+		if err == nil && val.Type() == cty.Bool && !val.IsNull() && val.IsKnown() && val.True() {
 			return nil
 		}
 	}
@@ -245,10 +218,6 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 	}
 
 	mod.Settings = mod.Settings.With("static_node_count", cty.NumberIntVal(int64(nodes)))
-
-	if nodes > 1 {
-		injectCompactPlacementPolicy(mod, tpuTopologyStr)
-	}
 
 	return nil
 }

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -305,6 +305,21 @@ func TestExpandHardwareSettings(t *testing.T) {
 	if mod4.Settings.Has("static_node_count") {
 		t.Errorf("expected static_node_count NOT to be set for non-TPU machine type")
 	}
+
+	// Test that it skips Flex Start pools
+	mod5 := &Module{
+		Settings: Dict{}.
+			With("machine_type", cty.StringVal("ct6e-standard-4t")).
+			With("tpu_topology", cty.StringVal("2x2")).
+			With("enable_flex_start", cty.BoolVal(true)),
+	}
+	err = expandHardwareSettings(bp, mod5)
+	if err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+	if mod5.Settings.Has("static_node_count") {
+		t.Errorf("expected static_node_count NOT to be set when enable_flex_start is true")
+	}
 }
 
 func TestResolveTopologyForChips(t *testing.T) {

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -217,33 +217,6 @@ func TestExtractTopologyFromWorkloadPolicy(t *testing.T) {
 
 }
 
-func TestInjectCompactPlacementPolicy(t *testing.T) {
-	mod1 := &Module{
-		Settings: Dict{},
-	}
-	injectCompactPlacementPolicy(mod1, "4x4x4")
-	if !mod1.Settings.Has("placement_policy") {
-		t.Fatal("expected placement_policy to be injected")
-	}
-	pp1 := mod1.Settings.Get("placement_policy").AsValueMap()
-	if pp1["type"].AsString() != "COMPACT" {
-		t.Errorf("expected pp type COMPACT, got %v", pp1["type"])
-	}
-	if pp1["tpu_topology"].AsString() != "4x4x4" {
-		t.Errorf("expected pp topology 4x4x4, got %v", pp1["tpu_topology"])
-	}
-
-	ppOrig := cty.ObjectVal(map[string]cty.Value{"foo": cty.StringVal("bar")})
-	mod2 := &Module{
-		Settings: Dict{}.With("placement_policy", ppOrig),
-	}
-	injectCompactPlacementPolicy(mod2, "2x2x2")
-	pp2 := mod2.Settings.Get("placement_policy").AsValueMap()
-	if pp2["type"].AsString() != "COMPACT" || pp2["tpu_topology"].AsString() != "2x2x2" || pp2["foo"].AsString() != "bar" {
-		t.Errorf("mod2 placement policy incorrect: %v", pp2)
-	}
-}
-
 func TestExpandHardwareSettings(t *testing.T) {
 	bp := Blueprint{}
 
@@ -289,9 +262,7 @@ func TestExpandHardwareSettings(t *testing.T) {
 	if count3 != 16 {
 		t.Errorf("expected static_node_count 16, got %d", count3)
 	}
-	if !mod3.Settings.Has("placement_policy") {
-		t.Errorf("expected placement_policy to be injected for multi-node setups")
-	}
+
 	// Test that it skips non-TPU machine types
 	mod4 := &Module{
 		Settings: Dict{}.


### PR DESCRIPTION
This PR resolves test validation failure in `test_deployment_variable_not_used` for the flex_start TPU blueprint.

The validator was incorrectly flagging tpu_topology as unused when placement_policy was injected via hardware.go logic for deployments with static node count > 1. 

### Key changes
- Removed the `injectCompactPlacementPolicy` function since this is already being handled in the blueprint modules.
- Also added a conditional logic to avoid static_node_count calculation in case of flex_start since it supports auto_scaling.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
