### PR TITLE
[Telemetry] Capture exit code upon fatal command failures

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,9 +79,9 @@ func init() {
 			userConfigExists = true
 
 			// Register the fatal hook to flush telemetry on hard failures
-			logging.FatalHook = func() {
-				if config.IsTelemetryEnabled() {
-					telemetryCollector.Execute(1) // Hard-code the exit code to 1 since logging.Fatal always exits with 1
+			logging.FatalHook = func(exitCode int) {
+				if config.IsTelemetryEnabled() && telemetryCollector != nil {
+					telemetryCollector.Execute(exitCode)
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -77,6 +77,13 @@ func init() {
 		if err := config.InitUserConfig(); err == nil {
 			telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
 			userConfigExists = true
+
+			// Register the fatal hook to flush telemetry on hard failures
+			logging.FatalHook = func() {
+				if config.IsTelemetryEnabled() {
+					telemetryCollector.Execute(1) // Hard-code the exit code to 1 since logging.Fatal always exits with 1
+				}
+			}
 		}
 	}
 

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -27,7 +27,7 @@ var (
 	infolog      *log.Logger
 	errorlog     *log.Logger
 	fatallog     *log.Logger
-	FatalHook    func() // FatalHook allows registering a callback to run before the program exits on a fatal error.
+	FatalHook    func(exitCode int) // FatalHook allows registering a callback to run before the program exits on a fatal error.
 	Exit         = os.Exit
 	TsColor      = color.New(color.FgMagenta)
 	WarningColor = color.New(color.FgYellow)
@@ -65,13 +65,13 @@ func Error(f string, a ...any) {
 
 // Fatal prints message to stderr and ends the program
 func Fatal(f string, a ...any) {
+	defer Exit(1)
+
 	msg := fmt.Sprintf(f, a...)
 	fatallog.Printf("%s: %s", formatTs(), msg)
 
 	// Execute the hook if it is registered
 	if FatalHook != nil {
-		FatalHook()
+		FatalHook(1)
 	}
-
-	Exit(1)
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -27,6 +27,7 @@ var (
 	infolog      *log.Logger
 	errorlog     *log.Logger
 	fatallog     *log.Logger
+	FatalHook    func() // FatalHook allows registering a callback to run before the program exits on a fatal error.
 	Exit         = os.Exit
 	TsColor      = color.New(color.FgMagenta)
 	WarningColor = color.New(color.FgYellow)
@@ -66,5 +67,11 @@ func Error(f string, a ...any) {
 func Fatal(f string, a ...any) {
 	msg := fmt.Sprintf(f, a...)
 	fatallog.Printf("%s: %s", formatTs(), msg)
+
+	// Execute the hook if it is registered
+	if FatalHook != nil {
+		FatalHook()
+	}
+
 	Exit(1)
 }


### PR DESCRIPTION
This pull request enhances the telemetry system by **ensuring that diagnostic data is captured and sent even when the application encounters a fatal error**. By introducing a hook in the logging infrastructure, the system can now reliably report command failures, providing better visibility into application crashes.

Changes:

* **Telemetry Improvement**: Added a FatalHook mechanism to the logging package to ensure telemetry data is flushed during hard failures.
* **Command Failure Tracking**: Implemented a hook in cmd/root.go that triggers telemetry collection with an exit code of 1 whenever a fatal error occurs.

Tested:

<img width="3110" height="772" alt="image" src="https://github.com/user-attachments/assets/c48040cf-63b3-45ca-8ee8-4f91dbe3b8e6" />
