### PR TITLE
feat(job submission): Dynamic topology routing for gke jobs

### DIFF
--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -228,7 +228,29 @@ Use `--node-constraint` to target a specific node pool. This maps to node labels
   --node-constraint "cloud.google.com/gke-nodepool=my-custom-nodepool"
 ```
 
-**Example 2: Use Placement Policy**
+**Example 2: Target Multiple Topologies (Dynamic Routing)**
+Use a pipe separator (`|`) in `--node-constraint` to specify multiple allowed values for a constraint. This generates a `nodeAffinity` block instead of a strict `nodeSelector`, allowing the workload to fall back to other pools if the preferred one is full.
+
+```bash
+./gcluster job submit \
+  --name my-fallback-job \
+  --command "python app.py" \
+  --compute-type v6e-4 \
+  --node-constraint "cloud.google.com/gke-tpu-topology=2x2|4x4"
+```
+
+> [!CAUTION]
+> **Dynamic Slicing Interaction:**
+>
+> When using GKE Dynamic Slicing, be careful setting topology constraints in `--node-constraint`.
+>
+> GKE labels nodes with their *physical* pool topology (e.g., `4x4`). If you request a smaller slice (e.g., `2x2`) via `--topology`, GKE handles the placement via annotations automatically.
+>
+> However, if you also pass `--node-constraint "cloud.google.com/gke-tpu-topology=2x2"`, you are forcing strict Node Affinity. The scheduler will only look for nodes physically labeled `2x2` and will **refuse to schedule** on the `4x4` pool, defeating Dynamic Slicing.
+>
+> To avoid this, either omit the topology from `--node-constraint` when using Dynamic Slicing, or explicitly include the larger pool topologies in the pipe-separated list (e.g., `"2x2|4x4"`).
+
+**Example 3: Use Placement Policy**
 Use `--placement-policy` to specify a GCE Placement Policy (e.g., for compact placement to reduce latency).
 
 ```bash
@@ -240,7 +262,7 @@ Use `--placement-policy` to specify a GCE Placement Policy (e.g., for compact pl
 
 *(Note: requires a `PlacementPolicy` resource named `compact-placement` to exist on the cluster)*
 
-**Example 3: Pod Failure Policy**
+**Example 4: Pod Failure Policy**
 Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (these do not count against the `restarts` budget).
 
 ```bash
@@ -250,7 +272,7 @@ Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (
   --restart-on-exit-codes 1,137
 ```
 
-**Example 4: Private Registry & Service Account**
+**Example 5: Private Registry & Service Account**
 Use `--image-pull-secret` and `--service-account` for secure jobs.
 
 ```bash
@@ -261,7 +283,7 @@ Use `--image-pull-secret` and `--service-account` for secure jobs.
   --service-account "my-workload-sa"
 ```
 
-**Example 5: Explicit Kueue Queue Selection**
+**Example 6: Explicit Kueue Queue Selection**
 Use `--queue` to submit the job to a specific Kueue LocalQueue.
 
 ```bash
@@ -912,7 +934,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--priority` | `string` | Priority class or level assigned to the job queue (e.g., `low`, `medium`, `high`). |
 | `--gke-ttl-after-finished` | `string` | Time duration to retain the JobSet resources after completion (Default: `1h`). |
 | `--grace-period` | `string` | Buffer period given to pods to save checkpoints before forced termination (Default: `30s`). |
-| `--node-constraint` | `string` | Maps to Kubernetes node labels to target specific hardware instance types. |
+| `--node-constraint` | `string` | Maps to Kubernetes node labels to target specific hardware instance types. Supports pipe separator (`|`) for multiple values. |
 | `--placement-policy` | `string` | Specifies a GCE Placement Policy name (e.g., `compact-placement`) to minimize latency. |
 | `--restart-on-exit-codes` | `string` | Comma-separated list of retriable exit codes that bypass the main restart budget. |
 | `--gke-scheduler` | `string` | Specific GKE scheduler selection (e.g., `gke.io/topology-aware-auto`). |

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -31,6 +31,7 @@ var tpuFamilyDefaults = map[string]int{
 }
 
 var tpuRegex = regexp.MustCompile(`^v[4-6][ep]?(-\d+)?$`)
+var TopologyRegex = regexp.MustCompile(`^[0-9]+x[0-9]+(x[0-9]+)?$`)
 
 type tpu3DConstraints struct {
 	maxCubes int
@@ -231,6 +232,11 @@ func expandHardwareSettings(bp Blueprint, mod *Module) error {
 // CalculateAcceleratorNodes derives the node count from topology and machine type.
 // If acceleratorsPerVM is <= 0, it falls back to deriving it from machineType or defaults.
 func CalculateAcceleratorNodes(machineType, topology string, acceleratorsPerVM int) (int, error) {
+	// Validate topology format
+	if !TopologyRegex.MatchString(topology) {
+		return 0, fmt.Errorf("provided topology has invalid format %q", topology)
+	}
+
 	// 1. Calculate Total Accelerators from topology
 	totalAccelerators := 1
 	for _, dim := range strings.Split(topology, "x") {
@@ -400,6 +406,9 @@ func ValidateHardwareRequest(machineType, topology string) error {
 }
 
 func validateTopologyMeshFormat(requested string, accelType string) error {
+	if !TopologyRegex.MatchString(requested) {
+		return fmt.Errorf("provided topology has invalid format %q", requested)
+	}
 	dims := strings.Split(requested, "x")
 	if matchesTPUFamily(accelType, valid2DTPUFamilies) {
 		if len(dims) != 2 {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1816,7 +1816,10 @@ func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, sched
 			return fmt.Errorf("topology is not allowed for GPU and CPU jobs")
 		}
 		if !isDynamicSlicing {
-			nodeSelector["cloud.google.com/gke-tpu-topology"] = schedOpts.Topology
+			_, hasFallback := schedOpts.NodeAffinityLabels[tpuTopologyLabel]
+			if !hasFallback {
+				nodeSelector[tpuTopologyLabel] = schedOpts.Topology
+			}
 		}
 	}
 	return nil

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1859,7 +1859,11 @@ func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orc
 }
 
 func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, error) {
-	if affinity := GetAffinity(schedOpts); affinity != nil {
+	affinity, err := GetAffinity(schedOpts)
+	if err != nil {
+		return "", err
+	}
+	if affinity != nil {
 		b, err := k8syaml.Marshal(affinity)
 		if err != nil {
 			return "", fmt.Errorf("failed to marshal affinity: %w", err)

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -117,6 +117,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		NodeAffinityLabels: job.NodeConstraint,
 		Topology:           job.Topology,
 		Scheduler:          job.GKEScheduler,
+		IsDynamicSlicing:   isDynamicSlicing,
 	}
 
 	parts := strings.Split(originalAccelType, "-")

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -16,6 +16,8 @@ package gke
 
 import (
 	"hpc-toolkit/pkg/config"
+	"slices"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -25,6 +27,7 @@ type SchedulingOptions struct {
 	Topology           string
 	Scheduler          string
 	NodeAffinityLabels map[string]string
+	IsDynamicSlicing   bool
 }
 
 func GetNodeSelector(opts SchedulingOptions) map[string]string {
@@ -35,6 +38,14 @@ func GetNodeSelector(opts SchedulingOptions) map[string]string {
 	}
 
 	for k, v := range opts.NodeAffinityLabels {
+		// Skip if it has a pipe (will go to affinity)
+		if strings.Contains(v, "|") {
+			continue
+		}
+		// Skip if it's topology and we have a baseline topology to merge with
+		if k == tpuTopologyLabel && opts.Topology != "" {
+			continue
+		}
 		nodeSelector[k] = v
 	}
 
@@ -45,23 +56,66 @@ func GetNodeSelector(opts SchedulingOptions) map[string]string {
 }
 
 func GetAffinity(opts SchedulingOptions) *corev1.Affinity {
-	return &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							{
-								Key:      "cloud.google.com/gke-nodepool",
-								Operator: corev1.NodeSelectorOpNotIn,
-								Values:   []string{"default-pool"},
-							},
-						},
-					},
-				},
+	// Build the inner term first to reduce nesting
+	defaultPoolExclusion := corev1.NodeSelectorTerm{
+		MatchExpressions: []corev1.NodeSelectorRequirement{
+			{
+				Key:      nodePoolLabel,
+				Operator: corev1.NodeSelectorOpNotIn,
+				Values:   []string{"default-pool"},
 			},
 		},
 	}
+
+	affinity := &corev1.Affinity{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{defaultPoolExclusion},
+			},
+		},
+	}
+
+	term := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
+
+	// Handle pipe-separated constraints and smart merging for topology
+	for k, v := range opts.NodeAffinityLabels {
+		// True if this is a topology label that needs to be merged with a baseline topology.
+		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "")
+		hasPipe := strings.Contains(v, "|")
+
+		if !hasPipe && !isTopologyMerge {
+			continue
+		}
+
+		var values []string
+		if isTopologyMerge && !opts.IsDynamicSlicing {
+			values = append(values, opts.Topology)
+		}
+
+		for _, val := range strings.Split(v, "|") {
+			if trimmed := strings.TrimSpace(val); trimmed != "" {
+				if !slices.Contains(values, trimmed) {
+					values = append(values, trimmed)
+				}
+			}
+		}
+
+		// Prevents invalid manifests if a user passes "|" by itself as node-constraints.
+		if len(values) == 0 {
+			continue
+		}
+
+		term.MatchExpressions = append(
+			term.MatchExpressions,
+			corev1.NodeSelectorRequirement{
+				Key:      k,
+				Operator: corev1.NodeSelectorOpIn,
+				Values:   values,
+			},
+		)
+	}
+
+	return affinity
 }
 
 func GetTopologyAnnotation(topology string) map[string]string {

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -15,6 +15,7 @@
 package gke
 
 import (
+	"fmt"
 	"hpc-toolkit/pkg/config"
 	"slices"
 	"strings"
@@ -42,8 +43,8 @@ func GetNodeSelector(opts SchedulingOptions) map[string]string {
 		if strings.Contains(v, "|") {
 			continue
 		}
-		// Skip if it's topology and we have a baseline topology to merge with
-		if k == tpuTopologyLabel && opts.Topology != "" {
+		// Skip if it's topology (will go to affinity)
+		if k == tpuTopologyLabel {
 			continue
 		}
 		nodeSelector[k] = v
@@ -55,7 +56,7 @@ func GetNodeSelector(opts SchedulingOptions) map[string]string {
 	return nodeSelector
 }
 
-func GetAffinity(opts SchedulingOptions) *corev1.Affinity {
+func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 	// Build the inner term first to reduce nesting
 	defaultPoolExclusion := corev1.NodeSelectorTerm{
 		MatchExpressions: []corev1.NodeSelectorRequirement{
@@ -80,29 +81,31 @@ func GetAffinity(opts SchedulingOptions) *corev1.Affinity {
 	// Handle pipe-separated constraints and smart merging for topology
 	for k, v := range opts.NodeAffinityLabels {
 		// True if this is a topology label that needs to be merged with a baseline topology.
-		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "")
+		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "") && (!opts.IsDynamicSlicing)
 		hasPipe := strings.Contains(v, "|")
 
-		if !hasPipe && !isTopologyMerge {
+		if !hasPipe && k != tpuTopologyLabel {
 			continue
 		}
 
 		var values []string
-		if isTopologyMerge && !opts.IsDynamicSlicing {
+		if isTopologyMerge {
 			values = append(values, opts.Topology)
 		}
 
-		for _, val := range strings.Split(v, "|") {
-			if trimmed := strings.TrimSpace(val); trimmed != "" {
+		if v != "" {
+			for _, val := range strings.Split(v, "|") {
+				trimmed := strings.TrimSpace(val)
+				if trimmed == "" {
+					return nil, fmt.Errorf("invalid node constraint for key %s: empty element in %q", k, v)
+				}
+				if k == tpuTopologyLabel && !config.TopologyRegex.MatchString(trimmed) {
+					return nil, fmt.Errorf("invalid topology format %q for key %s", trimmed, k)
+				}
 				if !slices.Contains(values, trimmed) {
 					values = append(values, trimmed)
 				}
 			}
-		}
-
-		// Prevents invalid manifests if a user passes "|" by itself as node-constraints.
-		if len(values) == 0 {
-			continue
 		}
 
 		term.MatchExpressions = append(
@@ -115,7 +118,7 @@ func GetAffinity(opts SchedulingOptions) *corev1.Affinity {
 		)
 	}
 
-	return affinity
+	return affinity, nil
 }
 
 func GetTopologyAnnotation(topology string) map[string]string {

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -37,7 +37,10 @@ func TestGetNodeSelector(t *testing.T) {
 
 func TestGetAffinity(t *testing.T) {
 	opts := SchedulingOptions{}
-	affinity := GetAffinity(opts)
+	affinity, err := GetAffinity(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if affinity == nil {
 		t.Fatal("Expected affinity, got nil")
 	}
@@ -133,6 +136,7 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 		opts       SchedulingOptions
 		wantKey    string
 		wantValues []string
+		wantErr    bool
 	}{
 		{
 			name: "pipe separated values (non-topology)",
@@ -167,15 +171,14 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 			wantValues: []string{"2x2x1", "2x2x2"},
 		},
 		{
-			name: "null safety with whitespace",
+			name: "null safety with whitespace (now fails)",
 			opts: SchedulingOptions{
 				Topology: "2x2x1",
 				NodeAffinityLabels: map[string]string{
 					"cloud.google.com/gke-tpu-topology": " | ",
 				},
 			},
-			wantKey:    "cloud.google.com/gke-tpu-topology",
-			wantValues: []string{"2x2x1"},
+			wantErr: true,
 		},
 		{
 			name: "null safety with empty string",
@@ -200,11 +203,38 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 			wantKey:    "cloud.google.com/gke-tpu-topology",
 			wantValues: []string{"2x2x2"},
 		},
+		{
+			name: "invalid topology format",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "invalid",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty element in list",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"pipe-key": "val1||val2",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			affinity := GetAffinity(tt.opts)
+			affinity, err := GetAffinity(tt.opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if affinity == nil {
 				t.Fatal("Expected affinity, got nil")
 			}

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -15,6 +15,7 @@
 package gke
 
 import (
+	"slices"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -101,5 +102,131 @@ func TestGetTolerations(t *testing.T) {
 				t.Errorf("expected nil toleration for %s, got %v", tt.acceleratorType, got)
 			}
 		}
+	}
+}
+
+func TestGetNodeSelector_DynamicTopology(t *testing.T) {
+	opts := SchedulingOptions{
+		NodeAffinityLabels: map[string]string{
+			"normal-key":                        "value",
+			"pipe-key":                          "val1|val2",
+			"cloud.google.com/gke-tpu-topology": "2x2",
+		},
+		Topology: "2x2",
+	}
+	selector := GetNodeSelector(opts)
+
+	if selector["normal-key"] != "value" {
+		t.Errorf("Expected normal-key to be 'value', got %v", selector["normal-key"])
+	}
+	if _, exists := selector["pipe-key"]; exists {
+		t.Errorf("Expected pipe-key to be excluded from nodeSelector")
+	}
+	if _, exists := selector["cloud.google.com/gke-tpu-topology"]; exists {
+		t.Errorf("Expected cloud.google.com/gke-tpu-topology to be excluded from nodeSelector due to smart merging")
+	}
+}
+
+func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       SchedulingOptions
+		wantKey    string
+		wantValues []string
+	}{
+		{
+			name: "pipe separated values (non-topology)",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"pipe-key": "val1|val2",
+				},
+			},
+			wantKey:    "pipe-key",
+			wantValues: []string{"val1", "val2"},
+		},
+		{
+			name: "smart merging (legacy case)",
+			opts: SchedulingOptions{
+				Topology: "2x2",
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "4x4",
+				},
+			},
+			wantKey:    "cloud.google.com/gke-tpu-topology",
+			wantValues: []string{"2x2", "4x4"},
+		},
+		{
+			name: "prioritize baseline and deduplicate",
+			opts: SchedulingOptions{
+				Topology: "2x2x1",
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "2x2x2|2x2x1",
+				},
+			},
+			wantKey:    "cloud.google.com/gke-tpu-topology",
+			wantValues: []string{"2x2x1", "2x2x2"},
+		},
+		{
+			name: "null safety with whitespace",
+			opts: SchedulingOptions{
+				Topology: "2x2x1",
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": " | ",
+				},
+			},
+			wantKey:    "cloud.google.com/gke-tpu-topology",
+			wantValues: []string{"2x2x1"},
+		},
+		{
+			name: "null safety with empty string",
+			opts: SchedulingOptions{
+				Topology: "2x2x1",
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "",
+				},
+			},
+			wantKey:    "cloud.google.com/gke-tpu-topology",
+			wantValues: []string{"2x2x1"},
+		},
+		{
+			name: "skip baseline for dynamic slicing",
+			opts: SchedulingOptions{
+				Topology: "2x2x1",
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "2x2x2",
+				},
+				IsDynamicSlicing: true,
+			},
+			wantKey:    "cloud.google.com/gke-tpu-topology",
+			wantValues: []string{"2x2x2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			affinity := GetAffinity(tt.opts)
+			if affinity == nil {
+				t.Fatal("Expected affinity, got nil")
+			}
+			terms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+			if len(terms) == 0 {
+				t.Fatal("Expected NodeSelectorTerms")
+			}
+			var found bool
+			for _, req := range terms[0].MatchExpressions {
+				if req.Key == tt.wantKey {
+					found = true
+					if !slices.Equal(req.Values, tt.wantValues) {
+						t.Errorf("Expected values %v, got %v", tt.wantValues, req.Values)
+					}
+					if req.Operator != corev1.NodeSelectorOpIn {
+						t.Errorf("Expected operator In, got %v", req.Operator)
+					}
+				}
+			}
+			if !found {
+				t.Errorf("Expected to find requirement for key %s", tt.wantKey)
+			}
+		})
 	}
 }

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -26,6 +26,13 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+const (
+	// tpuTopologyLabel is the GKE label for TPU topology.
+	tpuTopologyLabel = "cloud.google.com/gke-tpu-topology"
+	// nodePoolLabel is the GKE label for the node pool name.
+	nodePoolLabel = "cloud.google.com/gke-nodepool"
+)
+
 type Executor interface {
 	ExecuteCommand(name string, args ...string) shell.CommandResult
 	ExecuteCommandStream(name string, args ...string) error


### PR DESCRIPTION
Implements Dynamic Topology Routing in gcluster job submit to allow workloads to fall back to larger idle TPU/GPU pools when their preferred pool is full. This maximizes cluster utilization and reduces job starvation by providing more flexible scheduling constraints.

### Key Changes
 * Support for Pipe Separator in Constraints: Users can now specify multiple allowed values for any node constraint separated by a pipe (e.g., --node-constraint "cloud.google.com/gke-tpu-topology=2x2|4x8").
 * Dynamic NodeAffinity Generation: When multiple values are detected for a constraint, gcluster now generates a Kubernetes nodeAffinity block with the In operator instead of a strict nodeSelector.
 * Smart Merging for Topology: If both a baseline --topology and fallback topologies via --node-constraint are specified, they are automatically merged into a single nodeAffinity list to avoid scheduling conflicts.
 * Documentation: Added examples and updated flag references in docs/gcluster_job_guide.md.

### Tests: 
* Added unit tests in scheduling_test.go covering the new parsing and merging logic. All tests passed.

### Verification Results
Verified via gcluster job submit --dry-run-out that the generated manifest correctly emits nodeAffinity with In operator for fallback values and keeps nodeSelector clean of strict topology requirements when fallbacks are present.
