### PR TITLE
Remove the disk size attributes from deployment files

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml
@@ -32,7 +32,3 @@ vars:
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation: RESERVATION_NAME
   static_node_count: NODE_COUNT
-  system_node_pool_disk_size_gb: SYSTEM_NODE_POOL_DISK_SIZE_GB # the size of
-  # disk for each node of the system node pool.
-  a3ultra_node_pool_disk_size_gb: A3ULTRA_NODE_POOL_DISK_SIZE_GB # the size of
-  # disk for each node.

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -27,9 +27,10 @@ vars:
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation: # add this
+  static_node_count: # add this
+
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   gib_installer_path: $(ghpc_stage("./nccl-installer.yaml.tftpl"))
-  static_node_count: # add this
   system_node_pool_disk_size_gb: 200
   a3ultra_node_pool_disk_size_gb: 100
   accelerator_type: nvidia-h200-141gb

--- a/examples/gke-a4/gke-a4-deployment.yaml
+++ b/examples/gke-a4/gke-a4-deployment.yaml
@@ -45,9 +45,3 @@ vars:
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
-
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of a4 node pool for this deployment.
-  a4_node_pool_disk_size_gb:

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm-deployment.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm-deployment.yaml
@@ -45,9 +45,3 @@ vars:
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
-
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of a4x-max node pool for this deployment.
-  a4x_max_node_pool_disk_size_gb:

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -38,18 +38,17 @@ vars:
   # The number of nodes to be created
   static_node_count:
 
-  system_node_pool_disk_size_gb: 200
-  a4x_max_node_pool_disk_size_gb: 100
-  k8s_service_account_name: workload-identity-k8s-sa
-
   # The name of the compute engine reservation of A4X-Max nodes in the form of
   # <project>/<reservation-name>
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
+
   compute_nodepool_machine_type: a4x-maxgpu-4g-metal
   system_nodepool_machine_type: e2-standard-16
-
+  system_node_pool_disk_size_gb: 200
+  a4x_max_node_pool_disk_size_gb: 100
+  k8s_service_account_name: workload-identity-k8s-sa
   nvidia_dra_driver_path: $(ghpc_stage("./nvidia-dra-driver.yaml"))
   asapd_lite_installer_path: $(ghpc_stage("./asapd-lite-installer.yaml"))
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))

--- a/examples/gke-a4x/gke-a4x-deployment.yaml
+++ b/examples/gke-a4x/gke-a4x-deployment.yaml
@@ -45,9 +45,3 @@ vars:
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
-
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of a4x node pool for this deployment.
-  a4x_node_pool_disk_size_gb:

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -38,17 +38,11 @@ vars:
   # The number of nodes to be created
   static_node_count:
 
-  system_node_pool_disk_size_gb: 200
-  a4x_node_pool_disk_size_gb: 100
-  k8s_service_account_name: workload-identity-k8s-sa
-
   # The name of the compute engine reservation of A4X nodes in the form of
   # <project>/<reservation-name>
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
-  compute_nodepool_machine_type: a4x-highgpu-4g
-  system_nodepool_machine_type: e2-standard-16
 
   # Installs NCCL library and Google NCCL plugin
   # Runs an init container on all GB200 GPU nodes with the NCCL plugin image
@@ -57,6 +51,11 @@ vars:
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   accelerator_type: nvidia-gb200
   version_prefix: "1.35."
+  system_node_pool_disk_size_gb: 200
+  a4x_node_pool_disk_size_gb: 100
+  k8s_service_account_name: workload-identity-k8s-sa
+  compute_nodepool_machine_type: a4x-highgpu-4g
+  system_nodepool_machine_type: e2-standard-16
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu-deployment.yaml
@@ -42,9 +42,3 @@ vars:
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
-
-  # The disk size of system node pool for this deployment. Default value is 100.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of a3 ultra node pool for this deployment. Default value is 100.
-  a3ultra_node_pool_disk_size_gb:

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
@@ -57,9 +57,3 @@ vars:
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
-
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb: 200
-
-  # The disk size of v6e node pool for this deployment.
-  v6e_node_pool_disk_size_gb: 100

--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu-deployment.yaml
@@ -39,9 +39,3 @@ vars:
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
-
-  # The disk size of system node pool for this deployment. Default value is 100.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of a3 ultra node pool for this deployment. Default value is 100.
-  a3ultra_node_pool_disk_size_gb:

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
@@ -56,9 +56,3 @@ vars:
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
-
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of v6e node pool for this deployment.
-  v6e_node_pool_disk_size_gb:

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-deployment.yaml
@@ -51,11 +51,5 @@ vars:
   # The name of the compute engine reservation of TPU v6e nodes
   reservation:
 
-  # The disk size of system node pool for this deployment.
-  system_node_pool_disk_size_gb:
-
-  # The disk size of v6e node pool for this deployment.
-  v6e_node_pool_disk_size_gb:
-
   # The namespace to be configured for running workloads
   user_namespace: default

--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-deployment.yaml
@@ -30,7 +30,7 @@ vars:
   slurm_cluster_name: # supply name for slurm cluster (lowercase letters, numbers, and hyphens, max 20 characters, must start with a letter)
   a3_static_cluster_size: # supply a3-highgpu-8g reservation size
   a3_partition_name: # supply partition name
-  disk_size_gb: 200
+
   # Additional provisioning models (pick only one), can be used to substitute `a3_reservation_name`:
   #
   # a3_dws_flex_enabled: true

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-deployment.yaml
@@ -28,7 +28,6 @@ vars:
   enable_ops_agent: true
   enable_nvidia_dcgm: true
   enable_nvidia_persistenced: true
-  disk_size_gb: 200
   final_image_family: slurm-a3mega
   slurm_cluster_name: # supply name for slurm cluster (lowercase letters, numbers, and hyphens, max 20 characters, must start with a letter)
   a3mega_cluster_size:  # supply cluster size


### PR DESCRIPTION
This pull request focuses on **cleaning up deployment configurations by removing redundant disk size attributes**. The changes streamline the variable sets used in various GKE and Slurm deployment examples, ensuring a cleaner interface for users deploying these infrastructure templates.

Changes:

* **Cleanup of disk size attributes**: Removed explicit disk size configuration variables from multiple deployment and example files to simplify configuration management.
* **Refactoring variable placement**: Reorganized variable definitions in several YAML files to improve readability and consistency across different deployment templates.