### PR TITLE
update NCCL gIB version to 1.1.2

### DIFF
--- a/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml
@@ -36,8 +36,8 @@ vars:
     project: $(vars.instance_image_project)
     family: $(vars.instance_image_family)
   disk_size_gb: 100
-  nccl_gib_version: 1.1.0
-  libnccl_version: 2.27.5-1+cuda12.9
+  nccl_gib_version: 1.1.2
+  libnccl_version: 2.30.4-1+cuda13.0
   base_network_name: $(vars.deployment_name)
 
   #Provisioning models (set to true or fill in reservation name, pick only one)


### PR DESCRIPTION
This PR updates the NCCL gIB plugin version to `1.1.2`. The enhancements and new features in this release include:

- Environment Plugin
    - Introduced the GCP NCCL environment plugin that automatically applies the best NCCL environment variables based on the runtime platform. The environment plugin will be automatically loaded upon NCCL 2.28.7 or above. 
- gIB Net Plugin
   - Fixed an issue where the gIB net plugin may not be compatible with NCCL 2.27 or below.
- CoMMA (NCCL Profiler):
   - Introduced hang detection, a new feature on GCP that uses heartbeat telemetry to detect stalled NCCL processes.
   - Fixed stability issues.
