### PR TITLE
[Telemetry] Add OS name along with version to avoid confusion in Darwin systems

### DIFF
--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -242,7 +242,7 @@ func getMacVersion() string {
 	if err != nil {
 		return "Darwin (unknown version)"
 	}
-	return strings.TrimSpace(string(out))
+	return "Darwin " + strings.TrimSpace(string(out))
 }
 
 // getWindowsVersion uses the ver command to get the Windows version.
@@ -255,7 +255,7 @@ func getWindowsVersion() string {
 	if err != nil {
 		return "Windows (unknown version)"
 	}
-	return strings.TrimSpace(string(out))
+	return "Windows " + strings.TrimSpace(string(out))
 }
 
 // parseOsReleaseField helper to clean up quotes from /etc/os-release values

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -255,7 +255,7 @@ func getWindowsVersion() string {
 	if err != nil {
 		return "Windows (unknown version)"
 	}
-	return "Windows " + strings.TrimSpace(string(out))
+	return strings.TrimSpace(string(out))
 }
 
 // parseOsReleaseField helper to clean up quotes from /etc/os-release values


### PR DESCRIPTION
This pull request enhances the telemetry reporting mechanism by **explicitly prefixing the OS name to the version string** for macOS systems. This change ensures that the collected telemetry data is more descriptive and easier to interpret by removing potential ambiguity regarding the underlying operating system.

Changes:

* **Telemetry Data Clarity**: Updated OS version reporting to include the OS name (Darwin) to improve data readability and avoid ambiguity.