### PR TITLE
Running CHS lite and standard suites for TPU daily tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -90,18 +90,20 @@
       poll: 10
       changed_when: false
 
-    - name: "Run CHS standard suite"
+    - name: "Run CHS suites"
       ansible.builtin.shell: |
         set -e -u
-        chs run --scheduler {{ scheduler }} --machine-type {{ instance_type }} --suite standard
-      register: chs_run
+        chs run --scheduler {{ scheduler }} --machine-type {{ instance_type }} --suite {{ item }}
+      loop: "{{ chs_suites | default(['standard']) }}"
+      register: chs_runs
       async: 3000
       poll: 10
       changed_when: false
 
     - name: CHS run output
       ansible.builtin.debug:
-        var: chs_run.stdout_lines
+        msg: "{{ item.stdout_lines }}"
+      loop: "{{ chs_runs.results }}"
 
   rescue:
   - name: CHS Test Failure

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -102,8 +102,10 @@
 
     - name: CHS run output
       ansible.builtin.debug:
-        msg: "{{ item.stdout_lines }}"
+        msg: "{{ item.stdout }}"
       loop: "{{ chs_runs.results }}"
+      loop_control:
+        label: "{{ item.item }}"
 
   rescue:
   - name: CHS Test Failure

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -93,12 +93,14 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
         --extra-vars="region=us-central1 zone=us-central1-c" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"
-  secretEnv: ['GCLUSTER_GCS_PATH']
+  secretEnv: ['GCLUSTER_GCS_PATH', 'CHS_REPO']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
+  - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
+    env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -108,12 +108,14 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"
-  secretEnv: ['GCLUSTER_GCS_PATH']
+  secretEnv: ['GCLUSTER_GCS_PATH', 'CHS_REPO']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
+  - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
+    env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml
@@ -46,8 +46,8 @@ custom_vars:
 instance_type: "tpu7x"
 scheduler: "gke"
 chs_suites:
-  - lite
-  - standard
+- lite
+- standard
 post_deploy_tests:
 - test-validation/test-gke-tpu.yml
 - test-validation/test-gke-ml-diagnostics.yml

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml
@@ -43,6 +43,12 @@ custom_vars:
   tpu_topology: 2x2x1
   k8s_service_account: workload-identity-k8s-sa
   jobset_name: sample-tpu-jobset
+instance_type: "tpu7x"
+scheduler: "gke"
+chs_suites:
+  - lite
+  - standard
 post_deploy_tests:
 - test-validation/test-gke-tpu.yml
 - test-validation/test-gke-ml-diagnostics.yml
+- test-validation/test-chs.yml

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
@@ -44,8 +44,8 @@ custom_vars:
 instance_type: "tpuv6e"
 scheduler: "gke"
 chs_suites:
-  - lite
-  - standard
+- lite
+- standard
 post_deploy_tests:
 - test-validation/test-gke-tpu.yml
 - test-validation/test-gke-ml-diagnostics.yml

--- a/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-tpu-v6e.yml
@@ -41,6 +41,12 @@ custom_vars:
   tpu_topology: 2x2
   k8s_service_account: workload-identity-k8s-sa
   jobset_name: sample-tpu-jobset
+instance_type: "tpuv6e"
+scheduler: "gke"
+chs_suites:
+  - lite
+  - standard
 post_deploy_tests:
 - test-validation/test-gke-tpu.yml
 - test-validation/test-gke-ml-diagnostics.yml
+- test-validation/test-chs.yml


### PR DESCRIPTION
This pull request enables the execution of both the lite and standard suites of the Cluster Health Scanner (CHS) during TPU daily integration tests.

Key Changes:

- Ansible Playbook Update: Modified test-chs.yml to loop through multiple suites defined in chs_suites, defaulting to ['standard'] if not specified.
- Build Configuration: Updated gke-tpu-7x.yaml and gke-tpu-v6e.yaml to retrieve the CHS_REPO from Secret Manager and pass it as an extra variable to the integration test playbook.
- Test Definitions: Updated gke-tpu-7x.yml and gke-tpu-v6e.yml to:
    - Define instance_type and scheduler variables
    - Specify the list of CHS suites to run (lite and standard) 
    - Include test-validation/test-chs.yml in the post_deploy_tests list


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
