### PR TITLE
(gke) Remove additional networks from A4 nd A4X family blueprints

### DIFF
--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -188,7 +188,7 @@ deployment_groups:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
       additional_networks:
-        $(concat(gke-a4-net-1.additional_networks,
+        $(concat(gke-a4-net-1.instance_additional_networks,
          gke-a4-rdma-net.subnetwork_interfaces_gke
         ))
       # Cluster versions cannot be updated through the toolkit after creation
@@ -261,7 +261,7 @@ deployment_groups:
         specific_reservations:
         - name: $(vars.reservation)
       additional_networks:
-        $(concat(gke-a4-net-1.additional_networks,
+        $(concat(gke-a4-net-1.instance_additional_networks,
          gke-a4-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -188,19 +188,7 @@ deployment_groups:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
       additional_networks:
-        $(concat(
-          [{
-            network=gke-a4-net-1.network_name,
-            subnetwork=gke-a4-net-1.subnetwork_name,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+        $(concat(gke-a4-net-1.additional_networks,
          gke-a4-rdma-net.subnetwork_interfaces_gke
         ))
       # Cluster versions cannot be updated through the toolkit after creation
@@ -273,19 +261,7 @@ deployment_groups:
         specific_reservations:
         - name: $(vars.reservation)
       additional_networks:
-        $(concat(
-          [{
-            network=gke-a4-net-1.network_name,
-            subnetwork=gke-a4-net-1.subnetwork_name,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+        $(concat(gke-a4-net-1.additional_networks,
          gke-a4-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -105,6 +105,7 @@ deployment_groups:
     settings:
       network_name: $(vars.deployment_name)-net-1
       ips_per_nat: 6
+      nic_type: "IDPF"
       subnetworks:
       - subnet_name: $(vars.deployment_name)-sub-1
         subnet_region: $(vars.region)
@@ -254,18 +255,7 @@ deployment_groups:
           hugepage_size_2m: 4096
       additional_networks:
         $(concat(
-          [{
-            network = gke-a4x-max-net-1.network_name,
-            subnetwork = gke-a4x-max-net-1.subnetwork_name,
-            subnetwork_project = vars.project_id,
-            nic_type = "IDPF",
-            queue_count = null,
-            network_ip = null,
-            stack_type = null,
-            access_config = [],
-            ipv6_access_config = [],
-            alias_ip_range = []
-          }],
+          gke-a4x-max-net-1.additional_networks,
           gke-a4x-max-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -255,7 +255,7 @@ deployment_groups:
           hugepage_size_2m: 4096
       additional_networks:
         $(concat(
-          gke-a4x-max-net-1.additional_networks,
+          gke-a4x-max-net-1.instance_additional_networks,
           gke-a4x-max-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -205,19 +205,7 @@ deployment_groups:
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       additional_networks:
-        $(concat(
-          [{
-            network=gke-a4x-net-1.network_name,
-            subnetwork=gke-a4x-net-1.subnetwork_name,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+        $(concat(gke-a4x-net-1.additional_networks,
          gke-a4x-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]
@@ -292,19 +280,7 @@ deployment_groups:
         specific_reservations:
         - name: $(vars.reservation)
       additional_networks:
-        $(concat(
-          [{
-            network=gke-a4x-net-1.network_name,
-            subnetwork=gke-a4x-net-1.subnetwork_name,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+        $(concat(gke-a4x-net-1.additional_networks,
          gke-a4x-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -205,7 +205,7 @@ deployment_groups:
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       additional_networks:
-        $(concat(gke-a4x-net-1.additional_networks,
+        $(concat(gke-a4x-net-1.instance_additional_networks,
          gke-a4x-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]
@@ -280,7 +280,7 @@ deployment_groups:
         specific_reservations:
         - name: $(vars.reservation)
       additional_networks:
-        $(concat(gke-a4x-net-1.additional_networks,
+        $(concat(gke-a4x-net-1.instance_additional_networks,
          gke-a4x-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]


### PR DESCRIPTION
This PR eliminates additional network configuration in the GKE A4, A4X and A4X-Max-BM examples. This is a follow up item after [PR#5652](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5652)


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
