### PR TITLE
fix(slurm): correct vNUMA socket and SMT thread calculations in util.py

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -2075,13 +2075,13 @@ class Lookup:
         machine_conf.sockets = machine.sockets
         # the value below for SocketsPerBoard must be type int
         machine_conf.sockets_per_board = machine_conf.sockets // machine_conf.boards
-        threadsPerCore = getThreadsPerCore(template)
-        machine_conf.threads_per_core = threadsPerCore
-        _div = 2 if threadsPerCore == 1 else 1
+        threads_per_core = getThreadsPerCore(template)
+        machine_conf.threads_per_core = threads_per_core
+        _div = 2 if threads_per_core == 1 else 1
         # Check if visibleCoreCount is specified in the instance template
         visible_cores = template.advancedMachineFeatures.visibleCoreCount
         if visible_cores:
-            machine_conf.cpus = int(visible_cores) * threadsPerCore
+            machine_conf.cpus = int(visible_cores) * threads_per_core
         else:
             machine_conf.cpus = (
                 int(machine.guest_cpus / _div) if machine.supports_smt else machine.guest_cpus

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -162,16 +162,27 @@ class MachineType:
 
     @property
     def sockets(self) -> int:
+        if self.family == "n2d":
+            if "highmem" in self.name:
+                return 2 if self.guest_cpus >= 24 else 1
+            else:
+                return 2 if self.guest_cpus > 64 else 1
+        elif self.family == "n2":
+            # Without access to min-cpu-platform to distinguish ICX vs CLX,
+            # we default to the CLX split point (>= 32 vCPUs).
+            return 2 if self.guest_cpus >= 32 else 1
+
         return {
             "h3": 2,
             "h4d": 2,
-            "c2d": 2 if self.guest_cpus > 56 else 1,
             "a3": 2,
             "c2": 2 if self.guest_cpus > 30 else 1,
-            "c3": 2 if self.guest_cpus > 88 else 1,
+            "c2d": 2 if self.guest_cpus > 56 else 1,
+            "c3": 4 if self.guest_cpus > 88 else (2 if self.guest_cpus > 44 else 1),
             "c3d": 2 if self.guest_cpus > 180 else 1,
-            "c4": 2 if self.guest_cpus > 96 else 1,
+            "c4": 4 if self.guest_cpus > 96 else (2 if self.guest_cpus > 48 else 1),
             "c4d": 2 if self.guest_cpus > 192 else 1,
+            "n1": 2 if self.guest_cpus > 64 else 1,
         }.get(
             self.family,
             1,  # assume 1 socket for all other families
@@ -2064,18 +2075,19 @@ class Lookup:
         machine_conf.sockets = machine.sockets
         # the value below for SocketsPerBoard must be type int
         machine_conf.sockets_per_board = machine_conf.sockets // machine_conf.boards
-        machine_conf.threads_per_core = 1
-        _div = 2 if getThreadsPerCore(template) == 1 else 1
+        threadsPerCore = getThreadsPerCore(template)
+        machine_conf.threads_per_core = threadsPerCore
+        _div = 2 if threadsPerCore == 1 else 1
         # Check if visibleCoreCount is specified in the instance template
         visible_cores = template.advancedMachineFeatures.visibleCoreCount
         if visible_cores:
-            machine_conf.cpus = int(visible_cores) * getThreadsPerCore(template)
+            machine_conf.cpus = int(visible_cores) * threadsPerCore
         else:
             machine_conf.cpus = (
                 int(machine.guest_cpus / _div) if machine.supports_smt else machine.guest_cpus
             )
         # Calculate cores_per_socket once for both cases
-        machine_conf.cores_per_socket = machine_conf.cpus // machine_conf.sockets
+        machine_conf.cores_per_socket = (machine_conf.cpus // machine_conf.threads_per_core) // machine_conf.sockets
         # Because the actual memory on the host will be different than
         # what is configured (e.g. kernel will take it). From
         # experiments, about 16 MB per GB are used (plus about 400 MB


### PR DESCRIPTION
This PR is a solution to the issue - https://github.com/GoogleCloudPlatform/cluster-toolkit/issues/5668

This pull request updates the machine configuration logic for the Slurm GCP controller. It refines how sockets, threads, and cores are calculated for various instance families to better align with hardware specifications and instance template settings.

Changes:

* **Socket Configuration Updates**: Updated the socket calculation logic to include support for n2d and n2 families, and refined the socket counts for c3 and c4 families.
* **Core and Thread Calculation Refinement**: Improved the logic for calculating threads per core and cores per socket to ensure accurate machine configuration based on instance templates.

Tested locally to verify this change fixes the issue:

* Deployed a simple slurm blueprint after making the changes required for the fix.
* Ran the following commands after SSHing into the controller node.
* cloud.conf:
  <img width="2104" height="76" alt="image" src="https://github.com/user-attachments/assets/2540bcf9-ef25-482a-85c8-c5b3066f7753" />
* slurmd -C: 
  <img width="1838" height="64" alt="image" src="https://github.com/user-attachments/assets/4b1eafd7-c59c-40c4-9976-0699474b7ae4" />
* We can see that the values match.

