### PR TITLE
fix: Update the vpc module output name for additional network

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -171,7 +171,7 @@ deployment_groups:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
       additional_networks:
-        $(concat(gke-a3-ultra-net-1.additional_networks,
+        $(concat(gke-a3-ultra-net-1.instance_additional_networks,
          gke-a3-ultra-rdma-net.subnetwork_interfaces_gke
         ))
       # Cluster versions cannot be updated through the toolkit after creation
@@ -244,7 +244,7 @@ deployment_groups:
         specific_reservations:
         - name: $(vars.reservation)
       additional_networks:
-        $(concat(gke-a3-ultra-net-1.additional_networks,
+        $(concat(gke-a3-ultra-net-1.instance_additional_networks,
          gke-a3-ultra-rdma-net.subnetwork_interfaces_gke
         ))
     outputs: [instructions]

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -233,7 +233,7 @@ limitations under the License.
 
 | Name | Description |
 | ---- | ----------- |
-| <a name="output_additional_networks"></a> [additional\_networks](#output\_additional\_networks) | Network interface details compatible with gke-node-pool additional\_networks |
+| <a name="output_instance_additional_networks"></a> [instance\_additional\_networks](#output\_instance\_additional\_networks) | Network interface details compatible with gke-node-pool additional\_networks |
 | <a name="output_nat_ips"></a> [nat\_ips](#output\_nat\_ips) | External IPs of the Cloud NAT from which outbound internet traffic will arrive (empty list if no NAT is used) |
 | <a name="output_network_id"></a> [network\_id](#output\_network\_id) | ID of the new VPC network |
 | <a name="output_network_name"></a> [network\_name](#output\_network\_name) | Name of the new VPC network |

--- a/modules/network/vpc/outputs.tf
+++ b/modules/network/vpc/outputs.tf
@@ -73,7 +73,7 @@ output "nat_ips" {
   value       = flatten([for ipmod in module.nat_ip_addresses : ipmod.addresses])
 }
 
-output "additional_networks" {
+output "instance_additional_networks" {
   description = "Network interface details compatible with gke-node-pool additional_networks"
   value       = local.output_subnets_gke
   depends_on  = [module.vpc, module.cloud_router]


### PR DESCRIPTION
This PR is a follow up fix for the PR#5652. It modifies the vpc module output name to avoid the auto-wiring conflicts with other modules schedmd-slurm-gcp-v6-nodeset .
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
