### PR TITLE
gke-node-pool: ignore placement_policy[0].type drift to avoid spurious node rollings

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -313,6 +313,16 @@ resource "google_container_node_pool" "node_pool" {
       # Ignore local/ephemeral ssd configs as they are tied to machine types.
       node_config[0].ephemeral_storage_local_ssd_config,
       node_config[0].local_nvme_ssd_block_config,
+      # GKE's API does not persist `placementPolicy.type` — only
+      # `placementPolicy.policyName` round-trips on refresh. The
+      # resource-policy module's `placement_policy` output sets
+      # `type = "COMPACT"` whenever `workload_policy.type != null`,
+      # which causes terraform to plan `placement_policy.type:
+      # null -> "COMPACT"` on every refresh after the first apply,
+      # which in turn triggers a rolling node update on every apply
+      # for no functional change (compact placement is enforced via
+      # `policyName`).
+      placement_policy[0].type,
     ]
     precondition {
       condition     = !(length(compact(local.input_reservation_suffixes)) > 0 && length((var.zones != null ? var.zones : [])) == 0)


### PR DESCRIPTION
## Problem

\`google_container_node_pool.placement_policy.type\` is **write-only at the GKE API layer**: terraform sends \`type = "COMPACT"\` on update, but the GET response only returns \`placementPolicy.policyName\`. The field round-trips as \`null\` regardless of what we send.

This combines badly with the [`resource-policy` module's `placement_policy` output](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/compute/resource-policy/outputs.tf), which since [c8641355a](https://github.com/GoogleCloudPlatform/cluster-toolkit/commit/c8641355a) emits `type = "COMPACT"` whenever `workload_policy.type != null`:

```hcl
value = {
  type         = (var.group_placement_max_distance > 0 || var.workload_policy.type != null) ? "COMPACT" : null
  name         = ...
  tpu_topology = ...
}
```

Any pool that consumes a `workload_policy` (e.g. all A4X / GB200 pools with `accelerator_topology: "1x72"`) ends up in a permanent-diff state:

1. First apply sends `type = "COMPACT"`. GKE accepts the update, **triggers a rolling node restart** to propagate the node-pool-config change, then refreshes state with `type = null`.
2. Next `terraform plan` sees `null → "COMPACT"` and plans another apply.
3. Apply again → another rolling restart. Loop forever.

For our A4X cluster (4 NVL72 racks, 18 nodes each, `max_unavailable: 2`), every spurious apply rolled all 4 pools in parallel for ~22 min each, for no functional config change.

## Why `type` is safe to ignore

Compact placement is enforced by `placementPolicy.policyName` — the workload-policy resource itself carries `workloadPolicy.type: HIGH_THROUGHPUT` and `acceleratorTopology`. The `type` field on the node pool is a redundant marker; GKE infers it from the bound policy.

I verified this on a healthy A4X cluster: `gcloud container node-pools describe ...` returns `placementPolicy.policyName` only, and pods land correctly within the NVL72's IMEX fabric (confirmed via a 2-node NCCL all_reduce hitting 838 GB/s peak bus bandwidth).

## Fix

Add `placement_policy[0].type` to the existing `lifecycle.ignore_changes` block on `google_container_node_pool.node_pool`. This stops terraform from chasing a field GKE never reads back, eliminating the perpetual diff and the spurious rolling.

The fix is intentionally minimal and only affects the drift-detection behaviour — `placement_policy.type` is still set on initial create, and updates to other fields in the block (e.g. `policy_name`) remain managed.

## Alternative considered

Patching `modules/compute/resource-policy/outputs.tf` to emit `type = null` unconditionally would also work (only `policy_name` is consumed downstream), but that's a broader API surface change. The lifecycle approach is local to the node-pool resource and doesn't change any module outputs.

## Tested

- A4X / GB200 cluster (24x trays across 4 pools). With this patch, the second `terraform plan` after an apply reports `No changes`. Without it, every plan shows `placement_policy.type: null → "COMPACT"` on every pool.
- No regression on initial pool creation: `placementPolicy.policyName` and `placementPolicy.type` are both set as before (verified via `gcloud container node-pools describe`).

Drafted for upstream review. Happy to follow up with a CLA sign-off / requested changes.