### PR TITLE
[Telemetry] Add support to merge vars from deployment files and CLI --vars

### DIFF
--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -47,7 +47,7 @@ func NewCollector(cmd *cobra.Command, args []string, installationMode string) *C
 		eventCmd:         cmd,
 		eventArgs:        args,
 		eventStartTime:   time.Now(),
-		blueprint:        GetBlueprint(cmd, args),
+		blueprint:        getBlueprint(cmd, args),
 		installationMode: installationMode,
 		metadata:         make(map[string]string),
 	}

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -47,7 +47,7 @@ func NewCollector(cmd *cobra.Command, args []string, installationMode string) *C
 		eventCmd:         cmd,
 		eventArgs:        args,
 		eventStartTime:   time.Now(),
-		blueprint:        getBlueprint(args),
+		blueprint:        GetBlueprint(cmd, args),
 		installationMode: installationMode,
 		metadata:         make(map[string]string),
 	}

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
-	"hpc-toolkit/pkg/modulewriter"
 	"io"
 	"net/http"
 	"os"
@@ -36,7 +35,7 @@ import (
 
 func TestNewCollector(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	// Passing nil for args prevents getBlueprint from attempting to read a file
+	// Passing nil for args prevents GetBlueprint from attempting to read a file
 	c := NewCollector(cmd, nil, SOURCE)
 
 	if c == nil {
@@ -196,101 +195,95 @@ func TestGetBlueprint(t *testing.T) {
 	// Create a temporary directory for test files
 	tmpDir := t.TempDir()
 
-	// 1. Setup a valid blueprint file
-	validBlueprintPath := filepath.Join(tmpDir, "valid_blueprint.yaml")
-	validBlueprintContent := `
+	// 1. Create a dummy base blueprint
+	bpPath := filepath.Join(tmpDir, "blueprint.yaml")
+	bpContent := []byte(`
 blueprint_name: test-blueprint
-deployment_groups:
-  - group: primary
-    modules:
-      - id: network
-        source: modules/network/vpc
-`
-	if err := os.WriteFile(validBlueprintPath, []byte(validBlueprintContent), 0644); err != nil {
-		t.Fatalf("Failed to create valid blueprint file: %v", err)
-	}
+vars:
+  project_id: default-project
+  region: us-central1
+`)
+	_ = os.WriteFile(bpPath, bpContent, 0644)
 
-	// 2. Setup an invalid blueprint file (malformed YAML)
-	invalidBlueprintPath := filepath.Join(tmpDir, "invalid_blueprint.yaml")
-	if err := os.WriteFile(invalidBlueprintPath, []byte("invalid: yaml: content: ["), 0644); err != nil {
-		t.Fatalf("Failed to create invalid blueprint file: %v", err)
-	}
+	// 2. Create a dummy deployment file for override testing
+	depFile := filepath.Join(tmpDir, "deployment.yaml")
+	depContent := []byte(`
+vars:
+  project_id: deployment-file-project
+`)
+	_ = os.WriteFile(depFile, depContent, 0644)
 
-	// 3. Setup a valid deployment directory with an expanded blueprint
-	validDepDir := filepath.Join(tmpDir, "valid_deployment")
-	artifactsDir := modulewriter.ArtifactsDir(validDepDir)
-	if err := os.MkdirAll(artifactsDir, 0755); err != nil {
-		t.Fatalf("Failed to create artifacts directory: %v", err)
-	}
-
-	expandedBlueprintPath := filepath.Join(artifactsDir, modulewriter.ExpandedBlueprintName)
-	validExpandedContent := `
+	// 3. Create a dummy deployment directory with an artifacts folder
+	deployDir := filepath.Join(tmpDir, "my-deployment")
+	artifactsDir := filepath.Join(deployDir, ".ghpc", "artifacts")
+	_ = os.MkdirAll(artifactsDir, 0755)
+	expandedBpPath := filepath.Join(artifactsDir, "expanded_blueprint.yaml")
+	expandedBpContent := []byte(`
 blueprint_name: expanded-test-blueprint
-deployment_groups:
-  - group: primary
-    modules:
-      - id: network
-        source: modules/network/vpc
-`
-	if err := os.WriteFile(expandedBlueprintPath, []byte(validExpandedContent), 0644); err != nil {
-		t.Fatalf("Failed to create expanded blueprint file: %v", err)
-	}
+vars:
+  project_id: artifacts-project
+`)
+	_ = os.WriteFile(expandedBpPath, expandedBpContent, 0644)
 
-	// 4. Setup an invalid deployment directory (missing the expanded blueprint)
-	invalidDepDir := filepath.Join(tmpDir, "invalid_deployment")
-	if err := os.MkdirAll(invalidDepDir, 0755); err != nil {
-		t.Fatalf("Failed to create invalid deployment directory: %v", err)
-	}
-
-	// Define test cases
 	tests := []struct {
 		name          string
 		args          []string
-		expectedName  string
+		setupCmd      func() *cobra.Command
 		expectIsEmpty bool
+		expectedName  string
+		expectedVars  map[string]string // Key to expected variable value
 	}{
 		{
-			name:          "Empty arguments",
+			name:          "No arguments",
 			args:          []string{},
-			expectedName:  "",
+			setupCmd:      func() *cobra.Command { return &cobra.Command{} },
 			expectIsEmpty: true,
 		},
 		{
-			name:          "Non-existent path",
-			args:          []string{filepath.Join(tmpDir, "does_not_exist")},
-			expectedName:  "",
-			expectIsEmpty: true,
+			name:         "Basic blueprint file",
+			args:         []string{bpPath},
+			setupCmd:     func() *cobra.Command { return &cobra.Command{} },
+			expectedName: "test-blueprint",
+			expectedVars: map[string]string{"project_id": "default-project"},
 		},
 		{
-			name:          "Valid blueprint file",
-			args:          []string{validBlueprintPath},
-			expectedName:  "test-blueprint",
-			expectIsEmpty: false,
+			name:         "Deployment directory",
+			args:         []string{deployDir},
+			setupCmd:     func() *cobra.Command { return &cobra.Command{} },
+			expectedName: "expanded-test-blueprint",
+			expectedVars: map[string]string{"project_id": "artifacts-project"},
 		},
 		{
-			name:          "Invalid blueprint file",
-			args:          []string{invalidBlueprintPath},
-			expectedName:  "",
-			expectIsEmpty: true,
+			name: "With deployment-file override",
+			args: []string{bpPath},
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Flags().String("deployment-file", depFile, "")
+				return cmd
+			},
+			expectedName: "test-blueprint",
+			expectedVars: map[string]string{"project_id": "deployment-file-project"},
 		},
 		{
-			name:          "Valid deployment directory",
-			args:          []string{validDepDir},
-			expectedName:  "expanded-test-blueprint",
-			expectIsEmpty: false,
-		},
-		{
-			name:          "Deployment directory missing expanded blueprint",
-			args:          []string{invalidDepDir},
-			expectedName:  "",
-			expectIsEmpty: true,
+			name: "With vars flag override",
+			args: []string{bpPath},
+			setupCmd: func() *cobra.Command {
+				cmd := &cobra.Command{}
+				cmd.Flags().StringSlice("vars", []string{"project_id=cli-project", "zone=us-east1-a"}, "")
+				return cmd
+			},
+			expectedName: "test-blueprint",
+			expectedVars: map[string]string{
+				"project_id": "cli-project",
+				"zone":       "us-east1-a",
+			},
 		},
 	}
 
-	// Execute tests
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			bp := getBlueprint(tc.args)
+			cmd := tc.setupCmd()
+			bp := GetBlueprint(cmd, tc.args)
 
 			if tc.expectIsEmpty {
 				// Assert that the returned Blueprint is effectively empty
@@ -301,6 +294,21 @@ deployment_groups:
 				// Assert that the returned Blueprint parsed the correct file
 				if bp.BlueprintName != tc.expectedName {
 					t.Errorf("Expected BlueprintName %q, got %q", tc.expectedName, bp.BlueprintName)
+				}
+
+				// Assert that variables were properly overridden/merged
+				for k, expectedVal := range tc.expectedVars {
+					if !bp.Vars.Has(k) {
+						t.Errorf("Expected variable %q to exist, but it was missing", k)
+						continue
+					}
+
+					// Evaluate the variable to safely extract its string value
+					val := bp.Vars.Get(k)
+					unmarked, _ := val.Unmark()
+					if unmarked.AsString() != expectedVal {
+						t.Errorf("Expected variable %q to be %q, got %q", k, expectedVal, unmarked.AsString())
+					}
 				}
 			}
 		})

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/modulewriter"
 	"io"
 	"net/http"
 	"os"
@@ -215,7 +216,7 @@ vars:
 
 	// 3. Create a dummy deployment directory with an artifacts folder
 	deployDir := filepath.Join(tmpDir, "my-deployment")
-	artifactsDir := filepath.Join(deployDir, ".ghpc", "artifacts")
+	artifactsDir := modulewriter.ArtifactsDir(deployDir)
 	_ = os.MkdirAll(artifactsDir, 0755)
 	expandedBpPath := filepath.Join(artifactsDir, "expanded_blueprint.yaml")
 	expandedBpContent := []byte(`
@@ -283,7 +284,7 @@ vars:
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := tc.setupCmd()
-			bp := GetBlueprint(cmd, tc.args)
+			bp := getBlueprint(cmd, tc.args)
 
 			if tc.expectIsEmpty {
 				// Assert that the returned Blueprint is effectively empty

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -36,7 +36,7 @@ import (
 
 func TestNewCollector(t *testing.T) {
 	cmd := &cobra.Command{Use: "test"}
-	// Passing nil for args prevents GetBlueprint from attempting to read a file
+	// Passing nil for args prevents getBlueprint from attempting to read a file
 	c := NewCollector(cmd, nil, SOURCE)
 
 	if c == nil {

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/modulewriter"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -76,9 +77,9 @@ func mergeDeploymentFileVars(cmd *cobra.Command, bp *config.Blueprint) {
 		return
 	}
 
-	for k, v := range ds.Vars.Items() {
-		bp.Vars = bp.Vars.With(k, v)
-	}
+	vars := bp.Vars.Items()
+	maps.Copy(vars, ds.Vars.Items())
+	bp.Vars = config.NewDict(vars)
 }
 
 func mergeCLIVars(cmd *cobra.Command, bp *config.Blueprint) {

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -38,7 +38,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func GetBlueprint(cmd *cobra.Command, args []string) config.Blueprint {
+func getBlueprint(cmd *cobra.Command, args []string) config.Blueprint {
 	if len(args) == 0 {
 		return config.Blueprint{}
 	}
@@ -100,6 +100,7 @@ func mergeCLIVars(cmd *cobra.Command, bp *config.Blueprint) {
 
 		key := arr[0]
 		var v config.YamlValue
+		// Use YAML unmarshal to support complex types (lists, maps) passed via CLI.
 		if err := yaml.Unmarshal([]byte(arr[1]), &v); err == nil {
 			bp.Vars = bp.Vars.With(key, v.Unwrap())
 		}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -33,27 +33,77 @@ import (
 	billing "cloud.google.com/go/billing/apiv1"
 	resourcemanager "cloud.google.com/go/resourcemanager/apiv3"
 	resourcemanagerpb "cloud.google.com/go/resourcemanager/apiv3/resourcemanagerpb"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
-func getBlueprint(args []string) config.Blueprint {
+func GetBlueprint(cmd *cobra.Command, args []string) config.Blueprint {
 	if len(args) == 0 {
 		return config.Blueprint{}
 	}
 
-	targetPath := args[0]
-
-	// If the argument is a directory, it indicates a deployment folder (e.g., used in 'deploy' or 'destroy').
-	// We read the expanded blueprint from the artifacts directory instead.
-	if info, err := os.Stat(targetPath); err == nil && info.IsDir() {
-		targetPath = filepath.Join(modulewriter.ArtifactsDir(targetPath), modulewriter.ExpandedBlueprintName)
-	}
+	targetPath := resolveBlueprintPath(args[0])
 
 	bp, _, err := config.NewBlueprint(targetPath)
 	if err != nil {
 		return config.Blueprint{} // Return empty if it fails to parse
 	}
 
+	mergeDeploymentFileVars(cmd, &bp)
+	mergeCLIVars(cmd, &bp)
+
 	return bp
+}
+
+func resolveBlueprintPath(targetPath string) string {
+	// If the argument is a directory, it indicates a deployment folder (e.g., used in 'deploy' or 'destroy').
+	// We read the expanded blueprint from the artifacts directory instead.
+	if info, err := os.Stat(targetPath); err == nil && info.IsDir() {
+		return filepath.Join(modulewriter.ArtifactsDir(targetPath), modulewriter.ExpandedBlueprintName)
+	}
+	return targetPath
+}
+
+func mergeDeploymentFileVars(cmd *cobra.Command, bp *config.Blueprint) {
+	flag := cmd.Flag("deployment-file")
+	if flag == nil || flag.Value.String() == "" {
+		return
+	}
+
+	ds, _, err := config.NewDeploymentSettings(flag.Value.String())
+	if err != nil {
+		return
+	}
+
+	for k, v := range ds.Vars.Items() {
+		bp.Vars = bp.Vars.With(k, v)
+	}
+}
+
+func mergeCLIVars(cmd *cobra.Command, bp *config.Blueprint) {
+	flag := cmd.Flag("vars")
+	if flag == nil {
+		return
+	}
+
+	varsSlice, err := cmd.Flags().GetStringSlice("vars")
+	if err != nil {
+		return
+	}
+
+	for _, cliVar := range varsSlice {
+		arr := strings.SplitN(cliVar, "=", 2)
+		if len(arr) != 2 {
+			continue
+		}
+
+		key := arr[0]
+		var v config.YamlValue
+		if err := yaml.Unmarshal([]byte(arr[1]), &v); err == nil {
+			bp.Vars = bp.Vars.With(key, v.Unwrap())
+		}
+	}
 }
 
 func getEventMetadataKVPairs(sourceMetadata map[string]string) []map[string]string {


### PR DESCRIPTION
This pull request enhances the telemetry collection mechanism by allowing it to **incorporate configuration variables from external deployment files and command-line overrides**. By centralizing the blueprint resolution and variable merging logic, the system ensures that telemetry data accurately reflects the actual configuration used during deployment.

Changes:

* **Enhanced Telemetry Data Collection**: Updated the telemetry collector to support merging variables from deployment files and CLI arguments, ensuring more accurate data collection.
* **Improved Test Coverage**: Updated unit tests to validate variable merging logic for both deployment files and command-line flags.