### PR TITLE
Clean up custom spot VM variables during standard fallback

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -40,9 +40,7 @@ steps:
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
-  - "MACHINE_TYPE=tpu"
-  - "TPU_RUNTIME_VERSION=tpu7x-ubuntu-2404"
-  - "ACCELERATOR_TYPE=tpu7x-16"
+  - "MACHINE_TYPE=tpu7x-standard-4t"
   - "PROJECT_ID=$PROJECT_ID"
   - "NUM_NODES=2"
   - "INSTANCE_PREFIX=tpu7xsp"
@@ -53,12 +51,6 @@ steps:
   - -c
   - |
     set -e -u -o pipefail
-    echo "Sourcing find_available_zone.sh to determine zone."
-    source /workspace/tools/cloud-build/find_available_zone.sh
-    if [ -z "$${ZONE:-}" ]; then
-      echo "ERROR: ZONE not found" >&2
-      exit 1
-    fi
     set -x
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
@@ -69,7 +61,6 @@ steps:
     else
         make
     fi
-    REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     EXAMPLE_BP=examples/gke-tpu-7x/gke-tpu-7x.yaml
     # adding vm to act as remote node
@@ -95,13 +86,6 @@ steps:
 
     ENABLE_SPOT="true"
     GKE_VARS_FILE="tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml"
-    if [[ "$$PROVISIONING_MODEL" == "STANDARD" ]]; then
-      ENABLE_SPOT="false"
-      sed -i '/instance_labels:/,+1d' "$${GKE_VARS_FILE}"
-      sed -i '/enable_spot: true/d' "$${GKE_VARS_FILE}"
-    else
-      echo "INFO: Using $${GKE_VARS_FILE} as it is for SPOT provisioning."
-    fi
 
     sed -i -e '/reservation_affinity:/,+3c\      spot: '"$$ENABLE_SPOT"'' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
@@ -110,7 +94,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
-        --extra-vars="region=$${REGION} zone=$${ZONE}" \
+        --extra-vars="region=us-central1 zone=us-central1-c" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"
   secretEnv: ['GCLUSTER_GCS_PATH', 'CHS_REPO']

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -40,7 +40,9 @@ steps:
   env:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
-  - "MACHINE_TYPE=tpu7x-standard-4t"
+  - "MACHINE_TYPE=tpu"
+  - "TPU_RUNTIME_VERSION=tpu7x-ubuntu-2404"
+  - "ACCELERATOR_TYPE=tpu7x-16"
   - "PROJECT_ID=$PROJECT_ID"
   - "NUM_NODES=2"
   - "INSTANCE_PREFIX=tpu7xsp"
@@ -51,6 +53,12 @@ steps:
   - -c
   - |
     set -e -u -o pipefail
+    echo "Sourcing find_available_zone.sh to determine zone."
+    source /workspace/tools/cloud-build/find_available_zone.sh
+    if [ -z "$${ZONE:-}" ]; then
+      echo "ERROR: ZONE not found" >&2
+      exit 1
+    fi
     set -x
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
@@ -61,6 +69,7 @@ steps:
     else
         make
     fi
+    REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     EXAMPLE_BP=examples/gke-tpu-7x/gke-tpu-7x.yaml
     # adding vm to act as remote node
@@ -86,6 +95,13 @@ steps:
 
     ENABLE_SPOT="true"
     GKE_VARS_FILE="tools/cloud-build/daily-tests/tests/gke-tpu-7x.yml"
+    if [[ "$$PROVISIONING_MODEL" == "STANDARD" ]]; then
+      ENABLE_SPOT="false"
+      sed -i '/instance_labels:/,+1d' "$${GKE_VARS_FILE}"
+      sed -i '/enable_spot: true/d' "$${GKE_VARS_FILE}"
+    else
+      echo "INFO: Using $${GKE_VARS_FILE} as it is for SPOT provisioning."
+    fi
 
     sed -i -e '/reservation_affinity:/,+3c\      spot: '"$$ENABLE_SPOT"'' $${EXAMPLE_BP}
     sed -i '/reservation/d' $${EXAMPLE_BP}
@@ -94,7 +110,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
-        --extra-vars="region=us-central1 zone=us-central1-c" \
+        --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"
   secretEnv: ['GCLUSTER_GCS_PATH', 'CHS_REPO']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -80,6 +80,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/a3_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -82,6 +82,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/a3mega_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -69,6 +69,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${VARS_FILE}"
+      sed -i '/a3u_enable_spot_vm: true/d' "$${VARS_FILE}"
     else
       echo "INFO: Using $${VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -86,6 +86,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/a3u_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -70,6 +70,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${VARS_FILE}"
+      sed -i '/a4h_enable_spot_vm: true/d' "$${VARS_FILE}"
     else
       echo "INFO: Using $${VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -82,6 +82,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/a4h_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -77,6 +77,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/g4_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -76,6 +76,7 @@ steps:
       ENABLE_SPOT="false"
       sed -i '/instance_labels:/,+1d' "$${SLURM_VARS_FILE}"
       sed -i '/enable_spot: true/d' "$${SLURM_VARS_FILE}"
+      sed -i '/h4d_enable_spot_vm: true/d' "$${SLURM_VARS_FILE}"
     else
       echo "INFO: Using $${SLURM_VARS_FILE} as it is for SPOT provisioning."
     fi


### PR DESCRIPTION
This CL addresses a bug in the integration tests where the Standard fallback mechanism (which runs standard on-demand VMs if Spot capacity is unavailable) would fail.

Specific spot-related variables passed under cli_deployment_vars (like a3_enable_spot_vm: true) were left untouched in the variables files during standard fallback. This caused the compute nodes to still request Spot instances in zones where Spot capacity was exhausted, resulting in Resource exhausted deployment failures.

We now clean up or update all custom Spot VM variables when falling back to standard VM provisioning.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
