### PR TITLE
Adding upgrade guide for GKE clusters

### DIFF
--- a/docs/gke-cluster-management.md
+++ b/docs/gke-cluster-management.md
@@ -80,14 +80,37 @@ Run `gcluster deploy` to create the cluster. Sample command:
 
 ### 2.2 Upgrading an Existing Cluster
 
-To upgrade an existing cluster, you can perform a manual version upgrade to a specific target version or change the cluster's release channel to align with a different stability track. This section covers procedures for upgrading both the master control plane and individual node pools using either the **`gcloud` CLI** or the **Google Cloud Console (UI).**
+To upgrade an existing cluster, you can perform a version upgrade to a specific target version or change the cluster's release channel to align with a different stability track. This section covers procedures for upgrading both the master control plane and individual node pools using **Cluster Toolkit blueprints**, the **`gcloud` CLI**, or the **Google Cloud Console (UI)**.
 
 > [!WARNING]
 > **Configuration Drift**: Performing manual upgrades via `gcloud` or the Google Cloud Console will cause configuration drift. The actual state of the cluster will no longer match the Terraform state managed by the Cluster Toolkit.
 >
-> To maintain the blueprint as the source of truth, the preferred method is to update the `version_prefix` or `release_channel` in the blueprint and run `./gcluster deploy <path-to-blueprint.yaml>`.
+> To maintain the blueprint as the source of truth, the preferred method is to update the `version_prefix` or `release_channel` in the blueprint and run `./gcluster deploy <path-to-blueprint.yaml> -w`.
 >
 > If a manual upgrade is performed, subsequent toolkit operations may attempt to revert the cluster to the version defined in the blueprint unless the blueprint is also updated to match.
+
+### Upgrading via Blueprint
+
+To maintain your blueprint as the source of truth and avoid configuration drift, the recommended way to upgrade an existing cluster is by updating the blueprint and redeploying.
+
+#### Step 1: Update Blueprint
+Modify your blueprint file to specify the new GKE version or release channel.
+
+Example: Update `version_prefix` to a new minor version or specific patch.
+
+```yaml
+    settings:
+      version_prefix: "1.31." # Upgrading to 1.31
+```
+
+#### Step 2: Redeploy
+Run the `gcluster deploy` command again pointing to your blueprint:
+
+```shell
+./gcluster deploy <path-to-blueprint.yaml> -w
+```
+
+Cluster Toolkit will detect the configuration change in the underlying Terraform state and initiate the upgrade of the cluster control plane and node pools.
 
 ### Upgrading via gcloud CLI
 
@@ -215,7 +238,9 @@ Periodically, the Cluster Toolkit team will update the default versions defined 
 
 When performing manual upgrades, following aspects need to be considered:
 
-* **Disruption and Reboots**: Upgrading GKE clusters requires node replacement or restarts. Using `gcloud container clusters upgrade CLUSTER_NAME --node-pool=NODE_POOL_NAME` will trigger a rolling update of that node pool, replacing old nodes with new ones running the updated version. This process is disruptive as pods will be evicted and rescheduled.  
+* **Disruption and Reboots**:
+  * Upgrading GKE node pools requires node replacement or restarts. Whether triggered via blueprint redeployment, `gcloud` CLI, or the Cloud Console, upgrading a node pool initiates a rolling update. This process replaces old nodes with new ones running the updated version, which is disruptive as pods will be evicted and rescheduled.
+  * Standard rolling upgrades are disruptive to tightly-coupled distributed workloads (e.g., multi-node training jobs using `JobSet`). Losing a single node in a distributed job usually causes the entire job to fail. For these workloads, operators should gracefully pause or drain their jobs (e.g., scaling JobSets/deployments to 0) and verify that a successful checkpoint has been saved to persistent storage before initiating a node pool upgrade.
 * **Pod Disruption Budgets (PDBs)**: GKE respects PDBs during upgrades. If a PDB is overly restrictive, it can block or slow down the upgrade process. Conversely, ensure PDBs are configured correctly to maintain application availability during the rolling update.  
 * **Storage Persistence**: Temporary storage volumes (like `emptyDir`) are deleted when nodes are replaced. Persistent disks (PVs) are unaffected.  
 * **Channel Changes**:  

--- a/docs/gke-cluster-management.md
+++ b/docs/gke-cluster-management.md
@@ -183,17 +183,17 @@ gcloud container clusters update CLUSTER_NAME \
 
 #### Step 2: Upgrade Node Pools
 
-* After the control plane upgrade completes, click the **Nodes** tab on the cluster details page.  
-* Click the name of the node pool you want to upgrade.
+1. After the control plane upgrade completes, click the **Nodes** tab on the cluster details page.
+2. Click the name of the node pool you want to upgrade.
 
-* Click **Edit** at the top of the page.  
-* Click **Change** next to **Node version**, select the target version, and click **Save**.
+3. Click **Edit** at the top of the page.
+4. Click **Change** next to **Node version**, select the target version, and click **Save**.
 
 
 #### Changing Release Channel via Console (UI)
 
-* Under **Cluster basics** on the cluster details page, find the **Release channel** field and click **Edit**.  
-* Select the new channel and click **Save Changes**.
+1. Under **Cluster basics** on the cluster details page, find the **Release channel** field and click **Edit**.
+2. Select the new channel and click **Save Changes**.
 
 ## 3\. Cluster Toolkit Team Updates
 
@@ -217,7 +217,3 @@ When performing manual upgrades, following aspects need to be considered:
   * No Immediate Disruption: Changing the release channel is a metadata operation on the control plane and does not cause nodes to restart or be replaced, provided the current cluster version is valid in the new channel.  
   * Version Compatibility: The cluster's current version must be supported in the target channel. You may need to upgrade the cluster first if it's on a version too old for the new channel.  
 * **Monitoring Upgrade Progress**: Monitor the upgrade progress to ensure nodes successfully transition to the new version. You can monitor the status in the Google Cloud Console under the GKE section.
-
-
-
-

--- a/docs/gke-cluster-management.md
+++ b/docs/gke-cluster-management.md
@@ -73,7 +73,7 @@ deployment_groups:
 Run `gcluster deploy` to create the cluster. Sample command:
 
 ```shell
-./gcluster deploy examples/<path-to-blueprint.yaml>
+./gcluster deploy <path-to-blueprint.yaml>
 ```
 
 **Note**: For many machine types, deploy command would also have the deployment config file as well. Refer the respective READMEs of machine types in the toolkit for exact deployment commands.
@@ -81,6 +81,13 @@ Run `gcluster deploy` to create the cluster. Sample command:
 ### 2.2 Upgrading an Existing Cluster
 
 To upgrade an existing cluster, you can perform a manual version upgrade to a specific target version or change the cluster's release channel to align with a different stability track. This section covers procedures for upgrading both the master control plane and individual node pools using either the **`gcloud` CLI** or the **Google Cloud Console (UI).**
+
+> [!WARNING]
+> **Configuration Drift**: Performing manual upgrades via `gcloud` or the Google Cloud Console will cause configuration drift. The actual state of the cluster will no longer match the Terraform state managed by the Cluster Toolkit.
+>
+> To maintain the blueprint as the source of truth, the preferred method is to update the `version_prefix` or `release_channel` in the blueprint and run `./gcluster deploy <path-to-blueprint.yaml>`.
+>
+> If a manual upgrade is performed, subsequent toolkit operations may attempt to revert the cluster to the version defined in the blueprint unless the blueprint is also updated to match.
 
 ### Upgrading via gcloud CLI
 
@@ -203,7 +210,7 @@ Periodically, the Cluster Toolkit team will update the default versions defined 
 2. **Re-Deploy**: Regenerate your Terraform code from your blueprints using the updated toolkit and apply the changes. This ensures you pick up the new defaults without necessarily hardcoding versions in your blueprints.
 
 ```shell
-./gcluster deploy -d PATH_TO_DEPLOYMENT_FILE PATH_TO_BLUEPRINT_FILE.yaml
+./gcluster deploy <path-to-blueprint.yaml>
 ```
 
 ## 4\. Important Considerations During Upgrades

--- a/docs/gke-cluster-management.md
+++ b/docs/gke-cluster-management.md
@@ -1,0 +1,223 @@
+# GKE Upgrade Guide for Cluster Toolkit
+
+This guide provides comprehensive instructions for Cluster Toolkit users on how to manage and upgrade Google Kubernetes Engine (GKE) versions. It covers strategies for selecting appropriate versions, deploying new clusters with specific version requirements, and performing manual upgrades on existing clusters across various release channels. This guide helps you keep your GKE clusters secure, up-to-date, and stable for HPC and AI/ML workloads.
+
+## 1\. GKE Versioning and Release Channels
+
+Google Kubernetes Engine (GKE) regularly releases new versions containing new features, performance improvements, and security patches. GKE offers Release Channels to manage the balance between feature availability and stability.
+
+When planning an upgrade, you should review the official [GKE Release Notes](https://docs.cloud.google.com/kubernetes-engine/docs/release-notes) to understand the changes and identify the target version for your upgrade.
+
+## 2\. Cluster Upgrade Strategy
+
+Upgrade strategies differ depending on whether you are deploying a new cluster or updating an existing one. For new clusters, you can specify the target version or channel in the blueprint. For existing clusters, you perform a managed upgrade using `gcloud` commands.
+
+### 2.1 Deploying a New Cluster with a Specific Version
+
+When deploying a new cluster, you can configure your blueprint to use a specific GKE version or a release channel.
+
+#### Step 1: Identify Target Version
+
+Find the desired GKE version from the [GKE Release Notes](https://docs.cloud.google.com/kubernetes-engine/docs/release-notes). You should choose a version that is available in the channel you plan to use, or a version that meets your specific requirements (e.g., a specific patch for a bug fix). Note that versions available in the `RAPID` channel may not be available in `REGULAR` or `STABLE` yet.
+
+#### Step 2: Update Blueprint
+
+Modify your blueprint to specify the GKE version and release channel as shown below.
+
+##### Specifying GKE Versions in Blueprint
+
+In your Cluster Toolkit blueprint, you can control the GKE version via `version_prefix` var:  
+Blueprint snippet:
+
+```
+# ...
+deployment_groups:
+- group: primary
+  modules:
+  - id: my-gke-cluster
+    source: modules/scheduler/gke-cluster
+    settings:
+      # Specify the GKE version here
+      # version_prefix: "1.30.1-gke.1156000"
+      # ...
+```
+
+**Note** on `version_prefix`: By default, the `gke-cluster` module restricts upgrades to a specific minor version (like `1.31.`).
+
+* To stay on the same minor version: Leave `version_prefix` as is.  
+* To upgrade to a new minor version (or specific patch): You must update `version_prefix` to that new prefix or full version (e.g., `"1.32."` or `"1.32.2-gke.100"`).
+
+##### Specifying Release Channels in Blueprint
+
+GKE offers Release Channels (RAPID, REGULAR, STABLE) which can be configured in the `release_channel` variable.
+
+* **RAPID Channel**: Receives new features and versions first.  
+* **REGULAR Channel**: The default channel, balanced between stability and new features.  
+* **STABLE Channel**: Receives versions after they have been thoroughly soaked in other channels.
+
+Blueprint snippet:
+
+```
+# ...
+deployment_groups:
+- group: primary
+  modules:
+  - id: my-gke-cluster
+    source: modules/scheduler/gke-cluster
+    settings:
+      release_channel: REGULAR
+```
+
+#### Step 3: Deploy the cluster
+
+Run `gcluster deploy` to create the cluster. Sample command:
+
+```shell
+./gcluster deploy examples/<path-to-blueprint.yaml>
+```
+
+**Note**: For many machine types, deploy command would also have the deployment config file as well. Refer the respective READMEs of machine types in the toolkit for exact deployment commands.
+
+### 2.2 Upgrading an Existing Cluster
+
+To upgrade an existing cluster, you can perform a manual version upgrade to a specific target version or change the cluster's release channel to align with a different stability track. This section covers procedures for upgrading both the master control plane and individual node pools using either the **`gcloud` CLI** or the **Google Cloud Console (UI).**
+
+### Upgrading via gcloud CLI
+
+This operation updates the GKE version of the control plane and node pools of the cluster via the gcloud CLI.
+
+#### Step 1: Identify Target Version
+
+Find the target version from the [GKE Release Notes](https://docs.cloud.google.com/kubernetes-engine/docs/release-notes).
+
+#### Step 2: Upgrade Master Control Plane
+
+The GKE control plane must be upgraded before the nodes can be upgraded. Use the `gcloud` command with the `--master` flag.
+
+```shell
+gcloud container clusters upgrade CLUSTER_NAME \
+    --master \
+    --cluster-version=TARGET_GKE_VERSION \
+    --region=REGION \
+    --project=PROJECT_ID
+```
+
+#### Step 3: Upgrade Node Pools
+
+Once the master is upgraded, upgrade each node pool (including system and compute pools) individually.
+
+```shell
+gcloud container clusters upgrade CLUSTER_NAME \
+    --node-pool=NODE_POOL_NAME \
+    --cluster-version=TARGET_GKE_VERSION \
+    --region=REGION \
+    --project=PROJECT_ID
+```
+
+#### Step 4: Verify Upgrade of Cluster and Node pool
+
+Check that the nodes are running the target version:
+
+* ##### Verify Cluster Version and Release Channel
+
+**Command:**
+
+```shell
+gcloud container clusters describe CLUSTER_NAME \
+    --region=REGION \
+    --format="yaml(currentMasterVersion, releaseChannel)" \
+    --project=PROJECT_ID
+```
+
+**Expected Output:**
+
+```
+currentMasterVersion: TARGET_GKE_VERSION
+releaseChannel:
+  channel: REGULAR
+```
+
+* ##### Verify Node Pool Version
+
+**Command:**
+
+```shell
+gcloud container node-pools describe NODE_POOL_NAME \
+    --cluster=CLUSTER_NAME \
+    --region=REGION \
+    --format="yaml(version)" \
+    --project=PROJECT_ID
+```
+
+**Expected Output:**
+
+```
+version: TARGET_GKE_VERSION
+```
+
+#### Changing Release Channel via gcloud CLI
+
+This command is typically used to move a cluster from the `RAPID` channel back to `REGULAR` or `STABLE` once the desired version becomes available in those channels, allowing you to resume automatic upgrades on a more conservative track.
+
+To change the release channel of an existing cluster, use the `gcloud container clusters update` command:
+
+```shell
+gcloud container clusters update CLUSTER_NAME \
+    --release-channel=CHANNEL \
+    --region=REGION
+```
+
+*Replace `CHANNEL` with `rapid`, `regular`, `stable`, or `none`.*
+
+### Upgrading via Google Cloud Console (UI)
+
+#### Step 1: Upgrade Control Plane
+
+1. Navigate to Clusters: In the Google Cloud Console, go to the **Kubernetes Engine \> Clusters** page.  
+2. Select Cluster: Click the name of the cluster you want to upgrade to open the cluster details.
+
+3. Edit Version: In the **Cluster basics** section, locate the **Version** field and click the edit icon or **Upgrade available** link.  
+4. Upgrade Control Plane: Select the option to upgrade the cluster control plane.  
+5. Save Changes: Select your target version and click **Save Changes** to start the upgrade.
+
+
+#### Step 2: Upgrade Node Pools
+
+* After the control plane upgrade completes, click the **Nodes** tab on the cluster details page.  
+* Click the name of the node pool you want to upgrade.
+
+* Click **Edit** at the top of the page.  
+* Click **Change** next to **Node version**, select the target version, and click **Save**.
+
+
+#### Changing Release Channel via Console (UI)
+
+* Under **Cluster basics** on the cluster details page, find the **Release channel** field and click **Edit**.  
+* Select the new channel and click **Save Changes**.
+
+## 3\. Cluster Toolkit Team Updates
+
+Periodically, the Cluster Toolkit team will update the default versions defined in the modules to incorporate new stable GKE versions. To adopt these new defaults:
+
+1. **Update Toolkit**: You should update your Cluster Toolkit installation by downloading the latest cluster toolkit binary.  
+2. **Re-Deploy**: Regenerate your Terraform code from your blueprints using the updated toolkit and apply the changes. This ensures you pick up the new defaults without necessarily hardcoding versions in your blueprints.
+
+```shell
+./gcluster deploy -d PATH_TO_DEPLOYMENT_FILE PATH_TO_BLUEPRINT_FILE.yaml
+```
+
+## 4\. Important Considerations During Upgrades
+
+When performing manual upgrades, following aspects need to be considered:
+
+* **Disruption and Reboots**: Upgrading GKE clusters requires node replacement or restarts. Using `gcloud container clusters upgrade CLUSTER_NAME --node-pool=NODE_POOL_NAME` will trigger a rolling update of that node pool, replacing old nodes with new ones running the updated version. This process is disruptive as pods will be evicted and rescheduled.  
+* **Pod Disruption Budgets (PDBs)**: GKE respects PDBs during upgrades. If a PDB is overly restrictive, it can block or slow down the upgrade process. Conversely, ensure PDBs are configured correctly to maintain application availability during the rolling update.  
+* **Storage Persistence**: Temporary storage volumes (like `emptyDir`) are deleted when nodes are replaced. Persistent disks (PVs) are unaffected.  
+* **Channel Changes**:  
+  * No Immediate Disruption: Changing the release channel is a metadata operation on the control plane and does not cause nodes to restart or be replaced, provided the current cluster version is valid in the new channel.  
+  * Version Compatibility: The cluster's current version must be supported in the target channel. You may need to upgrade the cluster first if it's on a version too old for the new channel.  
+* **Monitoring Upgrade Progress**: Monitor the upgrade progress to ensure nodes successfully transition to the new version. You can monitor the status in the Google Cloud Console under the GKE section.
+
+
+
+

--- a/docs/gke-cluster-management.md
+++ b/docs/gke-cluster-management.md
@@ -29,7 +29,7 @@ Modify your blueprint to specify the GKE version and release channel as shown be
 In your Cluster Toolkit blueprint, you can control the GKE version via `version_prefix` var:  
 Blueprint snippet:
 
-```
+```yaml
 # ...
 deployment_groups:
 - group: primary
@@ -57,7 +57,7 @@ GKE offers Release Channels (RAPID, REGULAR, STABLE) which can be configured in 
 
 Blueprint snippet:
 
-```
+```yaml
 # ...
 deployment_groups:
 - group: primary
@@ -138,7 +138,7 @@ gcloud container clusters describe CLUSTER_NAME \
 
 **Expected Output:**
 
-```
+```yaml
 currentMasterVersion: TARGET_GKE_VERSION
 releaseChannel:
   channel: REGULAR
@@ -158,7 +158,7 @@ gcloud container node-pools describe NODE_POOL_NAME \
 
 **Expected Output:**
 
-```
+```yaml
 version: TARGET_GKE_VERSION
 ```
 
@@ -187,7 +187,6 @@ gcloud container clusters update CLUSTER_NAME \
 4. Upgrade Control Plane: Select the option to upgrade the cluster control plane.  
 5. Save Changes: Select your target version and click **Save Changes** to start the upgrade.
 
-
 #### Step 2: Upgrade Node Pools
 
 1. After the control plane upgrade completes, click the **Nodes** tab on the cluster details page.
@@ -195,7 +194,6 @@ gcloud container clusters update CLUSTER_NAME \
 
 3. Click **Edit** at the top of the page.
 4. Click **Change** next to **Node version**, select the target version, and click **Save**.
-
 
 #### Changing Release Channel via Console (UI)
 


### PR DESCRIPTION
## Description
This PR introduces a comprehensive guide for managing and upgrading Google Kubernetes Engine (GKE) clusters within the Cluster Toolkit environment. The guide covers both automated configurations via blueprints and manual upgrade procedures.
**File Added:** `docs/gke-cluster-management.md`

Keeping GKE clusters up-to-date is critical for security, stability, and accessing new features, especially for HPC and AI/ML workloads. This guide provides Cluster Toolkit users with clear, step-by-step instructions on how to handle version upgrades safely and effectively.
## Key Sections Covered
1. **GKE Versioning and Release Channels**: Explains how GKE versioning works and how to use Release Channels (RAPID, REGULAR, STABLE).
2. **Cluster Upgrade Strategy**:
    * **Deploying New Clusters**: How to specify target versions and channels in blueprints using `version_prefix` and `release_channel`.
    * **Upgrading Existing Clusters**: Detailed steps for upgrading both the control plane and node pools using:
        * **Blueprint**: Modify the version and channel and redploy via blueprint.
        * **`gcloud` CLI**: For automated or terminal-based workflows.
        * **Google Cloud Console (UI)**: For a visual, step-by-step approach.
4. **Important Considerations**: Information regarding disruption, reboots, Pod Disruption Budgets (PDBs) during upgrades.
