### PR TITLE
[Telemetry] Add a retry mechanism to get the GCP Project information to eliminate transient issues 

### DIFF
--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -310,7 +310,7 @@ func getTerraformVersion() string {
 func getBillingAccountId(bp config.Blueprint) string {
 	projectID := getKeyFromBlueprint("project_id", bp)
 	if projectID != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 
 		billingAccount := getProjectBillingAccount(ctx, projectID)

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -85,14 +85,16 @@ func (c *Collector) BuildConcordEvent() ConcordEvent {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	project_id := getKeyFromBlueprint("project_id", c.blueprint)
+
 	return ConcordEvent{
 		ConsoleType:      CLUSTER_TOOLKIT,
 		EventType:        "gclusterCLI",
 		EventName:        getCommandName(c.eventCmd),
 		EventMetadata:    getEventMetadataKVPairs(c.metadata),
-		ProjectNumber:    getProjectNumber(c.blueprint),
+		ProjectNumber:    getProjectNumber(project_id),
 		ClientInstallId:  getClientInstallId(),
-		BillingAccountId: getBillingAccountId(c.blueprint),
+		BillingAccountId: getBillingAccountId(project_id),
 		ReleaseVersion:   getReleaseVersion(),
 		IsGoogler:        getIsGoogler(),
 		LatencyMs:        getLatencyMs(c.eventStartTime),
@@ -194,13 +196,12 @@ func getIsVmInstance(modulesList []string) string {
 	return ifModulesMatchPatterns(modulesList, isVmInstanceModulePatterns)
 }
 
-func getProjectNumber(bp config.Blueprint) string {
-	projectID := getKeyFromBlueprint("project_id", bp)
+func getProjectNumber(projectID string) string {
 	if projectID == "" {
 		return ""
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout10Sec)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout15Sec)
 	defer cancel()
 
 	projectName, err := fetchProjectName(ctx, projectID)
@@ -307,18 +308,19 @@ func getTerraformVersion() string {
 	return version
 }
 
-func getBillingAccountId(bp config.Blueprint) string {
-	projectID := getKeyFromBlueprint("project_id", bp)
-	if projectID != "" {
-		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-		defer cancel()
-
-		billingAccount := getProjectBillingAccount(ctx, projectID)
-		if billingAccount != "" {
-			return strings.TrimPrefix(billingAccount, "billingAccounts/")
-		}
+func getBillingAccountId(projectID string) string {
+	if projectID == "" {
+		return ""
 	}
-	return ""
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout15Sec)
+	defer cancel()
+
+	billingAccount, err := getProjectBillingAccount(ctx, projectID)
+	if err != nil || billingAccount == "" {
+		return ""
+	}
+	return strings.TrimPrefix(billingAccount, "billingAccounts/")
 }
 
 // getIsGoogler determines if the credentials belong to a Google internal user or an internal CI service account.

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1017,87 +1017,51 @@ func TestGetIsVmInstance(t *testing.T) {
 	}
 }
 
-// TestGetProjectNumber verifies that the project number is correctly fetched
-// or gracefully fails depending on the blueprint configuration and API response.
+// TestGetProjectNumber verifies that the project number is correctly fetched or gracefully fails depending on the API response.
 func TestGetProjectNumber(t *testing.T) {
 	tests := []struct {
 		name      string
-		blueprint config.Blueprint
+		projectID string
 		clientErr error
 		mockErr   error
 		want      string
 	}{
 		{
-			name: "success_1",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("test-project-1"),
-				}),
-			},
-			want: "1234567890",
+			name:      "success_1",
+			projectID: "test-project-1",
+			want:      "1234567890",
 		},
 		{
-			name: "success_2",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("test-project-2"),
-				}),
-			},
-			want: "9876543210",
+			name:      "success_2",
+			projectID: "test-project-2",
+			want:      "9876543210",
 		},
 		{
-			name: "no_project_id",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{}),
-			},
-			want: "",
+			name:      "no_project_id",
+			projectID: "",
+			want:      "",
 		},
 		{
-			name: "client_creation_error",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("any-project"),
-				}),
-			},
+			name:      "client_creation_error",
+			projectID: "any-project",
 			clientErr: errors.New("failed to create client"),
 			want:      "",
 		},
 		{
-			name: "api_error",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("error-project"),
-				}),
-			},
-			mockErr: errors.New("project not found"),
-			want:    "",
+			name:      "api_error",
+			projectID: "error-project",
+			mockErr:   errors.New("project not found"),
+			want:      "",
 		},
 		{
-			name: "api_returns_empty_name",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal(""),
-				}),
-			},
-			want: "",
+			name:      "api_returns_empty_name",
+			projectID: "empty-name-project",
+			want:      "",
 		},
 		{
-			name: "api_returns_nil_project",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.StringVal("nil-project"),
-				}),
-			},
-			want: "",
-		},
-		{
-			name: "project_id_not_string_type",
-			blueprint: config.Blueprint{
-				Vars: config.NewDict(map[string]cty.Value{
-					"project_id": cty.NumberIntVal(123),
-				}),
-			},
-			want: "",
+			name:      "api_returns_nil_project",
+			projectID: "nil-project",
+			want:      "",
 		},
 	}
 
@@ -1122,10 +1086,13 @@ func TestGetProjectNumber(t *testing.T) {
 				if projectID == "test-project-2" {
 					return "projects/9876543210", nil
 				}
+				if projectID == "empty-name-project" || projectID == "nil-project" {
+					return "", nil
+				}
 				return "", errors.New("not found")
 			}
 
-			got := getProjectNumber(tt.blueprint)
+			got := getProjectNumber(tt.projectID)
 			if got != tt.want {
 				t.Errorf("getProjectNumber() = %v, want %v", got, tt.want)
 			}
@@ -1141,55 +1108,46 @@ func TestGetBillingAccountId(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		setupBp            func() config.Blueprint
+		projectID          string
 		mockBillingAccount string
+		mockErr            error
 		expected           string
 	}{
 		{
-			name: "Missing project_id in blueprint",
-			setupBp: func() config.Blueprint {
-				return config.Blueprint{
-					Vars: config.NewDict(map[string]cty.Value{}),
-				}
-			},
+			name:               "Missing project_id",
+			projectID:          "",
 			mockBillingAccount: "",
 			expected:           "",
 		},
 		{
-			name: "Project ID present but no billing account returned",
-			setupBp: func() config.Blueprint {
-				return config.Blueprint{
-					Vars: config.NewDict(map[string]cty.Value{
-						"project_id": cty.StringVal("test-project-123"),
-					}),
-				}
-			},
+			name:               "Project ID present but no billing account returned",
+			projectID:          "test-project-123",
 			mockBillingAccount: "",
 			expected:           "",
 		},
 		{
-			name: "Project ID present and billing account trimmed",
-			setupBp: func() config.Blueprint {
-				return config.Blueprint{
-					Vars: config.NewDict(map[string]cty.Value{
-						"project_id": cty.StringVal("test-project-123"),
-					}),
-				}
-			},
+			name:               "Project ID present and billing account trimmed",
+			projectID:          "test-project-123",
 			mockBillingAccount: "billingAccounts/012345-6789AB-CDEF01",
 			expected:           "012345-6789AB-CDEF01",
+		},
+		{
+			name:               "Project ID present but API fails",
+			projectID:          "test-project-123",
+			mockBillingAccount: "",
+			mockErr:            errors.New("api error"),
+			expected:           "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Mock the GCP call for this specific test case
-			getProjectBillingAccount = func(ctx context.Context, projectID string) string {
-				return tt.mockBillingAccount
+			// Mock the GCP call for this specific test case, now returning (string, error)
+			getProjectBillingAccount = func(ctx context.Context, projectID string) (string, error) {
+				return tt.mockBillingAccount, tt.mockErr
 			}
 
-			bp := tt.setupBp()
-			actual := getBillingAccountId(bp)
+			actual := getBillingAccountId(tt.projectID)
 
 			if actual != tt.expected {
 				t.Errorf("getBillingAccountId() = %q, want %q", actual, tt.expected)

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -223,10 +223,10 @@ func extractDefaultMachineType(key string, m config.Module) string {
 }
 
 // getProjectBillingAccount fetches the billing account associated with a given GCP project in the format "billingAccounts/{billing_account_id}". If billing is disabled for the project, this will return an empty string.
-var getProjectBillingAccount = func(ctx context.Context, projectID string) string {
+var getProjectBillingAccount = func(ctx context.Context, projectID string) (string, error) {
 	client, err := billing.NewCloudBillingClient(ctx)
 	if err != nil {
-		return ""
+		return "", err
 	}
 	defer client.Close()
 	req := &billingpb.GetProjectBillingInfoRequest{
@@ -240,7 +240,7 @@ var getProjectBillingAccount = func(ctx context.Context, projectID string) strin
 	for attempt := 1; attempt <= 3; attempt++ {
 		info, apiErr = client.GetProjectBillingInfo(ctx, req)
 		if apiErr == nil {
-			return info.GetBillingAccountName()
+			return info.GetBillingAccountName(), nil
 		}
 		// Check for context expiration and avoid sleep on the last iteration to reduce unnecessary latency on failure
 		if attempt == 3 || ctx.Err() != nil {
@@ -248,7 +248,7 @@ var getProjectBillingAccount = func(ctx context.Context, projectID string) strin
 		}
 		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond) // simple backoff
 	}
-	return ""
+	return "", apiErr
 }
 
 // fetchProjectName retrieves the project name (which contains the project number) for a given project ID.

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -242,6 +242,10 @@ var getProjectBillingAccount = func(ctx context.Context, projectID string) strin
 		if apiErr == nil {
 			return info.GetBillingAccountName()
 		}
+		// Check for context expiration and avoid sleep on the last iteration to reduce unnecessary latency on failure
+		if attempt == 3 || ctx.Err() != nil {
+			break
+		}
 		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond) // simple backoff
 	}
 	return ""
@@ -264,6 +268,10 @@ var fetchProjectName = func(ctx context.Context, projectID string) (string, erro
 		project, apiErr = client.GetProject(ctx, req)
 		if apiErr == nil {
 			return project.Name, nil
+		}
+		// Check for context expiration and avoid sleep on the last iteration to reduce unnecessary latency on failure
+		if attempt == 3 || ctx.Err() != nil {
+			break
 		}
 		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond) // simple backoff
 	}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -232,11 +232,19 @@ var getProjectBillingAccount = func(ctx context.Context, projectID string) strin
 	req := &billingpb.GetProjectBillingInfoRequest{
 		Name: fmt.Sprintf("projects/%s", projectID),
 	}
-	info, err := client.GetProjectBillingInfo(ctx, req)
-	if err != nil {
-		return ""
+
+	var info *billingpb.ProjectBillingInfo
+	var apiErr error
+
+	// Retry up to 3 times for transient failures (e.g., rate limits or network flakes)
+	for attempt := 1; attempt <= 3; attempt++ {
+		info, apiErr = client.GetProjectBillingInfo(ctx, req)
+		if apiErr == nil {
+			return info.GetBillingAccountName()
+		}
+		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond) // simple backoff
 	}
-	return info.GetBillingAccountName()
+	return ""
 }
 
 // fetchProjectName retrieves the project name (which contains the project number) for a given project ID.
@@ -247,11 +255,20 @@ var fetchProjectName = func(ctx context.Context, projectID string) (string, erro
 	}
 	defer client.Close()
 	req := &resourcemanagerpb.GetProjectRequest{Name: fmt.Sprintf("projects/%s", projectID)}
-	project, err := client.GetProject(ctx, req)
-	if err != nil {
-		return "", err
+
+	var project *resourcemanagerpb.Project
+	var apiErr error
+
+	// Retry up to 3 times for transient failures (e.g., rate limits or network flakes)
+	for attempt := 1; attempt <= 3; attempt++ {
+		project, apiErr = client.GetProject(ctx, req)
+		if apiErr == nil {
+			return project.Name, nil
+		}
+		time.Sleep(time.Duration(attempt) * 500 * time.Millisecond) // simple backoff
 	}
-	return project.Name, nil
+
+	return "", apiErr
 }
 
 // checkADCForInternalUser parses the ADC JSON file to extract the client email.

--- a/pkg/telemetry/types.go
+++ b/pkg/telemetry/types.go
@@ -26,6 +26,7 @@ import (
 const (
 	clearcutProdURL = "https://play.googleapis.com/log"
 	configDirName   = "cluster-toolkit"
+	timeout15Sec    = 15 * time.Second
 	timeout10Sec    = 10 * time.Second
 	timeout2Sec     = 2 * time.Second
 	CLUSTER_TOOLKIT = "CLUSTER_TOOLKIT"


### PR DESCRIPTION
This pull request introduces a **robust retry strategy for GCP telemetry data collection to improve the reliability of the process**. By incorporating a simple backoff mechanism optimizing context handling, the system is now better equipped to handle transient failures when fetching project billing information and project details, reducing the likelihood of telemetry collection errors.

Changes:

* **Resilience Improvement**: Implemented a retry mechanism with backoff for GCP API calls to handle transient network issues and rate limiting.
* **Enhanced Error Handling**: Updated the project billing and resource manager retrieval logic to attempt operations up to three times before failing, including context awareness to avoid unnecessary latency.
* **Timeout Adjustment**: Increased the context timeout for billing account retrieval from 10 to 15 seconds to accommodate the new retry logic.