### PR TITLE
[Telemetry] Collect the correct exit code when user intentionally stops deployment (0 instead of 1)

### DIFF
--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -63,15 +63,25 @@ func Error(f string, a ...any) {
 	errorlog.Printf("%s: %s", formatTs(), msg)
 }
 
-// Fatal prints message to stderr and ends the program
+// Fatal prints message to stderr and ends the program with exit code 1
 func Fatal(f string, a ...any) {
-	defer Exit(1)
+	FatalWithCode(1, f, a...)
+}
+
+// FatalWithCode prints message to stderr and ends the program with the specified exit code
+func FatalWithCode(exitCode int, f string, a ...any) {
+	defer Exit(exitCode)
 
 	msg := fmt.Sprintf(f, a...)
-	fatallog.Printf("%s: %s", formatTs(), msg)
+
+	if exitCode == 0 {
+		infolog.Printf("%s: %s", formatTs(), msg)
+	} else {
+		fatallog.Printf("%s: %s", formatTs(), msg)
+	}
 
 	// Execute the hook if it is registered
 	if FatalHook != nil {
-		FatalHook(1)
+		FatalHook(exitCode)
 	}
 }

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -23,6 +23,11 @@ import (
 	"github.com/fatih/color"
 )
 
+const (
+	successExitCode = 0
+	failureExitCode = 1
+)
+
 var (
 	infolog      *log.Logger
 	errorlog     *log.Logger
@@ -65,7 +70,7 @@ func Error(f string, a ...any) {
 
 // Fatal prints message to stderr and ends the program with exit code 1
 func Fatal(f string, a ...any) {
-	ExitWithCode(1, f, a...)
+	ExitWithCode(failureExitCode, f, a...)
 }
 
 // ExitWithCode ends the program with the specified exit code. It prints a message to stdout if exitCode is 0, or stderr otherwise.
@@ -74,7 +79,7 @@ func ExitWithCode(exitCode int, f string, a ...any) {
 
 	msg := fmt.Sprintf(f, a...)
 
-	if exitCode == 0 {
+	if exitCode == successExitCode {
 		infolog.Printf("%s: %s", formatTs(), msg)
 	} else {
 		fatallog.Printf("%s: %s", formatTs(), msg)

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -65,11 +65,11 @@ func Error(f string, a ...any) {
 
 // Fatal prints message to stderr and ends the program with exit code 1
 func Fatal(f string, a ...any) {
-	FatalWithCode(1, f, a...)
+	ExitWithCode(1, f, a...)
 }
 
-// FatalWithCode prints message to stderr and ends the program with the specified exit code
-func FatalWithCode(exitCode int, f string, a ...any) {
+// ExitWithCode ends the program with the specified exit code. It prints a message to stdout if exitCode is 0, or stderr otherwise.
+func ExitWithCode(exitCode int, f string, a ...any) {
 	defer Exit(exitCode)
 
 	msg := fmt.Sprintf(f, a...)

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -194,7 +194,7 @@ Please select an option [d,a,s,c]: `)
 		case "d":
 			fmt.Println(c.Full)
 		case "s":
-			logging.FatalWithCode(0, "user chose to stop execution of gcluster rather than make proposed changes to infrastructure")
+			logging.ExitWithCode(0, "user chose to stop execution of gcluster rather than make proposed changes to infrastructure")
 		}
 	}
 }

--- a/pkg/shell/common.go
+++ b/pkg/shell/common.go
@@ -194,7 +194,7 @@ Please select an option [d,a,s,c]: `)
 		case "d":
 			fmt.Println(c.Full)
 		case "s":
-			logging.Fatal("user chose to stop execution of gcluster rather than make proposed changes to infrastructure")
+			logging.FatalWithCode(0, "user chose to stop execution of gcluster rather than make proposed changes to infrastructure")
 		}
 	}
 }


### PR DESCRIPTION
**Issue**
When a user runs `gcluster deploy` and chooses to stop execution by selecting `(s)` at the prompt, the telemetry records an exit code of `1` instead of `0`. This incorrectly flags intentional, graceful terminations as application failures in the telemetry data.

**Root Cause**
The issue arises because of how the "s" (stop) action is handled during the deployment prompt. When the user stops execution, the CLI invokes `logging.Fatal()`. The `logging.Fatal()` automatically triggers the `FatalHook` hardcoded with an exit code of `1`. As a result, the tool treats this explicit user choice as a fatal application error.

**Solution**
The solution is to rename the core `Fatal` logic to `ExitWithCode` and make the existing `Fatal` a wrapper around it with an exit code `1`. Specifically, this PR:
1. Introduces `ExitWithCode(exitCode int, f string, a ...any)` in `pkg/logging/logging.go` to support specifying exit codes. It also ensures that a success code (0) logs to `stdout` via `infolog` instead of `fatallog`.
2. Updates `ApplyChangesChoice` in `pkg/shell/common.go` to use `logging.ExitWithCode(0, ...)` when the user selects "s".

This allows the CLI to stop cleanly, triggering the `FatalHook` with an exit code of `0` and ensuring telemetry metrics accurately reflect user intent without breaking existing `Fatal` calls across the repository.