### PR TITLE
[Telemetry] Add an atomic flag to ensure telemetry event is not recurrently called

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
@@ -49,7 +50,8 @@ var (
 var (
 	InstallationMode   string // Toolkit installation mode like "SOURCE", "BINARY", etc.
 	telemetryCollector *telemetry.Collector
-	userConfigExists   bool = false
+	userConfigExists   bool        = false
+	telemetryFlushed   atomic.Bool // 2-state flag for whether telemetry event is flushed or not.
 )
 
 var (
@@ -80,8 +82,11 @@ func init() {
 
 			// Register the fatal hook to flush telemetry on hard failures
 			logging.FatalHook = func(exitCode int) {
-				if config.IsTelemetryEnabled() && telemetryCollector != nil {
-					telemetryCollector.Execute(exitCode)
+				// Ensure telemetry is executed exactly once to prevent re-entrancy and duplicates.
+				if telemetryFlushed.CompareAndSwap(false, true) {
+					if config.IsTelemetryEnabled() && telemetryCollector != nil {
+						telemetryCollector.Execute(exitCode)
+					}
 				}
 			}
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -146,8 +146,11 @@ Commit info: {{index .Annotations "commitInfo"}}
 		}
 	}
 
-	if config.IsTelemetryEnabled() && userConfigExists {
-		telemetryCollector.Execute(exitCode)
+	// Ensure telemetry is executed exactly once on normal exits to prevent recurrency
+	if telemetryFlushed.CompareAndSwap(false, true) {
+		if config.IsTelemetryEnabled() && userConfigExists {
+			telemetryCollector.Execute(exitCode)
+		}
 	}
 
 	return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -262,10 +262,11 @@ func TestExecute_TelemetryAndErrorHandling(t *testing.T) {
 	t.Setenv("APPDATA", tempDir) // For Windows compatibility
 	t.Setenv("HOME", tempDir)    // For macOS/Linux compatibility
 
-	// Ensure config is initialized and telemetry is explicitly turned OFF
-	// to prevent actual network/telemetry calls during unit tests.
+	// Ensure config is initialized and telemetry is explicitly turned OFF to prevent actual network/telemetry calls during unit tests.
 	_ = config.InitUserConfig()
 	_ = config.SetTelemetry(false)
+	// Reset the flag at the start of the test block
+	telemetryFlushed.Store(false)
 
 	// Create a real *exec.ExitError for testing the exit code unwrapping logic
 	execCmd := exec.Command("false")
@@ -322,6 +323,9 @@ func TestExecute_TelemetryAndErrorHandling(t *testing.T) {
 			// Reset global state initialized by PersistentPreRun to ensure clean slates
 			userConfigExists = false
 			telemetryCollector = nil
+
+			// Reset the flag between subtests
+			telemetryFlushed.Store(false)
 
 			// Inject a dummy command to trigger specific error cases
 			dummyCmd := tt.setupCmd()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -21,10 +21,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
@@ -355,5 +357,46 @@ func TestExecute_TelemetryAndErrorHandling(t *testing.T) {
 			// Cleanup dummy command for the next iteration
 			rootCmd.RemoveCommand(dummyCmd)
 		})
+	}
+}
+
+func TestFatalHook_ConcurrencyAndReentrancy(t *testing.T) {
+	// 1. Isolate config and reset state
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	_ = config.InitUserConfig()
+	_ = config.SetTelemetry(false) // Prevent actual telemetry network calls during the test
+
+	// Reset the atomic flag to its default state for a clean test
+	telemetryFlushed.Store(false)
+	telemetryCollector = nil
+
+	// 2. Execute PersistentPreRun to register the FatalHook
+	rootCmd.PersistentPreRun(rootCmd, []string{})
+
+	if logging.FatalHook == nil {
+		t.Fatal("Expected logging.FatalHook to be registered by PersistentPreRun")
+	}
+
+	// 3. Simulate multiple concurrent calls to logging.FatalHook
+	var wg sync.WaitGroup
+	numCalls := 10
+
+	for i := 0; i < numCalls; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// This simulates multiple goroutines hitting logging.Fatal concurrently,
+			// or a recursive logging.Fatal call inside the collector.
+			logging.FatalHook(1)
+		}()
+	}
+
+	// Wait for all concurrent executions to finish
+	wg.Wait()
+
+	// 4. Verify that the atomic flag was flipped to true and handled concurrency safely
+	if !telemetryFlushed.Load() {
+		t.Errorf("Expected telemetryFlushed to be true after FatalHook execution")
 	}
 }


### PR DESCRIPTION
**Problem**
Currently, the `logging.FatalHook` unconditionally triggers telemetry collection whenever the CLI encounters a fatal error. This introduces two significant risks:
1. **Re-entrancy/Deadlocks:** If the telemetry collector itself encounters an error while gathering metrics (for instance, failing to rename or read a packer module), it can trigger another `logging.Fatal()` call. This recursive loop can lead to deadlocks or redundant executions.
2. **Concurrent Duplicates:** If multiple goroutines experience a fatal error simultaneously, they will both trigger the `FatalHook` at the same time, leading to duplicate payload generation and concurrent uploads to Clearcut.

**Solution**
This PR introduces a thread-safe atomic flag to guarantee that telemetry is flushed exactly once per CLI execution, regardless of concurrency or re-entrant fatal calls.

**Changes**
* **`cmd/root.go`**: Added `telemetryFlushed atomic.Bool` to serve as a 2-state flag for whether the telemetry event is flushed or not. 
* **`cmd/root.go`**: Wrapped the telemetry execution inside the `logging.FatalHook` with `if telemetryFlushed.CompareAndSwap(false, true)`. 
* **`cmd/root_test.go`**: Added the `TestFatalHook_ConcurrencyAndReentrancy` unit test. This test spawns multiple concurrent goroutines to simulate race conditions and verifies that the telemetry hook behaves safely under load.

**Rationale**
Using an `atomic.Bool` with `CompareAndSwap` is superior to using standard locking mechanisms (like `sync.Mutex` or `sync.Once`) for this specific issue. Atomic operations are non-blocking; if a recursive call or a concurrent goroutine reaches the hook, it immediately evaluates to `false` and skips the block without waiting, safely proceeding to termination.

**Advantages**
* **Prevents Duplicate Events:** Ensures Clearcut analytics only receive one payload per execution.
* **Safe CLI Termination:** Eliminates the risk of deadlocks from infinite recursive `logging.Fatal` loops during failure handling.
* **Ergonomic Types:** Utilizing `atomic.Bool` expresses the intent clearly and avoids the error-prone usage of generic integer-based atomics.