### PR TITLE
Reduce Log Noise from gcluster Unzip

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,8 +57,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,7 +57,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,7 +57,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,7 +44,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,8 +44,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,7 +44,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,8 +42,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,7 +42,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,7 +42,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,7 +78,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,7 +78,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,8 +78,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,7 +55,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,8 +55,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,7 +55,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,7 +51,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,8 +51,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,7 +51,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,8 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,7 +58,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,8 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,7 +58,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,7 +63,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,7 +63,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,8 +63,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,7 +61,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,7 +61,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,8 +61,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,8 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,7 +60,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,7 +38,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,7 +38,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,8 +38,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,8 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,7 +60,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,7 +53,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,8 +53,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,7 +53,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else


### PR DESCRIPTION
Reduce Log Noise from gcluster Unzip

### Summary
Previous builds used the unzip -o command to extract the gcluster bundle, which listed every file extracted. Updated this to suppress the verbose listing while still allowing error messages to be visible in the logs.

**Changes**
- Muted the verbose "inflating" file logs by redirecting standard output to /dev/null.
- Replaced the verbose logs with a clean, one-line summary showing the total files and extracted size.
- Chained the commands with && to ensure the success summary only prints if the extraction actually succeeds, allowing actual system errors to still be surfaced.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
