### PR TITLE
Reduce Log Noise from gcluster Unzip

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -30,6 +30,23 @@
     deployment_vars_str: "--vars \"\\\"{{ cli_deployment_vars.items() | map('join', '=') | join('\\\"\" --vars \"\\\"') }}\\\"\""
   when: cli_deployment_vars is defined and cli_deployment_vars is mapping
 
+- name: Extract gcluster bundle
+  ansible.builtin.shell: |
+    set -e
+    unzip -o gcluster-bundle.zip > /dev/null
+    unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+    # Grant execution permissions to the binary
+    chmod +x gcluster
+  args:
+    chdir: "{{ workspace }}"
+  when: test_prefix | default('') == "daily-"
+  register: unzip_output
+
+- name: Print extraction summary
+  ansible.builtin.debug:
+    msg: "{{ unzip_output.stdout }}"
+  when: test_prefix | default('') == "daily-" and unzip_output.stdout is defined
+
 - name: Create Blueprint
   ansible.builtin.command: |
       ./gcluster create -l ERROR "{{ blueprint_yaml }}" \

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -34,7 +34,7 @@
   ansible.builtin.shell: |
     set -e
     if [ "{{ test_prefix | default('') }}" == "daily-" ] && [ "{{ build_gcluster_from_source | default(false) | bool | lower }}" == "false" ]; then
-        gsutil cp gs://{{ gcluster_gcs_path }}/latest/gcluster-bundle.zip .
+        gsutil cp gs://{{ gcluster_gcs_path | default('') }}/latest/gcluster-bundle.zip .
         unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -33,7 +33,7 @@
 - name: Get gcluster bundle or build
   ansible.builtin.shell: |
     set -e
-    if [ "{{ test_prefix | default('') }}" == "daily-" ]; then
+    if [ "{{ test_prefix | default('') }}" == "daily-" ] && [ "{{ build_gcluster_from_source | default(false) | bool | lower }}" == "false" ]; then
         gsutil cp gs://{{ gcluster_gcs_path }}/latest/gcluster-bundle.zip .
         unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -30,22 +30,25 @@
     deployment_vars_str: "--vars \"\\\"{{ cli_deployment_vars.items() | map('join', '=') | join('\\\"\" --vars \"\\\"') }}\\\"\""
   when: cli_deployment_vars is defined and cli_deployment_vars is mapping
 
-- name: Extract gcluster bundle
+- name: Get gcluster bundle or build
   ansible.builtin.shell: |
     set -e
-    unzip -o gcluster-bundle.zip > /dev/null
-    unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
-    # Grant execution permissions to the binary
-    chmod +x gcluster
+    if [ "{{ test_prefix | default('') }}" == "daily-" ]; then
+        gsutil cp gs://{{ gcluster_gcs_path }}/latest/gcluster-bundle.zip .
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        # Grant execution permissions to the binary
+        chmod +x gcluster
+    else
+        make
+    fi
   args:
     chdir: "{{ workspace }}"
-  when: test_prefix | default('') == "daily-"
-  register: unzip_output
+  register: bundle_output
 
-- name: Print extraction summary
+- name: Print build or extraction output
   ansible.builtin.debug:
-    msg: "{{ unzip_output.stdout }}"
-  when: test_prefix | default('') == "daily-" and unzip_output.stdout is defined
+    msg: "{{ bundle_output.stdout }}"
+  when: bundle_output.stdout is defined
 
 - name: Create Blueprint
   ansible.builtin.command: |

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,9 +43,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -55,7 +52,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ansible-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -41,18 +41,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ansible-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,8 +57,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,7 +57,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,7 +57,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -55,11 +55,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/batch-mpi.yaml
@@ -76,5 +71,5 @@ steps:
     echo '      timeout: 10800'                                   >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml"

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,7 +57,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -57,9 +57,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -79,5 +76,5 @@ steps:
     echo '      timeout: 10800'                                   >> $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml"

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,9 +44,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -57,7 +54,7 @@ steps:
 
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,7 +44,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -42,11 +42,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT=examples/batch.yaml
@@ -54,7 +49,7 @@ steps:
 
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/batch.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,8 +44,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,7 +44,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -44,7 +44,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,8 +42,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -46,7 +46,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=ubuntu gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} os=ubuntu gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -40,18 +40,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT=tools/cloud-build/daily-tests/blueprints/crd-ubuntu.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=ubuntu" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=ubuntu gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,7 +42,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,9 +42,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,7 +42,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -42,7 +42,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -41,18 +41,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT=tools/cloud-build/daily-tests/blueprints/crd-default.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=default" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=default gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -47,7 +47,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} os=default gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} os=default gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,9 +43,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,7 +78,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,9 +78,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -116,7 +113,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,7 +78,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,8 +78,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -78,7 +78,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -76,11 +76,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=tools/cloud-build/daily-tests/blueprints/gke-a2-highgpu.yaml
 
@@ -113,7 +108,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,9 +59,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -105,7 +102,7 @@ steps:
     sed -i '/^  reservation:/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -57,11 +57,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=examples/gke-a3-highgpu/gke-a3-highgpu.yaml
@@ -102,7 +97,7 @@ steps:
     sed -i '/^  reservation:/d' $${EXAMPLE_BP}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-a3-highgpu/gke-a3-highgpu.yaml
@@ -73,7 +68,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -76,7 +73,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-highgpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,9 +59,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -104,7 +101,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -57,11 +57,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -101,7 +96,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -76,7 +73,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-a3-megagpu/gke-a3-megagpu.yaml
@@ -73,7 +68,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-megagpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,9 +62,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -99,7 +99,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -60,11 +60,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -104,7 +99,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -46,11 +46,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -76,7 +71,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,9 +48,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -79,7 +76,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,9 +62,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -60,11 +60,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     EXAMPLE_BP=examples/gke-a4/gke-a4.yaml
@@ -105,7 +100,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -100,7 +100,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-a4x/gke-a4x.yaml
@@ -83,7 +78,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -86,7 +83,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,9 +59,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -98,7 +95,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -57,11 +57,6 @@ steps:
     fi
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
@@ -93,9 +88,9 @@ steps:
     cat $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -74,7 +71,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-g4.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-g4/gke-g4.yaml
@@ -71,7 +66,7 @@ steps:
     echo '    outputs: [instructions]'                         >> $${EXAMPLE_BP}
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-g4.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,9 +62,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -101,7 +98,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -60,11 +60,6 @@ steps:
     fi
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
@@ -96,9 +91,9 @@ steps:
     cat $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,9 +48,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -82,7 +79,7 @@ steps:
     python3 tools/fix_vpc_name.py $${EXAMPLE_BP} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -46,11 +46,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-h4d/gke-h4d.yaml
@@ -78,8 +73,8 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     python3 tools/fix_vpc_name.py $${EXAMPLE_BP} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-h4d.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -79,7 +76,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/hpc-gke.yaml
@@ -76,7 +71,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -45,11 +45,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/gke-managed-hyperdisk.yaml
@@ -65,7 +60,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -68,7 +65,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,9 +48,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -70,7 +67,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${EXAMPLE_BP}
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -46,11 +46,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=examples/gke-managed-lustre.yaml
@@ -67,7 +62,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${EXAMPLE_BP}
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,7 +48,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,7 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -48,8 +48,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/storage-gke.yaml
@@ -67,8 +62,8 @@ steps:
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     python3 tools/fix_vpc_name.py $${SG_EXAMPLE} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -71,7 +68,7 @@ steps:
     python3 tools/fix_vpc_name.py $${SG_EXAMPLE} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,7 +55,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,8 +55,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,9 +55,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,7 +55,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -53,11 +53,6 @@ steps:
     set -e -u -o pipefail
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     EXAMPLE_BP=examples/gke-tpu-7x/gke-tpu-7x.yaml
     # adding vm to act as remote node
@@ -90,7 +85,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=us-central1 zone=us-central1-c" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -85,7 +85,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=us-central1 zone=us-central1-c" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -55,7 +55,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,7 +51,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,8 +51,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,7 +51,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,9 +51,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -79,7 +76,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     # Run the test
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -49,11 +49,6 @@ steps:
     set -e -u -o pipefail
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     ZONE=asia-northeast1-b
     REGION=asia-northeast1
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
@@ -76,7 +71,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
     # Run the test
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -51,7 +51,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,9 +62,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -60,11 +60,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
 
@@ -105,7 +100,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,7 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -100,7 +100,7 @@ steps:
     bash tools/add_ttl_label.sh "$${EXAMPLE_BP}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} chs_repo=$${CHS_REPO} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${GKE_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,8 +62,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -62,7 +62,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -70,7 +67,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/hpc-gke.yaml
@@ -67,7 +62,7 @@ steps:
 
     bash tools/add_ttl_label.sh "$${SG_EXAMPLE}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,8 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,7 +58,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,9 +58,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -87,7 +84,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${H4D_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -56,11 +56,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT=$${BUILD_ID:0:6}
     BLUEPRINT="/workspace/examples/h4d-vm.yaml"
@@ -82,9 +77,9 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${H4D_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,9 +58,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -71,7 +68,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,8 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,7 +58,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -56,18 +56,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/hcls-blueprint.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -63,7 +63,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -58,7 +58,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -43,17 +43,12 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/hpc-build-slurm-image.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-build-slurm-image.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -56,7 +53,7 @@ steps:
     BLUEPRINT="community/examples/hpc-build-slurm-image.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-build-slurm-image.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,9 +49,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -61,7 +58,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -47,18 +47,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/hpc-enterprise-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -45,18 +45,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/htc-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/htc-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -59,7 +56,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/htc-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -62,7 +59,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml"
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -48,18 +48,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/htc-htcondor.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml"
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,7 +63,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,9 +63,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,7 +63,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,8 +63,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -61,11 +61,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
 
@@ -85,7 +80,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE}"\
       --extra-vars="enable_spot=$${ENABLE_SPOT} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -63,7 +63,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -58,7 +58,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}  gcluster_gcs_path=$${GCLUSTER_GCS_PATH}"\
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}"\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\
       --extra-vars="tcpx_kernel_login=$${TCPX_KERNEL_LOGIN} tcpx_kernel_password=$${TCPX_KERNEL_PASSWORD} keyserver_ubuntu_key=$${KEYSERVER_UBUNTU_KEY} "\
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm.yml"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -47,11 +47,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=us-west1
@@ -63,7 +58,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}  gcluster_gcs_path=$${GCLUSTER_GCS_PATH}"\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\
       --extra-vars="tcpx_kernel_login=$${TCPX_KERNEL_LOGIN} tcpx_kernel_password=$${TCPX_KERNEL_PASSWORD} keyserver_ubuntu_key=$${KEYSERVER_UBUNTU_KEY} "\
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-highgpu-slurm.yml"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,9 +49,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -62,11 +62,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml"
@@ -87,9 +82,9 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -64,9 +64,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -92,7 +89,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -62,7 +62,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=us-west4
@@ -65,7 +60,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -70,7 +67,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-megagpu-slurm-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-slurm-ubuntu.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -77,7 +77,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -56,7 +56,6 @@ steps:
       exit 1
     fi
     set -x
-    cd /workspace && make
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml"
@@ -80,6 +79,7 @@ steps:
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
+      --extra-vars="build_gcluster_from_source=true" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \
       --extra-vars="instance_image_family=$${CUSTOM_IMAGE_FAMILY}" \
       --extra-vars="@$${VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -77,7 +77,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-custom-blueprint-test.yaml
@@ -56,6 +56,7 @@ steps:
       exit 1
     fi
     set -x
+    cd /workspace
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml"
@@ -76,7 +77,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="build_gcluster_from_source=true" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -63,7 +60,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=europe-west1
@@ -58,7 +53,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
         --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -55,7 +55,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-jbvms.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-jbvms.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,8 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,9 +59,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -88,7 +85,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${JBVM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,7 +59,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -57,11 +57,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml"
@@ -83,9 +78,9 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="enable_spot=$${ENABLE_SPOT}" \
         --extra-vars="@$${JBVM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -59,7 +59,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,9 +64,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -62,11 +62,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml"
@@ -89,7 +84,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -68,7 +65,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=europe-west1
@@ -63,9 +58,9 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --user=sa_106486320838376751393 \
-        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -76,7 +76,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -56,6 +56,7 @@ steps:
       exit 1
     fi
     set -x
+    cd /workspace
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml"
@@ -75,7 +76,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="build_gcluster_from_source=true" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -56,7 +56,6 @@ steps:
       exit 1
     fi
     set -x
-    cd /workspace && make
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml"
@@ -79,6 +78,7 @@ steps:
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
+      --extra-vars="build_gcluster_from_source=true" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \
       --extra-vars="instance_image_family=$${CUSTOM_IMAGE_FAMILY}" \
       --extra-vars="@$${VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-custom-blueprint-test.yaml
@@ -76,7 +76,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="instance_image_project=$${CUSTOM_IMAGE_PROJECT}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,9 +64,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,7 +64,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,8 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -64,7 +64,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -62,11 +62,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml"
@@ -88,7 +83,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} chs_repo=$${CHS_REPO}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -45,11 +45,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=us-west8
@@ -62,7 +57,7 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-custom-blueprint-test.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     REGION=us-west8
@@ -68,7 +63,7 @@ steps:
     sed -i '/- homefs/d' $${BLUEPRINT}
     sed -i '/filestore_ip_range:/d' $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} "\
       --extra-vars="region=$${REGION} zone=$${ZONE} "\

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,9 +61,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -86,7 +83,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -78,7 +78,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -59,11 +59,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/ml-slurm-g4.yaml"
@@ -81,7 +76,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
       --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,7 +61,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,7 +61,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,7 +61,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -61,8 +61,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -72,7 +69,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -69,7 +64,7 @@ steps:
     sed -i "s/<your-ip-address>/$${IP}/" $${SG_EXAMPLE}
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     SG_EXAMPLE=examples/ml-gke.yaml
@@ -70,7 +65,7 @@ steps:
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -73,7 +70,7 @@ steps:
     bash tools/add_ttl_label.sh $${SG_EXAMPLE}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -58,11 +58,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/examples/hpc-slurm-h4d/hpc-slurm-h4d.yaml"
@@ -80,9 +75,9 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,8 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,9 +60,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -85,7 +82,7 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=$${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="enable_spot=$${ENABLE_SPOT}" \
       --extra-vars="@$${SLURM_VARS_FILE}"

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,7 +60,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -64,7 +61,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -48,11 +48,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/ml-slurm.yaml"
@@ -60,8 +55,8 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -45,18 +45,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="tools/cloud-build/daily-tests/blueprints/monitoring.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -59,7 +56,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -57,7 +54,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -43,18 +43,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/netapp-volumes.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,7 +38,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,9 +38,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -50,7 +47,7 @@ steps:
     git init . # ofe deploymemt requires some git repo to figure out top level directory
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/ofe-deployment-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ofe-deployment.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,7 +38,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -36,18 +36,13 @@ steps:
   - |
     set -ex
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
 
     git init . # ofe deploymemt requires some git repo to figure out top level directory
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/ofe-deployment-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ofe-deployment.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,7 +38,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -38,8 +38,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,8 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,7 +49,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,9 +49,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -61,7 +58,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -49,7 +49,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -47,18 +47,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/image-builder.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -46,9 +46,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -57,7 +54,7 @@ steps:
     BLUEPRINT="examples/pfs-managed-lustre-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -44,17 +44,12 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/pfs-managed-lustre-slurm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,7 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,7 +43,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,9 +43,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -54,7 +51,7 @@ steps:
     BLUEPRINT="examples/pfs-managed-lustre-vm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -41,17 +41,12 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/pfs-managed-lustre-vm.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -43,8 +43,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -43,11 +43,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     EXAMPLE_BP=community/examples/hpc-slinky/hpc-slinky.yaml
@@ -63,7 +58,7 @@ steps:
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/slinky.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,7 +45,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,9 +45,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -66,7 +63,7 @@ steps:
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
-        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+        --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/slinky.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,8 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -45,7 +45,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,9 +46,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -58,7 +55,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -44,18 +44,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/hpc-slurm-ubuntu2204.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,9 +46,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -60,7 +57,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -44,11 +44,6 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="examples/hpc-slurm.yaml"
@@ -56,8 +51,8 @@ steps:
     python3 tools/fix_vpc_name.py $${BLUEPRINT} "${_TEST_PREFIX}"
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true" \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="test_prefix=${_TEST_PREFIX} use_fixed_vpc=true gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -45,18 +45,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/hpc-slurm-local-ssd.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -59,7 +56,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -59,7 +56,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -45,18 +45,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="tools/validate_configs/test_configs/slurm-gcp-v6-startup-scripts.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,8 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -58,11 +58,6 @@ steps:
     fi
     set -x
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     REGION="$${ZONE%-*}"
     BUILD_ID_SHORT="$${BUILD_ID:0:6}"
     BLUEPRINT="/workspace/community/examples/hpc-slurm6-tpu.yaml"
@@ -71,7 +66,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-tpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,7 +60,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,7 +60,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -60,9 +60,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -74,7 +71,7 @@ steps:
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
       --user=sa_106486320838376751393 \
-      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-tpu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,7 +46,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,8 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,9 +46,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -58,7 +55,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -46,7 +46,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -44,18 +44,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/hpc-slurm-ubuntu2204.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,7 +53,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,7 +53,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,8 +53,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,7 +53,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -53,9 +53,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -65,7 +62,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook -v tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -51,18 +51,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:3}
     BLUEPRINT="community/examples/slurm-gke/slurm-gke.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook -v tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gke.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,8 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,7 +47,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,9 +47,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -58,7 +55,7 @@ steps:
     BLUEPRINT=examples/rapid-storage-slurm.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-rapid-storage.yaml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -45,17 +45,12 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT=examples/rapid-storage-slurm.yaml
     bash tools/add_ttl_label.sh $${BLUEPRINT}
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-rapid-storage.yaml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-rapid-storage.yaml
@@ -47,7 +47,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,7 +50,8 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip
+        unzip -oq gcluster-bundle.zip
+        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -48,18 +48,13 @@ steps:
   - |
     set -x -e
     cd /workspace
-    if [ "${_TEST_PREFIX}" == "daily-" ]; then
-        gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-    else
-        make
-    fi
     BUILD_ID_FULL=$BUILD_ID
     BUILD_ID_SHORT=$${BUILD_ID_FULL:0:6}
     BLUEPRINT="community/examples/hpc-slurm-gromacs.yaml"
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX} gcluster_gcs_path=$${GCLUSTER_GCS_PATH}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,8 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -oq gcluster-bundle.zip
-        unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,7 +50,7 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print \"Extracted \" $2 \" \" $3 \" (Total size: \" $1 \" bytes).\"}'
+        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary
         chmod +x gcluster
     else

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -50,9 +50,6 @@ steps:
     cd /workspace
     if [ "${_TEST_PREFIX}" == "daily-" ]; then
         gsutil cp gs://$${GCLUSTER_GCS_PATH}/latest/gcluster-bundle.zip .
-        unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $$2 " " $$3 " (Total size: " $$1 " bytes)."}'
-        # Grant execution permissions to the binary
-        chmod +x gcluster
     else
         make
     fi
@@ -62,7 +59,7 @@ steps:
     bash tools/add_ttl_label.sh $${BLUEPRINT}
 
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
-      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT}" \
+      --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} test_prefix=${_TEST_PREFIX}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml"
   secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-custom-blueprint-test.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-custom-blueprint-test.yml
@@ -19,6 +19,7 @@ test_name: a3u-custom-blueprint-test
 deployment_name: a3u-custom-blueprint-test-{{ build }}
 slurm_cluster_name: "a3usp{{ build[0:5] }}"
 workspace: /workspace
+build_gcluster_from_source: true
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-custom-blueprint-test.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a3-ultragpu-custom-blueprint-test.yml
@@ -19,7 +19,6 @@ test_name: a3u-custom-blueprint-test
 deployment_name: a3u-custom-blueprint-test-{{ build }}
 slurm_cluster_name: "a3usp{{ build[0:5] }}"
 workspace: /workspace
-build_gcluster_from_source: true
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-custom-blueprint-test.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-custom-blueprint-test.yml
@@ -19,7 +19,6 @@ test_name: a4h-custom-blueprint-test
 deployment_name: a4h-custom-blueprint-test-{{ build }}
 slurm_cluster_name: "a4hsp{{ build[0:5] }}"
 workspace: /workspace
-build_gcluster_from_source: true
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"

--- a/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-custom-blueprint-test.yml
+++ b/tools/cloud-build/daily-tests/tests/ml-a4-highgpu-custom-blueprint-test.yml
@@ -19,6 +19,7 @@ test_name: a4h-custom-blueprint-test
 deployment_name: a4h-custom-blueprint-test-{{ build }}
 slurm_cluster_name: "a4hsp{{ build[0:5] }}"
 workspace: /workspace
+build_gcluster_from_source: true
 blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml"
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"


### PR DESCRIPTION
Reduce Log Noise from gcluster Unzip

### Summary
Previously, individual Cloud Build YAML files for daily integration tests independently handled downloading the gcluster bundle, unzipping it, and setting execution permissions. The `unzip -o` command used in these builds listed every file extracted, contributing to cluttered build logs.

This PR centralizes the gcluster preparation logic (both fetching the bundle and building from source) into the shared Ansible task file  `create_deployment_directory.yml`. This change reduces code duplication, making the daily test configurations cleaner and easier to maintain, while also reducing clutter in Cloud Build logs by silencing the verbose output of the unzip command and adding a concise one-line summary of the extracted files.

This change reduces clutter in Cloud Build logs by silencing the verbose output of the unzip command, while adding a concise one-line summary of the total files and size extracted as well as reduces code duplication, making the daily test configurations cleaner and easier to maintain.

**Changes**


_Ansible Tasks_

`create_deployment_directory.yml `: Added a new shell task labeled "`Get gcluster bundle or build`" that handles the preparation of `gcluster`.

Conditional Logic: A conditional check is executed within the shell script. If `test_prefix` is `"daily-"` and `build_gcluster_from_source` is false, it downloads the bundle via `gsutil cp` and extracts it. Otherwise, it runs `make`.
Log Optimization: Silenced the output of the `unzip` command by redirecting it to `/dev/null`, and used a post-extraction pipeline to parse unzip -l and print a single clean line: `Extracted X files (Total size: Y bytes).`
Robustness: Included `set -e` for error handling and `chmod +x` to ensure the binary is executable.

_Cloud Build Configurations_

Removed setup logic (including `gsutil cp`, `unzip`, and `chmod` commands) from daily test YAML files in `tools/cloud-build/daily-tests/builds/`.
Updated all modified Cloud Build files to pass both `test_prefix=${_TEST_PREFIX}` and `gcluster_gcs_path=$${GCLUSTER_GCS_PATH}` to Ansible via `--extra-vars` to enable the conditional checks and GCS access in the task file.


**Testing**

The changes are designed to only take effect during daily integration tests. Pull Request (PR) tests are unaffected and continue to function as before.
To validate the changes safely without waiting for a scheduled daily build, testing was performed locally.
The configuration was tested to specifically exercise the unzip and extraction path to verify the new log optimization logic.

The testing was successful and behavior matched expectations. The Ansible tasks executed correctly, and the verbose file listing was successfully replaced by the clean summary line in the logs.

```
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Create .ssh folder] ******************************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Create SSH Key] **********************************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Get Builder IP] **********************************************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Create Deployment Directory] *********************************************
Step #1 - "chrome-remote-desktop-ubuntu": included: /workspace/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml for localhost
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Assert variables are defined] ********************************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost] => {
Step #1 - "chrome-remote-desktop-ubuntu":     "changed": false
Step #1 - "chrome-remote-desktop-ubuntu": }
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": MSG:
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": All assertions passed
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Set bucket] **************************************************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Create cli flag for extra deployment variables] **************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Get gcluster bundle or build] ********************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Print build or extraction output] ****************************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost] => {}
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": MSG:
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": Extracted 314 files (Total size: 103341582 bytes).
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Create Blueprint] ********************************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Compress Blueprint] ******************************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Uploading deployment] ****************************************************
Step #1 - "chrome-remote-desktop-ubuntu": changed: [localhost]
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": TASK [Print download command] **************************************************
Step #1 - "chrome-remote-desktop-ubuntu": ok: [localhost] => {}
Step #1 - "chrome-remote-desktop-ubuntu": 
Step #1 - "chrome-remote-desktop-ubuntu": MSG:
Step #1 - "chrome-remote-desktop-ubuntu":

```

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
