### PR TITLE
fix: accelerator label auto resolution

### DIFF
--- a/pkg/config/machine_configs.go
+++ b/pkg/config/machine_configs.go
@@ -110,21 +110,18 @@ func ParseTPUCount(machineType string) int {
 
 // ResolveAcceleratorInfo returns the number and type of accelerators for a given machine type.
 func ResolveAcceleratorInfo(mt *compute.MachineType, machineType string) (count int, accelType string, isTPU bool) {
-	isTPU = strings.HasPrefix(machineType, "ct") || strings.HasPrefix(machineType, "tpu")
+	isTPU = IsTPU(machineType)
 
 	if len(mt.Accelerators) > 0 {
 		acc := mt.Accelerators[0]
-		if isTPU || strings.Contains(strings.ToLower(acc.GuestAcceleratorType), "tpu") {
-			return int(acc.GuestAcceleratorCount), "tpu", true
-		}
-		return int(acc.GuestAcceleratorCount), acc.GuestAcceleratorType, false
+		return int(acc.GuestAcceleratorCount), acc.GuestAcceleratorType, isTPU
 	}
 
 	if count := ParseTPUCount(machineType); count > 0 {
-		return count, "tpu", true
+		return count, "tpu", isTPU
 	}
 
-	return 0, "", false
+	return 0, "", isTPU
 }
 
 // GetMachineType fetches machine type information from GCP Compute API with caching.

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -385,6 +385,9 @@ func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinitio
 		"--project", job.ProjectID,
 		"--format=json")
 	if res.ExitCode != 0 {
+		if strings.Contains(res.Stderr, "403") || strings.Contains(strings.ToLower(res.Stderr), "permission denied") {
+			return fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", job.ClusterName, job.ProjectID)
+		}
 		return fmt.Errorf("failed to describe GKE cluster %s: %s", job.ClusterName, res.Stderr)
 	}
 
@@ -903,21 +906,41 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 	}
 
 	logging.Info("Auto-discovering Topology for %s...", job.MachineType)
-	output, err := g.queryDiscoveredTopologies()
+	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
+	output, err := g.queryDiscoveredTopologies(accelLabel)
 	if err != nil {
 		return "", false, err
 	}
 
 	topologies := g.parseTopologies(output)
 
-	res, err := g.selectTopology(job.Topology, topologies, job.MachineType)
+	parts := strings.Split(job.ComputeType, "-")
+	var requestedChips int
+	if len(parts) == 2 {
+		// If parts[1] is not a valid integer, Atoi returns 0.
+		// We ignore the error and fall back to resolving without size restriction.
+		requestedChips, _ = strconv.Atoi(parts[1])
+	}
+	res, err := g.selectTopology(job.Topology, topologies, job.MachineType, requestedChips)
 	if err == nil {
 		g.topologyCache[cacheKey] = res
 	}
 	return res, false, err
 }
 
-func (g *GKEOrchestrator) selectTopology(requested string, topologies map[string]bool, accelType string) (string, error) {
+func calculateChipsFromTopology(topology string) int {
+	parts := strings.Split(topology, "x")
+	chips := 1
+	for _, p := range parts {
+		n, _ := strconv.Atoi(p)
+		if n > 0 {
+			chips *= n
+		}
+	}
+	return chips
+}
+
+func (g *GKEOrchestrator) selectTopology(requested string, topologies map[string]bool, accelType string, requestedChips int) (string, error) {
 	if len(topologies) == 0 {
 		if requested != "" {
 			logging.Info("Warning: No active topologies discovered from Kueue or Nodes. Fast-tracking provided topology: %s", requested)
@@ -931,6 +954,17 @@ func (g *GKEOrchestrator) selectTopology(requested string, topologies map[string
 			return "", err
 		}
 		return requested, nil
+	}
+
+	if requestedChips > 0 {
+		for t := range topologies {
+			chips := calculateChipsFromTopology(t)
+			if chips == requestedChips {
+				logging.Info("Auto-discovered Topology matching requested size (%d chips): %s", requestedChips, t)
+				return t, nil
+			}
+		}
+		return "", fmt.Errorf("no discovered topologies match the requested size of %d chips", requestedChips)
 	}
 
 	uniqueTops := make([]string, 0, len(topologies))
@@ -1028,12 +1062,14 @@ func (g *GKEOrchestrator) parseTopologies(output string) map[string]bool {
 	return topologies
 }
 
-func (g *GKEOrchestrator) queryDiscoveredTopologies() (string, error) {
-	res := g.executor.ExecuteCommand("kubectl", "get", "resourceflavors.kueue.x-k8s.io", "-o", "jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}")
+func (g *GKEOrchestrator) queryDiscoveredTopologies(accelLabel string) (string, error) {
+	selector := fmt.Sprintf("cloud.google.com/gke-tpu-accelerator=%s", accelLabel)
+
+	res := g.executor.ExecuteCommand("kubectl", "get", "resourceflavors.kueue.x-k8s.io", "-o", "jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}", "-l", selector)
 	output := strings.TrimSpace(res.Stdout)
 
 	if output == "" {
-		res = g.executor.ExecuteCommand("kubectl", "get", "nodes", "-o", "jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}")
+		res = g.executor.ExecuteCommand("kubectl", "get", "nodes", "-o", "jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}", "-l", selector)
 		if res.ExitCode != 0 {
 			return "", fmt.Errorf("failed to query Nodes for topology: %s", res.Stderr)
 		}
@@ -1270,39 +1306,17 @@ func (g *GKEOrchestrator) determineIfCPUMachine(job *orchestrator.JobDefinition)
 		}
 	}
 
-	mapped := g.GenerateGKENodeSelectorLabel(job.MachineType)
-	if strings.Contains(strings.ToLower(mapped), "nvidia") || config.IsTPU(mapped) {
+	cap, err := g.FetchMachineCapabilities(job.MachineType, job.ClusterLocation)
+	if err != nil {
+		return false, 0, fmt.Errorf("failed to fetch machine capabilities for %s: %w", job.MachineType, err)
+	}
+
+	if len(cap.Accelerators) > 0 {
 		return false, 0, nil
 	}
 
-	count, err := g.FetchMachineCapacity(job.MachineType, job.ClusterLocation)
-	if err != nil {
-		return false, 0, fmt.Errorf("failed to describe machine type %s: %w", job.MachineType, err)
-	}
-	if count > 0 {
-		logging.Info("Dynamically determined %s is a CPU-only machine during manifest preparation", job.MachineType)
-		return true, g.getEffectiveCPUs(job.MachineType, count), nil
-	}
-	return false, 0, nil
-}
-
-func (g *GKEOrchestrator) isKnownAccelerator(accelType string) bool {
-	if _, exists := config.AcceleratorShorthandMap[accelType]; exists {
-		return true
-	}
-
-	for _, realMachine := range config.AcceleratorShorthandMap {
-		if accelType == realMachine {
-			return true
-		}
-	}
-
-	mapped := g.GenerateGKENodeSelectorLabel(accelType)
-	if strings.Contains(strings.ToLower(mapped), "nvidia") || config.IsTPU(mapped) {
-		return true
-	}
-
-	return false
+	logging.Info("Dynamically determined %s is a CPU-only machine during manifest preparation", job.MachineType)
+	return true, g.getEffectiveCPUs(job.MachineType, cap.GuestCpus), nil
 }
 
 func (g *GKEOrchestrator) getCPUsFromClusterDesc(job orchestrator.JobDefinition) (bool, int, error) {
@@ -1786,33 +1800,49 @@ func (g *GKEOrchestrator) waitWorkloadFinished(targetWorkloadName, ns, timeout, 
 	return nil
 }
 
-func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing bool, isCPUMachine bool) (string, error) {
-	nodeSelector := GetNodeSelector(schedOpts)
-	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
-
-	isGPU := strings.Contains(strings.ToLower(accelLabel), "nvidia")
-
+func (g *GKEOrchestrator) addAcceleratorLabel(nodeSelector map[string]string, accelLabel string, isCPUMachine bool, machineType string) {
 	if accelLabel != "" && !isCPUMachine {
-		if nodeSelector == nil {
-			nodeSelector = make(map[string]string)
-		}
-		if strings.Contains(accelLabel, "tpu-v6e") || strings.Contains(accelLabel, "tpu7x") {
+		if config.IsTPU(machineType) {
 			nodeSelector["cloud.google.com/gke-tpu-accelerator"] = accelLabel
 		} else {
 			nodeSelector["cloud.google.com/gke-accelerator"] = accelLabel
 		}
 	}
+}
 
+func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, schedOpts SchedulingOptions, isGPU bool, isCPUMachine bool, isDynamicSlicing bool) error {
 	if schedOpts.Topology != "" {
-		if isGPU {
-			return "", fmt.Errorf("topology is not allowed for GPU jobs")
-		}
-		if nodeSelector == nil {
-			nodeSelector = make(map[string]string)
+		if isGPU || isCPUMachine {
+			return fmt.Errorf("topology is not allowed for GPU and CPU jobs")
 		}
 		if !isDynamicSlicing {
 			nodeSelector["cloud.google.com/gke-tpu-topology"] = schedOpts.Topology
 		}
+	}
+	return nil
+}
+
+func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing bool, isCPUMachine bool) (string, error) {
+	nodeSelector := GetNodeSelector(schedOpts)
+	if nodeSelector == nil {
+		nodeSelector = make(map[string]string)
+	}
+	cap, err := g.FetchMachineCapabilities(job.MachineType, job.ClusterLocation)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch machine capabilities: %w", err)
+	}
+
+	var accelLabel string
+	if len(cap.Accelerators) > 0 {
+		accelLabel = cap.Accelerators[0].Type
+	}
+
+	isGPU := !isCPUMachine && !config.IsTPU(job.MachineType)
+
+	g.addAcceleratorLabel(nodeSelector, accelLabel, isCPUMachine, job.MachineType)
+
+	if err := g.addTopologyLabel(nodeSelector, schedOpts, isGPU, isCPUMachine, isDynamicSlicing); err != nil {
+		return "", err
 	}
 
 	if len(nodeSelector) > 0 {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -225,11 +225,11 @@ func TestGenerateGKEManifest_Accelerators(t *testing.T) {
 				"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
 				"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "16x16"}},
 				"gcloud compute machine-types describe n2-standard-2 --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"guestCpus": 2}`}},
-				"gcloud compute machine-types describe nvidia-h100-mega-80gb --zone=us-central1-a --format=json":                        {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe nvidia-gb200 --zone=us-central1-a --format=json":                                 {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json":                                    {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
-				"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4}]}`}},
-				"gcloud compute machine-types describe nvidia-unknown-new-gpu --zone=us-central1-a --format=json":                       {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1}]}`}},
+				"gcloud compute machine-types describe nvidia-h100-mega-80gb --zone=us-central1-a --format=json":                        {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1, "guestAcceleratorType": "nvidia-h100-mega-80gb"}]}`}},
+				"gcloud compute machine-types describe nvidia-gb200 --zone=us-central1-a --format=json":                                 {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1, "guestAcceleratorType": "nvidia-gb200"}]}`}},
+				"gcloud compute machine-types describe nvidia-l4 --zone=us-central1-a --format=json":                                    {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1, "guestAcceleratorType": "nvidia-l4"}]}`}},
+				"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+				"gcloud compute machine-types describe nvidia-unknown-new-gpu --zone=us-central1-a --format=json":                       {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 1, "guestAcceleratorType": "nvidia-unknown-new-gpu"}]}`}},
 			}
 			mockExec := NewMockExecutor(mockResponses)
 			orc := newTestGKEOrchestrator(mockExec)

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -82,8 +82,12 @@ func (g *GKEOrchestrator) FetchMachineCapabilities(machineType, zone string) (Ma
 			MemoryMb:  int(mt.MemoryMb),
 		}
 
-		count, accelType, _ := config.ResolveAcceleratorInfo(mt, machineType)
+		count, accelType, isTPU := config.ResolveAcceleratorInfo(mt, machineType)
 		if count > 0 {
+			// Fetch correct accelerator type for TPUs using map
+			if isTPU {
+				accelType = g.GenerateGKENodeSelectorLabel(machineType)
+			}
 			cap.Accelerators = append(cap.Accelerators, struct {
 				Count int    `json:"guestAcceleratorCount"`
 				Type  string `json:"guestAcceleratorType"`

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -205,6 +205,7 @@ type gkeNodePoolConfig struct {
 	Accelerators            []gkeAccelerator            `json:"accelerators"`
 	AdvancedMachineFeatures *gkeAdvancedMachineFeatures `json:"advancedMachineFeatures,omitempty"`
 	Taints                  []gkeTaint                  `json:"taints"`
+	Labels                  map[string]string           `json:"labels,omitempty"`
 }
 
 type gkeAutoscaling struct {


### PR DESCRIPTION
This PR fixes some bugs in the auto-resolution logic and improves error handling for missing gcloud permissions.

* GKE Client Integration: Introduced a GKEClient interface and a default implementation to fetch cluster metadata directly via the Google Cloud SDK instead of relying on gcloud CLI commands.
* Accelerator Label Resolution: Updated accelerator label resolution logic to use GKE node selector labels, improving accuracy in auto-discovering topologies.
* Error Handling: Added specific error handling for 403 Forbidden responses when accessing GKE clusters, providing clearer instructions to users regarding required permissions.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
