### PR TITLE
Checksum verification for tflint 

### DIFF
--- a/tools/cloud-workstations/Dockerfile
+++ b/tools/cloud-workstations/Dockerfile
@@ -38,15 +38,13 @@ RUN wget https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_V
     rm -rf shellcheck-*
 
 # --- Install TFLint Securely ---
-RUN curl -fsSLo /tmp/tflint_linux_amd64.zip \
-      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip && \
-    curl -fsSLo /tmp/checksums.txt \
-      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/checksums.txt && \
-    cd /tmp && \
-    grep "tflint_linux_amd64.zip" checksums.txt | sha256sum -c - && \
-    unzip /tmp/tflint_linux_amd64.zip -d /usr/local/bin && \
+RUN TFLINT_ZIP_HASH="c004ec45ade3caf87cd4089feb1d2af9f7df57b13140a36df8a63c0a8cc69f14" && \
+    curl -fsSLo /tmp/tflint_linux_amd64.zip \
+      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION:-v0.62.1}/tflint_linux_amd64.zip && \
+    echo "${TFLINT_ZIP_HASH}  /tmp/tflint_linux_amd64.zip" | sha256sum -c - && \
+    unzip -o /tmp/tflint_linux_amd64.zip -d /usr/local/bin && \
     chmod +x /usr/local/bin/tflint && \
-    rm -f /tmp/tflint_linux_amd64.zip /tmp/checksums.txt
+    rm -f /tmp/tflint_linux_amd64.zip
 
 # --- Add HashiCorp Repo and Install Terraform/Packer ---
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \

--- a/tools/cloud-workstations/Dockerfile
+++ b/tools/cloud-workstations/Dockerfile
@@ -37,8 +37,16 @@ RUN wget https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_V
     mv shellcheck-${SHELLCHECK_VER}/shellcheck /usr/local/bin/shellcheck && \
     rm -rf shellcheck-*
 
-# --- Install TFLint ---
-RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+# --- Install TFLint Securely ---
+RUN curl -fsSLo /tmp/tflint_linux_amd64.zip \
+      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip && \
+    curl -fsSLo /tmp/checksums.txt \
+      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/checksums.txt && \
+    cd /tmp && \
+    grep "tflint_linux_amd64.zip" checksums.txt | sha256sum -c - && \
+    unzip /tmp/tflint_linux_amd64.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/tflint && \
+    rm -f /tmp/tflint_linux_amd64.zip /tmp/checksums.txt
 
 # --- Add HashiCorp Repo and Install Terraform/Packer ---
 RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \

--- a/tools/cloud-workstations/workstation-image.yaml
+++ b/tools/cloud-workstations/workstation-image.yaml
@@ -24,7 +24,7 @@ steps:
   - '--cache-from'
   - '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/hpc-toolkit-workstation:latest'
   - '--build-arg'
-  - 'TFLINT_VERSION=v0.58.1'
+  - 'TFLINT_VERSION=v0.62.1'
   - '-f'
   - 'tools/cloud-workstations/Dockerfile'
   - '.'


### PR DESCRIPTION
Regarding this [bug](https://buganizer.corp.google.com/issues/511425143) for the TFLint installation flow in tools/cloud-workstations/Dockerfile, I added a security remediation for the reported curl | bash vulnerability.

### Changes made:

Removed direct unverified installation flow.
Added SHA256 checksum verification using the official checksums.txt published in the TFLint [GitHub releases](https://github.com/terraform-linters/tflint/releases/tag/v0.58.1)
Installation now proceeds only after checksum validation succeeds

### Validated by:

Successful Docker image build.
Verified tflint --version inside container after installation.

Logs: https://paste.googleplex.com/5321315602006016


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
