### PR TITLE
Pin DCGM to version 4.5.3

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -199,9 +199,9 @@ deployment_groups:
           apt install -y \
               cuda-toolkit-12-8 \
               nvidia-container-toolkit \
-              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
-              datacenter-gpu-manager-4-core=1:4.5.2-1
+              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
+              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
+              datacenter-gpu-manager-4-core=1:4.5.3-1
 
           # 2. Hold ALL components
           apt-mark hold \

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -158,9 +158,9 @@ deployment_groups:
           add-nvidia-repositories -y
           apt install -y \
               cuda-toolkit-12-8 \
-              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
-              datacenter-gpu-manager-4-core=1:4.5.2-1
+              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
+              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
+              datacenter-gpu-manager-4-core=1:4.5.3-1
 
           # 2. Hold ALL components
           apt-mark hold \

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -165,9 +165,9 @@ deployment_groups:
           apt update -y
           apt install -y \
               cuda-toolkit-12-8 \
-              datacenter-gpu-manager-4-cuda12=1:4.5.2-1 \
-              datacenter-gpu-manager-4-dev=1:4.5.2-1 \
-              datacenter-gpu-manager-4-core=1:4.5.2-1
+              datacenter-gpu-manager-4-cuda12=1:4.5.3-1 \
+              datacenter-gpu-manager-4-dev=1:4.5.3-1 \
+              datacenter-gpu-manager-4-core=1:4.5.3-1
 
           # 2. Hold ALL components
           apt-mark hold \


### PR DESCRIPTION
This PR pins the datacenter-gpu-manager (DCGM) version to 4.5.3 across multiple machine learning example blueprints and deployment configurations.

https://docs.nvidia.com/datacenter/dcgm/latest/release-notes/changelog.html

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
