### PR TITLE
fix(job): add labels for dynamic slicing to kueue

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -57,11 +57,12 @@ var (
 	gkeScheduler       string
 	platform           string
 
-	awaitJobCompletion bool
-	timeoutStr         string
-	priorityClassName  string
-	isPathwaysJob      bool
-	verbose            bool
+	awaitJobCompletion   bool
+	timeoutStr           string
+	priorityClassName    string
+	isPathwaysJob        bool
+	verbose              bool
+	enableTASAnnotations bool
 
 	volumeStr []string
 	pathways  orchestrator.PathwaysJobDefinition
@@ -131,6 +132,7 @@ func init() {
 	SubmitCmd.Flags().BoolVar(&awaitJobCompletion, "await-job-completion", false, "If true, gcluster will wait for the submitted job to complete.")
 	SubmitCmd.Flags().StringVar(&timeoutStr, "timeout", "-1s", "Time to wait for job in seconds or string format (e.g. 1h, 10m). Default is max timeout (-1s).")
 	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "medium", "A priority, one of `very-low`, `low`, `medium`, `high` or `very-high`. Defaults to `medium`.")
+	SubmitCmd.Flags().BoolVar(&enableTASAnnotations, "gke-enable-tas", true, "Enable Dynamic Slicing & Topology-Aware Scheduling (TAS) coordinate annotation injections in generated manifests.")
 
 	SubmitCmd.Flags().BoolVar(&isPathwaysJob, "pathways", false, "If present, gcluster will generate a manifest for a Pathways job.")
 	SubmitCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging for the workload (TPUs and GPUs).")
@@ -213,6 +215,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		UseParallelContainers:         !gkeDisableParallelContainers,
 		Timeout:                       timeoutStr,
 		PriorityClassName:             priorityClassName,
+		EnableTASAnnotations:          enableTASAnnotations,
 		IsPathwaysJob:                 isPathwaysJob,
 		Pathways:                      pathways,
 		Volumes:                       vols,

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -57,12 +57,11 @@ var (
 	gkeScheduler       string
 	platform           string
 
-	awaitJobCompletion   bool
-	timeoutStr           string
-	priorityClassName    string
-	isPathwaysJob        bool
-	verbose              bool
-	enableTASAnnotations bool
+	awaitJobCompletion bool
+	timeoutStr         string
+	priorityClassName  string
+	isPathwaysJob      bool
+	verbose            bool
 
 	volumeStr []string
 	pathways  orchestrator.PathwaysJobDefinition
@@ -112,6 +111,8 @@ func init() {
 	SubmitCmd.Flags().StringVarP(&dryRunManifest, "dry-run-out", "o", "", "Path to output the generated Kubernetes manifest instead of applying it.")
 	SubmitCmd.Flags().StringVarP(&platform, "platform", "f", "linux/amd64", "Target platform for the image build (e.g., 'linux/amd64', 'linux/arm64'). Used with --base-image.")
 
+	SubmitCmd.Flags().StringSliceVar(&volumeStr, "mount", nil, "Volumes to mount (format: <src>:<dest>[:<mode>], mode can be 'ro' or 'rw', default 'ro').")
+
 	SubmitCmd.Flags().StringVarP(&workloadName, "name", "n", "", "Name of the workload to create. Required.")
 	SubmitCmd.Flags().StringVarP(&kueueQueueName, "queue", "q", "", "Name of the Kueue LocalQueue to submit the workload to. If empty, it will be auto-discovered.")
 	SubmitCmd.Flags().IntVar(&numNodes, "num-nodes", 1, "The number of nodes to use per group/slice. Defaults to 1 for CPU/GPU, or auto-calculated for TPUs.")
@@ -132,10 +133,9 @@ func init() {
 	SubmitCmd.Flags().BoolVar(&awaitJobCompletion, "await-job-completion", false, "If true, gcluster will wait for the submitted job to complete.")
 	SubmitCmd.Flags().StringVar(&timeoutStr, "timeout", "-1s", "Time to wait for job in seconds or string format (e.g. 1h, 10m). Default is max timeout (-1s).")
 	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "medium", "A priority, one of `very-low`, `low`, `medium`, `high` or `very-high`. Defaults to `medium`.")
-	SubmitCmd.Flags().BoolVar(&enableTASAnnotations, "gke-enable-tas", true, "Enable Dynamic Slicing & Topology-Aware Scheduling (TAS) coordinate annotation injections in generated manifests.")
+	SubmitCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging for the workload (TPUs and GPUs).")
 
 	SubmitCmd.Flags().BoolVar(&isPathwaysJob, "pathways", false, "If present, gcluster will generate a manifest for a Pathways job.")
-	SubmitCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging for the workload (TPUs and GPUs).")
 	SubmitCmd.Flags().StringVar(&pathways.ProxyServerImage, "pathways-proxy-server-image", "", "The image for the Pathways proxy server.")
 	SubmitCmd.Flags().StringVar(&pathways.ServerImage, "pathways-server-image", "", "The image for the Pathways server.")
 	SubmitCmd.Flags().StringVar(&pathways.WorkerImage, "pathways-worker-image", "", "The image for the Pathways worker.")
@@ -148,8 +148,6 @@ func init() {
 	SubmitCmd.Flags().StringVar(&pathways.WorkerArgs, "pathways-worker-args", "", "Arbitrary additional command-line arguments to pass directly to the `pathways-worker` executable.")
 	SubmitCmd.Flags().StringVar(&pathways.ColocatedPythonSidecarImage, "pathways-colocated-python-sidecar-image", "", "Image for an optional Python-based sidecar container to run alongside the Pathways head components.")
 	SubmitCmd.Flags().StringVar(&pathways.HeadNodePool, "pathways-head-np", "", "The node pool to use for the Pathways head job. If empty, it will be auto-detected (looking for 'cpu-np' or 'pathways-np').")
-
-	SubmitCmd.Flags().StringSliceVar(&volumeStr, "mount", nil, "Volumes to mount (format: <src>:<dest>[:<mode>], mode can be 'ro' or 'rw', default 'ro').")
 
 	_ = SubmitCmd.MarkFlagRequired("command")
 	_ = SubmitCmd.MarkFlagRequired("name")
@@ -215,7 +213,6 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		UseParallelContainers:         !gkeDisableParallelContainers,
 		Timeout:                       timeoutStr,
 		PriorityClassName:             priorityClassName,
-		EnableTASAnnotations:          enableTASAnnotations,
 		IsPathwaysJob:                 isPathwaysJob,
 		Pathways:                      pathways,
 		Volumes:                       vols,

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -846,27 +846,26 @@ completed step: 5, seconds: 1.186, TFLOP/s/device: 166.597, Tokens/s/device: 345
 
 This section details how GCluster natively orchestrates advanced GKE hardware features—such as dynamic slice reconfiguration and the Pathways distributed AI framework—to deliver elite resource utilization and simplified scheduling.
 
-### 8.1 Dynamic Slicing
+### 8.1 Dynamic Slicing (TPU7x)
 
-GKE Dynamic Slicing provides unparalleled flexibility in TPU capacity scheduling by allowing physical nodes to be logically grouped or sliced dynamically.
+GKE Dynamic Slicing provides unparalleled flexibility in TPU capacity scheduling by allowing physical nodes to be logically grouped or sliced dynamically. In GCluster, dynamic slicing is supported exclusively on TPU v7x (Ironwood) nodes.
 
 #### Capabilities & Scheduling Benefits
 
-* **Elastic Topology Provisioning:** Run workloads requiring smaller topologies than the physical pool on any TPU platform, or stitch multiple physical blocks together into a larger logical slice on TPU v7x (e.g., wiring multiple `4x4x4` blocks together).
+* **Elastic Topology Provisioning:** Stitch multiple physical TPU v7x blocks together into a larger logical slice (e.g., wiring multiple `4x4x4` blocks together).
 * **Latency Optimization:** Kueue's Topology-Aware Scheduling (TAS) guarantees that TPU pods are placed with minimal network hop latency across the physical TPU architecture, ensuring maximum distributed training and inference throughput.
 * **Multi-Slice Synchronization:** For multi-slice jobs (`--num-slices > 1`), GCluster dynamically coordinates slice-level reservations to ensure all slices are acquired concurrently, preventing mismatched scaling or execution hangs.
 
 #### Orchestration & Under-The-Hood Mappings
 
-GCluster automatically translates a high-level TPU request into the specific scheduling annotations required by Kueue and the GKE Slice Controller based on the target compute platform:
+GCluster automatically translates a high-level TPU request into the specific scheduling annotations required by Kueue and the GKE Slice Controller:
 
 * **TPU v7x (Ironwood):** Maps topology to a partition-level requirement (`cloud.google.com/gke-tpu-partition-<topology>-id`) to align with configured physical sub-blocks.
-* **Other TPUs (v6e, v5p, v5e, v4):** Maps topology to a slice-level requirement (`cloud.google.com/gke-tpu-slice-<topology>-id`).
 * **Queue Admission Keys:** Dynamically switches between a single-slice (`kueue.x-k8s.io/podset-required-topology`) and multi-slice (`kueue.x-k8s.io/podset-slice-required-topology`) annotation key depending on `--num-slices`.
 
 Additionally, GCluster automatically includes standard TPU topology labels (`cloud.google.com/gke-tpu-slice-topology: <topology>`) in the JobSet workload template to guarantee topology-aware scheduling.
 
-This automated TAS annotation injection and nodeSelector decoupling is enabled by default. If you need to fallback to legacy manifest generation (without TAS annotations and with strict topology nodeSelectors), you can set the `--gke-enable-tas=false` flag.
+This automated TAS annotation injection and nodeSelector decoupling is enabled by default for supported TPU v7x configurations.
 
 #### GKE Documentation Reference
 
@@ -998,7 +997,6 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--service-account` | `string` | Kubernetes service account name used to provide fine-grained IAM roles to the job pods. |
 | `--cpu-affinity` | `string` | CPU affinity rules (e.g., `'numa'`). |
 | `--gke-disable-parallel-containers` | `bool` | Disable parallel containers for TPU v7/v7x on GKE. (Default: `false`) |
-| `--gke-enable-tas` | `bool` | Enable Dynamic Slicing & Topology-Aware Scheduling (TAS) coordinate annotation injections in generated manifests. (Default: `true`) |
 
 ### 9.4 `list` Flags
 *Use these flags to filter the list of jobs.*

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -866,6 +866,8 @@ GCluster automatically translates a high-level TPU request into the specific sch
 
 Additionally, GCluster automatically includes standard TPU topology labels (`cloud.google.com/gke-tpu-slice-topology: <topology>`) in the JobSet workload template to guarantee topology-aware scheduling.
 
+This automated TAS annotation injection and nodeSelector decoupling is enabled by default. If you need to fallback to legacy manifest generation (without TAS annotations and with strict topology nodeSelectors), you can set the `--gke-enable-tas=false` flag.
+
 #### GKE Documentation Reference
 
 For a deeper conceptual understanding or custom configurations, refer to Google Cloud's official public guides:
@@ -996,6 +998,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--service-account` | `string` | Kubernetes service account name used to provide fine-grained IAM roles to the job pods. |
 | `--cpu-affinity` | `string` | CPU affinity rules (e.g., `'numa'`). |
 | `--gke-disable-parallel-containers` | `bool` | Disable parallel containers for TPU v7/v7x on GKE. (Default: `false`) |
+| `--gke-enable-tas` | `bool` | Enable Dynamic Slicing & Topology-Aware Scheduling (TAS) coordinate annotation injections in generated manifests. (Default: `true`) |
 
 ### 9.4 `list` Flags
 *Use these flags to filter the list of jobs.*

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -842,9 +842,63 @@ completed step: 4, seconds: 1.182, TFLOP/s/device: 167.154, Tokens/s/device: 346
 completed step: 5, seconds: 1.186, TFLOP/s/device: 166.597, Tokens/s/device: 3452.840, loss: 9.184
 ```
 
-## 8. `gcluster job` Command Reference
+## 8. Advanced GKE Infrastructure Features
 
-### 8.1 Common Flags
+This section details how GCluster natively orchestrates advanced GKE hardware features—such as dynamic slice reconfiguration and the Pathways distributed AI framework—to deliver elite resource utilization and simplified scheduling.
+
+### 8.1 Dynamic Slicing
+
+GKE Dynamic Slicing provides unparalleled flexibility in TPU capacity scheduling by allowing physical nodes to be logically grouped or sliced dynamically.
+
+#### Capabilities & Scheduling Benefits
+
+* **Elastic Topology Provisioning:** Run workloads requiring smaller topologies than the physical pool on any TPU platform, or stitch multiple physical blocks together into a larger logical slice on TPU v7x (e.g., wiring multiple `4x4x4` blocks together).
+* **Latency Optimization:** Kueue's Topology-Aware Scheduling (TAS) guarantees that TPU pods are placed with minimal network hop latency across the physical TPU architecture, ensuring maximum distributed training and inference throughput.
+* **Multi-Slice Synchronization:** For multi-slice jobs (`--num-slices > 1`), GCluster dynamically coordinates slice-level reservations to ensure all slices are acquired concurrently, preventing mismatched scaling or execution hangs.
+
+#### Orchestration & Under-The-Hood Mappings
+
+GCluster automatically translates a high-level TPU request into the specific scheduling annotations required by Kueue and the GKE Slice Controller based on the target compute platform:
+
+* **TPU v7x (Ironwood):** Maps topology to a partition-level requirement (`cloud.google.com/gke-tpu-partition-<topology>-id`) to align with configured physical sub-blocks.
+* **Other TPUs (v6e, v5p, v5e, v4):** Maps topology to a slice-level requirement (`cloud.google.com/gke-tpu-slice-<topology>-id`).
+* **Queue Admission Keys:** Dynamically switches between a single-slice (`kueue.x-k8s.io/podset-required-topology`) and multi-slice (`kueue.x-k8s.io/podset-slice-required-topology`) annotation key depending on `--num-slices`.
+
+Additionally, GCluster automatically includes standard TPU topology labels (`cloud.google.com/gke-tpu-slice-topology: <topology>`) in the JobSet workload template to guarantee topology-aware scheduling.
+
+#### GKE Documentation Reference
+
+For a deeper conceptual understanding or custom configurations, refer to Google Cloud's official public guides:
+
+* [TPU Dynamic Slicing on GKE Concepts](https://cloud.google.com/kubernetes-engine/docs/concepts/tpu-dynamic-slicing)
+* [Scheduling Dynamic Slices with Kueue and TAS on GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/kueue-tpu-dynamic-slicing)
+* [GKE Workloads with Topology-Aware Scheduling (TAS)](https://cloud.google.com/kubernetes-engine/docs/how-to/kueue-topology-aware-scheduling)
+
+---
+
+### 8.2 Pathways Distributed AI Orchestration
+
+Pathways is a specialized distributed AI execution framework designed to coordinate large-scale multi-slice TPU workloads. GCluster provides first-class integration for compiling and deploying Pathways-enabled workloads without complex manual manifest configuration.
+
+#### Capabilities & Scheduling Benefits
+
+* **Simplified Multi-Slice Scaling:** Easily coordinate JAX/Pathways initialization across independent TPU slices without configuring complex master-worker setups.
+* **Resilient Orchestration:** Run resilient, restart-safe model training using Pathways elastic slices via native CLI flags.
+* **Co-located Sidecar Provisioning:** GCluster automatically builds and links all complementary Pathways infrastructure components directly inside your JobSet manifest.
+
+#### Orchestration & Under-The-Hood Mappings
+
+When the `--pathways` flag is specified, GCluster automatically refactors the JobSet manifest to deploy and coordinate three distinct functional roles across your GKE cluster:
+
+* **Pathways ResourceManager/Server:** Deployed within the JobSet to manage dynamic TPU worker allocations and host mappings.
+* **Pathways Proxy:** Handles execution requests and acts as the coordinator/entry point for the client workload.
+* **Co-located JAX Workers & Sidecars:** Deployed as worker pods hosting JAX and PJRT runtimes, with optional co-located sidecar containers using `--pathways-colocated-python-sidecar-image`.
+
+All GCS pathways artifact locations, elastic slice configurations, and proxy command arguments are dynamically compiled into the manifest based on your `--pathways-*` flags.
+
+## 9. `gcluster job` Command Reference
+
+### 9.1 Common Flags
 *These flags are common to almost all `gcluster job` subcommands (except `config`). They can be set as defaults via `config set`.*
 
 | Flag | Type | Description |
@@ -853,7 +907,7 @@ completed step: 5, seconds: 1.186, TFLOP/s/device: 166.597, Tokens/s/device: 345
 | `-l, --location` | `string` | Google Cloud location (Zone or Region) of the GKE cluster. |
 | `-p, --project` | `string` | Google Cloud Project ID. |
 
-### 8.2 Configuration Commands
+### 9.2 Configuration Commands
 *Use these commands to manage persistent defaults for your job submissions, avoiding the need to pass common flags repeatedly.*
 
 #### `gcluster job config set [key] [value]`
@@ -873,10 +927,10 @@ Sets a persistent configuration property.
 #### `gcluster job config list`
 Lists all persistent configuration properties currently set.
 
-### 8.3 `submit` Flags
+### 9.3 `submit` Flags
 The `gcluster job submit` command deploys a container image as a job (Kubernetes JobSet) on a GKE cluster, integrated with Kueue for advanced queuing. It can use pre-built images or build images on-the-fly without a local Docker daemon (powered internally by the [Crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md) container utility).
 
-#### 8.3.1 General Flags
+#### 9.3.1 General Flags
 *These flags control core workload execution, identity, and basic build context options regardless of the underlying hardware paradigm.*
 
 | Flag | Type | Description |
@@ -897,9 +951,9 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--timeout` | `string` | Time to wait for job completion (e.g., `1h`, `10m`). Used with `--await-job-completion`. |
 | `--verbose` | `bool` | Enable verbose logging for the workload. |
 
-*(Note: `--cluster`, `--location`, and `--project` are also supported as common flags, see 8.1)*
+*(Note: `--cluster`, `--location`, and `--project` are also supported as common flags, see 9.1)*
 
-#### 8.3.2 TPU Related Flags
+#### 9.3.2 TPU Related Flags
 *Use these flags to orchestrate specialized TPU multi-slice topologies or leverage the Pathways distributed execution framework.*
 
 | Flag | Type | Description |
@@ -919,13 +973,13 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--pathways-colocated-python-sidecar-image` | `string` | Image for an optional Python-based sidecar container running alongside workers. |
 | `--pathways-head-np` | `string` | The node pool name to target for the Pathways head job. |
 
-#### 8.3.3 GPU Related Flags
+#### 9.3.3 GPU Related Flags
 *Use these flags to tune specialized multi-GPU topologies and related node parameters.*
 
 > [!NOTE]
 > Currently, GPU workloads leverage the standard **General Flags** (such as passing `--compute-type nvidia-l4` or `--compute-type nvidia-h100-8px`) and **GKE Only Flags** (such as placement policies). Specialized GPU flags (e.g., multi-node NVLink topologies or custom GPU drivers) will be documented here as they are added.
 
-#### 8.3.4 GKE & Advanced Orchestration Flags
+#### 9.3.4 GKE & Advanced Orchestration Flags
 *These flags unlock advanced GKE capabilities, including Kueue queue priorities, workload identities, network placements, and robust lifecycle failure policies.*
 
 | Flag | Type | Description |
@@ -943,7 +997,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--cpu-affinity` | `string` | CPU affinity rules (e.g., `'numa'`). |
 | `--gke-disable-parallel-containers` | `bool` | Disable parallel containers for TPU v7/v7x on GKE. (Default: `false`) |
 
-### 8.4 `list` Flags
+### 9.4 `list` Flags
 *Use these flags to filter the list of jobs.*
 
 | Flag | Type | Description |
@@ -951,14 +1005,14 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--status` | `string` | Filter jobs by status (e.g., `Pending`, `Running`, `Succeeded`, `Failed`, `Suspended`). |
 | `--name-contains` | `string` | Filter jobs by name containing the specified string. |
 
-### 8.5 `logs` Flags
+### 9.5 `logs` Flags
 *Use these flags when fetching logs.*
 
 | Flag | Type | Description |
 | :--- | :--- | :--- |
 | `-f, --follow` | `flag` | Stream logs continuously (like `tail -f`). |
 
-## 9. Troubleshooting: ImagePullBackOff
+## 10. Troubleshooting: ImagePullBackOff
 
 If your job status remains `Pending` and the underlying pods show `ImagePullBackOff` or `ErrImagePull`, the GKE node pool service account may lack permission to read from the Artifact Registry repository.
 
@@ -975,7 +1029,7 @@ gcloud artifacts repositories add-iam-policy-binding <REPOSITORY_NAME> \
 > [!TIP]
 > You can find the service account used by your node pool in the GKE console or by running `kubectl get nodes -o jsonpath='{.items[*].spec.providerID}'`.
 
-## 10. Cleanup
+## 11. Cleanup
 
 To avoid incurring unnecessary costs, destroy the deployed GKE cluster and its resources:
 

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -31,7 +31,7 @@ var tpuFamilyDefaults = map[string]int{
 }
 
 var tpuRegex = regexp.MustCompile(`^v[4-6][ep]?(-\d+)?$`)
-var TopologyRegex = regexp.MustCompile(`^[0-9]+x[0-9]+(x[0-9]+)?$`)
+var TopologyRegex = regexp.MustCompile("^[1-9][0-9]*x[1-9][0-9]*(x[1-9][0-9]*)?$")
 
 type tpu3DConstraints struct {
 	maxCubes int

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -435,6 +435,9 @@ func isValid3DDimension(x int) bool {
 	return x >= 4 && x%4 == 0
 }
 
+// Validate3DTopology validates the 3D topology dimensions for a given machine type.
+// If superSlicingCheck is true, it skips the common 3D shapes check and strictly validates
+// that each dimension is a multiple of 4 and >= 4.
 func Validate3DTopology(topology string, machineType string, superSlicingCheck bool) error {
 
 	if !superSlicingCheck && valid3DShapes[topology] {

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -130,10 +130,14 @@ var allowed2DTopologies = map[int]string{
 }
 
 var valid2DShapes = make(map[string]bool)
+var valid3DShapes = make(map[string]bool)
 
 func init() {
 	for _, v := range allowed2DTopologies {
 		valid2DShapes[v] = true
+	}
+	for _, v := range common3DTopologies {
+		valid3DShapes[v] = true
 	}
 }
 
@@ -399,7 +403,7 @@ func ValidateHardwareRequest(machineType, topology string) error {
 		}
 		return nil
 	} else if matchesTPUFamily(machineType, valid3DTPUFamilies) {
-		return validate3DTopology(topology, machineType)
+		return Validate3DTopology(topology, machineType, false)
 	} else {
 		return fmt.Errorf("TPU type %q is recognized but its topology family is unknown; please report a bug to the toolkit maintainers.", machineType)
 	}
@@ -431,14 +435,16 @@ func isValid3DDimension(x int) bool {
 	return x >= 4 && x%4 == 0
 }
 
-func validate3DTopology(topology string, machineType string) error {
-	for _, v := range common3DTopologies {
-		if topology == v {
-			return nil
-		}
+func Validate3DTopology(topology string, machineType string, superSlicingCheck bool) error {
+
+	if !superSlicingCheck && valid3DShapes[topology] {
+		return nil
 	}
 
 	dims := strings.Split(topology, "x")
+	if len(dims) != 3 {
+		return fmt.Errorf("topology format invalid for 3D family: requested %s, expected AxBxC (3 dimensions)", topology)
+	}
 	a, _ := strconv.Atoi(dims[0])
 	b, _ := strconv.Atoi(dims[1])
 	c, _ := strconv.Atoi(dims[2])

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1873,8 +1873,8 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
-func (g *GKEOrchestrator) buildTopologyAnnotation(topology string) string {
-	topologyAnnotation := GetTopologyAnnotation(topology)
+func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int) string {
+	topologyAnnotation := GetTopologyAnnotation(topology, numSlices)
 	if len(topologyAnnotation) > 0 {
 		b, err := yaml.Marshal(topologyAnnotation)
 		if err == nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -106,6 +106,9 @@ func (g *GKEOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {
 	if err != nil {
 		return err
 	}
+	if !job.EnableTASAnnotations {
+		isDynamicSlicing = false
+	}
 
 	if err := g.validateJobConflicts(job.WorkloadName, job.ClusterName, job.ClusterLocation, job.ProjectID); err != nil {
 		return err
@@ -1008,11 +1011,6 @@ func (g *GKEOrchestrator) validateRequestedTopology(requested string, topologies
 }
 
 func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDefinition) (string, bool, error) {
-	// This function should work only for TPU 7x
-	if !strings.Contains(job.MachineType, "tpu7x") {
-		return "", false, nil
-	}
-
 	active, err := g.verifyDynamicSlicingActive(ManifestOptions{
 		ClusterName:     job.ClusterName,
 		ClusterLocation: job.ClusterLocation,
@@ -1025,26 +1023,6 @@ func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDef
 	if active {
 		logging.Info("Dynamic-slicing detected. Skipping strict physical state queries for topology.")
 		if job.Topology != "" {
-			dims := strings.Split(job.Topology, "x")
-			if len(dims) != 3 {
-				return "", true, fmt.Errorf("invalid topology format %s. Must be AxBxC", job.Topology)
-			}
-
-			a, err1 := strconv.Atoi(dims[0])
-			b, err2 := strconv.Atoi(dims[1])
-			c, err3 := strconv.Atoi(dims[2])
-			if err1 != nil || err2 != nil || err3 != nil {
-				return "", true, fmt.Errorf("invalid topology dimensions in %s", job.Topology)
-			}
-
-			if a%4 != 0 || b%4 != 0 || c%4 != 0 {
-				return "", true, fmt.Errorf("all values in the topology %s must be a multiple of 4", job.Topology)
-			}
-
-			if (a*b*c)/64 > 144 {
-				return "", true, fmt.Errorf("requested cubes for topology %s exceeds the maximum limit of 144", job.Topology)
-			}
-
 			logging.Info("Validated provided Topology (Dynamic-Slicing): %s", job.Topology)
 			return job.Topology, true, nil
 		}

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -877,6 +877,7 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 			ClusterName:     job.ClusterName,
 			ClusterLocation: job.ClusterLocation,
 			ComputeType:     job.ComputeType,
+			Topology:        job.Topology,
 		})
 		if err != nil {
 			logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
@@ -1016,6 +1017,7 @@ func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDef
 		ClusterName:     job.ClusterName,
 		ClusterLocation: job.ClusterLocation,
 		ComputeType:     job.ComputeType,
+		Topology:        job.Topology,
 	})
 	if err != nil {
 		logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
@@ -1873,8 +1875,8 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
-func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int) string {
-	topologyAnnotation := GetTopologyAnnotation(topology, numSlices)
+func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType string, numSlices int) string {
+	topologyAnnotation := GetTopologyAnnotation(topology, machineType, numSlices)
 	if len(topologyAnnotation) > 0 {
 		b, err := yaml.Marshal(topologyAnnotation)
 		if err == nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1855,8 +1855,15 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
-func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int) string {
-	topologyAnnotation := GetTopologyAnnotation(topology, numSlices)
+func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int, isDynamicSlicing bool) string {
+	var topologyAnnotation map[string]string
+	if isDynamicSlicing {
+		topologyAnnotation = GetTopologyAnnotation(topology, numSlices)
+	} else if topology != "" {
+		topologyAnnotation = map[string]string{
+			"cloud.google.com/gke-tpu-slice-topology": topology,
+		}
+	}
 	if len(topologyAnnotation) > 0 {
 		b, err := yaml.Marshal(topologyAnnotation)
 		if err == nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -106,10 +106,6 @@ func (g *GKEOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {
 	if err != nil {
 		return err
 	}
-	if !job.EnableTASAnnotations {
-		isDynamicSlicing = false
-	}
-
 	if err := g.validateJobConflicts(job.WorkloadName, job.ClusterName, job.ClusterLocation, job.ProjectID); err != nil {
 		return err
 	}
@@ -883,6 +879,9 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 			Topology:        job.Topology,
 		})
 		if err != nil {
+			if isDyn {
+				return "", true, err
+			}
 			logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
 		}
 		return val, isDyn, nil
@@ -1018,6 +1017,9 @@ func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDef
 		Topology:        job.Topology,
 	})
 	if err != nil {
+		if active {
+			return "", true, err
+		}
 		logging.Warn("Failed to verify if dynamic slicing is active: %v. Assuming not active.", err)
 	}
 	if active {
@@ -1853,8 +1855,8 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
-func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType string, numSlices int) string {
-	topologyAnnotation := GetTopologyAnnotation(topology, machineType, numSlices)
+func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int) string {
+	topologyAnnotation := GetTopologyAnnotation(topology, numSlices)
 	if len(topologyAnnotation) > 0 {
 		b, err := yaml.Marshal(topologyAnnotation)
 		if err == nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1025,6 +1025,9 @@ func (g *GKEOrchestrator) resolveDynamicSlicingTopology(job *orchestrator.JobDef
 	if active {
 		logging.Info("Dynamic-slicing detected. Skipping strict physical state queries for topology.")
 		if job.Topology != "" {
+			if err := config.Validate3DTopology(job.Topology, job.MachineType, true); err != nil {
+				return "", true, err
+			}
 			logging.Info("Validated provided Topology (Dynamic-Slicing): %s", job.Topology)
 			return job.Topology, true, nil
 		}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2021,7 +2021,7 @@ func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
 		"kubectl get topologies.kueue.x-k8s.io -o json": {{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`}},
 		"kubectl get admissioncheck":                    {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
 		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu7x": {{ExitCode: 0, Stdout: "8x8x8"}},
-		"gcloud compute machine-types describe tpu7x-standard-4t --zone=us-central1-a --format=json":                            {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu7x-standard-4t"}]}`}},
+		"gcloud compute machine-types describe tpu7x-standard-4t --zone=us-central1-a --format=json":                                                                          {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu7x-standard-4t"}]}`}},
 	}
 	mockExec := NewMockExecutor(mockResponses)
 	orc := newTestGKEOrchestrator(mockExec)
@@ -2067,4 +2067,3 @@ func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
 		}
 	}
 }
-

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -947,6 +947,93 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: true,
 		},
 		{
+			name: "Success - Dynamic-slicing active via sub-slicing intent (static reservation)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu-v6e-slice",
+				Topology:        "2x4",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu-v6e-slice",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "4x4",
+						},
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get crd topologies.kueue.x-k8s.io": {
+					{ExitCode: 0},
+				},
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "Success - TPU7x Dynamic-slicing active via sub-slicing intent (static reservation)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "2x2x1",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "4x4x4",
+						},
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get crd topologies.kueue.x-k8s.io": {
+					{ExitCode: 0},
+				},
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: true,
+		},
+		{
+			name: "Failure - Requested topology matches physical topology (not dynamic sub-slicing)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu-v6e-slice",
+				Topology:        "4x4",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu-v6e-slice",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "4x4",
+						},
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get crd topologies.kueue.x-k8s.io": {
+					{ExitCode: 0},
+				},
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: false,
+		},
+		{
 			name: "Failure - No TPU",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -919,17 +919,18 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name: "Success - Dynamic-slicing active",
+			name: "Success - TPU7x Dynamic-slicing active via PROVISION_ONLY",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
-				ComputeType:     "tpu-v6e-slice",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "4x4x4",
 			},
 			nodePools: []gkeJobNodePool{
 				{
 					Name: "test-pool",
 					Config: gkeNodePoolConfig{
-						MachineType: "tpu-v6e-slice",
+						MachineType: "tpu7x-standard-4t",
 					},
 					PlacementPolicy: &gkePlacementPolicy{
 						AcceleratorTopologyMode: "PROVISION_ONLY",
@@ -937,9 +938,6 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
 				"kubectl get admissioncheck -o json": {
 					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
 				},
@@ -947,7 +945,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			name: "Success - Dynamic-slicing active via topology subset (static reservation)",
+			name: "Failure - Dynamic-slicing inactive for non-TPU7x via topology subset",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
@@ -965,18 +963,37 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 					},
 				},
 			},
-			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
+			mockResponses: nil,
+			wantResult:    false,
+		},
+		{
+			name: "Success - TPU7x Dynamic-slicing active via topology subset (static reservation)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "4x4x4",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "8x8x8",
+						},
+					},
 				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
 				"kubectl get admissioncheck -o json": {
 					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
 				},
 			},
-			wantResult: true,
+			wantResult: false,
 		},
 		{
-			name: "Success - TPU7x Dynamic-slicing active via topology subset (static reservation)",
+			name: "Failure - TPU7x Dynamic-slicing requested topology under 4x4x4",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
@@ -988,21 +1005,100 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 					Name: "test-pool",
 					Config: gkeNodePoolConfig{
 						MachineType: "tpu7x-standard-4t",
-						Labels: map[string]string{
-							"cloud.google.com/gke-tpu-topology": "4x4x4",
-						},
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						AcceleratorTopologyMode: "PROVISION_ONLY",
 					},
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
 				"kubectl get admissioncheck -o json": {
 					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
 				},
 			},
 			wantResult: true,
+			wantErr:    true,
+		},
+		{
+			name: "Failure - TPU7x Dynamic-slicing requested topology 2x4x8 (product 64 but a < 4)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "2x4x8",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						AcceleratorTopologyMode: "PROVISION_ONLY",
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: true,
+			wantErr:    true,
+		},
+		{
+			name: "Failure - TPU7x Dynamic-slicing requested topology empty",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						AcceleratorTopologyMode: "PROVISION_ONLY",
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: true,
+			wantErr:    true,
+		},
+		{
+			name: "Failure - TPU7x Dynamic-slicing requested topology 2D (4x4)",
+			opts: ManifestOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ComputeType:     "tpu7x-standard-4t",
+				Topology:        "4x4",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "test-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						AcceleratorTopologyMode: "PROVISION_ONLY",
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get admissioncheck -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
+				},
+			},
+			wantResult: true,
+			wantErr:    true,
 		},
 		{
 			name: "Failure - Requested topology matches physical topology (not dynamic topology subset)",
@@ -1023,15 +1119,8 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 					},
 				},
 			},
-			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
-				"kubectl get admissioncheck -o json": {
-					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
-				},
-			},
-			wantResult: false,
+			mockResponses: nil,
+			wantResult:    false,
 		},
 		{
 			name: "Failure - No TPU",
@@ -1059,34 +1148,27 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 					},
 				},
 			},
-			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
-				"kubectl get admissioncheck -o json": {
-					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"accelerator.gke.io/slice"}}]}`},
-				},
-			},
-			wantResult: false,
-			wantErr:    true,
+			mockResponses: nil,
+			wantResult:    false,
+			wantErr:       true,
 		},
 		{
 			name: "Failure - CRD not found",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
-				ComputeType:     "tpu-v6e-slice",
+				ComputeType:     "tpu7x-standard-4t",
 			},
 			nodePools: []gkeJobNodePool{
 				{
 					Name: "test-pool",
 					Config: gkeNodePoolConfig{
-						MachineType: "tpu-v6e-slice",
+						MachineType: "tpu7x-standard-4t",
 					},
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
 					{ExitCode: 1},
 				},
 			},
@@ -1097,13 +1179,13 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
-				ComputeType:     "tpu-v6e-slice",
+				ComputeType:     "tpu7x-standard-4t",
 			},
 			nodePools: []gkeJobNodePool{
 				{
 					Name: "test-pool",
 					Config: gkeNodePoolConfig{
-						MachineType: "tpu-v6e-slice",
+						MachineType: "tpu7x-standard-4t",
 					},
 					PlacementPolicy: &gkePlacementPolicy{
 						AcceleratorTopologyMode: "PROVISION_ONLY",
@@ -1111,9 +1193,6 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
 				"kubectl get admissioncheck -o json": {
 					{ExitCode: 0, Stdout: `{"items":[{"spec":{"controllerName":"other-controller"}}]}`},
 				},
@@ -1125,13 +1204,13 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
-				ComputeType:     "tpu-v6e-slice",
+				ComputeType:     "tpu7x-standard-4t",
 			},
 			nodePools: []gkeJobNodePool{
 				{
 					Name: "test-pool",
 					Config: gkeNodePoolConfig{
-						MachineType: "tpu-v6e-slice",
+						MachineType: "tpu7x-standard-4t",
 					},
 					PlacementPolicy: &gkePlacementPolicy{
 						AcceleratorTopologyMode: "PROVISION_ONLY",
@@ -1139,9 +1218,6 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"kubectl get crd topologies.kueue.x-k8s.io": {
-					{ExitCode: 0},
-				},
 				"kubectl get admissioncheck -o json": {
 					{ExitCode: 1, Stderr: "error"},
 				},
@@ -1152,6 +1228,13 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.mockResponses != nil {
+				if _, ok := tt.mockResponses["kubectl get topologies.kueue.x-k8s.io -o json"]; !ok {
+					tt.mockResponses["kubectl get topologies.kueue.x-k8s.io -o json"] = []shell.CommandResult{
+						{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`},
+					}
+				}
+			}
 			mockExecutor := NewMockExecutor(tt.mockResponses)
 			orc := newTestGKEOrchestrator(mockExecutor)
 			orc.clusterDesc.NodePools = tt.nodePools
@@ -1841,25 +1924,23 @@ func TestGetNodeCount(t *testing.T) {
 	}
 }
 
-func TestGenerateGKEManifest_EnableTASAnnotationsFlag(t *testing.T) {
+func TestGenerateGKEManifest_DynamicSlicingActive_TPU7x(t *testing.T) {
 	setupMockMachineConfig(t)
 
 	job := orchestrator.JobDefinition{
-		WorkloadName:         "test-tas-flag-job",
-		CommandToRun:         "echo hello",
-		ComputeType:          "v6e-8",
-		Topology:             "2x4",
-		ClusterLocation:      "us-central1-a",
-		EnableTASAnnotations: false, // Explicitly disabled!
+		WorkloadName:    "test-tas-tpu7x-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "tpu7x-standard-4t",
+		Topology:        "4x4x4",
+		ClusterLocation: "us-central1-a",
 	}
 
 	mockResponses := map[string][]shell.CommandResult{
-		"kubectl get resourceflavors":               {{ExitCode: 0, Stdout: ""}},
-		"kubectl get crd topologies.kueue.x-k8s.io": {{ExitCode: 0, Stdout: "found"}},
-		"kubectl get admissioncheck":                {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
-		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "4x4"}},
-		"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
-		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json":                             {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+		"kubectl get resourceflavors":                   {{ExitCode: 0, Stdout: ""}},
+		"kubectl get topologies.kueue.x-k8s.io -o json": {{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`}},
+		"kubectl get admissioncheck":                    {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "8x8x8"}},
+		"gcloud compute machine-types describe tpu7x-standard-4t --zone=us-central1-a --format=json":                            {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu7x-standard-4t"}]}`}},
 	}
 
 	mockExec := NewMockExecutor(mockResponses)
@@ -1869,10 +1950,10 @@ func TestGenerateGKEManifest_EnableTASAnnotationsFlag(t *testing.T) {
 		{
 			Name: "tpu-pool",
 			Config: gkeNodePoolConfig{
-				MachineType: "ct6e-standard-8t",
-				Labels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "4x4",
-				},
+				MachineType: "tpu7x-standard-4t",
+			},
+			PlacementPolicy: &gkePlacementPolicy{
+				AcceleratorTopologyMode: "PROVISION_ONLY",
 			},
 		},
 	}
@@ -1882,84 +1963,7 @@ func TestGenerateGKEManifest_EnableTASAnnotationsFlag(t *testing.T) {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
 
-	// Crucial check: The CLI resolved it as dynamic slicing because it's a 2x2 subset of 4x4
-	if !isDynamicSlicing {
-		t.Fatalf("Expected resolveHardwareRequirements to initially flag isDynamicSlicing as true")
-	}
-
-	// Now simulate gke_job_orchestrator submission override logic
-	if !job.EnableTASAnnotations {
-		isDynamicSlicing = false
-	}
-
-	if isDynamicSlicing {
-		t.Fatalf("Expected isDynamicSlicing to be overridden to false when EnableTASAnnotations is false")
-	}
-
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
-	if err != nil {
-		t.Fatalf("PrepareManifestOptions failed: %v", err)
-	}
-
-	manifest, err := orc.GenerateGKEManifest(opts, profile)
-	if err != nil {
-		t.Fatalf("GenerateGKEManifest failed: %v", err)
-	}
-
-	// Because dynamic slicing was overridden to false:
-	// 1. NodeSelector MUST include the topology strictly (Fix A bypassed)
-	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x4") {
-		t.Errorf("Expected manifest to contain strict nodeSelector topology, but it was missing\nManifest: %s", manifest)
-	}
-
-	// 2. Kueue TAS annotations MUST NOT be injected (Fix B bypassed)
-	if strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology") {
-		t.Errorf("Expected manifest to NOT contain kueue TAS annotations, but they were found\nManifest: %s", manifest)
-	}
-}
-
-func TestGenerateGKEManifest_DynamicSlicingActive_V6e(t *testing.T) {
-	setupMockMachineConfig(t)
-
-	job := orchestrator.JobDefinition{
-		WorkloadName:         "test-tas-v6e-job",
-		CommandToRun:         "echo hello",
-		ComputeType:          "v6e-8",
-		Topology:             "2x4",
-		ClusterLocation:      "us-central1-a",
-		EnableTASAnnotations: true, // Enabled!
-	}
-
-	mockResponses := map[string][]shell.CommandResult{
-		"kubectl get resourceflavors":               {{ExitCode: 0, Stdout: ""}},
-		"kubectl get crd topologies.kueue.x-k8s.io": {{ExitCode: 0, Stdout: "found"}},
-		"kubectl get admissioncheck":                {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
-		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "4x4"}},
-		"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
-		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json":                             {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
-	}
-
-	mockExec := NewMockExecutor(mockResponses)
-	orc := newTestGKEOrchestrator(mockExec)
-	orc.projectID = "mock-project"
-	orc.clusterDesc.NodePools = []gkeJobNodePool{
-		{
-			Name: "tpu-pool",
-			Config: gkeNodePoolConfig{
-				MachineType: "ct6e-standard-8t",
-				Labels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "4x4",
-				},
-			},
-		},
-	}
-
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
-	if err != nil {
-		t.Fatalf("resolveHardwareRequirements failed: %v", err)
-	}
-
-	// Crucial check: The CLI resolved it as dynamic slicing because it's a 2x4 subset of 4x4
+	// Crucial check: The CLI resolved it as dynamic slicing because it's a 4x4x4 subset of 8x8x8
 	if !isDynamicSlicing {
 		t.Fatalf("Expected resolveHardwareRequirements to flag isDynamicSlicing as true")
 	}
@@ -1976,15 +1980,15 @@ func TestGenerateGKEManifest_DynamicSlicingActive_V6e(t *testing.T) {
 
 	// Because dynamic slicing is true:
 	// 1. NodeSelector MUST NOT include the topology strictly (Fix A)
-	if strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x4") {
+	if strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 4x4x4") {
 		t.Errorf("Expected manifest to NOT contain strict nodeSelector topology, but it was found\nManifest: %s", manifest)
 	}
 
 	// 2. Kueue TAS annotations MUST be injected (Fix B)
-	if !strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology: cloud.google.com/gke-tpu-slice-2x4-id") {
+	if !strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology: cloud.google.com/gke-tpu-partition-4x4x4-id") {
 		t.Errorf("Expected manifest to contain kueue TAS annotation, but it was missing or incorrect\nManifest: %s", manifest)
 	}
-	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-slice-topology: 2x4") {
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-slice-topology: 4x4x4") {
 		t.Errorf("Expected manifest to contain gke-tpu-slice-topology annotation, but it was missing\nManifest: %s", manifest)
 	}
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1997,3 +1997,74 @@ func TestGenerateGKEManifest_DynamicSlicingActive_TPU7x(t *testing.T) {
 		t.Errorf("Expected manifest to NOT contain exclusive-topology annotation for dynamic slicing, but it was found\nManifest: %s", manifest)
 	}
 }
+
+func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
+	setupMockMachineConfig(t)
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "pathways-test",
+		CommandToRun:    "echo hello",
+		NumSlices:       2,
+		ClusterLocation: "us-central1-a",
+		ComputeType:     "tpu7x-standard-4t",
+		Topology:        "4x4x4",
+		Pathways: orchestrator.PathwaysJobDefinition{
+			ProxyServerImage: "proxy:latest",
+			ServerImage:      "server:latest",
+			WorkerImage:      "worker:latest",
+			GCSLocation:      "gs://my-bucket",
+			HeadNodePool:     "pathways-np",
+		},
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors":                   {{ExitCode: 0, Stdout: ""}},
+		"kubectl get topologies.kueue.x-k8s.io -o json": {{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`}},
+		"kubectl get admissioncheck":                    {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu7x": {{ExitCode: 0, Stdout: "8x8x8"}},
+		"gcloud compute machine-types describe tpu7x-standard-4t --zone=us-central1-a --format=json":                            {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu7x-standard-4t"}]}`}},
+	}
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{
+			Name: "tpu-pool",
+			Config: gkeNodePoolConfig{
+				MachineType: "tpu7x-standard-4t",
+			},
+			PlacementPolicy: &gkePlacementPolicy{
+				AcceleratorTopologyMode: "PROVISION_ONLY",
+			},
+		},
+	}
+
+	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+	if !isDynamicSlicing {
+		t.Fatalf("Expected isDynamicSlicing to be true")
+	}
+
+	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing)
+	if err != nil {
+		t.Fatalf("GeneratePathwaysManifest failed: %v", err)
+	}
+
+	// 1. Manifest must NOT contain strict NodeSelector topology
+	if strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 4x4x4") {
+		t.Errorf("Expected manifest to NOT contain strict nodeSelector topology, but it was found\nManifest: %s", manifest)
+	}
+
+	// 2. Kueue TAS annotations must be present under pathways worker replicatedJob template annotations
+	expectedSubstrs := []string{
+		"kueue.x-k8s.io/podset-slice-required-topology: cloud.google.com/gke-tpu-partition-4x4x4-id",
+		"cloud.google.com/gke-tpu-slice-topology: 4x4x4",
+	}
+	for _, substr := range expectedSubstrs {
+		if !strings.Contains(manifest, substr) {
+			t.Errorf("manifest missing expected substring %q\nManifest: %s", substr, manifest)
+		}
+	}
+}
+

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1991,4 +1991,9 @@ func TestGenerateGKEManifest_DynamicSlicingActive_TPU7x(t *testing.T) {
 	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-slice-topology: 4x4x4") {
 		t.Errorf("Expected manifest to contain gke-tpu-slice-topology annotation, but it was missing\nManifest: %s", manifest)
 	}
+
+	// 3. Exclusive-topology annotation MUST NOT be set for dynamic slicing
+	if strings.Contains(manifest, "alpha.jobset.sigs.k8s.io/exclusive-topology") {
+		t.Errorf("Expected manifest to NOT contain exclusive-topology annotation for dynamic slicing, but it was found\nManifest: %s", manifest)
+	}
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1840,3 +1840,151 @@ func TestGetNodeCount(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateGKEManifest_EnableTASAnnotationsFlag(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:         "test-tas-flag-job",
+		CommandToRun:         "echo hello",
+		ComputeType:          "v6e-8",
+		Topology:             "2x4",
+		ClusterLocation:      "us-central1-a",
+		EnableTASAnnotations: false, // Explicitly disabled!
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors":               {{ExitCode: 0, Stdout: ""}},
+		"kubectl get crd topologies.kueue.x-k8s.io": {{ExitCode: 0, Stdout: "found"}},
+		"kubectl get admissioncheck":                {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "4x4"}},
+		"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json":                             {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+	}
+
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{
+			Name: "tpu-pool",
+			Config: gkeNodePoolConfig{
+				MachineType: "ct6e-standard-8t",
+				Labels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "4x4",
+				},
+			},
+		},
+	}
+
+	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	// Crucial check: The CLI resolved it as dynamic slicing because it's a 2x2 subset of 4x4
+	if !isDynamicSlicing {
+		t.Fatalf("Expected resolveHardwareRequirements to initially flag isDynamicSlicing as true")
+	}
+
+	// Now simulate gke_job_orchestrator submission override logic
+	if !job.EnableTASAnnotations {
+		isDynamicSlicing = false
+	}
+
+	if isDynamicSlicing {
+		t.Fatalf("Expected isDynamicSlicing to be overridden to false when EnableTASAnnotations is false")
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Because dynamic slicing was overridden to false:
+	// 1. NodeSelector MUST include the topology strictly (Fix A bypassed)
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x4") {
+		t.Errorf("Expected manifest to contain strict nodeSelector topology, but it was missing\nManifest: %s", manifest)
+	}
+
+	// 2. Kueue TAS annotations MUST NOT be injected (Fix B bypassed)
+	if strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology") {
+		t.Errorf("Expected manifest to NOT contain kueue TAS annotations, but they were found\nManifest: %s", manifest)
+	}
+}
+
+func TestGenerateGKEManifest_DynamicSlicingActive_V6e(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:         "test-tas-v6e-job",
+		CommandToRun:         "echo hello",
+		ComputeType:          "v6e-8",
+		Topology:             "2x4",
+		ClusterLocation:      "us-central1-a",
+		EnableTASAnnotations: true, // Enabled!
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors":               {{ExitCode: 0, Stdout: ""}},
+		"kubectl get crd topologies.kueue.x-k8s.io": {{ExitCode: 0, Stdout: "found"}},
+		"kubectl get admissioncheck":                {{ExitCode: 0, Stdout: `{"items": [{"spec": {"controllerName": "accelerator.gke.io/slice"}}]}`}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "4x4"}},
+		"gcloud compute machine-types describe tpu-v6e-slice --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json":                             {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+	}
+
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{
+			Name: "tpu-pool",
+			Config: gkeNodePoolConfig{
+				MachineType: "ct6e-standard-8t",
+				Labels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "4x4",
+				},
+			},
+		},
+	}
+
+	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	// Crucial check: The CLI resolved it as dynamic slicing because it's a 2x4 subset of 4x4
+	if !isDynamicSlicing {
+		t.Fatalf("Expected resolveHardwareRequirements to flag isDynamicSlicing as true")
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Because dynamic slicing is true:
+	// 1. NodeSelector MUST NOT include the topology strictly (Fix A)
+	if strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x4") {
+		t.Errorf("Expected manifest to NOT contain strict nodeSelector topology, but it was found\nManifest: %s", manifest)
+	}
+
+	// 2. Kueue TAS annotations MUST be injected (Fix B)
+	if !strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology: cloud.google.com/gke-tpu-slice-2x4-id") {
+		t.Errorf("Expected manifest to contain kueue TAS annotation, but it was missing or incorrect\nManifest: %s", manifest)
+	}
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-slice-topology: 2x4") {
+		t.Errorf("Expected manifest to contain gke-tpu-slice-topology annotation, but it was missing\nManifest: %s", manifest)
+	}
+}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -947,7 +947,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			name: "Success - Dynamic-slicing active via sub-slicing intent (static reservation)",
+			name: "Success - Dynamic-slicing active via topology subset (static reservation)",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
@@ -976,7 +976,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			name: "Success - TPU7x Dynamic-slicing active via sub-slicing intent (static reservation)",
+			name: "Success - TPU7x Dynamic-slicing active via topology subset (static reservation)",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
@@ -1005,7 +1005,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: true,
 		},
 		{
-			name: "Failure - Requested topology matches physical topology (not dynamic sub-slicing)",
+			name: "Failure - Requested topology matches physical topology (not dynamic topology subset)",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -187,7 +187,7 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 		opts.ImagePullSecrets = g.indentYaml(imagePullSecretsStr, 16)
 	}
 
-	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology)
+	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices)
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)
 	if err != nil {

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -188,7 +188,7 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 	}
 
 	if isDynamicSlicing {
-		opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.MachineType, job.NumSlices)
+		opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices)
 	}
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -187,7 +187,9 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 		opts.ImagePullSecrets = g.indentYaml(imagePullSecretsStr, 16)
 	}
 
-	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.MachineType, job.NumSlices)
+	if isDynamicSlicing {
+		opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.MachineType, job.NumSlices)
+	}
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)
 	if err != nil {

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -187,7 +187,7 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 		opts.ImagePullSecrets = g.indentYaml(imagePullSecretsStr, 16)
 	}
 
-	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices)
+	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.MachineType, job.NumSlices)
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)
 	if err != nil {

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -187,9 +187,7 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 		opts.ImagePullSecrets = g.indentYaml(imagePullSecretsStr, 16)
 	}
 
-	if isDynamicSlicing {
-		opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices)
-	}
+	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices, isDynamicSlicing)
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)
 	if err != nil {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -314,8 +314,8 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 			}
 		}
 
-		// 3. Resolve Topology
-		topology, isDynamicSlicing, err := g.resolveTopology(job)
+		var topology string
+		topology, isDynamicSlicing, err = g.resolveTopology(job)
 		if err != nil {
 			return JobProfile{}, isDynamicSlicing, err
 		}

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -161,13 +161,13 @@ func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName stri
 			if err != nil {
 				logging.Warn("Failed to check topology containment for %s and %s: %v", opts.Topology, physicalTopology, err)
 			} else if contained && opts.Topology != physicalTopology {
-				logging.Info("Dynamic-slicing sub-slicing intent detected: requested topology %s is a proper subset of discovered physical topology %s for node pool %s.", opts.Topology, physicalTopology, np.Name)
+				logging.Info("Dynamic-slicing topology subset detected: requested topology %s is a proper subset of discovered physical topology %s for node pool %s.", opts.Topology, physicalTopology, np.Name)
 				return true
 			}
 		}
 	}
 
-	logging.Info("Node pool does not have PROVISION_ONLY mode or dynamic sub-slicing intent. Dynamic-slicing not active.")
+	logging.Info("Node pool does not have PROVISION_ONLY mode or dynamic topology subset requirement. Dynamic-slicing not active.")
 	return false
 }
 

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -116,6 +116,10 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 		return false, nil
 	}
 
+	if g.dynamicSlicingCache == nil {
+		g.dynamicSlicingCache = make(map[string]bool)
+	}
+
 	cacheKey := opts.ComputeType + ":" + opts.Topology
 	if val, ok := g.dynamicSlicingCache[cacheKey]; ok {
 		return val, nil
@@ -127,7 +131,7 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 		return false, err
 	}
 
-	isTPU7x := strings.Contains(requestedMachineName, "tpu7x")
+	isTPU7x := strings.Contains(strings.ToLower(requestedMachineName), "tpu7x")
 	if !isTPU7x || !g.hasKueueTopologies() || !g.hasSliceAdmissionCheck() {
 		g.dynamicSlicingCache[cacheKey] = false
 		return false, nil
@@ -332,7 +336,7 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 	job.MachineType = machineName
 	isDynamicSlicing := false
 	if config.IsTPU(machineName) {
-		isTPU7x := strings.Contains(machineName, "tpu7x")
+		isTPU7x := strings.Contains(strings.ToLower(machineName), "tpu7x")
 		if isTPU7x && job.Topology == "" {
 			return JobProfile{}, false, fmt.Errorf("topology must be specified explicitly via --topology flag for TPU 7x machine type %s", machineName)
 		}

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -116,7 +116,8 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 		return false, nil
 	}
 
-	if val, ok := g.dynamicSlicingCache[opts.ComputeType]; ok {
+	cacheKey := opts.ComputeType + ":" + opts.Topology
+	if val, ok := g.dynamicSlicingCache[cacheKey]; ok {
 		return val, nil
 	}
 
@@ -124,12 +125,12 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 	cResult := g.executor.ExecuteCommand("kubectl", "get", "crd", "topologies.kueue.x-k8s.io")
 	if cResult.ExitCode != 0 {
 		logging.Warn("Topology CRD not found. Kueue Dynamic-slicing not active.")
-		g.dynamicSlicingCache[opts.ComputeType] = false
+		g.dynamicSlicingCache[cacheKey] = false
 		return false, nil
 	}
 
 	if !g.hasSliceAdmissionCheck() {
-		g.dynamicSlicingCache[opts.ComputeType] = false
+		g.dynamicSlicingCache[cacheKey] = false
 		return false, nil
 	}
 
@@ -138,19 +139,36 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 	if err != nil {
 		return false, err
 	}
+
+	active := g.checkNodePoolsDynamicSlicing(requestedMachineName, opts)
+	g.dynamicSlicingCache[cacheKey] = active
+	return active, nil
+}
+
+func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions) bool {
 	for _, np := range g.clusterDesc.NodePools {
-		if np.Config.MachineType == requestedMachineName {
-			if np.PlacementPolicy != nil && np.PlacementPolicy.AcceleratorTopologyMode == "PROVISION_ONLY" {
-				logging.Info("Dynamic-slicing PROVISION_ONLY mode detected for node pool %s.", np.Name)
-				g.dynamicSlicingCache[opts.ComputeType] = true
-				return true, nil
+		if np.Config.MachineType != requestedMachineName {
+			continue
+		}
+		if np.PlacementPolicy != nil && np.PlacementPolicy.AcceleratorTopologyMode == "PROVISION_ONLY" {
+			logging.Info("Dynamic-slicing PROVISION_ONLY mode detected for node pool %s.", np.Name)
+			return true
+		}
+
+		// Intent Check: Compare requested topology vs node pool physical topology
+		if physicalTopology, ok := np.Config.Labels[tpuTopologyLabel]; ok && opts.Topology != "" {
+			contained, err := config.CheckTopologyContainment(opts.Topology, physicalTopology, opts.ComputeType)
+			if err != nil {
+				logging.Warn("Failed to check topology containment for %s and %s: %v", opts.Topology, physicalTopology, err)
+			} else if contained && opts.Topology != physicalTopology {
+				logging.Info("Dynamic-slicing sub-slicing intent detected: requested topology %s is a proper subset of discovered physical topology %s for node pool %s.", opts.Topology, physicalTopology, np.Name)
+				return true
 			}
 		}
 	}
 
-	logging.Info("Node pool does not have PROVISION_ONLY mode. Dynamic-slicing not active.")
-	g.dynamicSlicingCache[opts.ComputeType] = false
-	return false, nil
+	logging.Info("Node pool does not have PROVISION_ONLY mode or dynamic sub-slicing intent. Dynamic-slicing not active.")
+	return false
 }
 
 func (g *GKEOrchestrator) hasSliceAdmissionCheck() bool {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -121,54 +121,55 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 		return val, nil
 	}
 
-	// Check for topologies.kueue.x-k8s.io CRD
-	cResult := g.executor.ExecuteCommand("kubectl", "get", "crd", "topologies.kueue.x-k8s.io")
-	if cResult.ExitCode != 0 {
-		logging.Warn("Topology CRD not found. Kueue Dynamic-slicing not active.")
-		g.dynamicSlicingCache[cacheKey] = false
-		return false, nil
-	}
-
-	if !g.hasSliceAdmissionCheck() {
-		g.dynamicSlicingCache[cacheKey] = false
-		return false, nil
-	}
-
 	// Check discovered node pools for dynamic-slicing
 	requestedMachineName, err := g.resolveMachineName(opts.ComputeType)
 	if err != nil {
 		return false, err
 	}
 
-	active := g.checkNodePoolsDynamicSlicing(requestedMachineName, opts)
+	isTPU7x := strings.Contains(requestedMachineName, "tpu7x")
+	if !isTPU7x || !g.hasKueueTopologies() || !g.hasSliceAdmissionCheck() {
+		g.dynamicSlicingCache[cacheKey] = false
+		return false, nil
+	}
+
+	active, err := g.checkNodePoolsDynamicSlicing(requestedMachineName, opts, isTPU7x)
+	if err != nil {
+		return active, err
+	}
 	g.dynamicSlicingCache[cacheKey] = active
 	return active, nil
 }
 
-func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions) bool {
+func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions, isTPU7x bool) (bool, error) {
 	for _, np := range g.clusterDesc.NodePools {
-		if np.Config.MachineType != requestedMachineName {
+		if !strings.EqualFold(np.Config.MachineType, requestedMachineName) {
 			continue
 		}
-		if np.PlacementPolicy != nil && np.PlacementPolicy.AcceleratorTopologyMode == "PROVISION_ONLY" {
-			logging.Info("Dynamic-slicing PROVISION_ONLY mode detected for node pool %s.", np.Name)
-			return true
-		}
 
-		// Intent Check: Compare requested topology vs node pool physical topology
-		if physicalTopology, ok := np.Config.Labels[tpuTopologyLabel]; ok && opts.Topology != "" {
-			contained, err := config.CheckTopologyContainment(opts.Topology, physicalTopology, opts.ComputeType)
-			if err != nil {
-				logging.Warn("Failed to check topology containment for %s and %s: %v", opts.Topology, physicalTopology, err)
-			} else if contained && opts.Topology != physicalTopology {
-				logging.Info("Dynamic-slicing topology subset detected: requested topology %s is a proper subset of discovered physical topology %s for node pool %s.", opts.Topology, physicalTopology, np.Name)
-				return true
+		isProvisionOnly := isTPU7x && np.PlacementPolicy != nil && np.PlacementPolicy.AcceleratorTopologyMode == "PROVISION_ONLY"
+
+		if isProvisionOnly {
+			if err := validateTPU7xTopology(opts.Topology, requestedMachineName); err != nil {
+				return true, err
 			}
+			logging.Info("Dynamic-slicing PROVISION_ONLY mode validated for TPU7x node pool %s with topology %s.", np.Name, opts.Topology)
+			return true, nil
 		}
 	}
 
-	logging.Info("Node pool does not have PROVISION_ONLY mode or dynamic topology subset requirement. Dynamic-slicing not active.")
-	return false
+	logging.Info("Node pool does not have dynamic topology subset requirement. Dynamic-slicing not active.")
+	return false, nil
+}
+
+func validateTPU7xTopology(topology string, machineType string) error {
+	if topology == "" {
+		return fmt.Errorf("topology must be specified explicitly via --topology flag for TPU 7x dynamic slicing")
+	}
+	if !config.TopologyRegex.MatchString(topology) {
+		return fmt.Errorf("invalid topology format %s", topology)
+	}
+	return config.Validate3DTopology(topology, machineType, true)
 }
 
 func (g *GKEOrchestrator) hasSliceAdmissionCheck() bool {
@@ -199,6 +200,30 @@ func (g *GKEOrchestrator) hasSliceAdmissionCheck() bool {
 
 	logging.Info("No AdmissionCheck with controller 'accelerator.gke.io/slice' found. Dynamic-slicing not active.")
 	return false
+}
+
+func (g *GKEOrchestrator) hasKueueTopologies() bool {
+	tResult := g.executor.ExecuteCommand("kubectl", "get", "topologies.kueue.x-k8s.io", "-o", "json")
+	if tResult.ExitCode != 0 {
+		logging.Warn("Failed to query Kueue topologies. Assuming dynamic-slicing not active.")
+		return false
+	}
+
+	var tList struct {
+		Items []interface{} `json:"items"`
+	}
+
+	if err := json.Unmarshal([]byte(tResult.Stdout), &tList); err != nil {
+		logging.Warn("Failed to parse Kueue topologies JSON: %v. Assuming dynamic-slicing not active.", err)
+		return false
+	}
+
+	if len(tList.Items) == 0 {
+		logging.Info("No Kueue topology resources found. Dynamic-slicing not active.")
+		return false
+	}
+
+	return true
 }
 
 func (g *GKEOrchestrator) calculateResourceLimits(opts ManifestOptions, profile JobProfile) (cpu, mem, gpu, tpu string, err error) {
@@ -307,6 +332,11 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 	job.MachineType = machineName
 	isDynamicSlicing := false
 	if config.IsTPU(machineName) {
+		isTPU7x := strings.Contains(machineName, "tpu7x")
+		if isTPU7x && job.Topology == "" {
+			return JobProfile{}, false, fmt.Errorf("topology must be specified explicitly via --topology flag for TPU 7x machine type %s", machineName)
+		}
+
 		// Validate topology shape before resolving/discovering
 		if job.Topology != "" {
 			if err := config.ValidateHardwareRequest(job.MachineType, job.Topology); err != nil {

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -322,6 +322,11 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 			acceleratorType: "tpu7x-32",
 			wantErr:         true,
 		},
+		{
+			name:            "TPU7x full machine type fails with empty topology",
+			acceleratorType: "tpu7x-standard-4t",
+			wantErr:         true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -78,9 +78,15 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 
 	term := &affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0]
 
-	// Handle pipe-separated constraints and smart merging for topology
-	for k, v := range opts.NodeAffinityLabels {
-		// True if this is a topology label that needs to be merged with a baseline topology.
+	// Collect and sort keys of NodeAffinityLabels to ensure deterministic output
+	keys := make([]string, 0, len(opts.NodeAffinityLabels))
+	for k := range opts.NodeAffinityLabels {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+
+	for _, k := range keys {
+		v := opts.NodeAffinityLabels[k]
 		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "") && (!opts.IsDynamicSlicing)
 		hasPipe := strings.Contains(v, "|")
 
@@ -88,26 +94,14 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 			continue
 		}
 
-		var values []string
-		if isTopologyMerge {
-			values = append(values, opts.Topology)
+		values, err := parseAffinityValues(k, v, opts.Topology, isTopologyMerge)
+		if err != nil {
+			return nil, err
 		}
 
-		if v != "" {
-			for _, val := range strings.Split(v, "|") {
-				trimmed := strings.TrimSpace(val)
-				if trimmed == "" {
-					return nil, fmt.Errorf("invalid node constraint for key %s: empty element in %q", k, v)
-				}
-				if k == tpuTopologyLabel && !config.TopologyRegex.MatchString(trimmed) {
-					return nil, fmt.Errorf("invalid topology format %q for key %s", trimmed, k)
-				}
-				if !slices.Contains(values, trimmed) {
-					values = append(values, trimmed)
-				}
-			}
+		if len(values) == 0 {
+			continue
 		}
-
 		term.MatchExpressions = append(
 			term.MatchExpressions,
 			corev1.NodeSelectorRequirement{
@@ -121,7 +115,35 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 	return affinity, nil
 }
 
-func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
+func parseAffinityValues(k string, v string, topology string, isTopologyMerge bool) ([]string, error) {
+	if v == "" && !isTopologyMerge {
+		return nil, nil
+	}
+
+	var values []string
+	if isTopologyMerge {
+		values = append(values, topology)
+	}
+
+	if v != "" {
+		for _, val := range strings.Split(v, "|") {
+			trimmed := strings.TrimSpace(val)
+			if trimmed == "" {
+				return nil, fmt.Errorf("invalid node constraint for key %s: empty element in %q", k, v)
+			}
+			if k == tpuTopologyLabel && !config.TopologyRegex.MatchString(trimmed) {
+				return nil, fmt.Errorf("invalid topology format %q for key %s", trimmed, k)
+			}
+			if !slices.Contains(values, trimmed) {
+				values = append(values, trimmed)
+			}
+		}
+	}
+
+	return values, nil
+}
+
+func GetTopologyAnnotation(topology string, machineType string, numSlices int) map[string]string {
 	if topology == "" {
 		return nil
 	}
@@ -131,9 +153,14 @@ func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
 		annotationKey = "kueue.x-k8s.io/podset-slice-required-topology"
 	}
 
+	partitionValue := fmt.Sprintf("cloud.google.com/gke-tpu-slice-%s-id", topology)
+	if strings.Contains(machineType, "tpu7x") {
+		partitionValue = fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology)
+	}
+
 	return map[string]string{
 		"cloud.google.com/gke-tpu-slice-topology": topology,
-		annotationKey: fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology),
+		annotationKey: partitionValue,
 	}
 }
 

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -143,7 +143,7 @@ func parseAffinityValues(k string, v string, topology string, isTopologyMerge bo
 	return values, nil
 }
 
-func GetTopologyAnnotation(topology string, machineType string, numSlices int) map[string]string {
+func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
 	if topology == "" {
 		return nil
 	}
@@ -153,10 +153,8 @@ func GetTopologyAnnotation(topology string, machineType string, numSlices int) m
 		annotationKey = "kueue.x-k8s.io/podset-slice-required-topology"
 	}
 
-	partitionValue := fmt.Sprintf("cloud.google.com/gke-tpu-slice-%s-id", topology)
-	if strings.Contains(machineType, "tpu7x") {
-		partitionValue = fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology)
-	}
+	// Dynamic slicing is only active for TPU7x, which uses partition-level requirements.
+	partitionValue := fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology)
 
 	return map[string]string{
 		"cloud.google.com/gke-tpu-slice-topology": topology,

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -143,6 +143,8 @@ func parseAffinityValues(k string, v string, topology string, isTopologyMerge bo
 	return values, nil
 }
 
+// GetTopologyAnnotation returns the GKE and Kueue topology annotations for the given topology and slice count.
+// It dynamically selects the appropriate Kueue annotation key based on whether it is a single-slice or multi-slice job.
 func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
 	if topology == "" {
 		return nil

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -121,12 +121,19 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 	return affinity, nil
 }
 
-func GetTopologyAnnotation(topology string) map[string]string {
+func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
 	if topology == "" {
 		return nil
 	}
+
+	annotationKey := "kueue.x-k8s.io/podset-required-topology"
+	if numSlices > 1 {
+		annotationKey = "kueue.x-k8s.io/podset-slice-required-topology"
+	}
+
 	return map[string]string{
 		"cloud.google.com/gke-tpu-slice-topology": topology,
+		annotationKey: fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology),
 	}
 }
 

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -59,57 +59,37 @@ func TestGetAffinity(t *testing.T) {
 
 func TestGetTopologyAnnotation(t *testing.T) {
 	tests := []struct {
-		name        string
-		topology    string
-		machineType string
-		numSlices   int
-		wantKey     string
-		wantVal     string
+		name      string
+		topology  string
+		numSlices int
+		wantKey   string
+		wantVal   string
 	}{
 		{
-			name:        "single slice - tpu7x",
-			topology:    "2x2x1",
-			machineType: "tpu7x-standard-4t",
-			numSlices:   1,
-			wantKey:     "kueue.x-k8s.io/podset-required-topology",
-			wantVal:     "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:      "single slice - tpu7x",
+			topology:  "2x2x1",
+			numSlices: 1,
+			wantKey:   "kueue.x-k8s.io/podset-required-topology",
+			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
 		},
 		{
-			name:        "multislice - tpu7x",
-			topology:    "2x2x1",
-			machineType: "tpu7x-standard-4t",
-			numSlices:   2,
-			wantKey:     "kueue.x-k8s.io/podset-slice-required-topology",
-			wantVal:     "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:      "multislice - tpu7x",
+			topology:  "2x2x1",
+			numSlices: 2,
+			wantKey:   "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
 		},
 		{
-			name:        "single slice - v6e",
-			topology:    "2x4",
-			machineType: "ct6e-standard",
-			numSlices:   1,
-			wantKey:     "kueue.x-k8s.io/podset-required-topology",
-			wantVal:     "cloud.google.com/gke-tpu-slice-2x4-id",
-		},
-		{
-			name:        "multislice - v6e",
-			topology:    "2x4",
-			machineType: "ct6e-standard",
-			numSlices:   2,
-			wantKey:     "kueue.x-k8s.io/podset-slice-required-topology",
-			wantVal:     "cloud.google.com/gke-tpu-slice-2x4-id",
-		},
-		{
-			name:        "empty topology",
-			topology:    "",
-			machineType: "ct6e-standard",
-			numSlices:   1,
-			wantKey:     "",
-			wantVal:     "",
+			name:      "empty topology",
+			topology:  "",
+			numSlices: 1,
+			wantKey:   "",
+			wantVal:   "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetTopologyAnnotation(tt.topology, tt.machineType, tt.numSlices)
+			got := GetTopologyAnnotation(tt.topology, tt.numSlices)
 			if tt.topology == "" {
 				if got != nil {
 					t.Errorf("Expected nil for empty topology, got %v", got)

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -59,23 +59,50 @@ func TestGetAffinity(t *testing.T) {
 
 func TestGetTopologyAnnotation(t *testing.T) {
 	tests := []struct {
-		topology string
-		want     string
+		name      string
+		topology  string
+		numSlices int
+		wantKey   string
+		wantVal   string
 	}{
-		{"2x2x1", "2x2x1"},
-		{"", ""},
+		{
+			name:      "single slice",
+			topology:  "2x2x1",
+			numSlices: 1,
+			wantKey:   "kueue.x-k8s.io/podset-required-topology",
+			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+		},
+		{
+			name:      "multislice",
+			topology:  "2x2x1",
+			numSlices: 2,
+			wantKey:   "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+		},
+		{
+			name:      "empty topology",
+			topology:  "",
+			numSlices: 1,
+			wantKey:   "",
+			wantVal:   "",
+		},
 	}
 	for _, tt := range tests {
-		got := GetTopologyAnnotation(tt.topology)
-		if tt.want == "" {
-			if got != nil {
-				t.Errorf("Expected nil for empty topology, got %v", got)
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetTopologyAnnotation(tt.topology, tt.numSlices)
+			if tt.topology == "" {
+				if got != nil {
+					t.Errorf("Expected nil for empty topology, got %v", got)
+				}
+				return
 			}
-		} else {
-			if got["cloud.google.com/gke-tpu-slice-topology"] != tt.want {
-				t.Errorf("Expected %s, got %v", tt.want, got)
+			if got["cloud.google.com/gke-tpu-slice-topology"] != tt.topology {
+				t.Errorf("Expected topology %s, got %v", tt.topology, got["cloud.google.com/gke-tpu-slice-topology"])
 			}
-		}
+			if got[tt.wantKey] != tt.wantVal {
+				t.Errorf("Expected %s = %s, got %v", tt.wantKey, tt.wantVal, got[tt.wantKey])
+			}
+		})
 	}
 }
 

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -59,37 +59,57 @@ func TestGetAffinity(t *testing.T) {
 
 func TestGetTopologyAnnotation(t *testing.T) {
 	tests := []struct {
-		name      string
-		topology  string
-		numSlices int
-		wantKey   string
-		wantVal   string
+		name        string
+		topology    string
+		machineType string
+		numSlices   int
+		wantKey     string
+		wantVal     string
 	}{
 		{
-			name:      "single slice",
-			topology:  "2x2x1",
-			numSlices: 1,
-			wantKey:   "kueue.x-k8s.io/podset-required-topology",
-			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:        "single slice - tpu7x",
+			topology:    "2x2x1",
+			machineType: "tpu7x-standard-4t",
+			numSlices:   1,
+			wantKey:     "kueue.x-k8s.io/podset-required-topology",
+			wantVal:     "cloud.google.com/gke-tpu-partition-2x2x1-id",
 		},
 		{
-			name:      "multislice",
-			topology:  "2x2x1",
-			numSlices: 2,
-			wantKey:   "kueue.x-k8s.io/podset-slice-required-topology",
-			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:        "multislice - tpu7x",
+			topology:    "2x2x1",
+			machineType: "tpu7x-standard-4t",
+			numSlices:   2,
+			wantKey:     "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:     "cloud.google.com/gke-tpu-partition-2x2x1-id",
 		},
 		{
-			name:      "empty topology",
-			topology:  "",
-			numSlices: 1,
-			wantKey:   "",
-			wantVal:   "",
+			name:        "single slice - v6e",
+			topology:    "2x4",
+			machineType: "ct6e-standard",
+			numSlices:   1,
+			wantKey:     "kueue.x-k8s.io/podset-required-topology",
+			wantVal:     "cloud.google.com/gke-tpu-slice-2x4-id",
+		},
+		{
+			name:        "multislice - v6e",
+			topology:    "2x4",
+			machineType: "ct6e-standard",
+			numSlices:   2,
+			wantKey:     "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:     "cloud.google.com/gke-tpu-slice-2x4-id",
+		},
+		{
+			name:        "empty topology",
+			topology:    "",
+			machineType: "ct6e-standard",
+			numSlices:   1,
+			wantKey:     "",
+			wantVal:     "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetTopologyAnnotation(tt.topology, tt.numSlices)
+			got := GetTopologyAnnotation(tt.topology, tt.machineType, tt.numSlices)
 			if tt.topology == "" {
 				if got != nil {
 					t.Errorf("Expected nil for empty topology, got %v", got)

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -167,8 +167,15 @@ spec:
           metadata:
             labels:
               gcluster.google.com/workload: {{.WorkloadName}}
+{{- if or .TopologyAnnotation .GCSFuseEnabled }}
             annotations:
+{{- if .TopologyAnnotation }}
+{{.TopologyAnnotation}}
+{{- end }}
+{{- if .GCSFuseEnabled }}
               gke-gcsfuse/volumes: "true"
+{{- end }}
+{{- end }}
           spec:
             hostNetwork: true
             dnsPolicy: ClusterFirstWithHostNet

--- a/pkg/orchestrator/gke/templates/priority_classes.tmpl
+++ b/pkg/orchestrator/gke/templates/priority_classes.tmpl
@@ -16,7 +16,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: very-low
-value: -100
+value: 100
 globalDefault: false
 description: "User-defined priority class for very low priority workloads."
 ---
@@ -24,7 +24,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: low
-value: 0
+value: 250
 globalDefault: false
 description: "User-defined priority class for low priority workloads."
 ---
@@ -32,7 +32,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: medium
-value: 100
+value: 500
 globalDefault: true
 description: "User-defined priority class for medium priority workloads."
 ---
@@ -40,7 +40,7 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: high
-value: 200
+value: 750
 globalDefault: false
 description: "User-defined priority class for high priority workloads."
 ---
@@ -48,6 +48,6 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: very-high
-value: 300
+value: 1000
 globalDefault: false
 description: "User-defined priority class for very high priority workloads."

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -82,6 +82,7 @@ type JobDefinition struct {
 	UseParallelContainers bool
 	Timeout               string
 	PriorityClassName     string
+	EnableTASAnnotations  bool
 
 	// Pathways-specific fields
 	IsPathwaysJob bool

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -82,7 +82,6 @@ type JobDefinition struct {
 	UseParallelContainers bool
 	Timeout               string
 	PriorityClassName     string
-	EnableTASAnnotations  bool
 
 	// Pathways-specific fields
 	IsPathwaysJob bool


### PR DESCRIPTION
## Description
This change introduces support for dynamic slicing in Kueue by adding the required podset topology annotations to GKE TPU job manifests. It ensures that Kueue can correctly identify the required topology for both single-slice and multislice configurations.

## Changes

  * Orchestrator Logic:
     * Updated GetTopologyAnnotation to accept numSlices as an argument .
     *  Added logic to select the appropriate Kueue annotation key:
          *  kueue.x-k8s.io/podset-required-topology for single-slice jobs.
          *  kueue.x-k8s.io/podset-slice-required-topology for multislice jobs.
  
     * The value for these annotations is now set to cloud.google.com/gke-tpu-partition-{topology}-id .
 
  * Manifest Generation: Modified the GKE orchestrator to pass the number of slices (job.NumSlices) when generating the topology annotations.

  * Testing: Expanded TestGetTopologyAnnotation to verify the correct annotation keys and values for both single-slice and multislice scenarios.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
