### PR TITLE
Switching Canonical's transitional packages to NVIDIA's official, version-isolated repository packages

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
@@ -191,8 +191,8 @@ deployment_groups:
               package_filename: /tmp/{{ package_url | basename }}
               nvidia_packages:
               - cuda-toolkit-12-8
-              - nvidia-dkms-570-server-open
-              - nvidia-driver-570-server-open
+              - nvidia-dkms-570-open
+              - nvidia-driver-570-open
               - datacenter-gpu-manager
               - libnvidia-nscq-570
               - nvidia-container-toolkit


### PR DESCRIPTION
Switched package names in `configure_gpu_packages.yml` from Canonical's 
  transitional packages (`nvidia-dkms-570-server-open` / `nvidia-driver-570-server-open`)
  to NVIDIA's official, version-isolated repository packages (`nvidia-dkms-570-open` /
  `nvidia-driver-570-open`).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
