### PR TITLE
feat(gke): Add example for GKE H4D - DWS flex start compact placement 

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
@@ -56,7 +56,7 @@ Note: If you create multiple clusters using these same cluster blueprints, ensur
     PROJECT_ID: ID of the project where the bucket is being created.\
     COMPUTE_REGION: the compute region where you want to store the state of the Terraform deployment.
 
-5. In the `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d-deployment.yaml` file, fill in the following settings in the `terraform_backend_defaults` and `vars` sections to match the specific values for your deployment:
+5. In the `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d-deployment.yaml` file, fill in the following settings in the `terraform_backend_defaults` and `vars` sections to match the specific values for your deployment:
 
     `bucket`: the name of the Cloud Storage bucket you created in the previous step.\
     `deployment_name`: the name of the deployment.\
@@ -65,7 +65,7 @@ Note: If you create multiple clusters using these same cluster blueprints, ensur
     `zone`: the compute zone for the node pool of H4D machines.\
     `authorized_cidr`: The IP address range that you want to allow to connect with the cluster. This CIDR block must include the IP address of the machine to call Terraform.\
     **`enable_flex_start`**: enable DWS Flex Start.\
-    To modify advanced settings, edit `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d.yaml`.
+    To modify advanced settings, edit `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml`.
 
 6. Generate [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp) to provide access to Terraform.
 
@@ -78,8 +78,8 @@ Note: If you create multiple clusters using these same cluster blueprints, ensur
     ```sh
     cd ~/cluster-toolkit
     ./gcluster deploy -d \
-    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d-deployment.yaml \
-    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d.yaml
+    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d-deployment.yaml \
+    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
     ```
 
 8. When prompted, select (A)pply to deploy the blueprint.
@@ -97,7 +97,7 @@ The example folder provides a sample job test-job.yaml that runs a sleep contain
 Any job applied to this node pool must meet the following requirements:
 * **Tolerations**: Because the `h4d-pool` node pool is tainted (`node-type=h4d:NoSchedule`) to prevent generic scheduling, any job you apply **must** include the matching toleration under `spec.template.spec.tolerations`
 
-  ```sh
+  ```yaml
   tolerations:
   - key: "node-type"
     operator: "Equal"
@@ -116,7 +116,7 @@ Any job applied to this node pool must meet the following requirements:
 2. Submit the sample test job:
 
     ```sh
-    kubectl apply -f examples/gke-consumption-options/dws-flex-start-compact-placement/test-job.yaml
+    kubectl apply -f examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/test-job.yaml
     ```
 
 3. Monitor the scale-up and execution timeline:

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
@@ -1,0 +1,138 @@
+# DWS Flex Start with Compact Placement (Workload Policy)
+
+[Dynamic Workload Scheduler (DWS)](https://cloud.google.com/blog/products/compute/introducing-dynamic-workload-scheduler) is a resource management and job scheduling platform designed for AI Hypercomputer. Dynamic Workload Scheduler improves your access to AI/ML resources, helps you optimize your spend, and can improve the experience of workloads such as training and fine-tuning jobs, by scheduling all the accelerators needed simultaneously. Dynamic Workload Scheduler supports TPUs and NVIDIA GPUs, and brings scheduling advancements from Google ML fleet to Google Cloud customers.
+
+This directory contains the GKE blueprint, deployment variables, and test job for running DWS Flex Start combined with a custom **Compute Engine Workload Policy** to enforce physical compact placement on the provisioned nodes.
+
+1. **Workload Policy definition:** The blueprint defines a custom GCE resource policy using the `workload_policy` module:
+
+    ```yaml
+    - id: workload_policy
+      source: modules/compute/resource-policy
+      settings:
+        name: "h4d-workload-policy"
+        workload_policy:
+          type: "HIGH_THROUGHPUT"
+          # Optional: physical boundary constraint for compaction.
+          # Supported values: "SUBBLOCK", "BLOCK", or "CLUSTER" (default)
+          max_topology_distance: "CLUSTER"
+    ```
+
+2. **Mapping to Node Pool:** The policy is then mapped directly to the GKE node pool MIG. This binds the physical `HIGH_THROUGHPUT` constraint to the pool along with the physical boundary limit (`max_topology_distance`) so that when the GKE Autoscaler requests nodes, they are guaranteed to sit in a physically collocated cluster matching the selected topology constraint.
+
+## Create a cluster
+These steps guide you through the cluster creation process.
+
+Note: If you create multiple clusters using these same cluster blueprints, ensure that all VPCs and subnet names are unique per project to prevent errors.
+
+1. Launch [Cloud Shell](https://cloud.google.com/shell/docs/launching-cloud-shell). You can use a different environment; however, we recommend Cloud Shell because the dependencies are already pre-installed for Cluster Toolkit. If you don't want to use Cloud Shell, follow the [instructions to install dependencies](https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies) to prepare a different environment.
+
+2. Clone the Cluster Toolkit from the git repository:
+
+    ```sh
+    cd ~
+    git clone https://github.com/GoogleCloudPlatform/cluster-toolkit.git
+    ```
+
+3. Install the Cluster Toolkit:
+
+    ```sh
+    cd cluster-toolkit && git checkout main && make
+    ```
+
+4. Create a Cloud Storage bucket to store the state of the Terraform deployment:
+
+    ```sh
+    gcloud storage buckets create gs://BUCKET_NAME \
+        --project=PROJECT_ID \
+        --default-storage-class=STANDARD \
+        --location=COMPUTE_REGION \
+        --uniform-bucket-level-access
+    gcloud storage buckets update gs://BUCKET_NAME --versioning
+    ```
+
+    Replace the following variables:\
+    BUCKET_NAME: the name of the new Cloud Storage bucket.\
+    PROJECT_ID: ID of the project where the bucket is being created.\
+    COMPUTE_REGION: the compute region where you want to store the state of the Terraform deployment.
+
+5. In the `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d-deployment.yaml` file, fill in the following settings in the `terraform_backend_defaults` and `vars` sections to match the specific values for your deployment:
+
+    `bucket`: the name of the Cloud Storage bucket you created in the previous step.\
+    `deployment_name`: the name of the deployment.\
+    `project_id`: your Google Cloud project ID.\
+    `region`: the compute region for the cluster.\
+    `zone`: the compute zone for the node pool of H4D machines.\
+    `authorized_cidr`: The IP address range that you want to allow to connect with the cluster. This CIDR block must include the IP address of the machine to call Terraform.\
+    **`enable_flex_start`**: enable DWS Flex Start.\
+    To modify advanced settings, edit `examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d.yaml`.
+
+6. Generate [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/provide-credentials-adc#google-idp) to provide access to Terraform.
+
+    ```sh
+    gcloud auth application-default login
+    ```
+
+7. Deploy the blueprint to provision the GKE infrastructure:
+
+    ```sh
+    cd ~/cluster-toolkit
+    ./gcluster deploy -d \
+    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d-deployment.yaml \
+    examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d.yaml
+    ```
+
+8. When prompted, select (A)pply to deploy the blueprint.
+   * The blueprint creates VPC networks, an RDMA VPC network, service accounts, a cluster, and a nodepool mapping the custom workload policy.
+
+## Note
+* DWS Flex Start does not work with static nodes. So, `static_node_count` cannot be set.
+* To use DWS Flex Start, `auto_repair` should be set to `false`.
+* Compact placement using custom GCE workload policies (like `HIGH_THROUGHPUT` topology constraints) with DWS Flex Start is currently supported for **A4**, **A3 Ultra**, and **H4D** machine types.
+
+## Run a job
+
+The example folder provides a sample job test-job.yaml that runs a sleep container for `10s`.
+
+Any job applied to this node pool must meet the following requirements:
+* **Tolerations**: Because the `h4d-pool` node pool is tainted (`node-type=h4d:NoSchedule`) to prevent generic scheduling, any job you apply **must** include the matching toleration under `spec.template.spec.tolerations`
+
+  ```sh
+  tolerations:
+  - key: "node-type"
+    operator: "Equal"
+    value: "h4d"
+    effect: "NoSchedule"
+  ```
+
+1. Connect to the GKE cluster using gcloud command.
+
+    ```sh
+    gcloud container clusters get-credentials <cluster-name> --location <location> --project <project-id>
+    ```
+
+    Replace `<cluster-name>` with the name of your cluster, `<location>` with the name of the compute region, and `<project-id>` with the ID of the project.
+
+2. Submit the sample test job:
+
+    ```sh
+    kubectl apply -f examples/gke-consumption-options/dws-flex-start-compact-placement/test-job.yaml
+    ```
+
+3. Monitor the scale-up and execution timeline:
+    *Immediately after submitting, the pods will be `Pending` because the H4D node pool is at size `0`:
+
+      ```sh
+      kubectl get pods -w
+      ```
+
+4. Describe one of the pending pods to verify GKE is triggering a scale-up for the H4D partition:
+
+      ```sh
+      kubectl describe pod <pod-name>
+      ```
+
+    You should see events like `TriggeredScaleUp` mentioning the node group scale-up from `0->1` node.
+    After some time, the physical VM will boot and register. The pods will transition to `Running` and then `Completed`.
+
+*NOTE:* Since the node pool is configured with default `max_run_duration: 900` (15 minutes), the nodes will be automatically deleted by GKE after running for 15 minutes, or when the jobs complete and GKE Autoscaler scales down the idle nodes.

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/README.md
@@ -89,6 +89,7 @@ Note: If you create multiple clusters using these same cluster blueprints, ensur
 * DWS Flex Start does not work with static nodes. So, `static_node_count` cannot be set.
 * To use DWS Flex Start, `auto_repair` should be set to `false`.
 * Compact placement using custom GCE workload policies (like `HIGH_THROUGHPUT` topology constraints) with DWS Flex Start is currently supported for **A4**, **A3 Ultra**, and **H4D** machine types.
+* TPUs are natively scheduled as compact physical slices via the `tpu_topology` parameter. So, for TPUs (incl. Flex-Start) users must specify `tpu_topology`. This is already supported for Flex-start because it’s mandatory for TPU Slice scheduling.
 
 ## Run a job
 
@@ -116,23 +117,76 @@ Any job applied to this node pool must meet the following requirements:
 2. Submit the sample test job:
 
     ```sh
-    kubectl apply -f examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/test-job.yaml
+    kubectl apply -f examples/gke-consumption-options/dws-flex-start-compact-placement/dws-flex-start-h4d.yaml
     ```
 
 3. Monitor the scale-up and execution timeline:
-    *Immediately after submitting, the pods will be `Pending` because the H4D node pool is at size `0`:
+    ***Check Pod Status**: Immediately after submitting, the pods will be `Pending` because the H4D node pool is at size `0`:
 
       ```sh
       kubectl get pods -w
       ```
 
-4. Describe one of the pending pods to verify GKE is triggering a scale-up for the H4D partition:
+      Output:
 
-      ```sh
-      kubectl describe pod <pod-name>
+      ```text
+      NAME              READY   STATUS    RESTARTS   AGE
+      h4d-job-1-q2ksv   0/1     Pending   0          10s
+      h4d-job-2-j9wla   0/1     Pending   0          10s
       ```
 
-    You should see events like `TriggeredScaleUp` mentioning the node group scale-up from `0->1` node.
-    After some time, the physical VM will boot and register. The pods will transition to `Running` and then `Completed`.
+    ***Inspect Autoscaler Events**: Describe one of the pending pods or list events to verify GKE is triggering a scale-up for the H4D partition:
+
+      ```sh
+      kubectl describe pod h4d-job-1-q2ksv
+      ```
+
+      Look for the `TriggeredScaleUp` event:
+
+      ```text
+      Events:
+        Type    Reason            Age   From                Message
+        ----    ------            ---   ----                -------
+        Normal  TriggeredScaleUp  15s   cluster-autoscaler  pod triggered scale-up by cluster-autoscaler: group h4d-pool-xxxx
+      ```
+
+    ***Track Node Readiness**: After sometime, the physical VM will boot and register. The pods will transition to `Running` and then `Completed`.
+
+      ```sh
+      kubectl get nodes -w
+      ```
+
+      Output:
+
+      ```text
+      NAME                      STATUS   ROLES    AGE   VERSION
+      gke-h4d-pool-8hwg         Ready    <none>   10s   v1.32.1-gke.1001000
+      ```
+
+    ***Observe Completion**: Once the sleep workload finishes, the pods will move to `Completed`.
+
+      ```sh
+      kubectl get pods
+      ```
+
+      Output:
+
+      ```text
+      NAME              READY   STATUS      RESTARTS   AGE
+      h4d-job-1-q2ksv   0/1     Completed   0          2m
+      h4d-job-2-j9wla   0/1     Completed   0          2m
+      ```
 
 *NOTE:* Since the node pool is configured with default `max_run_duration: 900` (15 minutes), the nodes will be automatically deleted by GKE after running for 15 minutes, or when the jobs complete and GKE Autoscaler scales down the idle nodes.
+
+## Verification via Google Cloud Console
+
+To verify the workload policy configuration using the Google Cloud Console UI:
+
+1. In the Google Cloud Console, navigate to the **Kubernetes Engine > Clusters** page.
+2. Click on the name of your GKE cluster.
+3. Select the **Nodes** tab.
+4. Scroll down to the node pool details and click on the link to the Managed Instance Group (MIG) under the **Instance groups** column.
+5. On the Managed Instance Group page, select the **Details** tab.
+6. Scroll down to locate the **Workload policy** section.
+7. Verify that the attached policy configuration shows the correct type and topology distance.

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d-deployment.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d-deployment.yaml
@@ -1,0 +1,40 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform_backend_defaults:
+  type: gcs
+  configuration:
+    # The GCS bucket used for storing terraform state
+    bucket:
+
+vars:
+  # Your GCP Project ID
+  project_id:
+
+  # This should be unique across all of your Cluster
+  # Toolkit Deployments.
+  deployment_name:
+
+  # The GCP Region used for this deployment.
+  region:
+
+  # The GCP Zone used for this deployment.
+  zone:
+
+  # Cidr block containing the IP of the machine calling terraform.
+  # The following line must be updated for this example to work.
+  authorized_cidr:
+
+  # Enable DWS Flex Start.
+  enable_flex_start: true

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
@@ -1,0 +1,184 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+blueprint_name: gke-h4d
+
+vars:
+  # The following variables should be over-written in the deployment.yaml file.
+  # Your GCP Project ID
+  project_id:
+
+  # This should be unique across all of your Cluster
+  # Toolkit Deployments.
+  deployment_name:
+
+  # The GCP Region used for this deployment.
+  region:
+
+  # The GCP Zone used for this deployment.
+  zone:
+
+  # Cidr block containing the IP of the machine calling terraform.
+  # The following line must be updated for this example to work.
+  authorized_cidr:
+
+  system_node_pool_disk_size_gb: 100
+  h4d_node_pool_disk_size_gb: 100
+
+  # Enable DWS Flex Start.
+  enable_flex_start: true
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: gke-h4d-net
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.deployment_name)-net
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-sub
+        subnet_region: $(vars.region)
+        subnet_ip: 10.10.0.0/20
+      secondary_ranges_list:
+      - subnetwork_name: $(vars.deployment_name)-sub
+        ranges:
+        - range_name: pods
+          ip_cidr_range: 10.11.0.0/16
+        - range_name: services
+          ip_cidr_range: 10.10.16.0/20
+      firewall_rules:
+      - name: $(vars.deployment_name)-internal
+        ranges: ["10.10.0.0/15"]
+        allow:
+        - protocol: tcp
+          ports: ["0-65535"]
+        - protocol: udp
+          ports: ["0-65535"]
+        - protocol: icmp
+
+  - id: gke-h4d-rdma-net
+    source: modules/network/multivpc
+    settings:
+      network_name_prefix: $(vars.deployment_name)-rdma-net
+      network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-falcon
+      network_routing_mode: "REGIONAL"
+      network_count: 1
+      enable_cloud_router: false
+      enable_cloud_nat: false
+      global_ip_address_range: 10.20.0.0/16
+      subnetwork_cidr_suffix: 24
+      subnetwork_private_access: false
+      network_interface_defaults:
+        nic_type: "IRDMA"
+
+  - id: node_pool_service_account
+    source: modules/project/service-account
+    settings:
+      name: gke-np-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectViewer
+      - artifactregistry.reader
+
+  - id: workload_service_account
+    source: modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
+  - id: h4d-cluster
+    source: modules/scheduler/gke-cluster
+    use: [gke-h4d-net, gke-h4d-rdma-net, workload_service_account]
+    settings:
+      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
+      system_node_pool_taints: []
+      enable_multi_networking: true
+      enable_dcgm_monitoring: true
+      enable_private_endpoint: false # Allows access from authorized public IPs
+      configure_workload_identity_sa: true
+      enable_filestore_csi: true
+      master_authorized_networks:
+      - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
+        display_name: "kubectl-access-network"
+      # Cluster versions cannot be updated through the toolkit after creation
+      # Please manage cluster version from the Google Cloud Console directly
+      version_prefix: "1.32."
+      release_channel: REGULAR
+      maintenance_exclusions:
+      - name: no-minor-or-node-upgrades-indefinite
+        start_time: "2025-12-01T00:00:00Z"
+        exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
+        exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
+    outputs: [instructions]
+
+  - id: workload_policy
+    source: modules/compute/resource-policy
+    settings:
+      name: "h4d-workload-policy"
+      project_id: $(vars.project_id)
+      region: $(vars.region)
+      workload_policy:
+        type: "HIGH_THROUGHPUT"
+        max_topology_distance: CLUSTER
+
+  - id: h4d-pool
+    source: modules/compute/gke-node-pool
+    use: [h4d-cluster, gke-h4d-rdma-net, node_pool_service_account, workload_policy]
+    settings:
+      machine_type: h4d-standard-192
+      enable_flex_start: $(vars.enable_flex_start) # flex-start
+      auto_repair: false # flex-start dependency
+      auto_upgrade: true
+      zones: [$(vars.zone)]
+      max_run_duration: 900
+      disk_size_gb: $(vars.h4d_node_pool_disk_size_gb)
+      taints:
+      # (Optional, but suggested)
+      # In order prevent scheduling of generic workloads onto the H4D nodepool,
+      # we suggest a Kubernetes taint. In order to schedule workloads, add the following
+      # tolerance to a PodSpec that you want to allow to use the H4D nodes. See
+      # https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ for
+      # details
+      # tolerations:
+      # - key: "node-type"
+      #   operator: "Equal"
+      #   value: "h4d"
+      #   effect: "NoSchedule"
+      - key: node-type
+        value: h4d
+        effect: NO_SCHEDULE
+    outputs: [instructions]
+
+  # Install Kueue and Jobset
+  - id: workload-manager-install
+    source: modules/management/kubectl-apply
+    use: [h4d-cluster]
+    settings:
+      kueue:
+        install: true
+      jobset:
+        install: true
+      apply_manifests:
+      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.7.0/deploy/v2beta1/mpi-operator.yaml"
+        server_side_apply: true

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/test-job.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/test-job.yaml
@@ -1,0 +1,53 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: h4d-job-1
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-flex-start: "true"
+      tolerations:
+      - key: "node-type"
+        operator: "Equal"
+        value: "h4d"
+        effect: "NoSchedule"
+      containers:
+      - name: gpu-container-1
+        image: gcr.io/k8s-staging-perf-tests/sleep:latest
+        args: ["10s"] # Sleep for 10 seconds
+      restartPolicy: OnFailure
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: h4d-job-2
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-flex-start: "true"
+      tolerations:
+      - key: "node-type"
+        operator: "Equal"
+        value: "h4d"
+        effect: "NoSchedule"
+      containers:
+      - name: gpu-container-2
+        image: gcr.io/k8s-staging-perf-tests/sleep:latest
+        args: ["10s"] # Sleep for 10 seconds
+      restartPolicy: OnFailure

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -449,6 +449,14 @@ resource "google_container_node_pool" "node_pool" {
       )
       error_message = "When is_reservation_active is set to false, static_node_count, autoscaling_min_node_count, autoscaling_max_node_count, and initial_node_count must all be either null or 0."
     }
+    precondition {
+      condition = !(
+        var.enable_flex_start &&
+        try(var.placement_policy.type == "COMPACT", false) &&
+        !can(regex("^(a3-ultragpu-|a4-|h4d-)", var.machine_type))
+      )
+      error_message = "Compact placement with DWS Flex is only supported for A3 Ultra, A4, and H4D machine types."
+    }
   }
 }
 

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -455,7 +455,7 @@ resource "google_container_node_pool" "node_pool" {
         try(var.placement_policy.type == "COMPACT", false) &&
         !can(regex("^(a3-ultragpu-|a4-|h4d-)", var.machine_type))
       )
-      error_message = "Compact placement with DWS Flex is only supported for A3 Ultra, A4, and H4D machine types."
+      error_message = "Compact placement with DWS Flex start is only supported for A3 Ultra, A4, and H4D machine types."
     }
   }
 }

--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -453,6 +453,7 @@ resource "google_container_node_pool" "node_pool" {
       condition = !(
         var.enable_flex_start &&
         try(var.placement_policy.type == "COMPACT", false) &&
+        !module.tpu.is_tpu &&
         !can(regex("^(a3-ultragpu-|a4-|h4d-)", var.machine_type))
       )
       error_message = "Compact placement with DWS Flex start is only supported for A3 Ultra, A4, and H4D machine types."

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -181,7 +181,7 @@ locals {
       queue_count        = null
       network_ip         = null
       stack_type         = local.output_primary_subnetwork_stack_type
-      access_config      = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }]
+      access_config      = []
       ipv6_access_config = []
       alias_ip_range     = []
     }

--- a/modules/network/vpc/main.tf
+++ b/modules/network/vpc/main.tf
@@ -181,7 +181,7 @@ locals {
       queue_count        = null
       network_ip         = null
       stack_type         = local.output_primary_subnetwork_stack_type
-      access_config      = []
+      access_config      = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }]
       ipv6_access_config = []
       alias_ip_range     = []
     }


### PR DESCRIPTION
This PR adds a complete example for GKE - H4D machines using DWS Flex Start combined with a workload policy for compact placement. 

### File Changes
- *gke-h4d-deployment.yaml* - Deployment configuration template with backend defaults and variable placeholders
- *gke-h4d.yaml* - A sample H4D blueprint with creation of workload_policy for compact placement and then injecting it into gke-node-pool
- *test-job.yaml* - sample job with appropriate node selectors and tolerations for H4D node pool
- *README.md* - Complete deployment guide with step-by-step instructions for creating the cluster, configuring DWS Flex Start with workload policies, and running test jobs
- *gke-node-pool/main.tf* - Added precondition validation to ensure compact placement with Flex Start is only used with supported machine types (A3 Ultra, A4, H4D)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
