### PR TITLE
Remove additional network settings from slurm blueprints - A3U, A4H, A4X

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -618,18 +618,7 @@ deployment_groups:
         ThreadsPerCore: 2
       additional_networks:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a3ultra-slurm-net-1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip="",
-            stack_type=null,
-            access_config=[],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a3ultra-slurm-net-1.instance_additional_networks,
           a3ultra-slurm-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -643,18 +643,7 @@ deployment_groups:
         ThreadsPerCore: 2
       additional_networks:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a4high-slurm-net-1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip="",
-            stack_type=null,
-            access_config=[],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a4high-slurm-net-1.instance_additional_networks,
           a4high-slurm-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -619,18 +619,7 @@ deployment_groups:
         ThreadsPerCore: 1
       additional_networks:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a4x-slurm-net-1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip="",
-            stack_type=null,
-            access_config=[],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a4x-slurm-net-1.instance_additional_networks,
           a4x-slurm-rdma-net.subnetwork_interfaces
         ))
 


### PR DESCRIPTION
This PR eliminates additional network configuration in the slurm A3U, A4 and A4X examples. This is a follow up item referencing [PR#5652](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5652)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
