### PR TITLE
Remove additional network settings from slurm A3U,A4,A4X VM examples

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -127,7 +127,7 @@ deployment_groups:
           merge(a3ultra-net-0.instance_additional_networks[0],
           { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
           ],
-          a3ultra-net-1.instance_additional_networks,,
+          a3ultra-net-1.instance_additional_networks,
           a3ultra-rdma-net.subnetwork_interfaces,
         ))
 

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -125,9 +125,10 @@ deployment_groups:
         $(concat(
           [
           merge(a3ultra-net-0.instance_additional_networks[0],
+          { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] }),
+          merge(a3ultra-net-1.instance_additional_networks[0],
           { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
           ],
-          a3ultra-net-1.instance_additional_networks,
           a3ultra-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -128,7 +128,7 @@ deployment_groups:
           { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
           ],
           a3ultra-net-1.instance_additional_networks,
-          a3ultra-rdma-net.subnetwork_interfaces,
+          a3ultra-rdma-net.subnetwork_interfaces
         ))
 
   - id: wait-for-vms

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -123,30 +123,8 @@ deployment_groups:
       provisioning_model: $(vars.a3u_provisioning_model)
       network_interfaces:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a3ultra-net-0.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          },
-          {
-            network=null,
-            subnetwork=a3ultra-net-1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a3ultra-net-0.instance_additional_networks,
+          a3ultra-net-1.instance_additional_networks,,
           a3ultra-rdma-net.subnetwork_interfaces,
         ))
 

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-vm.yaml
@@ -123,7 +123,10 @@ deployment_groups:
       provisioning_model: $(vars.a3u_provisioning_model)
       network_interfaces:
         $(concat(
-          a3ultra-net-0.instance_additional_networks,
+          [
+          merge(a3ultra-net-0.instance_additional_networks[0],
+          { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
+          ],
           a3ultra-net-1.instance_additional_networks,,
           a3ultra-rdma-net.subnetwork_interfaces,
         ))

--- a/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
@@ -332,9 +332,10 @@ deployment_groups:
         $(concat(
          [
          merge(a4high-net-0.instance_additional_networks[0],
-         { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
+         { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] }),
+         merge(a4high-net-1.instance_additional_networks[0],
+         { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null  }] })
          ],
-          a4high-net-1.instance_additional_networks,
           a4high-rdma-net.subnetwork_interfaces
         ))
 

--- a/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
@@ -330,30 +330,8 @@ deployment_groups:
       provisioning_model: $(vars.a4h_provisioning_model)
       network_interfaces:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a4high-net-0.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          },
-          {
-            network=null,
-            subnetwork=a4high-net-1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a4high-net-0.instance_additional_networks,
+          a4high-net-1.instance_additional_networks,
           a4high-rdma-net.subnetwork_interfaces,
         ))
 

--- a/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
@@ -335,7 +335,7 @@ deployment_groups:
          { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
          ],
           a4high-net-1.instance_additional_networks,
-          a4high-rdma-net.subnetwork_interfaces,
+          a4high-rdma-net.subnetwork_interfaces
         ))
 
   - id: wait-for-vms

--- a/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-vm.yaml
@@ -330,7 +330,10 @@ deployment_groups:
       provisioning_model: $(vars.a4h_provisioning_model)
       network_interfaces:
         $(concat(
-          a4high-net-0.instance_additional_networks,
+         [
+         merge(a4high-net-0.instance_additional_networks[0],
+         { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
+         ],
           a4high-net-1.instance_additional_networks,
           a4high-rdma-net.subnetwork_interfaces,
         ))

--- a/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
@@ -323,30 +323,8 @@ deployment_groups:
       instance_image: $(vars.instance_image)
       network_interfaces:
         $(concat(
-          [{
-            network=null,
-            subnetwork=a4x_net_0.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          },
-          {
-            network=null,
-            subnetwork=a4x_net_1.subnetwork_self_link,
-            subnetwork_project=vars.project_id,
-            nic_type="GVNIC",
-            queue_count=null,
-            network_ip=null,
-            stack_type=null,
-            access_config=[{nat_ip=null, public_ptr_domain_name=null, network_tier=null}],
-            ipv6_access_config=[],
-            alias_ip_range=[]
-          }],
+          a4x_net_0.instance_additional_networks,
+          a4x_net_1.instance_additional_networks,
           a4x_rdma_net.subnetwork_interfaces
         ))
   - id: wait-for-vms

--- a/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
@@ -323,7 +323,10 @@ deployment_groups:
       instance_image: $(vars.instance_image)
       network_interfaces:
         $(concat(
-          a4x_net_0.instance_additional_networks,
+          [
+          merge(a4x_net_0.instance_additional_networks[0],
+          { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
+          ],
           a4x_net_1.instance_additional_networks,
           a4x_rdma_net.subnetwork_interfaces
         ))

--- a/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4x-vm.yaml
@@ -326,8 +326,9 @@ deployment_groups:
           [
           merge(a4x_net_0.instance_additional_networks[0],
           { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
+          merge(a4x_net_1.instance_additional_networks[0],
+          { access_config = [{ nat_ip = null, public_ptr_domain_name = null, network_tier = null }] })
           ],
-          a4x_net_1.instance_additional_networks,
           a4x_rdma_net.subnetwork_interfaces
         ))
   - id: wait-for-vms


### PR DESCRIPTION
This PR eliminates additional network configuration in the slurm A3U, A4 and A4X VM examples. This is a follow up item referencing [PR#5652](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5652)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
