### PR TITLE
Add integration test for GKE GCSFuse Storage Profiles

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -305,6 +305,7 @@ deployment_groups:
     source: modules/compute/gke-job-template
     use: [checkpointing-pv, training-pv, a3-ultragpu-pool]
     settings:
+      name: gcsfuse-fio-job
       security_context:  # to make sure the job have enough access to install the fio packages
       - key: runAsUser
         value: 0

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -337,6 +337,7 @@ deployment_groups:
     source: modules/compute/gke-job-template
     use: [checkpointing-pv, training-pv, a4-pool]
     settings:
+      name: gcsfuse-fio-job
       security_context:  # to make sure the job have enough access to install the fio packages
       - key: runAsUser
         value: 0

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -365,6 +365,7 @@ deployment_groups:
     source: modules/compute/gke-job-template
     use: [checkpointing-pv, training-pv, a4x-pool]
     settings:
+      name: gcsfuse-fio-job
       security_context:  # to make sure the job have enough access to install the fio packages
       - key: runAsUser
         value: 0

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
@@ -27,57 +27,60 @@
   - name: Execute the GCS Fuse test job
     delegate_to: localhost
     ansible.builtin.shell: |
-      array=("{{ workspace }}/{{ deployment_name }}/primary"/my-job*)
+      array=("{{ workspace }}/{{ deployment_name }}/primary"/gcsfuse-fio-job*)
       kubectl create -f "${array[0]}" -v=9
     args:
       executable: /bin/bash
     changed_when: False
 
-  - name: Wait for Pod to be created
-    delegate_to: localhost
-    ansible.builtin.shell: |
-      kubectl get pods -l job-name -o jsonpath='{.items[*].metadata.name}'
-    register: pod_check
-    until: pod_check.stdout | length > 0
-    retries: 12
-    delay: 10
-    changed_when: False
-
-  - name: Verify PVC Storage Classes
-    delegate_to: localhost
-    ansible.builtin.shell: |
-      kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-training" && \
-      kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-checkpointing"
-    register: pvc_validation
-    until: pvc_validation.rc == 0
-    retries: 5
-    delay: 5
-    changed_when: False
-
-  - name: Verify Pod Annotations and Sidecar Injection
-    delegate_to: localhost
-    ansible.builtin.shell: |
-      # Resolve the job name
-      JOB_NAME=$(kubectl get job -o jsonpath='{.items[0].metadata.name}')
-      # Check if the pod has the gke-gcsfuse/volumes annotation
-      kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
-      # Check if the pod has the gke-gcsfuse/profile-managed label
-      kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.labels['gke-gcsfuse/profile-managed']}" | grep -q "true" && \
-      # Check if the gke-gcsfuse-sidecar container is present in the pod spec (either initContainers or containers)
-      (kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.initContainers[*].name}' | grep -q "gke-gcsfuse-sidecar" || \
-       kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.containers[*].name}' | grep -q "gke-gcsfuse-sidecar")
-    register: pod_validation
-    until: pod_validation.rc == 0
-    retries: 5
-    delay: 5
-    changed_when: False
-
-  - name: Block to wait for job completion and capture failures
+  - name: Execute checks with error capturing
     block:
+    - name: Wait for Pod to be created
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl get pods -l job-name -o jsonpath='{.items[*].metadata.name}'
+      register: pod_check
+      until: pod_check.stdout | length > 0
+      retries: 12
+      delay: 10
+      changed_when: False
+
+    - name: Verify PVC Storage Classes
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-training" && \
+        kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-checkpointing"
+      register: pvc_validation
+      until: pvc_validation.rc == 0
+      retries: 5
+      delay: 5
+      changed_when: False
+
+    - name: Verify Pod Annotations and Sidecar Injection
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        # Resolve the specific FIO job name using label filters
+        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[?(@.metadata.name=="gcsfuse-fio-job")].metadata.name}' || \
+                   kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[0].metadata.name}')
+
+        # Check if the pod has the gke-gcsfuse/volumes annotation
+        kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
+        # Check if the pod has the gke-gcsfuse/profile-managed label
+        kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.labels['gke-gcsfuse/profile-managed']}" | grep -q "true" && \
+        # Check if the gke-gcsfuse-sidecar container is present in the pod spec (either initContainers or containers)
+        (kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.initContainers[*].name}' | grep -q "gke-gcsfuse-sidecar" || \
+         kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.containers[*].name}' | grep -q "gke-gcsfuse-sidecar")
+      register: pod_validation
+      until: pod_validation.rc == 0
+      retries: 5
+      delay: 5
+      changed_when: False
+
     - name: Wait for GCS Fuse test job to complete
       delegate_to: localhost
       ansible.builtin.shell: |
-        JOB_NAME=$(kubectl get job -o jsonpath='{.items[0].metadata.name}')
+        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[?(@.metadata.name=="gcsfuse-fio-job")].metadata.name}' || \
+                   kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[0].metadata.name}')
         kubectl wait --for=condition=complete "job/${JOB_NAME}" --timeout=15m
       args:
         executable: /bin/bash
@@ -86,10 +89,11 @@
       retries: 3
       delay: 10
       changed_when: False
+
     rescue:
-    - name: "FAILURE: Job did not complete. Capturing debug info."
+    - name: "FAILURE: GCS Fuse validation checks failed. Capturing debug info."
       ansible.builtin.debug:
-        msg: "The Job failed to complete within the expected time. See debug output below."
+        msg: "An error occurred during verification checks. See debug output below."
 
     - name: Get all pods status on failure
       delegate_to: localhost
@@ -102,7 +106,7 @@
       ansible.builtin.debug:
         msg: "{{ pods_on_failure.stdout_lines }}"
 
-    - name: Describe the job on failure
+    - name: Describe the jobs on failure
       delegate_to: localhost
       ansible.builtin.shell: |
         kubectl describe job
@@ -150,7 +154,7 @@
 
     - name: Fail the playbook
       ansible.builtin.fail:
-        msg: "GKE Job did not complete successfully."
+        msg: "GKE GCS Fuse validation failed."
 
   always:
   - name: Clean up resources from the cluster

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
@@ -27,8 +27,8 @@
   - name: Execute the GCS Fuse test job
     delegate_to: localhost
     ansible.builtin.shell: |
-      array=({{ workspace }}/{{ deployment_name }}/primary/my-job*)
-      kubectl create -f ${array[0]} -v=9
+      array=("{{ workspace }}/{{ deployment_name }}/primary"/my-job*)
+      kubectl create -f "${array[0]}" -v=9
     args:
       executable: /bin/bash
     changed_when: False
@@ -60,12 +60,12 @@
       # Resolve the job name
       JOB_NAME=$(kubectl get job -o jsonpath='{.items[0].metadata.name}')
       # Check if the pod has the gke-gcsfuse/volumes annotation
-      kubectl get pods -l job-name=${JOB_NAME} -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
+      kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
       # Check if the pod has the gke-gcsfuse/profile-managed label
-      kubectl get pods -l job-name=${JOB_NAME} -o jsonpath="{.items[0].metadata.labels['gke-gcsfuse/profile-managed']}" | grep -q "true" && \
+      kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.labels['gke-gcsfuse/profile-managed']}" | grep -q "true" && \
       # Check if the gke-gcsfuse-sidecar container is present in the pod spec (either initContainers or containers)
-      (kubectl get pods -l job-name=${JOB_NAME} -o jsonpath='{.items[0].spec.initContainers[*].name}' | grep -q "gke-gcsfuse-sidecar" || \
-       kubectl get pods -l job-name=${JOB_NAME} -o jsonpath='{.items[0].spec.containers[*].name}' | grep -q "gke-gcsfuse-sidecar")
+      (kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.initContainers[*].name}' | grep -q "gke-gcsfuse-sidecar" || \
+       kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath='{.items[0].spec.containers[*].name}' | grep -q "gke-gcsfuse-sidecar")
     register: pod_validation
     until: pod_validation.rc == 0
     retries: 5
@@ -137,7 +137,7 @@
     - name: Get logs from the pod on failure
       delegate_to: localhost
       ansible.builtin.shell: |
-        kubectl logs {{ item }}
+        kubectl logs {{ item }} --all-containers
       loop: "{{ pod_name_on_failure.stdout_lines }}"
       register: pod_logs_on_failure
       changed_when: false

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
@@ -59,9 +59,8 @@
     - name: Verify Pod Annotations and Sidecar Injection
       delegate_to: localhost
       ansible.builtin.shell: |
-        # Resolve the specific FIO job name using label filters
-        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[?(@.metadata.name=="gcsfuse-fio-job")].metadata.name}' || \
-                   kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[0].metadata.name}')
+        # Resolve the specific FIO job name using pattern filters
+        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep '^gcsfuse-fio-job' | head -n 1)
 
         # Check if the pod has the gke-gcsfuse/volumes annotation
         kubectl get pods -l job-name="${JOB_NAME}" -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
@@ -79,8 +78,7 @@
     - name: Wait for GCS Fuse test job to complete
       delegate_to: localhost
       ansible.builtin.shell: |
-        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[?(@.metadata.name=="gcsfuse-fio-job")].metadata.name}' || \
-                   kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[0].metadata.name}')
+        JOB_NAME=$(kubectl get job -l ghpc_module=gke-job-template -o jsonpath='{.items[*].metadata.name}' | tr ' ' '\n' | grep '^gcsfuse-fio-job' | head -n 1)
         kubectl wait --for=condition=complete "job/${JOB_NAME}" --timeout=15m
       args:
         executable: /bin/bash

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gcsfuse-mounts.yml
@@ -1,0 +1,162 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: GCS Fuse Storage Profiles Verification Tasks
+  block:
+  - name: Assert variables are defined
+    ansible.builtin.assert:
+      that:
+      - region is defined
+      - custom_vars.project is defined
+
+  - name: Get cluster credentials for kubectl
+    delegate_to: localhost
+    ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }} --verbosity=debug
+
+  - name: Execute the GCS Fuse test job
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      array=({{ workspace }}/{{ deployment_name }}/primary/my-job*)
+      kubectl create -f ${array[0]} -v=9
+    args:
+      executable: /bin/bash
+    changed_when: False
+
+  - name: Wait for Pod to be created
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get pods -l job-name -o jsonpath='{.items[*].metadata.name}'
+    register: pod_check
+    until: pod_check.stdout | length > 0
+    retries: 12
+    delay: 10
+    changed_when: False
+
+  - name: Verify PVC Storage Classes
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-training" && \
+      kubectl get pvc -o jsonpath='{.items[*].spec.storageClassName}' | grep -q "gcsfusecsi-checkpointing"
+    register: pvc_validation
+    until: pvc_validation.rc == 0
+    retries: 5
+    delay: 5
+    changed_when: False
+
+  - name: Verify Pod Annotations and Sidecar Injection
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      # Resolve the job name
+      JOB_NAME=$(kubectl get job -o jsonpath='{.items[0].metadata.name}')
+      # Check if the pod has the gke-gcsfuse/volumes annotation
+      kubectl get pods -l job-name=${JOB_NAME} -o jsonpath="{.items[0].metadata.annotations['gke-gcsfuse/volumes']}" | grep -q "true" && \
+      # Check if the pod has the gke-gcsfuse/profile-managed label
+      kubectl get pods -l job-name=${JOB_NAME} -o jsonpath="{.items[0].metadata.labels['gke-gcsfuse/profile-managed']}" | grep -q "true" && \
+      # Check if the gke-gcsfuse-sidecar container is present in the pod spec (either initContainers or containers)
+      (kubectl get pods -l job-name=${JOB_NAME} -o jsonpath='{.items[0].spec.initContainers[*].name}' | grep -q "gke-gcsfuse-sidecar" || \
+       kubectl get pods -l job-name=${JOB_NAME} -o jsonpath='{.items[0].spec.containers[*].name}' | grep -q "gke-gcsfuse-sidecar")
+    register: pod_validation
+    until: pod_validation.rc == 0
+    retries: 5
+    delay: 5
+    changed_when: False
+
+  - name: Block to wait for job completion and capture failures
+    block:
+    - name: Wait for GCS Fuse test job to complete
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        JOB_NAME=$(kubectl get job -o jsonpath='{.items[0].metadata.name}')
+        kubectl wait --for=condition=complete "job/${JOB_NAME}" --timeout=15m
+      args:
+        executable: /bin/bash
+      register: job_completion
+      until: job_completion.rc == 0
+      retries: 3
+      delay: 10
+      changed_when: False
+    rescue:
+    - name: "FAILURE: Job did not complete. Capturing debug info."
+      ansible.builtin.debug:
+        msg: "The Job failed to complete within the expected time. See debug output below."
+
+    - name: Get all pods status on failure
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl get pods -o wide
+      register: pods_on_failure
+      changed_when: false
+
+    - name: Print all pods status on failure
+      ansible.builtin.debug:
+        msg: "{{ pods_on_failure.stdout_lines }}"
+
+    - name: Describe the job on failure
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl describe job
+      register: job_describe_on_failure
+      changed_when: false
+
+    - name: Print job description on failure
+      ansible.builtin.debug:
+        msg: "{{ job_describe_on_failure.stdout_lines }}"
+
+    - name: Get pod name on failure
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl get pods --selector=job-name --no-headers -o custom-columns=":metadata.name"
+      register: pod_name_on_failure
+      changed_when: false
+
+    - name: Describe the pod on failure
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl describe pod {{ item }}
+      loop: "{{ pod_name_on_failure.stdout_lines }}"
+      register: pod_describe_on_failure
+      changed_when: false
+      when: pod_name_on_failure.stdout_lines | length > 0
+
+    - name: Print pod description on failure
+      ansible.builtin.debug:
+        msg: "{{ pod_describe_on_failure.results }}"
+      when: pod_name_on_failure.stdout_lines | length > 0
+
+    - name: Get logs from the pod on failure
+      delegate_to: localhost
+      ansible.builtin.shell: |
+        kubectl logs {{ item }}
+      loop: "{{ pod_name_on_failure.stdout_lines }}"
+      register: pod_logs_on_failure
+      changed_when: false
+      when: pod_name_on_failure.stdout_lines | length > 0
+
+    - name: Print pod logs on failure
+      ansible.builtin.debug:
+        msg: "{{ pod_logs_on_failure.results }}"
+      when: pod_name_on_failure.stdout_lines | length > 0
+
+    - name: Fail the playbook
+      ansible.builtin.fail:
+        msg: "GKE Job did not complete successfully."
+
+  always:
+  - name: Clean up resources from the cluster
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl delete job -l ghpc_module=gke-job-template --ignore-not-found -v=9
+    args:
+      executable: /bin/bash
+    changed_when: False

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
@@ -40,6 +40,7 @@ custom_vars:
   enable_spot: true
 post_deploy_tests:
 - test-validation/test-gcsfuse-mounts.yml
+- test-validation/test-gke-job.yml
 - test-validation/test-gke-a3-ultra.yml
 - test-validation/test-gke-kueue-config.yml
 - test-validation/test-chs.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu-onspot.yml
@@ -39,7 +39,7 @@ custom_vars:
     a3ultra_onspot: true
   enable_spot: true
 post_deploy_tests:
-- test-validation/test-gke-job.yml
+- test-validation/test-gcsfuse-mounts.yml
 - test-validation/test-gke-a3-ultra.yml
 - test-validation/test-gke-kueue-config.yml
 - test-validation/test-chs.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
@@ -39,6 +39,6 @@ cli_deployment_vars:
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
-- test-validation/test-gke-job.yml
+- test-validation/test-gcsfuse-mounts.yml
 - test-validation/test-gke-a3-ultra.yml
 - test-validation/test-gke-kueue-config.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a3-ultragpu.yml
@@ -40,5 +40,6 @@ custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
 - test-validation/test-gcsfuse-mounts.yml
+- test-validation/test-gke-job.yml
 - test-validation/test-gke-a3-ultra.yml
 - test-validation/test-gke-kueue-config.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
@@ -42,6 +42,7 @@ custom_vars:
   enable_spot: true
 post_deploy_tests:
 - test-validation/test-gcsfuse-mounts.yml
+- test-validation/test-gke-job.yml
 - test-validation/test-gke-a4.yml
 - test-validation/test-gke-kueue-config.yml
 - test-validation/test-chs.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
@@ -41,7 +41,7 @@ custom_vars:
     a4_onspot: true
   enable_spot: true
 post_deploy_tests:
-- test-validation/test-gke-job.yml
+- test-validation/test-gcsfuse-mounts.yml
 - test-validation/test-gke-a4.yml
 - test-validation/test-gke-kueue-config.yml
 - test-validation/test-chs.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a4x.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a4x.yml
@@ -39,5 +39,6 @@ custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
 - test-validation/test-gcsfuse-mounts.yml
+- test-validation/test-gke-job.yml
 - test-validation/test-gke-a4x.yml
 - test-validation/test-gke-a4x-kueue-config.yml

--- a/tools/cloud-build/daily-tests/tests/gke-a4x.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a4x.yml
@@ -38,6 +38,6 @@ cli_deployment_vars:
 custom_vars:
   project: "{{ project }}"
 post_deploy_tests:
-- test-validation/test-gke-job.yml
+- test-validation/test-gcsfuse-mounts.yml
 - test-validation/test-gke-a4x.yml
 - test-validation/test-gke-a4x-kueue-config.yml


### PR DESCRIPTION
This PR adds validation playbook (test-gcsfuse-mounts.yml) to verify GCS Fuse Storage Profiles functionality across all GKE daily integration tests that deploy them.
It replaces the generic test-gke-job.yml validation with deep assertions on GCS Fuse annotations, labels, StorageClasses, and sidecar container injection.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
