### PR TITLE
fix(gke): expand the precondition for PROVISION_ONLY

### DIFF
--- a/modules/compute/gke-node-pool/main.tf
+++ b/modules/compute/gke-node-pool/main.tf
@@ -437,8 +437,8 @@ resource "google_container_node_pool" "node_pool" {
       error_message = "Spot consumption option only works with reservation_affinity consume_reservation_type NO_RESERVATION."
     }
     precondition {
-      condition     = !(var.accelerator_topology_mode == "PROVISION_ONLY" && var.enable_queued_provisioning == true)
-      error_message = "Custom accelerator topology modes (like PROVISION_ONLY) are incompatible with Dynamic Workload Scheduler (queued provisioning)."
+      condition     = !(var.accelerator_topology_mode == "PROVISION_ONLY" && try(var.reservation_affinity.consume_reservation_type, "") != "SPECIFIC_RESERVATION")
+      error_message = "PROVISION_ONLY accelerator topology mode is only supported on GKE node pools configured with SPECIFIC_RESERVATION reservation affinity."
     }
     precondition {
       condition = var.is_reservation_active || (


### PR DESCRIPTION
This PR enhances a precondition to enforce that the PROVISION_ONLY accelerator topology mode is exclusively used with SPECIFIC_RESERVATION reservation affinity.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
