### PR TITLE
Loosen Terraform version constraints in modules and add version warning

### DIFF
--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.54 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |

--- a/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/vpc_tf/GCP/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }
 
 provider "google" {

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/README.md
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.87.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.2 |

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/README.md
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers

--- a/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/versions.tf
+++ b/community/front-end/ofe/infrastructure_files/workbench_tf/google/wait-for-startup/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/front-end/ofe/tf/README.md
+++ b/community/front-end/ofe/tf/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/community/front-end/ofe/tf/network/README.md
+++ b/community/front-end/ofe/tf/network/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 4.0 |
 
 ## Providers

--- a/community/front-end/ofe/tf/network/versions.tf
+++ b/community/front-end/ofe/tf/network/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/front-end/ofe/tf/versions.tf
+++ b/community/front-end/ofe/tf/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/gke-nodeset/README.md
+++ b/community/modules/compute/gke-nodeset/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 
 ## Providers

--- a/community/modules/compute/gke-nodeset/versions.tf
+++ b/community/modules/compute/gke-nodeset/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/gke-partition/README.md
+++ b/community/modules/compute/gke-partition/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 
 ## Providers

--- a/community/modules/compute/gke-partition/versions.tf
+++ b/community/modules/compute/gke-partition/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -197,7 +197,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/mig/README.md
+++ b/community/modules/compute/mig/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 
 ## Providers

--- a/community/modules/compute/mig/versions.tf
+++ b/community/modules/compute/mig/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/notebook/README.md
+++ b/community/modules/compute/notebook/README.md
@@ -68,7 +68,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.34 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/compute/notebook/versions.tf
+++ b/community/modules/compute/notebook/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/README.md
@@ -61,7 +61,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.92.0"
   }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/README.md
@@ -38,7 +38,7 @@ be accessed as `tpu` partition.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.92.0"

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/README.md
@@ -165,7 +165,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 5.11 |
 
 ## Providers

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/README.md
@@ -64,7 +64,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.92.0"

--- a/community/modules/container/artifact-registry/README.md
+++ b/community/modules/container/artifact-registry/README.md
@@ -103,7 +103,7 @@ Note: only Docker registries have been tested so far. Placeholders do exist for 
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/container/artifact-registry/versions.tf
+++ b/community/modules/container/artifact-registry/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/bigquery-dataset/README.md
+++ b/community/modules/database/bigquery-dataset/README.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/bigquery-dataset/versions.tf
+++ b/community/modules/database/bigquery-dataset/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/bigquery-table/README.md
+++ b/community/modules/database/bigquery-table/README.md
@@ -44,7 +44,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/bigquery-table/versions.tf
+++ b/community/modules/database/bigquery-table/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/database/slurm-cloudsql-federation/README.md
+++ b/community/modules/database/slurm-cloudsql-federation/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/file-system/nfs-server/README.md
+++ b/community/modules/file-system/nfs-server/README.md
@@ -84,7 +84,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.14 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/file-system/weka-client/README.md
+++ b/community/modules/file-system/weka-client/README.md
@@ -150,7 +150,7 @@ weka local rm -f --all
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/file-system/weka-client/versions.tf
+++ b/community/modules/file-system/weka-client/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/files/fsi-montecarlo-on-batch/README.md
+++ b/community/modules/files/fsi-montecarlo-on-batch/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/community/modules/files/fsi-montecarlo-on-batch/versions.tf
+++ b/community/modules/files/fsi-montecarlo-on-batch/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/internal/slurm-gcp/instance/README.md
+++ b/community/modules/internal/slurm-gcp/instance/README.md
@@ -46,7 +46,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.43 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 

--- a/community/modules/internal/slurm-gcp/instance/versions.tf
+++ b/community/modules/internal/slurm-gcp/instance/versions.tf
@@ -16,7 +16,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/internal/slurm-gcp/instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/instance_template/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |
 
 ## Providers

--- a/community/modules/internal/slurm-gcp/instance_template/versions.tf
+++ b/community/modules/internal/slurm-gcp/instance_template/versions.tf
@@ -14,7 +14,7 @@
 
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     local = {

--- a/community/modules/internal/slurm-gcp/internal_instance_template/README.md
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.88 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 

--- a/community/modules/internal/slurm-gcp/internal_instance_template/versions.tf
+++ b/community/modules/internal/slurm-gcp/internal_instance_template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/internal/slurm-gcp/login/README.md
+++ b/community/modules/internal/slurm-gcp/login/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 
 ## Providers

--- a/community/modules/internal/slurm-gcp/login/versions.tf
+++ b/community/modules/internal/slurm-gcp/login/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/internal/slurm-gcp/nodeset_tpu/README.md
+++ b/community/modules/internal/slurm-gcp/nodeset_tpu/README.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.53 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 

--- a/community/modules/internal/slurm-gcp/nodeset_tpu/versions.tf
+++ b/community/modules/internal/slurm-gcp/nodeset_tpu/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/management/dependencies-installer/README.md
+++ b/community/modules/management/dependencies-installer/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 

--- a/community/modules/management/dependencies-installer/helm_install/README.md
+++ b/community/modules/management/dependencies-installer/helm_install/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 
 ## Providers

--- a/community/modules/management/dependencies-installer/helm_install/versions.tf
+++ b/community/modules/management/dependencies-installer/helm_install/versions.tf
@@ -20,5 +20,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/management/dependencies-installer/kubernetes_manifest/README.md
+++ b/community/modules/management/dependencies-installer/kubernetes_manifest/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.23 |
 
 ## Providers

--- a/community/modules/management/dependencies-installer/kubernetes_manifest/versions.tf
+++ b/community/modules/management/dependencies-installer/kubernetes_manifest/versions.tf
@@ -20,5 +20,5 @@ terraform {
       version = "~> 2.23"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/management/dependencies-installer/versions.tf
+++ b/community/modules/management/dependencies-installer/versions.tf
@@ -26,5 +26,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/management/direct-helm-install/README.md
+++ b/community/modules/management/direct-helm-install/README.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 

--- a/community/modules/management/direct-helm-install/versions.tf
+++ b/community/modules/management/direct-helm-install/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = "~> 2.17"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/management/helm-upgrade/README.md
+++ b/community/modules/management/helm-upgrade/README.md
@@ -49,7 +49,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/management/helm-upgrade/versions.tf
+++ b/community/modules/management/helm-upgrade/versions.tf
@@ -22,5 +22,5 @@ terraform {
       version = ">= 3.0"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/project/service-enablement/README.md
+++ b/community/modules/project/service-enablement/README.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/pubsub/bigquery-sub/README.md
+++ b/community/modules/pubsub/bigquery-sub/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/pubsub/bigquery-sub/versions.tf
+++ b/community/modules/pubsub/bigquery-sub/versions.tf
@@ -31,5 +31,5 @@ terraform {
   provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.92.0"
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/pubsub/topic/README.md
+++ b/community/modules/pubsub/topic/README.md
@@ -39,7 +39,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/community/modules/pubsub/topic/versions.tf
+++ b/community/modules/pubsub/topic/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/remote-desktop/chrome-remote-desktop/README.md
+++ b/community/modules/remote-desktop/chrome-remote-desktop/README.md
@@ -53,7 +53,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
+++ b/community/modules/remote-desktop/chrome-remote-desktop/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-access-point/README.md
+++ b/community/modules/scheduler/htcondor-access-point/README.md
@@ -105,7 +105,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-central-manager/README.md
+++ b/community/modules/scheduler/htcondor-central-manager/README.md
@@ -91,7 +91,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-pool-secrets/README.md
+++ b/community/modules/scheduler/htcondor-pool-secrets/README.md
@@ -118,7 +118,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.84 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -29,5 +29,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-service-accounts/README.md
+++ b/community/modules/scheduler/htcondor-service-accounts/README.md
@@ -90,7 +90,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/htcondor-service-accounts/versions.tf
+++ b/community/modules/scheduler/htcondor-service-accounts/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/htcondor-setup/README.md
+++ b/community/modules/scheduler/htcondor-setup/README.md
@@ -80,7 +80,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/htcondor-setup/versions.tf
+++ b/community/modules/scheduler/htcondor-setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -261,7 +261,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0.0 |
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_compute/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     null = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/README.md
@@ -42,7 +42,7 @@ No outputs.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/cleanup_tpu/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     null = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | ~> 2.0 |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     archive = {
       source  = "hashicorp/archive"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -59,7 +59,7 @@ modules. For support with the underlying modules, see the instructions in the
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.92.0"

--- a/community/modules/scheduler/slinky/README.md
+++ b/community/modules/scheduler/slinky/README.md
@@ -114,7 +114,7 @@ squeue
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.16 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 

--- a/community/modules/scheduler/slinky/versions.tf
+++ b/community/modules/scheduler/slinky/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     helm = {

--- a/community/modules/scripts/gcloud/README.md
+++ b/community/modules/scripts/gcloud/README.md
@@ -45,7 +45,7 @@ deployment_groups:
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scripts/gcloud/versions.tf
+++ b/community/modules/scripts/gcloud/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = ">= 3.0"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scripts/gke-backend-fetcher/README.md
+++ b/community/modules/scripts/gke-backend-fetcher/README.md
@@ -45,7 +45,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | >= 2.0 |
 
 ## Providers

--- a/community/modules/scripts/gke-backend-fetcher/versions.tf
+++ b/community/modules/scripts/gke-backend-fetcher/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scripts/htcondor-install/README.md
+++ b/community/modules/scripts/htcondor-install/README.md
@@ -116,7 +116,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scripts/htcondor-install/versions.tf
+++ b/community/modules/scripts/htcondor-install/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scripts/ramble-execute/README.md
+++ b/community/modules/scripts/ramble-execute/README.md
@@ -64,7 +64,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 
 ## Providers

--- a/community/modules/scripts/ramble-execute/versions.tf
+++ b/community/modules/scripts/ramble-execute/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/community/modules/scripts/ramble-setup/README.md
+++ b/community/modules/scripts/ramble-setup/README.md
@@ -71,7 +71,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 

--- a/community/modules/scripts/ramble-setup/versions.tf
+++ b/community/modules/scripts/ramble-setup/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/scripts/spack-execute/README.md
+++ b/community/modules/scripts/spack-execute/README.md
@@ -91,7 +91,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 
 ## Providers

--- a/community/modules/scripts/spack-execute/versions.tf
+++ b/community/modules/scripts/spack-execute/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/community/modules/scripts/spack-setup/README.md
+++ b/community/modules/scripts/spack-setup/README.md
@@ -325,7 +325,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 

--- a/community/modules/scripts/spack-setup/versions.tf
+++ b/community/modules/scripts/spack-setup/versions.tf
@@ -15,7 +15,7 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/community/modules/scripts/spanner-migrations-runner/README.md
+++ b/community/modules/scripts/spanner-migrations-runner/README.md
@@ -41,7 +41,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
 
 ## Providers

--- a/community/modules/scripts/spanner-migrations-runner/versions.tf
+++ b/community/modules/scripts/spanner-migrations-runner/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scripts/wait-for-startup/README.md
+++ b/community/modules/scripts/wait-for-startup/README.md
@@ -50,7 +50,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 
 ## Providers

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/community/modules/scripts/windows-startup-script/README.md
+++ b/community/modules/scripts/windows-startup-script/README.md
@@ -76,7 +76,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -19,5 +19,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
-	github.com/hashicorp/go-version v1.8.0 // indirect
+	github.com/hashicorp/go-version v1.9.0
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/hashicorp/go-getter v1.8.4 h1:hGEd2xsuVKgwkMtPVufq73fAmZU/x65PPcqH3cb
 github.com/hashicorp/go-getter v1.8.4/go.mod h1:x27pPGSg9kzoB147QXI8d/nDvp2IgYGcwuRjpaXE9Yg=
 github.com/hashicorp/go-retryablehttp v0.7.8 h1:ylXZWnqa7Lhqpk0L1P1LzDtGcCR0rPVUrx/c8Unxc48=
 github.com/hashicorp/go-retryablehttp v0.7.8/go.mod h1:rjiScheydd+CxvumBsIrFKlx3iS0jrZ7LvzFGFmuKbw=
-github.com/hashicorp/go-version v1.8.0 h1:KAkNb1HAiZd1ukkxDFGmokVZe1Xy9HG6NUp+bPle2i4=
-github.com/hashicorp/go-version v1.8.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
+github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.9.2 h1:v80EtNX4fCVHqzL9Lg/2xkp62bbvQMnvPQ0G+OmtO24=
 github.com/hashicorp/hc-install v0.9.2/go.mod h1:XUqBQNnuT4RsxoxiM9ZaUk0NX8hi2h+Lb6/c0OZnC/I=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=

--- a/modules/compute/cloud-run/README.md
+++ b/modules/compute/cloud-run/README.md
@@ -39,7 +39,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.48.0 |
 
 ## Providers

--- a/modules/compute/cloud-run/versions.tf
+++ b/modules/compute/cloud-run/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = ">= 4.48.0"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/compute/gke-job-template/README.md
+++ b/modules/compute/gke-job-template/README.md
@@ -73,7 +73,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/compute/gke-job-template/versions.tf
+++ b/modules/compute/gke-job-template/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     random = {

--- a/modules/compute/gke-node-pool/README.md
+++ b/modules/compute/gke-node-pool/README.md
@@ -291,7 +291,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.24.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/compute/resource-policy/README.md
+++ b/modules/compute/resource-policy/README.md
@@ -42,7 +42,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.24.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/compute/resource-policy/versions.tf
+++ b/modules/compute/resource-policy/versions.tf
@@ -30,5 +30,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:resource-policy/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/compute/vm-instance/README.md
+++ b/modules/compute/vm-instance/README.md
@@ -168,7 +168,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -37,5 +37,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/database/redis/README.md
+++ b/modules/database/redis/README.md
@@ -36,7 +36,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/database/redis/versions.tf
+++ b/modules/database/redis/versions.tf
@@ -21,5 +21,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/database/spanner/README.md
+++ b/modules/database/spanner/README.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.0 |
 
 ## Providers

--- a/modules/database/spanner/versions.tf
+++ b/modules/database/spanner/versions.tf
@@ -22,5 +22,5 @@ terraform {
       version = ">= 6.0"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/cloud-storage-bucket/README.md
+++ b/modules/file-system/cloud-storage-bucket/README.md
@@ -107,7 +107,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.9.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/modules/file-system/cloud-storage-bucket/versions.tf
@@ -35,5 +35,5 @@ terraform {
   provider_meta "google-beta" {
     module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.92.0"
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/filestore/README.md
+++ b/modules/file-system/filestore/README.md
@@ -190,7 +190,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.4 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -194,7 +194,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.42 |
 | <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.7.0 |
 

--- a/modules/file-system/gke-persistent-volume/versions.tf
+++ b/modules/file-system/gke-persistent-volume/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/modules/file-system/gke-storage/README.md
+++ b/modules/file-system/gke-storage/README.md
@@ -87,7 +87,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/file-system/gke-storage/versions.tf
+++ b/modules/file-system/gke-storage/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.92.0"

--- a/modules/file-system/managed-lustre/README.md
+++ b/modules/file-system/managed-lustre/README.md
@@ -268,7 +268,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.27.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/managed-lustre/versions.tf
+++ b/modules/file-system/managed-lustre/versions.tf
@@ -32,5 +32,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/netapp-storage-pool/README.md
+++ b/modules/file-system/netapp-storage-pool/README.md
@@ -141,7 +141,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/file-system/netapp-storage-pool/versions.tf
+++ b/modules/file-system/netapp-storage-pool/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -149,7 +149,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
 
 ## Providers

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -28,5 +28,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/file-system/parallelstore/README.md
+++ b/modules/file-system/parallelstore/README.md
@@ -146,7 +146,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/file-system/parallelstore/versions.tf
+++ b/modules/file-system/parallelstore/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -155,7 +155,7 @@ the network storage doc for a complete list of supported modules.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/file-system/pre-existing-network-storage/versions.tf
+++ b/modules/file-system/pre-existing-network-storage/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/iam/iap-policy/README.md
+++ b/modules/iam/iap-policy/README.md
@@ -33,7 +33,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/iam/iap-policy/versions.tf
+++ b/modules/iam/iap-policy/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/internal/gpu-definition/README.md
+++ b/modules/internal/gpu-definition/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/gpu-definition/main.tf
+++ b/modules/internal/gpu-definition/main.tf
@@ -48,5 +48,5 @@ output "machine_type_guest_accelerator" {
 }
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/internal/instance_validations/README.md
+++ b/modules/internal/instance_validations/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/instance_validations/versions.tf
+++ b/modules/internal/instance_validations/versions.tf
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/internal/network-attachment/README.md
+++ b/modules/internal/network-attachment/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 6.0.0 |
 
 ## Providers

--- a/modules/internal/network-attachment/main.tf
+++ b/modules/internal/network-attachment/main.tf
@@ -59,7 +59,7 @@ output "self_link" {
 }
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google-beta = {

--- a/modules/internal/tpu-definition/README.md
+++ b/modules/internal/tpu-definition/README.md
@@ -52,7 +52,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/internal/tpu-definition/main.tf
+++ b/modules/internal/tpu-definition/main.tf
@@ -53,5 +53,5 @@ locals {
 }
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/internal/vpc_peering/README.md
+++ b/modules/internal/vpc_peering/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/internal/vpc_peering/main.tf
+++ b/modules/internal/vpc_peering/main.tf
@@ -69,7 +69,7 @@ output "peering_name" {
 }
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -214,7 +214,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | ~> 3.0 |

--- a/modules/management/kubectl-apply/helm_install/README.md
+++ b/modules/management/kubectl-apply/helm_install/README.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 
 ## Providers

--- a/modules/management/kubectl-apply/helm_install/versions.tf
+++ b/modules/management/kubectl-apply/helm_install/versions.tf
@@ -20,5 +20,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/management/kubectl-apply/versions.tf
+++ b/modules/management/kubectl-apply/versions.tf
@@ -42,5 +42,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:kubectl-apply/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/management/kubernetes-namespace/README.md
+++ b/modules/management/kubernetes-namespace/README.md
@@ -33,7 +33,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 

--- a/modules/management/kubernetes-namespace/versions.tf
+++ b/modules/management/kubernetes-namespace/versions.tf
@@ -23,5 +23,5 @@ terraform {
       version = ">= 2.10"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/management/mldiagnostics/README.md
+++ b/modules/management/mldiagnostics/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.2 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.17 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 3.0.0 |

--- a/modules/management/mldiagnostics/versions.tf
+++ b/modules/management/mldiagnostics/versions.tf
@@ -34,5 +34,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:mldiagnostics/v1.84.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/monitoring/dashboard/README.md
+++ b/modules/monitoring/dashboard/README.md
@@ -48,7 +48,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/dns-managed-zone/README.md
+++ b/modules/network/dns-managed-zone/README.md
@@ -43,7 +43,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.73.0 |
 
 ## Providers

--- a/modules/network/dns-managed-zone/versions.tf
+++ b/modules/network/dns-managed-zone/versions.tf
@@ -22,5 +22,5 @@ terraform {
     }
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/firewall-rules/README.md
+++ b/modules/network/firewall-rules/README.md
@@ -69,7 +69,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/firewall-rules/versions.tf
+++ b/modules/network/firewall-rules/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/global-static-ip/README.md
+++ b/modules/network/global-static-ip/README.md
@@ -36,7 +36,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/global-static-ip/versions.tf
+++ b/modules/network/global-static-ip/versions.tf
@@ -19,5 +19,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/gpu-rdma-vpc/README.md
+++ b/modules/network/gpu-rdma-vpc/README.md
@@ -93,7 +93,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/network/gpu-rdma-vpc/versions.tf
+++ b/modules/network/gpu-rdma-vpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/multivpc/README.md
+++ b/modules/network/multivpc/README.md
@@ -76,7 +76,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/network/multivpc/versions.tf
+++ b/modules/network/multivpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/pre-existing-subnetwork/README.md
+++ b/modules/network/pre-existing-subnetwork/README.md
@@ -55,7 +55,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/pre-existing-subnetwork/versions.tf
+++ b/modules/network/pre-existing-subnetwork/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/pre-existing-vpc/README.md
+++ b/modules/network/pre-existing-vpc/README.md
@@ -67,7 +67,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/private-service-access/README.md
+++ b/modules/network/private-service-access/README.md
@@ -75,7 +75,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.40 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 

--- a/modules/network/private-service-access/versions.tf
+++ b/modules/network/private-service-access/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/network/vpc/README.md
+++ b/modules/network/vpc/README.md
@@ -163,7 +163,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/network/vpc/versions.tf
+++ b/modules/network/vpc/versions.tf
@@ -15,5 +15,5 @@
 */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/project/service-account/README.md
+++ b/modules/project/service-account/README.md
@@ -66,7 +66,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 
 ## Providers
 

--- a/modules/project/service-account/versions.tf
+++ b/modules/project/service-account/versions.tf
@@ -18,5 +18,5 @@ terraform {
   required_providers {
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/project/workload_identity_binding/README.md
+++ b/modules/project/workload_identity_binding/README.md
@@ -35,7 +35,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/project/workload_identity_binding/versions.tf
+++ b/modules/project/workload_identity_binding/versions.tf
@@ -22,5 +22,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/scheduler/batch-job-template/README.md
+++ b/modules/scheduler/batch-job-template/README.md
@@ -127,7 +127,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |

--- a/modules/scheduler/batch-job-template/versions.tf
+++ b/modules/scheduler/batch-job-template/versions.tf
@@ -33,5 +33,5 @@ terraform {
       version = ">= 4.0"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/scheduler/batch-login-node/README.md
+++ b/modules/scheduler/batch-login-node/README.md
@@ -78,7 +78,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 
 ## Providers

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -25,5 +25,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/scheduler/gke-cluster/README.md
+++ b/modules/scheduler/gke-cluster/README.md
@@ -109,7 +109,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.20.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.20.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.36 |

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/modules/scheduler/pre-existing-gke-cluster/README.md
+++ b/modules/scheduler/pre-existing-gke-cluster/README.md
@@ -75,7 +75,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | > 5.0 |
 
 ## Providers

--- a/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -26,5 +26,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/scripts/startup-script/README.md
+++ b/modules/scripts/startup-script/README.md
@@ -289,7 +289,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.41 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -33,5 +33,5 @@ terraform {
     module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.92.0"
   }
 
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/modules/security/kubernetes-secret/README.md
+++ b/modules/security/kubernetes-secret/README.md
@@ -37,7 +37,7 @@ limitations under the License.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.10 |
 

--- a/modules/security/kubernetes-secret/versions.tf
+++ b/modules/security/kubernetes-secret/versions.tf
@@ -25,5 +25,5 @@ terraform {
       version = ">= 2.10"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -18,6 +18,7 @@ package dependencies
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -55,7 +56,7 @@ func PatchPath() error {
 	}
 
 	currentPath := os.Getenv("PATH")
-	newPath := currentPath + string(os.PathListSeparator) + tfCacheDir + string(os.PathListSeparator) + packerCacheDir
+	newPath := tfCacheDir + string(os.PathListSeparator) + packerCacheDir + string(os.PathListSeparator) + currentPath
 	os.Setenv("PATH", newPath)
 
 	return nil
@@ -74,8 +75,30 @@ func EnsureDependencies(decision DownloadDecision) error {
 }
 
 func ensureBinary(binaryName, version string, decision DownloadDecision) error {
-	if _, err := exec.LookPath(binaryName); err == nil {
-		return nil
+	path, err := exec.LookPath(binaryName)
+	if err == nil {
+		if binaryName == "terraform" {
+			installedVersion, err := getInstalledTfVersion(path)
+			if err != nil {
+				fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s.\n", err, version)
+			} else {
+				cmp, err := compareVersions(installedVersion, version)
+				if err != nil {
+					fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s.\n", installedVersion, err, version)
+				} else if cmp == 0 {
+					return nil // exact match
+				} else if cmp > 0 {
+					// installed version is newer
+					fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features.\n", installedVersion, version)
+					return nil // proceed with newer version
+				} else {
+					// installed version is older (incompatible)
+					fmt.Printf("Installed terraform version %s is older than required version %s.\n", installedVersion, version)
+				}
+			}
+		} else {
+			return nil // for packer, just check existence for now
+		}
 	}
 
 	if err := confirmDownload(binaryName, version, decision); err != nil {
@@ -88,6 +111,69 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 	}
 
 	return downloadAndExtract(binaryName, version, binaryCacheDir)
+}
+
+func getInstalledTfVersion(path string) (string, error) {
+	cmd := exec.Command(path, "version", "--json")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	var version struct {
+		TerraformVersion string `json:"terraform_version"`
+	}
+	if err := json.Unmarshal(out, &version); err != nil {
+		return "", err
+	}
+
+	return version.TerraformVersion, nil
+}
+
+// compareVersions returns:
+//
+//	-1 if v1 < v2
+//	 0 if v1 == v2
+//	 1 if v1 > v2
+func compareVersions(v1, v2 string) (int, error) {
+	v1 = strings.TrimPrefix(v1, "v")
+	v2 = strings.TrimPrefix(v2, "v")
+
+	// Strip pre-release info
+	v1 = strings.Split(v1, "-")[0]
+	v2 = strings.Split(v2, "-")[0]
+
+	var major1, minor1, patch1 int
+	var major2, minor2, patch2 int
+
+	_, err := fmt.Sscanf(v1, "%d.%d.%d", &major1, &minor1, &patch1)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version format %q: %w", v1, err)
+	}
+	_, err = fmt.Sscanf(v2, "%d.%d.%d", &major2, &minor2, &patch2)
+	if err != nil {
+		return 0, fmt.Errorf("invalid version format %q: %w", v2, err)
+	}
+
+	if major1 != major2 {
+		if major1 < major2 {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if minor1 != minor2 {
+		if minor1 < minor2 {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	if patch1 != patch2 {
+		if patch1 < patch2 {
+			return -1, nil
+		}
+		return 1, nil
+	}
+	return 0, nil
 }
 
 func confirmDownload(binaryName, version string, decision DownloadDecision) error {

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -24,6 +24,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/hashicorp/go-version"
 )
 
 type DownloadDecision int
@@ -76,31 +78,41 @@ func EnsureDependencies(decision DownloadDecision) error {
 
 func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 	path, err := exec.LookPath(binaryName)
-	if err == nil {
-		if binaryName == "terraform" {
-			installedVersion, err := getInstalledTfVersion(path)
-			if err != nil {
-				fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s.\n", err, version)
-			} else {
-				cmp, err := compareVersions(installedVersion, version)
-				if err != nil {
-					fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s.\n", installedVersion, err, version)
-				} else if cmp == 0 {
-					return nil // exact match
-				} else if cmp > 0 {
-					// installed version is newer
-					fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features.\n", installedVersion, version)
-					return nil // proceed with newer version
-				} else {
-					// installed version is older (incompatible)
-					fmt.Printf("Installed terraform version %s is older than required version %s.\n", installedVersion, version)
-				}
-			}
-		} else {
-			return nil // for packer, just check existence for now
-		}
+	if err != nil {
+		return downloadFlow(binaryName, version, decision)
 	}
 
+	if binaryName != "terraform" {
+		return nil // for packer, just check existence for now
+	}
+
+	installedVersion, err := getInstalledTfVersion(path)
+	if err != nil {
+		fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s.\n", err, version)
+		return downloadFlow(binaryName, version, decision)
+	}
+
+	cmp, err := compareVersions(installedVersion, version)
+	if err != nil {
+		fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s.\n", installedVersion, err, version)
+		return downloadFlow(binaryName, version, decision)
+	}
+
+	switch {
+	case cmp == 0:
+		return nil // exact match, use installed version
+	case cmp > 0:
+		// installed version is newer
+		fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features.\n", installedVersion, version)
+		return nil // proceed with newer version
+	default:
+		// installed version is older (cmp < 0)
+		fmt.Printf("Installed terraform version %s is older than required version %s.\n", installedVersion, version)
+		return downloadFlow(binaryName, version, decision)
+	}
+}
+
+func downloadFlow(binaryName, version string, decision DownloadDecision) error {
 	if err := confirmDownload(binaryName, version, decision); err != nil {
 		return err
 	}
@@ -136,44 +148,16 @@ func getInstalledTfVersion(path string) (string, error) {
 //	 0 if v1 == v2
 //	 1 if v1 > v2
 func compareVersions(v1, v2 string) (int, error) {
-	v1 = strings.TrimPrefix(v1, "v")
-	v2 = strings.TrimPrefix(v2, "v")
-
-	// Strip pre-release info
-	v1 = strings.Split(v1, "-")[0]
-	v2 = strings.Split(v2, "-")[0]
-
-	var major1, minor1, patch1 int
-	var major2, minor2, patch2 int
-
-	_, err := fmt.Sscanf(v1, "%d.%d.%d", &major1, &minor1, &patch1)
+	ver1, err := version.NewVersion(v1)
 	if err != nil {
 		return 0, fmt.Errorf("invalid version format %q: %w", v1, err)
 	}
-	_, err = fmt.Sscanf(v2, "%d.%d.%d", &major2, &minor2, &patch2)
+	ver2, err := version.NewVersion(v2)
 	if err != nil {
 		return 0, fmt.Errorf("invalid version format %q: %w", v2, err)
 	}
 
-	if major1 != major2 {
-		if major1 < major2 {
-			return -1, nil
-		}
-		return 1, nil
-	}
-	if minor1 != minor2 {
-		if minor1 < minor2 {
-			return -1, nil
-		}
-		return 1, nil
-	}
-	if patch1 != patch2 {
-		if patch1 < patch2 {
-			return -1, nil
-		}
-		return 1, nil
-	}
-	return 0, nil
+	return ver1.Compare(ver2), nil
 }
 
 func confirmDownload(binaryName, version string, decision DownloadDecision) error {

--- a/pkg/dependencies/resolver_test.go
+++ b/pkg/dependencies/resolver_test.go
@@ -170,7 +170,7 @@ func TestCompareVersions(t *testing.T) {
 		{"1.12.1", "1.12.2", -1, false},
 		{"1.11.0", "1.12.2", -1, false},
 		{"v1.12.2", "1.12.2", 0, false},
-		{"1.12.2-beta1", "1.12.2", 0, false},
+		{"1.12.2-beta1", "1.12.2", -1, false},
 		{"invalid", "1.12.2", 0, true},
 	}
 

--- a/pkg/dependencies/resolver_test.go
+++ b/pkg/dependencies/resolver_test.go
@@ -49,8 +49,8 @@ func TestPatchPath(t *testing.T) {
 	if !strings.Contains(newPath, expectedPackerPath) {
 		t.Errorf("Expected PATH to contain %s, got %s", expectedPackerPath, newPath)
 	}
-	if !strings.HasPrefix(newPath, oldPath) {
-		t.Errorf("Expected new PATH to start with old PATH")
+	if !strings.HasSuffix(newPath, oldPath) {
+		t.Errorf("Expected new PATH to end with old PATH")
 	}
 }
 
@@ -129,6 +129,7 @@ func TestEnsureDependencies_Exists(t *testing.T) {
 	tempDir := t.TempDir()
 
 	tf, _ := os.Create(filepath.Join(tempDir, "terraform"))
+	_, _ = tf.WriteString("#!/bin/sh\necho '{\"terraform_version\": \"1.12.2\"}'\n")
 	_ = tf.Chmod(0755)
 	tf.Close()
 
@@ -154,5 +155,67 @@ func TestEnsureDependencies_Missing(t *testing.T) {
 	err := EnsureDependencies(DownloadDecisionNo)
 	if err == nil {
 		t.Fatalf("expected error when dependencies are missing and decision is No")
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		v1, v2  string
+		want    int
+		wantErr bool
+	}{
+		{"1.12.2", "1.12.2", 0, false},
+		{"1.12.3", "1.12.2", 1, false},
+		{"1.13.0", "1.12.2", 1, false},
+		{"1.12.1", "1.12.2", -1, false},
+		{"1.11.0", "1.12.2", -1, false},
+		{"v1.12.2", "1.12.2", 0, false},
+		{"1.12.2-beta1", "1.12.2", 0, false},
+		{"invalid", "1.12.2", 0, true},
+	}
+
+	for _, tt := range tests {
+		got, err := compareVersions(tt.v1, tt.v2)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("compareVersions(%q, %q) error = %v, wantErr %v", tt.v1, tt.v2, err, tt.wantErr)
+			continue
+		}
+		if got != tt.want {
+			t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+		}
+	}
+}
+
+func TestEnsureBinary_TerraformNewerVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	tf, _ := os.Create(filepath.Join(tempDir, "terraform"))
+	_, _ = tf.WriteString("#!/bin/sh\necho '{\"terraform_version\": \"1.13.0\"}'\n")
+	_ = tf.Chmod(0755)
+	tf.Close()
+
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", tempDir+string(os.PathListSeparator)+oldPath)
+
+	err := ensureBinary("terraform", "1.12.2", DownloadDecisionNo)
+	if err != nil {
+		t.Fatalf("expected no error for newer version, got %v", err)
+	}
+}
+
+func TestEnsureBinary_TerraformOlderVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	tf, _ := os.Create(filepath.Join(tempDir, "terraform"))
+	_, _ = tf.WriteString("#!/bin/sh\necho '{\"terraform_version\": \"1.11.0\"}'\n")
+	_ = tf.Chmod(0755)
+	tf.Close()
+
+	oldPath := os.Getenv("PATH")
+	defer os.Setenv("PATH", oldPath)
+	os.Setenv("PATH", tempDir+string(os.PathListSeparator)+oldPath)
+
+	err := ensureBinary("terraform", "1.12.2", DownloadDecisionNo)
+	if err == nil {
+		t.Fatalf("expected error for older version with DownloadDecisionNo")
 	}
 }

--- a/pkg/modulereader/modules/test_role/test_module/versions.tf
+++ b/pkg/modulereader/modules/test_role/test_module/versions.tf
@@ -21,5 +21,5 @@ terraform {
       version = ">= 3.83"
     }
   }
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -414,7 +414,7 @@ func (s *zeroSuite) TestWriteVersions(c *C) {
 		c.Assert(err, IsNil)
 		c.Check(string(b), Equals, license+`
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     elephant = {

--- a/pkg/modulewriter/tfwriter.go
+++ b/pkg/modulewriter/tfwriter.go
@@ -207,7 +207,7 @@ func writeVersions(providers map[string]config.TerraformProvider, dst string) er
 	body := f.Body()
 	body.AppendNewline()
 	tfb := body.AppendNewBlock("terraform", []string{}).Body()
-	tfb.SetAttributeValue("required_version", cty.StringVal("= 1.12.2"))
+	tfb.SetAttributeValue("required_version", cty.StringVal(">= 1.12.2"))
 	tfb.AppendNewline()
 
 	pb := tfb.AppendNewBlock("required_providers", []string{}).Body()

--- a/pkg/sourcereader/modules/network/vpc/main.tf
+++ b/pkg/sourcereader/modules/network/vpc/main.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 }
 
 locals {

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -19,7 +19,7 @@ When prompted for project, use integration test project.
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 

--- a/tools/cloud-build/provision/trigger-schedule/README.md
+++ b/tools/cloud-build/provision/trigger-schedule/README.md
@@ -5,7 +5,7 @@
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | = 1.12.2 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 5.0 |
 
 ## Providers

--- a/tools/cloud-build/provision/trigger-schedule/versions.tf
+++ b/tools/cloud-build/provision/trigger-schedule/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/cloud-build/provision/versions.tf
+++ b/tools/cloud-build/provision/versions.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
@@ -15,7 +15,7 @@
   */
 
 terraform {
-  required_version = "= 1.12.2"
+  required_version = ">= 1.12.2"
 
   required_providers {
     google = {


### PR DESCRIPTION
This PR loosens the strict Terraform version constraint (= 1.12.2) across all modules in the repository to required_version = ">= 1.12.2". It also updates the cluster-toolkit's dependency resolver to perform pre-flight version checks, warning users when they use non-standard versions rather than blocking execution.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
