### PR TITLE
test: increase timeout for gke tpuv6e and 7x tests to 3h

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -25,7 +25,7 @@ tags:
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix
 
-timeout: 7200s
+timeout: 10800s
 
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -24,7 +24,7 @@ tags:
 substitutions:
   _TEST_PREFIX: "" # Default to no prefix
 
-timeout: 7200s
+timeout: 10800s
 
 steps:
 # While using static network names we are guarding against more than 1 instance running at a time (for multi-group tests)


### PR DESCRIPTION
Increased timeout for GKE TPU v6e and 7x tests from 2 hours (7200s) to 3 hours (10800s).