### PR TITLE
fix: Resolve syntax error in daily tests bundle extraction

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/create_deployment_directory.yml
@@ -33,7 +33,7 @@
 - name: Get gcluster bundle or build
   ansible.builtin.shell: |
     set -e
-    if [ "{{ test_prefix | default('') }}" == "daily-" ] && [ "{{ build_gcluster_from_source | default(false) | bool | lower }}" == "false" ]; then
+    if [ "{{ test_prefix | default('') }}" = "daily-" ] && [ "{{ build_gcluster_from_source | default(false) | bool | lower }}" = "false" ]; then
         gsutil cp gs://{{ gcluster_gcs_path | default('') }}/latest/gcluster-bundle.zip .
         unzip -o gcluster-bundle.zip > /dev/null && unzip -l gcluster-bundle.zip | tail -n 1 | awk '{print "Extracted " $2 " " $3 " (Total size: " $1 " bytes)."}'
         # Grant execution permissions to the binary


### PR DESCRIPTION
### Submission Checklist

The task "Get gcluster bundle or build" was incorrectly defaulting to the else block (running make) even when the required conditions for downloading the prebuilt bundle were met (i.e., `test_prefix` set to `daily-` and `build_gcluster_from_source` set to `false`).

This occurred because the shell script used the == operator for string comparisons. Ansible's shell module defaults to using `/bin/sh` as its interpreter. On the Ubuntu-based runners used in Cloud Build, `/bin/sh` is linked to dash, a strictly POSIX-compliant shell that does not support == for the [ command. The resulting syntax error caused the `if` condition to fail, triggering the `else` branch.

**Solution**
Replaced the bash-specific `==` operator with the POSIX-compliant `=` operator in the shell script. This ensures the conditional logic evaluates correctly across different shell environments, including `dash`.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
