### PR TITLE
Update integration tests to validate CMEK support in Managed Lustre

### DIFF
--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -35,6 +35,7 @@ vars:
   size_gib: 36000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
+  kms_key: null
 
 deployment_groups:
 - group: primary
@@ -86,6 +87,7 @@ deployment_groups:
       remote_mount: lustrefs
       size_gib: $(vars.size_gib)
       per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
+      kms_key: $(vars.kms_key)
 
   - id: node_pool_service_account
     source: modules/project/service-account

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -35,7 +35,7 @@ vars:
   size_gib: 36000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
-  kms_key: null
+  kms_key: ""
 
 deployment_groups:
 - group: primary

--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -34,7 +34,7 @@ vars:
   lustre_size_gib: 36000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
-  kms_key: null
+  kms_key: ""
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -34,6 +34,7 @@ vars:
   lustre_size_gib: 36000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
+  kms_key: null
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -58,6 +59,7 @@ deployment_groups:
       remote_mount: lustrefs
       size_gib: $(vars.lustre_size_gib)
       per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
+      kms_key: $(vars.kms_key)
 
 - group: slurm-cluster
   modules:

--- a/modules/file-system/managed-lustre/main.tf
+++ b/modules/file-system/managed-lustre/main.tf
@@ -73,7 +73,7 @@ resource "google_lustre_instance" "lustre_instance" {
   network = var.network_id
 
   gke_support_enabled = var.gke_support_enabled
-  kms_key             = var.kms_key
+  kms_key             = var.kms_key == "" ? null : var.kms_key
 
   timeouts {
     create = "1h"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
@@ -220,7 +220,7 @@
   changed_when: True
 
 - name: Verify Lustre instance is encrypted with the expected KMS key
-  ansible.builtin.shell: >
+  ansible.builtin.command: >
     gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
     --location={{ zone }} --project={{ custom_vars.project }}
     --format='value(kmsKey)'

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
@@ -219,13 +219,5 @@
   ansible.builtin.command: kubectl delete pod lustre-test-pod --ignore-not-found=true
   changed_when: True
 
-- name: Verify Lustre instance is encrypted with the expected KMS key
-  ansible.builtin.command: >
-    gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
-    --location={{ zone }} --project={{ custom_vars.project }}
-    --format='value(kmsKey)'
-  delegate_to: localhost
-  register: lustre_kms_key
-  changed_when: false
-  failed_when: lustre_kms_key.rc != 0 or lustre_kms_key.stdout | trim != cli_deployment_vars.kms_key
-  when: cli_deployment_vars is defined and cli_deployment_vars.kms_key is defined and cli_deployment_vars.kms_key != ""
+- name: Verify Lustre KMS Key
+  ansible.builtin.include_tasks: verify-lustre-cmek.yml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-managed-lustre.yml
@@ -218,3 +218,14 @@
   delegate_to: localhost
   ansible.builtin.command: kubectl delete pod lustre-test-pod --ignore-not-found=true
   changed_when: True
+
+- name: Verify Lustre instance is encrypted with the expected KMS key
+  ansible.builtin.shell: >
+    gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
+    --location={{ zone }} --project={{ custom_vars.project }}
+    --format='value(kmsKey)'
+  delegate_to: localhost
+  register: lustre_kms_key
+  changed_when: false
+  failed_when: lustre_kms_key.rc != 0 or lustre_kms_key.stdout | trim != cli_deployment_vars.kms_key
+  when: cli_deployment_vars is defined and cli_deployment_vars.kms_key is defined and cli_deployment_vars.kms_key != ""

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
@@ -56,9 +56,9 @@
     state: absent
 
 - name: Verify Lustre instance is encrypted with the expected KMS key
-  ansible.builtin.shell: >
+  ansible.builtin.command: >
     gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
-    --location={{ zone }} --project={{ project }}
+    --location={{ zone }} --project={{ custom_vars.project }}
     --format='value(kmsKey)'
   delegate_to: localhost
   register: lustre_kms_key

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
@@ -54,3 +54,14 @@
   ansible.builtin.file:
     path: "/{{ custom_vars.output_dir }}/{{ item }}.txt"
     state: absent
+
+- name: Verify Lustre instance is encrypted with the expected KMS key
+  ansible.builtin.shell: >
+    gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
+    --location={{ zone }} --project={{ project }}
+    --format='value(kmsKey)'
+  delegate_to: localhost
+  register: lustre_kms_key
+  changed_when: false
+  failed_when: lustre_kms_key.rc != 0 or lustre_kms_key.stdout | trim != cli_deployment_vars.kms_key
+  when: cli_deployment_vars is defined and cli_deployment_vars.kms_key is defined and cli_deployment_vars.kms_key != ""

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-managed-lustre-slurm.yml
@@ -55,13 +55,5 @@
     path: "/{{ custom_vars.output_dir }}/{{ item }}.txt"
     state: absent
 
-- name: Verify Lustre instance is encrypted with the expected KMS key
-  ansible.builtin.command: >
-    gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
-    --location={{ zone }} --project={{ custom_vars.project }}
-    --format='value(kmsKey)'
-  delegate_to: localhost
-  register: lustre_kms_key
-  changed_when: false
-  failed_when: lustre_kms_key.rc != 0 or lustre_kms_key.stdout | trim != cli_deployment_vars.kms_key
-  when: cli_deployment_vars is defined and cli_deployment_vars.kms_key is defined and cli_deployment_vars.kms_key != ""
+- name: Verify Lustre KMS Key
+  ansible.builtin.include_tasks: verify-lustre-cmek.yml

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/verify-lustre-cmek.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/verify-lustre-cmek.yml
@@ -1,0 +1,24 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Verify Lustre instance is encrypted with the expected KMS key
+  ansible.builtin.command: >
+    gcloud lustre instances describe {{ cli_deployment_vars.lustre_instance_id }}
+    --location={{ zone }} --project={{ custom_vars.project }}
+    --format='value(kmsKey)'
+  delegate_to: localhost
+  register: lustre_kms_key
+  changed_when: false
+  failed_when: lustre_kms_key.rc != 0 or lustre_kms_key.stdout | trim != cli_deployment_vars.kms_key
+  when: cli_deployment_vars is defined and cli_deployment_vars.kms_key is defined and cli_deployment_vars.kms_key != ""

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -35,3 +35,4 @@ cli_deployment_vars:
   size_gib: "{{ size_gib }}"
   per_unit_storage_throughput: "{{ per_unit_storage_throughput }}"
   gcp_public_cidrs_access_enabled: true
+  kms_key: "projects/{{ project }}/locations/us-central1/keyRings/lustre-keyring/cryptoKeys/lustre-key"

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
@@ -36,6 +36,7 @@ post_deploy_tests:
 - test-validation/test-mounts.yml
 - test-validation/test-managed-lustre-slurm.yml
 custom_vars:
+  project: "{{ project }}"
   output_dir: /lustre/test
   num_slurm_nodes: 1
   mounts:

--- a/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
+++ b/tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml
@@ -27,6 +27,7 @@ cli_deployment_vars:
   compute_node_machine_type: c2-standard-4
   slurm_cluster_name: "{{ slurm_cluster_name }}"
   lustre_instance_id: "lustre-instance-{{build}}"
+  kms_key: "projects/{{ project }}/locations/us-central1/keyRings/lustre-keyring/cryptoKeys/lustre-key"
 # Note: Pattern matching in gcloud only supports 1 wildcard.
 login_node: "{{ slurm_cluster_name }}-slurm-login-*"
 controller_node: "{{ slurm_cluster_name }}-controller"


### PR DESCRIPTION
This PR updates the Slurm and GKE Managed Lustre blueprints and their daily integration tests to support and validate Customer-Managed Encryption Keys (CMEK).

To ensure the encryption actually applies, a new post-deployment validation task has been introduced to query the GCP API and verify the associated KMS key.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
