### PR TITLE
fix: add null check for controller_state_disk

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -244,7 +244,7 @@ def setup_key(lkp: util.Lookup, is_primary: bool = True) -> None:
             if shared_key.exists():
                 log.info(f"Restoring {file_name} from {shared_key}")
                 shutil.copyfile(shared_key, dst)
-            elif lkp.cfg.controller_state_disk.device_name:
+            elif lkp.cfg.controller_state_disk and lkp.cfg.controller_state_disk.device_name:
                  # For zonal state disk (files might be directly there if mounted at slurmdirs.state)
                  # But if slurmdirs.state IS shared_dir, we already checked shared_key.exists()
                  # If controller_state_disk is used, slurmdirs.state IS the persistence.
@@ -481,7 +481,7 @@ def setup_controller(is_primary: bool):
 
     # Primary-specific state disk mounting
     if is_primary:
-        if lkp.cfg.controller_state_disk.device_name != None:
+        if lkp.cfg.controller_state_disk and lkp.cfg.controller_state_disk.device_name:
             mount_save_state_disk()
 
     setup_jwt_key()


### PR DESCRIPTION
This PR adds a safety check to ensure controller_state_disk exists before accessing the device_name attribute.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
