### PR TITLE
[Closed] Fix: resolve pipe deadlock in ExecPackerCmd and address tflint null-check

### DIFF
--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -95,7 +95,7 @@ locals {
     for index, manifest in local.enabled_manifests : index => manifest
     if try(manifest.source, null) != null &&
     !contains(keys(local.url_manifests), index) &&
-    (endswith(manifest.source, "/") || (!fileexists(manifest.source) && can(fileset(manifest.source, "*"))))
+    (manifest.source != null && (endswith(manifest.source, "/") || (!fileexists(manifest.source) && can(fileset(manifest.source, "*")))))
   }
 
   # Pre-calculate normalized names for each manifest

--- a/pkg/shell/packer.go
+++ b/pkg/shell/packer.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"sync"
 )
 
 // ConfigurePacker errors if packer is not in the user PATH
@@ -41,53 +40,28 @@ func ConfigurePacker() error {
 func ExecPackerCmd(workingDir string, printToScreen bool, args ...string) error {
 	cmd := exec.Command("packer", args...)
 	cmd.Dir = workingDir
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return err
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
 
-	if err := cmd.Start(); err != nil {
-		return err
-	}
+	// Create buffers to capture output
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
 
-	// capture stdout/stderr; print to screen in real-time or upon error
-	var wg sync.WaitGroup
-	var outBuf io.Writer
-	var errBuf io.Writer
-
+	// Assign writers directly. This lets os/exec manage the streams internally
+	// and avoids manual WaitGroup management which can lead to deadlocks.
 	if printToScreen {
-		outBuf = newTimestampWriter(os.Stdout)
-		errBuf = newTimestampWriter(os.Stderr)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
 	} else {
-		outBuf = bytes.NewBuffer([]byte{})
-		errBuf = bytes.NewBuffer([]byte{})
+		cmd.Stdout = &outBuf
+		cmd.Stderr = &errBuf
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		io.Copy(outBuf, stdout)
-	}()
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		io.Copy(errBuf, stderr)
-	}()
-	wg.Wait()
 
-	if err := cmd.Wait(); err != nil {
+	// Run() starts the command and waits for it to finish.
+	if err := cmd.Run(); err != nil {
 		if !printToScreen {
-			if out, ok := outBuf.(*bytes.Buffer); ok {
-				// Explicitly ignore the error to satisfy the linter
-				_, _ = io.Copy(os.Stdout, out)
-			}
-			if errB, ok := errBuf.(*bytes.Buffer); ok {
-				// Explicitly ignore the error to satisfy the linter
-				_, _ = io.Copy(os.Stderr, errB)
-			}
+			// If we weren't printing in real-time, dump the captured
+			// output now to help with debugging the failure.
+			io.Copy(os.Stdout, &outBuf)
+			io.Copy(os.Stderr, &errBuf)
 		}
 		return err
 	}

--- a/pkg/shell/packer.go
+++ b/pkg/shell/packer.go
@@ -60,8 +60,8 @@ func ExecPackerCmd(workingDir string, printToScreen bool, args ...string) error 
 		if !printToScreen {
 			// If we weren't printing in real-time, dump the captured
 			// output now to help with debugging the failure.
-			io.Copy(os.Stdout, &outBuf)
-			io.Copy(os.Stderr, &errBuf)
+			_, _ = io.Copy(os.Stdout, &outBuf)
+			_, _ = io.Copy(os.Stderr, &errBuf)
 		}
 		return err
 	}


### PR DESCRIPTION
### Summary
This PR addresses two issues impacting CI stability and code quality: a permanent process hang in gcluster during Packer builds and a Terraform validation failure in the kubectl-apply module ([ source](https://github.com/GoogleCloudPlatform/cluster-toolkit/compare/develop...SwarnaBharathiMantena:swarnabm/packer_test_failure?expand=1&content_ref=fix+resolve+pipe+deadlock+in+execpackercmd+and+address+tflint+null+c)).

### 1. Resolve ExecPackerCmd Deadlock
Recent builds for the PR-test-packer trigger (e.g., ID 16c21cdc) have consistently timed out after 4 hours without producing terminal errors ([ source](https://pantheon.corp.google.com/cloud-build/builds;region=global/16c21cdc-e42f-4d7d-9065-0fbc405d8960?e=13803378&project=hpc-toolkit-dev&content_ref=timed+out+16c21cdc+e42f+4d7d+9065+0fbc405d8960)). The root cause is a deadlock in pkg/shell/packer.go where ExecPackerCmd manually managed pipes using a sync.WaitGroup ([ source](http://source.corp.google.com/piper///depot/google3/experimental/users/kentwhf/oss-repos/oss/cluster-toolkit/reviews/Review_pkg_shell_packer_go.json?content_ref=execpackercmd+uses+a+sync+waitgroup+to+block+on+io+copy+operations+from+cmd+stdoutpipe+until+an+eof+is+observed)).

The Issue: If Packer spawns background processes (like IAP tunnels or SSH helpers) that inherit standard output/error file descriptors, those pipes remain open after the main Packer process exits. This causes wg.Wait() to block indefinitely, preventing gcluster from finishing ([ source](http://source.corp.google.com/piper///depot/google3/experimental/users/kentwhf/oss-repos/oss/cluster-toolkit/reviews/Review_pkg_shell_packer_go.json?content_ref=if+the+spawned+packer+process+forks+background+processes+e+g+via+a+shell+provisioner+that+inherit+the+standard+output+error+file+descriptors+the+pipes+will+remain+open+after+packer+finishes+this+will+block+wg+wait+indefinitely)).
**The Fix**: Refactored ExecPackerCmd to assign os.Stdout or output buffers directly to the exec.Command struct. This allows the Go standard library to manage stream lifecycles robustly via cmd.Run() ([ source](http://source.corp.google.com/piper///depot/google3/experimental/users/kentwhf/oss-repos/oss/cluster-toolkit/reviews/Review_pkg_shell_packer_go.json?content_ref=nstead+of+waiting+for+an+eof+via+sync+waitgroup+assign+standard+buffers+directly+cmd+stdout+outbuf+which+the+internal+cmd+wait+manages+logically)).

### 2. Address tflint Null Argument Failures
The kubectl-apply module was failing tflint checks because the endswith, fileexists, and fileset functions were being called with a null value for manifest.source.

**The Fix**: Added a short-circuiting null check (manifest.source != null) in modules/management/kubectl-apply/main.tf to prevent these functions from evaluating when a manifest is defined via direct content instead of a source path.