### PR TITLE
Fix(slurm): resolve KeyError control_host in slurmdbd config templates

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -387,6 +387,7 @@ def install_slurm_conf(lkp: util.Lookup) -> None:
 def install_slurmdbd_conf(lkp: util.Lookup) -> None:
     """install slurmdbd.conf"""
     conf_options = {
+        "control_host": lkp.control_host,
         "dbd_host_str": f"DbdHost={lkp.control_host}",
         "slurmlog": dirs.log,
         "state_save": slurmdirs.state,


### PR DESCRIPTION
### Description
This PR resolves a template rendering bug in the SchedMD Slurm v6 controller startup setup. During cluster provisioning, the Slurm Database Daemon setup failed to compile `slurmdbd.conf` because the `{control_host}` formatting key was missing from the configuration options context, causing the automated cluster deployment tests to abort.

### Root Cause
In `modules/scheduler/schedmd-slurm-gcp-v6-controller/files/conf.py`, the `install_slurmdbd_conf` function attempts to format the `slurmdbd_conf_tpl` template using `.format(**conf_options)`. Since the template contains the `{control_host}` placeholder, but "control_host" was omitted from the local `conf_options` dictionary, a `Python KeyError: 'control_host'` was thrown.

This error halted the setup scripts midway, preventing `slurmctld` from starting and causing overall integration tests (such as htc-slurm-v6) to fail under Cloud Build.

### Fix Applied
Added the `"control_host": lkp.control_host` key-value pair to the local `conf_options` dictionary inside the `install_slurmdbd_conf` function in `conf.py`. This ensures that all required placeholders in `slurmdbd_conf_tpl` render successfully on controller bootstrap.