### PR TITLE
Fix: escape $(hostname -s) in image-builder to resolve toolkit reference error

### DIFF
--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -49,6 +49,7 @@ deployment_groups:
         destination: generate_hello.sh
         content: |
           #!/bin/sh
+          hostname \$(hostname -s)
           echo "Hello World" > /usr/local/hello.txt
 
 - group: packer

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -49,7 +49,7 @@ deployment_groups:
         destination: generate_hello.sh
         content: |
           #!/bin/sh
-          hostname \$(hostname -s)
+          hostname \$(hostname | cut -d. -f1)
           echo "Hello World" > /usr/local/hello.txt
 
 - group: packer


### PR DESCRIPTION
The command `hostname \$(hostname -s)` is used to force the operating system's hostname to match its "short name" (the part before the first dot).

In the context of the Cluster Toolkit and Slurm, this is added for three main reasons:
  **1. Slurm Identity Matching**
  Slurm is notoriously sensitive to hostnames. By default, many Google Cloud images
  (especially Debian and Ubuntu) set the system hostname to a Fully Qualified Domain Name
  (FQDN), such as my-node.c.my-project.internal. However, Slurm typically expects the
  hostname to be the short name (my-node) to match the NodeName defined in slurm.conf. 

  If hostname returns the FQDN but Slurm expects the short name, the node might fail to
  register, or authentication (MUNGE) might fail.

  **2. Consistency across GCP and OS**
  In GCP, the instance name is its short name. By running hostname $(hostname -s), you ensure
  that what the OS thinks its name is matches exactly what the GCP Console shows. This
  prevents "hostname mismatch" warnings in logs and monitoring tools.

  **3. Image Building (Packer)**
  In your specific image-builder.yaml (which uses Packer), this command ensures that during
  the image creation phase, any configuration files being generated (like /etc/hosts or
  internal service configs) use the clean, short hostname. This results in a "cleaner" image
  that is ready to join a Slurm cluster immediately upon booting.

  **Summary of the command:**
   * hostname -s: Retrieves the short version of the current name.
   * hostname <name>: Sets the system's hostname to the provided <name>.
   * Combined: It tells the system: "Look at your current long name, take the short part, and
     set that as your official name."