### PR TITLE
Static slicing

### DIFF
--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -436,11 +436,11 @@ func isValid3DDimension(x int) bool {
 }
 
 // Validate3DTopology validates the 3D topology dimensions for a given machine type.
-// If superSlicingCheck is true, it skips the common 3D shapes check and strictly validates
-// that each dimension is a multiple of 4 and >= 4.
-func Validate3DTopology(topology string, machineType string, superSlicingCheck bool) error {
+// If dynamicSlicingCheck is true, it validates that the topology is either a valid subslice
+// (2x2x1, 2x2x2, 2x2x4, 2x4x4) or a valid superslice (dimensions are multiples of 4 and >= 4).
+func Validate3DTopology(topology string, machineType string, dynamicSlicingCheck bool) error {
 
-	if !superSlicingCheck && valid3DShapes[topology] {
+	if !dynamicSlicingCheck && valid3DShapes[topology] {
 		return nil
 	}
 
@@ -452,23 +452,13 @@ func Validate3DTopology(topology string, machineType string, superSlicingCheck b
 	b, _ := strconv.Atoi(dims[1])
 	c, _ := strconv.Atoi(dims[2])
 
-	if !isValid3DDimension(a) || !isValid3DDimension(b) || !isValid3DDimension(c) {
-		return fmt.Errorf("topology %s dimensions must be >= 4 and multiples of 4 (unless it is a common base topology)", topology)
+	if err := validateDimensions(topology, a, b, c, dynamicSlicingCheck); err != nil {
+		return err
 	}
 
-	maxCubes := 0
-	found := false
-
-	for prefix, constraints := range tpu3DConstraintsMap {
-		if strings.HasPrefix(machineType, prefix) {
-			maxCubes = constraints.maxCubes
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		return fmt.Errorf("unknown 3D TPU family for machine type %s", machineType)
+	maxCubes, err := getMaxCubes(machineType)
+	if err != nil {
+		return err
 	}
 
 	cubes := (a / 4) * (b / 4) * (c / 4)
@@ -477,10 +467,36 @@ func Validate3DTopology(topology string, machineType string, superSlicingCheck b
 	}
 
 	if !(a <= b && b <= c) {
-		return fmt.Errorf("topology %s dimensions must be in non-decreasing order (A <= B <= C)", topology)
+		if topology != "2x2x1" {
+			return fmt.Errorf("topology %s dimensions must be in non-decreasing order (A <= B <= C)", topology)
+		}
 	}
 
 	return nil
+}
+
+func validateDimensions(topology string, a, b, c int, dynamicSlicingCheck bool) error {
+	if dynamicSlicingCheck {
+		isSubSlice := (topology == "2x2x1" || topology == "2x2x2" || topology == "2x2x4" || topology == "2x4x4")
+		isSuperSlice := (isValid3DDimension(a) && isValid3DDimension(b) && isValid3DDimension(c))
+		if !isSubSlice && !isSuperSlice {
+			return fmt.Errorf("topology %s is not valid for dynamic slicing. It must be a valid subslice (2x2x1, 2x2x2, 2x2x4, 2x4x4) or superslice (dimensions >= 4 and multiples of 4)", topology)
+		}
+	} else {
+		if !isValid3DDimension(a) || !isValid3DDimension(b) || !isValid3DDimension(c) {
+			return fmt.Errorf("topology %s dimensions must be >= 4 and multiples of 4 (unless it is a common base topology)", topology)
+		}
+	}
+	return nil
+}
+
+func getMaxCubes(machineType string) (int, error) {
+	for prefix, constraints := range tpu3DConstraintsMap {
+		if strings.HasPrefix(machineType, prefix) {
+			return constraints.maxCubes, nil
+		}
+	}
+	return 0, fmt.Errorf("unknown 3D TPU family for machine type %s", machineType)
 }
 
 // CheckTopologyContainment returns true if the requested topology fits within the container topology.
@@ -505,4 +521,20 @@ func CheckTopologyContainment(requested, container string, accelType string) (bo
 	}
 
 	return true, nil
+}
+
+// Is3DTorusTPU returns true if the machine type belongs to a 3D Torus TPU family (v4 or v5p)
+// where static sub-slicing coordinate labeling is unsupported by GKE.
+func Is3DTorusTPU(machineType string) bool {
+	lower := strings.ToLower(machineType)
+	// Filter out tpu7x (v7) which uses its own dynamic coordinates/partition scheme.
+	if strings.Contains(lower, "tpu7") {
+		return false
+	}
+	for _, family := range []string{"v4", "v5p", "ct4p", "ct5p"} {
+		if strings.Contains(lower, family) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -575,3 +575,61 @@ func TestCheckTopologyContainment(t *testing.T) {
 		})
 	}
 }
+
+func TestIs3DTorusTPU(t *testing.T) {
+	tests := []struct {
+		name        string
+		machineType string
+		wantResult  bool
+	}{
+		{
+			name:        "v4 chip name (Torus)",
+			machineType: "ct4p-hightpu-4t",
+			wantResult:  true,
+		},
+		{
+			name:        "v5p machine name (Torus)",
+			machineType: "ct5p-hightpu-4t",
+			wantResult:  true,
+		},
+		{
+			name:        "v5e machine name (2D Mesh)",
+			machineType: "ct5l-hightpu-4t",
+			wantResult:  false,
+		},
+		{
+			name:        "v6e machine name (2D Mesh)",
+			machineType: "ct6e-standard-8t",
+			wantResult:  false,
+		},
+		{
+			name:        "tpu7x machine name (Exclude)",
+			machineType: "tpu7x-standard-16t",
+			wantResult:  false,
+		},
+		{
+			name:        "Shorthand v4-8",
+			machineType: "v4-8",
+			wantResult:  true,
+		},
+		{
+			name:        "Shorthand v5p-8",
+			machineType: "v5p-8",
+			wantResult:  true,
+		},
+		{
+			name:        "Non-TPU machine type",
+			machineType: "a2-highgpu-1g",
+			wantResult:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Is3DTorusTPU(tt.machineType)
+			if got != tt.wantResult {
+				t.Errorf("Is3DTorusTPU(%q) = %v, want %v", tt.machineType, got, tt.wantResult)
+			}
+		})
+	}
+}

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -60,6 +60,7 @@ func NewGKEOrchestrator() *GKEOrchestrator {
 		machineCapCache:          make(map[string]MachineTypeCap),
 		topologyCache:            make(map[string]string),
 		dynamicSlicingCache:      make(map[string]bool),
+		staticSlicingCache:       make(map[string]bool),
 	}
 }
 
@@ -102,7 +103,7 @@ func (g *GKEOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {
 		return err
 	}
 
-	profile, isDynamicSlicing, err := g.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := g.resolveHardwareRequirements(&job)
 	if err != nil {
 		return err
 	}
@@ -115,7 +116,7 @@ func (g *GKEOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {
 		return err
 	}
 
-	if err := g.generateAndSubmitManifests(job, fullImageName, profile, isDynamicSlicing); err != nil {
+	if err := g.generateAndSubmitManifests(job, fullImageName, profile, isDynamicSlicing, isStaticSlicing); err != nil {
 		return err
 	}
 
@@ -250,16 +251,16 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 	return res.Stdout, nil
 }
 
-func (g *GKEOrchestrator) generateAndSubmitManifests(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool) error {
+func (g *GKEOrchestrator) generateAndSubmitManifests(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool) error {
 	if job.IsPathwaysJob {
-		manifestContent, err := g.GeneratePathwaysManifest(job, fullImageName, profile, isDynamicSlicing)
+		manifestContent, err := g.GeneratePathwaysManifest(job, fullImageName, profile, isDynamicSlicing, isStaticSlicing)
 		if err != nil {
 			return err
 		}
 		return g.ApplyManifest(manifestContent, job.DryRunManifest, job.WorkloadName)
 	}
 
-	manifestOpts, err := g.PrepareManifestOptions(job, fullImageName, profile, isDynamicSlicing)
+	manifestOpts, err := g.PrepareManifestOptions(job, fullImageName, profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		return err
 	}
@@ -302,7 +303,7 @@ func (g *GKEOrchestrator) validateJobConflicts(workloadName string, clusterName 
 	return nil
 }
 
-func (g *GKEOrchestrator) GeneratePathwaysManifest(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool) (string, error) {
+func (g *GKEOrchestrator) GeneratePathwaysManifest(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool) (string, error) {
 	// Set default values for Pathways-specific fields if not provided
 	if job.Pathways.ProxyServerImage == "" {
 		job.Pathways.ProxyServerImage = defaultPathwaysProxyImage
@@ -320,7 +321,7 @@ func (g *GKEOrchestrator) GeneratePathwaysManifest(job orchestrator.JobDefinitio
 		return "", fmt.Errorf("failed to parse pathways jobset template: %w", err)
 	}
 
-	opts, err := g.PrepareManifestOptions(job, fullImageName, profile, isDynamicSlicing)
+	opts, err := g.PrepareManifestOptions(job, fullImageName, profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		return "", err
 	}
@@ -1797,12 +1798,12 @@ func (g *GKEOrchestrator) addAcceleratorLabel(nodeSelector map[string]string, ac
 	}
 }
 
-func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, schedOpts SchedulingOptions, isGPU bool, isCPUMachine bool, isDynamicSlicing bool) error {
+func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, schedOpts SchedulingOptions, isGPU bool, isCPUMachine bool) error {
 	if schedOpts.Topology != "" {
 		if isGPU || isCPUMachine {
 			return fmt.Errorf("topology is not allowed for GPU and CPU jobs")
 		}
-		if !isDynamicSlicing {
+		if !schedOpts.IsDynamicSlicing && !schedOpts.IsStaticSlicing {
 			_, hasFallback := schedOpts.NodeAffinityLabels[tpuTopologyLabel]
 			if !hasFallback {
 				nodeSelector[tpuTopologyLabel] = schedOpts.Topology
@@ -1812,7 +1813,7 @@ func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, sched
 	return nil
 }
 
-func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing bool, isCPUMachine bool) (string, error) {
+func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isCPUMachine bool) (string, error) {
 	nodeSelector := GetNodeSelector(schedOpts)
 	if nodeSelector == nil {
 		nodeSelector = make(map[string]string)
@@ -1831,7 +1832,7 @@ func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orc
 
 	g.addAcceleratorLabel(nodeSelector, accelLabel, isCPUMachine, job.MachineType)
 
-	if err := g.addTopologyLabel(nodeSelector, schedOpts, isGPU, isCPUMachine, isDynamicSlicing); err != nil {
+	if err := g.addTopologyLabel(nodeSelector, schedOpts, isGPU, isCPUMachine); err != nil {
 		return "", err
 	}
 
@@ -1860,10 +1861,10 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
-func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, numSlices int, isDynamicSlicing bool) string {
+func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType string, numSlices int, nodesPerSlice int, isSubSlicing bool) string {
 	var topologyAnnotation map[string]string
-	if isDynamicSlicing {
-		topologyAnnotation = GetTopologyAnnotation(topology, numSlices)
+	if isSubSlicing {
+		topologyAnnotation = GetTopologyAnnotation(topology, machineType, numSlices, nodesPerSlice)
 	} else if topology != "" {
 		topologyAnnotation = map[string]string{
 			"cloud.google.com/gke-tpu-slice-topology": topology,

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -81,6 +81,7 @@ func newTestGKEOrchestrator(executor Executor) *GKEOrchestrator {
 		machineCapCache:          make(map[string]MachineTypeCap),
 		topologyCache:            make(map[string]string),
 		dynamicSlicingCache:      make(map[string]bool),
+		staticSlicingCache:       make(map[string]bool),
 	}
 }
 
@@ -243,11 +244,11 @@ func TestGenerateGKEManifest_Accelerators(t *testing.T) {
 				{Config: gkeNodePoolConfig{MachineType: "n2-standard-2"}},
 			}
 
-			profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+			profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 			var manifest string
 			if err == nil {
 				var opts ManifestOptions
-				opts, err = orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+				opts, err = orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 				if err == nil {
 					manifest, err = orc.GenerateGKEManifest(opts, profile)
 				}
@@ -307,11 +308,11 @@ func TestGenerateGKEManifest_Volumes(t *testing.T) {
 		},
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("prepareManifestOptions failed: %v", err)
 	}
@@ -454,11 +455,11 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 	orc.clusterDesc.NodePools = []gkeJobNodePool{
 		{Name: "default-pool", Config: gkeNodePoolConfig{MachineType: "n2-standard-2"}},
 	}
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
-	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing)
+	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("generatePathwaysManifest failed: %v", err)
 	}
@@ -993,7 +994,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 			wantResult: false,
 		},
 		{
-			name: "Failure - TPU7x Dynamic-slicing requested topology under 4x4x4",
+			name: "Success - TPU7x Dynamic-slicing requested subslice topology (2x2x1)",
 			opts: ManifestOptions{
 				ClusterName:     "test-cluster",
 				ClusterLocation: "us-central1-a",
@@ -1017,7 +1018,7 @@ func TestVerifyDynamicSlicingActive(t *testing.T) {
 				},
 			},
 			wantResult: true,
-			wantErr:    true,
+			wantErr:    false,
 		},
 		{
 			name: "Failure - TPU7x Dynamic-slicing requested topology 2x4x8 (product 64 but a < 4)",
@@ -1549,12 +1550,12 @@ func TestGenerateGKEManifest_DynamicVmsPerSlice(t *testing.T) {
 		NodesPerSlice:   0,
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
 
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("prepareManifestOptions failed: %v", err)
 	}
@@ -1600,12 +1601,12 @@ func TestGenerateGKEManifest_RespectUserNumNodes(t *testing.T) {
 		NodesPerSlice:   32,     // Explicitly set to 32 (representing --num-nodes)
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
 
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("PrepareManifestOptions failed: %v", err)
 	}
@@ -1650,12 +1651,12 @@ func TestGenerateGKEManifest_ParallelContainers(t *testing.T) {
 		UseParallelContainers: true,    // Enable parallel containers
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
 
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("PrepareManifestOptions failed: %v", err)
 	}
@@ -1821,11 +1822,11 @@ func TestGPUTopologyAwareScheduling(t *testing.T) {
 		{Name: "default-pool", Config: gkeNodePoolConfig{MachineType: "nvidia-tesla-a100"}},
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("PrepareManifestOptions failed: %v", err)
 	}
@@ -1958,7 +1959,7 @@ func TestGenerateGKEManifest_DynamicSlicingActive_TPU7x(t *testing.T) {
 		},
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
@@ -1968,7 +1969,7 @@ func TestGenerateGKEManifest_DynamicSlicingActive_TPU7x(t *testing.T) {
 		t.Fatalf("Expected resolveHardwareRequirements to flag isDynamicSlicing as true")
 	}
 
-	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing)
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("PrepareManifestOptions failed: %v", err)
 	}
@@ -2038,7 +2039,7 @@ func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
 		},
 	}
 
-	profile, isDynamicSlicing, err := orc.resolveHardwareRequirements(&job)
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
 	if err != nil {
 		t.Fatalf("resolveHardwareRequirements failed: %v", err)
 	}
@@ -2046,7 +2047,7 @@ func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
 		t.Fatalf("Expected isDynamicSlicing to be true")
 	}
 
-	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing)
+	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
 	if err != nil {
 		t.Fatalf("GeneratePathwaysManifest failed: %v", err)
 	}
@@ -2065,5 +2066,72 @@ func TestGeneratePathwaysManifest_DynamicSlicing(t *testing.T) {
 		if !strings.Contains(manifest, substr) {
 			t.Errorf("manifest missing expected substring %q\nManifest: %s", substr, manifest)
 		}
+	}
+}
+
+func TestGenerateGKEManifest_StaticSlicingActive_v6e(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "test-tas-v6e-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "v6e-8",
+		Topology:        "2x2",
+		ClusterLocation: "us-central1-a",
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors":                   {{ExitCode: 0, Stdout: ""}, {ExitCode: 0, Stdout: ""}},
+		"kubectl get topologies.kueue.x-k8s.io -o json": {{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`}, {ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`}},
+		"kubectl get nodes":                             {{ExitCode: 0, Stdout: "4x4"}, {ExitCode: 0, Stdout: "4x4"}},
+		"gcloud compute machine-types describe ct6e-standard-8t --zone=us-central1-a --format=json": {{ExitCode: 0, Stdout: `{"guestCpus": 8, "memoryMb": 32768, "accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v6e-slice"}]}`}},
+	}
+
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{
+			Name: "tpu-pool",
+			Config: gkeNodePoolConfig{
+				MachineType: "tpu-v6e-slice",
+			},
+		},
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	if isDynamicSlicing {
+		t.Fatalf("Expected isDynamicSlicing to be false for v6e")
+	}
+	if !isStaticSlicing {
+		t.Fatalf("Expected resolveHardwareRequirements to flag isStaticSlicing as true")
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Because static sub-slicing is true:
+	// 1. NodeSelector MUST NOT include the topology strictly (Fix A)
+	if strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x2") {
+		t.Errorf("Expected manifest to NOT contain strict nodeSelector topology, but it was found\nManifest: %s", manifest)
+	}
+
+	// 2. Kueue TAS annotations MUST be injected with slice-based format (Fix B)
+	if !strings.Contains(manifest, "kueue.x-k8s.io/podset-required-topology: cloud.google.com/gke-tpu-slice-2x2-id") {
+		t.Errorf("Expected manifest to contain kueue TAS slice-based annotation, but it was missing or incorrect\nManifest: %s", manifest)
+	}
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-slice-topology: 2x2") {
+		t.Errorf("Expected manifest to contain gke-tpu-slice-topology annotation, but it was missing\nManifest: %s", manifest)
 	}
 }

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -109,7 +109,7 @@ func (g *GKEOrchestrator) buildResourcesString(cpu, mem, gpu, tpu string, indent
 	return g.indentYaml(resourcesStr, indent), nil
 }
 
-func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool) (ManifestOptions, error) {
+func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool) (ManifestOptions, error) {
 	originalAccelType := job.ComputeType
 
 	schedOpts := SchedulingOptions{
@@ -118,6 +118,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		Topology:           job.Topology,
 		Scheduler:          job.GKEScheduler,
 		IsDynamicSlicing:   isDynamicSlicing,
+		IsStaticSlicing:    isStaticSlicing,
 	}
 
 	parts := strings.Split(originalAccelType, "-")
@@ -126,6 +127,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 
 	opts := ManifestOptions{
 		IsDynamicSlicing:              isDynamicSlicing,
+		IsStaticSlicing:               isStaticSlicing,
 		WorkloadName:                  job.WorkloadName,
 		FullImageName:                 fullImageName,
 		CommandToRun:                  job.CommandToRun,
@@ -149,7 +151,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		Verbose:                       job.Verbose,
 	}
 
-	if err := g.fillManifestStrings(&opts, schedOpts, job, isDynamicSlicing, profile.IsCPUMachine); err != nil {
+	if err := g.fillManifestStrings(&opts, schedOpts, job, isDynamicSlicing, isStaticSlicing, profile.IsCPUMachine); err != nil {
 		return ManifestOptions{}, err
 	}
 
@@ -163,8 +165,8 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 	return opts, nil
 }
 
-func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing, isCPUMachine bool) error {
-	nodeSelectorStr, err := g.buildNodeSelector(schedOpts, job, isDynamicSlicing, isCPUMachine)
+func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts SchedulingOptions, job orchestrator.JobDefinition, isDynamicSlicing bool, isStaticSlicing bool, isCPUMachine bool) error {
+	nodeSelectorStr, err := g.buildNodeSelector(schedOpts, job, isCPUMachine)
 	if err != nil {
 		return err
 	}
@@ -187,7 +189,8 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 		opts.ImagePullSecrets = g.indentYaml(imagePullSecretsStr, 16)
 	}
 
-	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.NumSlices, isDynamicSlicing)
+	isSubSlicing := isDynamicSlicing || isStaticSlicing
+	opts.TopologyAnnotation = g.buildTopologyAnnotation(schedOpts.Topology, job.MachineType, job.NumSlices, job.NodesPerSlice, isSubSlicing)
 
 	tolerationsStr, err := g.resolveTolerations(job.MachineType)
 	if err != nil {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -145,6 +145,49 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 	return active, nil
 }
 
+func (g *GKEOrchestrator) verifyStaticSlicingActive(job *orchestrator.JobDefinition) (bool, error) {
+	if !config.IsTPU(job.MachineType) {
+		return false, nil
+	}
+
+	// Static sub-slicing (logical partitioning) is strictly unsupported for 3D Torus TPUs (v4 and v5p)
+	if config.Is3DTorusTPU(job.MachineType) {
+		return false, nil
+	}
+
+	cacheKey := fmt.Sprintf("%s-%s", job.MachineType, job.Topology)
+	if val, ok := g.staticSlicingCache[cacheKey]; ok {
+		return val, nil
+	}
+
+	if !g.hasKueueTopologies() {
+		g.staticSlicingCache[cacheKey] = false
+		return false, nil
+	}
+
+	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
+	output, err := g.queryDiscoveredTopologies(accelLabel)
+	if err != nil {
+		return false, fmt.Errorf("failed to discover topologies for static sub-slicing check: %w", err)
+	}
+	discoveredTopologies := g.parseTopologies(output)
+
+	for t := range discoveredTopologies {
+		fits, err := config.CheckTopologyContainment(job.Topology, t, job.MachineType)
+		if err != nil {
+			return false, err
+		}
+		if fits {
+			logging.Info("Static sub-slicing/TAS active: requested topology %s fits inside discovered physical topology %s.", job.Topology, t)
+			g.staticSlicingCache[cacheKey] = true
+			return true, nil
+		}
+	}
+
+	g.staticSlicingCache[cacheKey] = false
+	return false, nil
+}
+
 func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions, isTPU7x bool) (bool, error) {
 	for _, np := range g.clusterDesc.NodePools {
 		if !strings.EqualFold(np.Config.MachineType, requestedMachineName) {
@@ -308,70 +351,90 @@ func (g *GKEOrchestrator) resolveMachineName(acceleratorType string) (string, er
 	return "", fmt.Errorf("machine type %q could not be resolved from static maps or cluster state", acceleratorType)
 }
 
-func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefinition) (JobProfile, bool, error) {
-	if job.ComputeType == "" {
-		return JobProfile{}, false, nil
+func (g *GKEOrchestrator) resolveJobMachineType(computeType string) (string, error) {
+	parts := strings.Split(computeType, "-")
+	machineName, err := g.resolveMachineName(computeType)
+	if err == nil {
+		return machineName, nil
 	}
 
-	originalInput := job.ComputeType
-	parts := strings.Split(originalInput, "-")
+	prefix := parts[0]
+	candidates := config.GetCandidatesForShorthand(prefix)
+	if len(candidates) == 0 {
+		return "", fmt.Errorf("compute type %q is not a known shorthand and could not be resolved", prefix)
+	}
 
-	var machineName string
-	var err error
-
-	// 1. Try to resolve as full machine type or direct shorthand match
-	machineName, err = g.resolveMachineName(job.ComputeType)
+	machineName, err = g.resolveAmbiguousComputeShorthand(prefix, candidates)
 	if err != nil {
-		prefix := parts[0]
-		candidates := config.GetCandidatesForShorthand(prefix)
-		if len(candidates) == 0 {
-			return JobProfile{}, false, fmt.Errorf("compute type %q is not a known shorthand and could not be resolved", prefix)
-		}
+		return "", err
+	}
+	return machineName, nil
+}
 
-		machineName, err = g.resolveAmbiguousComputeShorthand(prefix, candidates)
-		if err != nil {
-			return JobProfile{}, false, err
+func (g *GKEOrchestrator) resolveTPURequirements(job *orchestrator.JobDefinition) (isDynamicSlicing bool, isStaticSlicing bool, err error) {
+	isTPU7x := strings.Contains(strings.ToLower(job.MachineType), "tpu7x")
+	if isTPU7x && job.Topology == "" {
+		return false, false, fmt.Errorf("topology must be specified explicitly via --topology flag for TPU 7x machine type %s", job.MachineType)
+	}
+
+	// Validate topology shape before resolving/discovering
+	if job.Topology != "" {
+		if err := config.ValidateHardwareRequest(job.MachineType, job.Topology); err != nil {
+			return false, false, err
 		}
+	}
+
+	var topology string
+	topology, isDynamicSlicing, err = g.resolveTopology(job)
+	if err != nil {
+		return false, false, err
+	}
+	job.Topology = topology
+
+	if !isDynamicSlicing && job.Topology != "" {
+		isStaticSlicing, err = g.verifyStaticSlicingActive(job)
+		if err != nil {
+			return false, false, err
+		}
+	}
+
+	// Calculate VMs per slice
+	err = g.dynamicallyCalculateNodesPerSlice(job)
+	if err != nil {
+		return false, false, err
+	}
+
+	return isDynamicSlicing, isStaticSlicing, nil
+}
+
+func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefinition) (profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool, err error) {
+	if job.ComputeType == "" {
+		return JobProfile{}, false, false, nil
+	}
+
+	machineName, err := g.resolveJobMachineType(job.ComputeType)
+	if err != nil {
+		return JobProfile{}, false, false, err
 	}
 	job.MachineType = machineName
-	isDynamicSlicing := false
+
 	if config.IsTPU(machineName) {
-		isTPU7x := strings.Contains(strings.ToLower(machineName), "tpu7x")
-		if isTPU7x && job.Topology == "" {
-			return JobProfile{}, false, fmt.Errorf("topology must be specified explicitly via --topology flag for TPU 7x machine type %s", machineName)
-		}
-
-		// Validate topology shape before resolving/discovering
-		if job.Topology != "" {
-			if err := config.ValidateHardwareRequest(job.MachineType, job.Topology); err != nil {
-				return JobProfile{}, isDynamicSlicing, err
-			}
-		}
-
-		var topology string
-		topology, isDynamicSlicing, err = g.resolveTopology(job)
+		isDynamicSlicing, isStaticSlicing, err = g.resolveTPURequirements(job)
 		if err != nil {
-			return JobProfile{}, isDynamicSlicing, err
-		}
-		job.Topology = topology
-
-		// 4. Calculate VMs per slice
-		err = g.dynamicallyCalculateNodesPerSlice(job)
-		if err != nil {
-			return JobProfile{}, isDynamicSlicing, err
+			return JobProfile{}, false, false, err
 		}
 	}
 
-	// 5. Determine if CPU machine
+	// Determine if CPU machine
 	isCPUMachine, capacity, err := g.determineIfCPUMachine(job)
 	if err != nil {
-		return JobProfile{}, isDynamicSlicing, err
+		return JobProfile{}, isDynamicSlicing, isStaticSlicing, err
 	}
 
 	return JobProfile{
 		IsCPUMachine:  isCPUMachine,
 		CapacityCount: capacity,
-	}, isDynamicSlicing, nil
+	}, isDynamicSlicing, isStaticSlicing, nil
 }
 
 func (g *GKEOrchestrator) resolveAmbiguousComputeShorthand(prefix string, candidates []string) (string, error) {

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -358,7 +358,7 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 				ComputeType: tt.acceleratorType,
 			}
 
-			_, _, err := orc.resolveHardwareRequirements(job)
+			_, _, _, err := orc.resolveHardwareRequirements(job)
 
 			if tt.wantErr {
 				if err == nil {
@@ -373,6 +373,131 @@ func TestResolveAcceleratorShorthand(t *testing.T) {
 				}
 				if tt.wantTopology != "" && job.Topology != tt.wantTopology {
 					t.Errorf("Expected job.Topology %q, got %q", tt.wantTopology, job.Topology)
+				}
+			}
+		})
+	}
+}
+
+func TestVerifyStaticSlicingActive(t *testing.T) {
+	tests := []struct {
+		name           string
+		machineType    string
+		requestedTopo  string
+		mockResponses  map[string][]shell.CommandResult
+		wantActive     bool
+		wantErr        bool
+		verifyCacheHit bool
+	}{
+		{
+			name:          "Non-TPU machine type",
+			machineType:   "n2-standard-8",
+			requestedTopo: "2x2",
+			wantActive:    false,
+		},
+		{
+			name:          "TPU v4 (3D Torus) bypasses static sub-slicing",
+			machineType:   "ct4p-hightpu-4t",
+			requestedTopo: "2x2x1",
+			wantActive:    false,
+		},
+		{
+			name:          "TPU v5p (3D Torus) bypasses static sub-slicing",
+			machineType:   "ct5p-hightpu-4t",
+			requestedTopo: "2x2x2",
+			wantActive:    false,
+		},
+		{
+			name:          "No Kueue topologies configured",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "2x2",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 1, Stderr: "NotFound"},
+				},
+			},
+			wantActive: false,
+		},
+		{
+			name:          "Empty topologies configured",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "2x2",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 0, Stdout: `{"items":[]}`},
+				},
+			},
+			wantActive: false,
+		},
+		{
+			name:          "Static sub-slicing active (requested shape fits physical)",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "2x2",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`},
+				},
+				"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+					{ExitCode: 0, Stdout: "4x4\n"},
+				},
+			},
+			wantActive:     true,
+			verifyCacheHit: true,
+		},
+		{
+			name:          "Full-slice topology matches physical (Still TAS active)",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "4x4",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`},
+				},
+				"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+					{ExitCode: 0, Stdout: "4x4\n"},
+				},
+			},
+			wantActive: true,
+		},
+		{
+			name:          "Requested shape too large for physical",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "8x8",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`},
+				},
+				"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+					{ExitCode: 0, Stdout: "4x4\n"},
+				},
+			},
+			wantActive: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := NewMockExecutor(tt.mockResponses)
+			orc := newTestGKEOrchestrator(mockExec)
+
+			job := &orchestrator.JobDefinition{
+				MachineType: tt.machineType,
+				Topology:    tt.requestedTopo,
+			}
+
+			got, err := orc.verifyStaticSlicingActive(job)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("verifyStaticSlicingActive() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.wantActive {
+				t.Errorf("verifyStaticSlicingActive() = %v, want %v", got, tt.wantActive)
+			}
+
+			if tt.verifyCacheHit && err == nil && got == tt.wantActive {
+				// Clear mock executor to ensure subsequent call is satisfied entirely from cache
+				orc.executor = NewMockExecutor(nil)
+				got2, err2 := orc.verifyStaticSlicingActive(job)
+				if err2 != nil || got2 != tt.wantActive {
+					t.Errorf("cache hit failed: got %v, err %v", got2, err2)
 				}
 			}
 		})

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"slices"
+	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,6 +30,7 @@ type SchedulingOptions struct {
 	Scheduler          string
 	NodeAffinityLabels map[string]string
 	IsDynamicSlicing   bool
+	IsStaticSlicing    bool
 }
 
 func GetNodeSelector(opts SchedulingOptions) map[string]string {
@@ -87,7 +89,7 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 
 	for _, k := range keys {
 		v := opts.NodeAffinityLabels[k]
-		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "") && (!opts.IsDynamicSlicing)
+		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "") && !(opts.IsDynamicSlicing || opts.IsStaticSlicing)
 		hasPipe := strings.Contains(v, "|")
 
 		if !hasPipe && k != tpuTopologyLabel {
@@ -145,23 +147,25 @@ func parseAffinityValues(k string, v string, topology string, isTopologyMerge bo
 
 // GetTopologyAnnotation returns the GKE and Kueue topology annotations for the given topology and slice count.
 // It dynamically selects the appropriate Kueue annotation key based on whether it is a single-slice or multi-slice job.
-func GetTopologyAnnotation(topology string, numSlices int) map[string]string {
+func GetTopologyAnnotation(topology string, machineType string, numSlices int, nodesPerSlice int) map[string]string {
 	if topology == "" {
 		return nil
 	}
 
 	annotationKey := "kueue.x-k8s.io/podset-required-topology"
+	annotations := map[string]string{
+		"cloud.google.com/gke-tpu-slice-topology": topology,
+	}
+	partitionValue := fmt.Sprintf("cloud.google.com/gke-tpu-slice-%s-id", topology)
+	if strings.Contains(machineType, "tpu7x") {
+		partitionValue = fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology)
+	}
 	if numSlices > 1 {
 		annotationKey = "kueue.x-k8s.io/podset-slice-required-topology"
+		annotations["kueue.x-k8s.io/podset-slice-size"] = strconv.Itoa(nodesPerSlice)
 	}
-
-	// Dynamic slicing is only active for TPU7x, which uses partition-level requirements.
-	partitionValue := fmt.Sprintf("cloud.google.com/gke-tpu-partition-%s-id", topology)
-
-	return map[string]string{
-		"cloud.google.com/gke-tpu-slice-topology": topology,
-		annotationKey: partitionValue,
-	}
+	annotations[annotationKey] = partitionValue
+	return annotations
 }
 
 func GetTolerations(acceleratorType string) []corev1.Toleration {

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -59,37 +59,66 @@ func TestGetAffinity(t *testing.T) {
 
 func TestGetTopologyAnnotation(t *testing.T) {
 	tests := []struct {
-		name      string
-		topology  string
-		numSlices int
-		wantKey   string
-		wantVal   string
+		name          string
+		topology      string
+		machineType   string
+		numSlices     int
+		nodesPerSlice int
+		wantKey       string
+		wantVal       string
+		wantSize      string
 	}{
 		{
-			name:      "single slice - tpu7x",
-			topology:  "2x2x1",
-			numSlices: 1,
-			wantKey:   "kueue.x-k8s.io/podset-required-topology",
-			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:          "single slice - tpu7x",
+			topology:      "2x2x1",
+			machineType:   "tpu7x-standard-4t",
+			numSlices:     1,
+			nodesPerSlice: 1,
+			wantKey:       "kueue.x-k8s.io/podset-required-topology",
+			wantVal:       "cloud.google.com/gke-tpu-partition-2x2x1-id",
 		},
 		{
-			name:      "multislice - tpu7x",
-			topology:  "2x2x1",
-			numSlices: 2,
-			wantKey:   "kueue.x-k8s.io/podset-slice-required-topology",
-			wantVal:   "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			name:          "multislice - tpu7x",
+			topology:      "2x2x1",
+			machineType:   "tpu7x-standard-4t",
+			numSlices:     2,
+			nodesPerSlice: 1,
+			wantKey:       "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:       "cloud.google.com/gke-tpu-partition-2x2x1-id",
+			wantSize:      "1",
 		},
 		{
-			name:      "empty topology",
-			topology:  "",
-			numSlices: 1,
-			wantKey:   "",
-			wantVal:   "",
+			name:          "single slice - v6e",
+			topology:      "2x2",
+			machineType:   "v6e-standard-8t",
+			numSlices:     1,
+			nodesPerSlice: 1,
+			wantKey:       "kueue.x-k8s.io/podset-required-topology",
+			wantVal:       "cloud.google.com/gke-tpu-slice-2x2-id",
+		},
+		{
+			name:          "multislice - v6e",
+			topology:      "2x2",
+			machineType:   "v6e-standard-8t",
+			numSlices:     4,
+			nodesPerSlice: 1,
+			wantKey:       "kueue.x-k8s.io/podset-slice-required-topology",
+			wantVal:       "cloud.google.com/gke-tpu-slice-2x2-id",
+			wantSize:      "1",
+		},
+		{
+			name:          "empty topology",
+			topology:      "",
+			machineType:   "v6e-standard-8t",
+			numSlices:     1,
+			nodesPerSlice: 1,
+			wantKey:       "",
+			wantVal:       "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetTopologyAnnotation(tt.topology, tt.numSlices)
+			got := GetTopologyAnnotation(tt.topology, tt.machineType, tt.numSlices, tt.nodesPerSlice)
 			if tt.topology == "" {
 				if got != nil {
 					t.Errorf("Expected nil for empty topology, got %v", got)
@@ -101,6 +130,9 @@ func TestGetTopologyAnnotation(t *testing.T) {
 			}
 			if got[tt.wantKey] != tt.wantVal {
 				t.Errorf("Expected %s = %s, got %v", tt.wantKey, tt.wantVal, got[tt.wantKey])
+			}
+			if tt.wantSize != "" && got["kueue.x-k8s.io/podset-slice-size"] != tt.wantSize {
+				t.Errorf("Expected slice size %s, got %s", tt.wantSize, got["kueue.x-k8s.io/podset-slice-size"])
 			}
 		})
 	}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -78,6 +78,7 @@ type GKEOrchestrator struct {
 	resolvedHeadNodePool        string
 	machineTypeToThreadsPerCore map[string]string
 	dynamicSlicingCache         map[string]bool
+	staticSlicingCache          map[string]bool
 	topologyCache               map[string]string
 }
 
@@ -168,6 +169,7 @@ type ManifestOptions struct {
 	VolumeMountsYAML              string
 	GCSFuseEnabled                bool
 	IsDynamicSlicing              bool
+	IsStaticSlicing               bool
 	IsCPUMachine                  bool
 	Pathways                      orchestrator.PathwaysJobDefinition
 	Verbose                       bool


### PR DESCRIPTION
* Static Sub-slicing: Implemented static sub-slicing logic for TPU topologies to allow for more flexible hardware scheduling on supported TPU families.
* Orchestrator Updates: Updated GKE orchestrator manifest generation to support the new storage and slicing configurations, including assembly of additional manifests.
* Documentation and Testing: Updated user documentation with new storage examples and added comprehensive unit tests for storage and slicing features.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
