### PR TITLE
fix(ofe): add alt text to template images for accessibility

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/templates/application/container_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/container_detail.html
@@ -31,9 +31,9 @@
 
   <p><b>Status:</b>
     {% if object.status in "pqi" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
     {% elif object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/container_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/container_detail.html
@@ -31,9 +31,9 @@
 
   <p><b>Status:</b>
     {% if object.status in "pqi" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
     {% elif object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/detail.html
@@ -30,10 +30,10 @@
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/detail.html
@@ -30,10 +30,10 @@
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/list.html
@@ -54,19 +54,19 @@
         <td>{{ application.installed_architecture }}</td>        
         <td>
           {% if application.status == "p" or application.status == "q" or application.status == "i" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if application.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
           {% endif %}
           {% if application.status == "r" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if application.status == "e" %}
-          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="Error">
+          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="">
           {% endif %}
           {% if application.status == "x" %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="">
           {% endif %}
           {% for key, value in status_messages.items %}
             {% if application.status == key %}

--- a/community/front-end/ofe/website/ghpcfe/templates/application/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/list.html
@@ -54,19 +54,19 @@
         <td>{{ application.installed_architecture }}</td>        
         <td>
           {% if application.status == "p" or application.status == "q" or application.status == "i" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
           {% endif %}
           {% if application.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
           {% endif %}
           {% if application.status == "r" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
           {% endif %}
           {% if application.status == "e" %}
-          <img src="/static/img/status-error.png" style="width:32px;height:20px;">
+          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="Error">
           {% endif %}
           {% if application.status == "x" %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
           {% endif %}
           {% for key, value in status_messages.items %}
             {% if application.status == key %}

--- a/community/front-end/ofe/website/ghpcfe/templates/application/log.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/log.html
@@ -48,10 +48,10 @@ window.onload=function(event) {
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/log.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/log.html
@@ -48,10 +48,10 @@ window.onload=function(event) {
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/spack_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/spack_detail.html
@@ -30,10 +30,10 @@
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/application/spack_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/application/spack_detail.html
@@ -30,10 +30,10 @@
   <p><b>Cluster Name:</b> {{ object.cluster.name }}</p>
   <p><b>Status:</b>
     {% if object.status == "p" or object.status == "q" or object.status  == "i" %}
-       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+       <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
     {% endif %}
     {% if object.status == "r" %}
-       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+       <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/base_generic.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/base_generic.html
@@ -48,7 +48,7 @@
   <nav class="navbar navbar-expand-sm" style="background-color: #306dc1;">
     <div class="container-fluid">
       <a class="navbar-brand" href="{% url 'index' %}" style="color: white;">
-        <img src="/static/img/white-hamburger.png" width="24">&nbsp;&nbsp;Cluster Toolkit FrontEnd
+        <img src="/static/img/white-hamburger.png" width="24" alt="">&nbsp;&nbsp;Cluster Toolkit FrontEnd
       </a>
 
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar-list-4" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
@@ -69,12 +69,12 @@
             <a class="nav-link dropdown-toggle" href="{% url 'login'%}?next={{ request.path }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             {% if user.is_authenticated %}
               {% if loggedin_user %}
-            <img src="{{ loggedin_user.get_avatar_url }}" width="32" style="border-radius: 50%;">
+            <img src="{{ loggedin_user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User avatar">
               {% else %}
-            <img src="{{ user.get_avatar_url }}" width="32" style="border-radius: 50%;">
+            <img src="{{ user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User avatar">
               {% endif %}
             {% else %}
-            <img src="/static/img/unknown_user.png" width="32" style="border-radius: 50%;">
+            <img src="/static/img/unknown_user.png" width="32" style="border-radius: 50%;" alt="User avatar">
             {% endif %}
             </a>
 
@@ -104,48 +104,48 @@
         <nav class="navbar flex-grow-1 align-content-start">
           <ul class="navbar-nav">
             <li id="navtab-home" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'index' %}"><img src="/static/img/white-home.png">Home</a>
+              <a class="nav-link" style="color: white;" href="{% url 'index' %}"><img src="/static/img/white-home.png" alt="">Home</a>
             </li>
             <li id="navtab-user" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'users' %}"><img src="/static/img/white-user.png">Users</a>
+              <a class="nav-link" style="color: white;" href="{% url 'users' %}"><img src="/static/img/white-user.png" alt="">Users</a>
             </li>
             <li id="navtab-credential" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'credentials' %}"><img src="/static/img/white-credential.png">Credentials</a>
+              <a class="nav-link" style="color: white;" href="{% url 'credentials' %}"><img src="/static/img/white-credential.png" alt="">Credentials</a>
             </li>
             <li id="navtab-vpc" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'vpcs' %}"><img src="/static/img/white-network.png">Networks</a>
+              <a class="nav-link" style="color: white;" href="{% url 'vpcs' %}"><img src="/static/img/white-network.png" alt="">Networks</a>
             </li>
             <li id="navtab-fs" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'filesystems' %}"><img src="/static/img/white-filesystem.png">Filesystems</a>
+              <a class="nav-link" style="color: white;" href="{% url 'filesystems' %}"><img src="/static/img/white-filesystem.png" alt="">Filesystems</a>
             </li>
             <li id="navtab-image" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'images' %}"><img src="/static/img/image.png" style="filter: invert(100%);">Images</a>
+              <a class="nav-link" style="color: white;" href="{% url 'images' %}"><img src="/static/img/image.png" style="filter: invert(100%);" alt="">Images</a>
             </li>
             <li id="navtab-cluster" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'clusters' %}"><img src="/static/img/white-cluster.png">Clusters</a>
+              <a class="nav-link" style="color: white;" href="{% url 'clusters' %}"><img src="/static/img/white-cluster.png" alt="">Clusters</a>
             </li>
             <li id="navtab-registry" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'registry' %}"><img src="/static/img/white-registry.png">Containers</a>
+              <a class="nav-link" style="color: white;" href="{% url 'registry' %}"><img src="/static/img/white-registry.png" alt="">Containers</a>
             </li>
             <li id="navtab-application" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'applications' %}"><img src="/static/img/white-application.png">Applications</a>
+              <a class="nav-link" style="color: white;" href="{% url 'applications' %}"><img src="/static/img/white-application.png" alt="">Applications</a>
             </li>
             <li id="navtab-job" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'jobs' %}"><img src="/static/img/white-job.png">Jobs</a>
+              <a class="nav-link" style="color: white;" href="{% url 'jobs' %}"><img src="/static/img/white-job.png" alt="">Jobs</a>
             </li>
             <li id="navtab-workbench" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'workbench' %}"><img src="/static/img/workbench-white.png">Workbench</a>
+              <a class="nav-link" style="color: white;" href="{% url 'workbench' %}"><img src="/static/img/workbench-white.png" alt="">Workbench</a>
             </li>
             <li id="navtab-benchmark" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'benchmarks' %}"><img src="/static/img/white-benchmark.png">Benchmarks</a>
+              <a class="nav-link" style="color: white;" href="{% url 'benchmarks' %}"><img src="/static/img/white-benchmark.png" alt="">Benchmarks</a>
             </li>
             <li id="navtab-grafana" class="nav-item">
-              <a class="nav-link" style="color: white;" href="{% url 'grafana' %}"><img src="/static/img/white-grafana.png">Grafana</a>
+              <a class="nav-link" style="color: white;" href="{% url 'grafana' %}"><img src="/static/img/white-grafana.png" alt="">Grafana</a>
             </li>
           </ul>
         </nav>  
         <div class="col-1 align-bottom mb-5 ml-5"> <!-- fixed-bottom -->
-          <img src="/static/img/white-servers.png" width="128">
+          <img src="/static/img/white-servers.png" width="128" alt="">
         </div>
         </div>
       </div>

--- a/community/front-end/ofe/website/ghpcfe/templates/base_generic.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/base_generic.html
@@ -69,12 +69,12 @@
             <a class="nav-link dropdown-toggle" href="{% url 'login'%}?next={{ request.path }}" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             {% if user.is_authenticated %}
               {% if loggedin_user %}
-            <img src="{{ loggedin_user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User avatar">
+            <img src="{{ loggedin_user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User menu">
               {% else %}
-            <img src="{{ user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User avatar">
+            <img src="{{ user.get_avatar_url }}" width="32" style="border-radius: 50%;" alt="User menu">
               {% endif %}
             {% else %}
-            <img src="/static/img/unknown_user.png" width="32" style="border-radius: 50%;" alt="User avatar">
+            <img src="/static/img/unknown_user.png" width="32" style="border-radius: 50%;" alt="Login">
             {% endif %}
             </a>
 

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
@@ -76,7 +76,7 @@
 <p id="status-p">
   <b>Status:</b>
   {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" or cluster.status == "n" %}
-  <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+  <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
   <script>
     setInterval(function () {
       $.ajax({
@@ -103,7 +103,7 @@
   {% endif %}
 
   {% if object.status == "r" %}
-  <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+  <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
   {% endif %}
   {{ object.get_status_display }}
   {% if object.grafana_dashboard_url %}

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
@@ -78,7 +78,10 @@
   {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" or cluster.status == "n" %}
   <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
   <script>
-    var refreshIntervalId = setInterval(function () {
+    // Poll with a recursive setTimeout (rather than setInterval) so the next
+    // request is only scheduled after the previous one completes, avoiding
+    // overlapping requests if the server is slow.
+    function pollClusterStatus() {
       $.ajax({
         url: "{% url 'backend-cluster-status' object.id %}",
         type: "GET",
@@ -87,15 +90,18 @@
           // when the cluster becomes ready, stop polling and reload the page
           // so it renders the fully-ready state
           if (data.status === "r") {
-            clearInterval(refreshIntervalId);
             location.reload();
+          } else {
+            setTimeout(pollClusterStatus, 5000);
           }
         },
         error: function (xhr, status, error) {
           console.log("Error refreshing data:", error);
+          setTimeout(pollClusterStatus, 5000);
         }
       });
-    }, 5000);
+    }
+    pollClusterStatus();
   </script>
   {% endif %}
 

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
@@ -76,7 +76,7 @@
 <p id="status-p">
   <b>Status:</b>
   {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" or cluster.status == "n" %}
-  <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+  <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
   <script>
     setInterval(function () {
       $.ajax({
@@ -103,7 +103,7 @@
   {% endif %}
 
   {% if object.status == "r" %}
-  <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+  <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
   {% endif %}
   {{ object.get_status_display }}
   {% if object.grafana_dashboard_url %}

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
@@ -87,9 +87,10 @@
         type: "GET",
         dataType: "json",
         success: function (data) {
-          // when the cluster becomes ready, stop polling and reload the page
-          // so it renders the fully-ready state
-          if (data.status === "r") {
+          // If the status is no longer in an active polling state, reload the
+          // page to render the final state (e.g., ready, error, deleted).
+          const activeStatuses = ["c", "i", "t", "n"];
+          if (!activeStatuses.includes(data.status)) {
             location.reload();
           } else {
             setTimeout(pollClusterStatus, 5000);

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/detail.html
@@ -78,24 +78,21 @@
   {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" or cluster.status == "n" %}
   <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
   <script>
-    setInterval(function () {
+    var refreshIntervalId = setInterval(function () {
       $.ajax({
         url: "{% url 'backend-cluster-status' object.id %}",
         type: "GET",
         dataType: "json",
         success: function (data) {
-          // update the object status display
-          var statusElement = $("#status-p");
-          var statusText = response.status;
-          statusElement.html("<b>Status: {{ object.get_status_display }}</b>");
-
-          // check if the status is "r" and stop the refresh interval
-          if (statusText == "r") {
+          // when the cluster becomes ready, stop polling and reload the page
+          // so it renders the fully-ready state
+          if (data.status === "r") {
             clearInterval(refreshIntervalId);
+            location.reload();
           }
         },
         error: function (xhr, status, error) {
-          console.log("Error refreshing data");
+          console.log("Error refreshing data:", error);
         }
       });
     }, 5000);

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
@@ -70,19 +70,19 @@
         </td>        
         <td>
           {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if cluster.status == "r" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if cluster.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
           {% endif %}
           {% if cluster.status == "d" %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="">
           {% endif %}
           {% if cluster.status == "s" %}
-          <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="Paused">
+          <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="">
           {% endif %}
           {{ cluster.get_status_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
@@ -70,19 +70,19 @@
         </td>        
         <td>
           {% if cluster.status == "c" or cluster.status == "i" or cluster.status == "t" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
           {% endif %}
           {% if cluster.status == "r" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
           {% endif %}
           {% if cluster.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
           {% endif %}
           {% if cluster.status == "d" %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
           {% endif %}
           {% if cluster.status == "s" %}
-          <img src="/static/img/status-paused.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="Paused">
           {% endif %}
           {{ cluster.get_status_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/log.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/log.html
@@ -57,7 +57,7 @@ window.onload=function(event) {
   <p><b>VPC & Subnet:</b> {{ object.subnet.vpc.name }} - {{object.subnet.name}}</p>
   <p><b>Status:</b>
     {% if cluster.status == "c" or cluster.status == "i" or cluster.status  == "t" %}
-        <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+        <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/log.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/log.html
@@ -57,7 +57,7 @@ window.onload=function(event) {
   <p><b>VPC & Subnet:</b> {{ object.subnet.vpc.name }} - {{object.subnet.name}}</p>
   <p><b>Status:</b>
     {% if cluster.status == "c" or cluster.status == "i" or cluster.status  == "t" %}
-        <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+        <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
     {% endif %}
     {{ object.get_status_display }}
   </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/credential/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/credential/list.html
@@ -22,7 +22,7 @@
     {% for credential in credential_list %}
       <hr>
       <p>
-         <img src="/static/img/GCP_logo.png" style="width:64px;height:64px;">
+         <img src="/static/img/GCP_logo.png" style="width:64px;height:64px;" alt="Google Cloud Platform logo">
          &nbsp;{{ credential.name }}     
       </p>
       <p>

--- a/community/front-end/ofe/website/ghpcfe/templates/credential/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/credential/list.html
@@ -22,7 +22,7 @@
     {% for credential in credential_list %}
       <hr>
       <p>
-         <img src="/static/img/GCP_logo.png" style="width:64px;height:64px;" alt="Google Cloud Platform logo">
+         <img src="/static/img/GCP_logo.png" style="width:64px;height:64px;" alt="Google Cloud Platform">
          &nbsp;{{ credential.name }}     
       </p>
       <p>

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/filestore_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/filestore_detail.html
@@ -53,10 +53,10 @@ window.onload=function(event) {
     <p>
       <b>Status:</b>
       {% if "c" in object.cloud_state or "d" in object.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
       {% endif %}
       {% if object.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
       {% endif %}
       {{ object.get_cloud_state_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/filestore_detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/filestore_detail.html
@@ -53,10 +53,10 @@ window.onload=function(event) {
     <p>
       <b>Status:</b>
       {% if "c" in object.cloud_state or "d" in object.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
       {% endif %}
       {% if object.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
       {% endif %}
       {{ object.get_cloud_state_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
@@ -53,16 +53,16 @@
         <td>{{ fs.cloud_zone }}</td>
         <td>
           {% if "c" in fs.cloud_state or "d" in fs.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if "i" in fs.cloud_state or fs.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if "n" in fs.cloud_state %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
           {% endif %}
           {% if "x" in fs.cloud_state %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="">
           {% endif %}
           {{ fs.get_cloud_state_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
@@ -53,16 +53,16 @@
         <td>{{ fs.cloud_zone }}</td>
         <td>
           {% if "c" in fs.cloud_state or "d" in fs.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
           {% endif %}
           {% if "i" in fs.cloud_state or fs.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
           {% endif %}
           {% if "n" in fs.cloud_state %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
           {% endif %}
           {% if "x" in fs.cloud_state %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
           {% endif %}
           {{ fs.get_cloud_state_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -102,7 +102,7 @@
           {% endfor %}
         </td>
         <td data-image-id="{{ image.id }}" id="status-{{ image.id }}">
-          <img src="" style="width:32px;height:32px;">
+          <img src="" style="width:32px;height:32px;" alt="Status">
         </td>
         <td>
           <a href="{% url 'image-view' image.id %}" class="action-link btn-primary btn">View</a>

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -190,11 +190,11 @@ function refreshImageStatus(imageId) {
       var statusElement = $('#status-' + imageId + ' img');
 
       if (data.status === 'n' || data.status === 'c') {
-        statusElement.attr('src', '/static/img/loading.gif');
+        statusElement.attr('src', '/static/img/loading.gif').attr('alt', 'Loading');
       } else if (data.status === 'r') {
-        statusElement.attr('src', '/static/img/status-ready.png');
+        statusElement.attr('src', '/static/img/status-ready.png').attr('alt', 'Ready');
       } else if (data.status === 'e') {
-        statusElement.attr('src', '/static/img/status-error.png');
+        statusElement.attr('src', '/static/img/status-error.png').attr('alt', 'Error');
       }
 
       // Schedule the next refresh after 5 seconds

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -193,8 +193,10 @@ function refreshImageStatus(imageId) {
         statusElement.attr('src', '/static/img/loading.gif').attr('alt', 'Loading');
       } else if (data.status === 'r') {
         statusElement.attr('src', '/static/img/status-ready.png').attr('alt', 'Ready');
+        return; // Stop polling once the image is in a terminal ready state
       } else if (data.status === 'e') {
         statusElement.attr('src', '/static/img/status-error.png').attr('alt', 'Error');
+        return; // Stop polling once the image is in a terminal error state
       }
 
       // Schedule the next refresh after 5 seconds

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -102,7 +102,7 @@
           {% endfor %}
         </td>
         <td data-image-id="{{ image.id }}" id="status-{{ image.id }}">
-          <img src="" style="width:32px;height:32px;" alt="Status">
+          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="width:32px;height:32px;" alt="Status">
         </td>
         <td>
           <a href="{% url 'image-view' image.id %}" class="action-link btn-primary btn">View</a>

--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -102,7 +102,7 @@
           {% endfor %}
         </td>
         <td data-image-id="{{ image.id }}" id="status-{{ image.id }}">
-          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="width:32px;height:32px;" alt="Status">
+          <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" style="width:32px;height:32px;" alt="">
         </td>
         <td>
           <a href="{% url 'image-view' image.id %}" class="action-link btn-primary btn">View</a>

--- a/community/front-end/ofe/website/ghpcfe/templates/job/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/job/detail.html
@@ -48,7 +48,7 @@
   {% else %}
     <p class="text-warning">
       {% if object.status == "p" or object.status == "q" or object.status == "d" or object.status == "r" or object.status == "u" %}
-      <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+      <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
       {% endif %}
       {{ object.get_status_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/job/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/job/detail.html
@@ -48,7 +48,7 @@
   {% else %}
     <p class="text-warning">
       {% if object.status == "p" or object.status == "q" or object.status == "d" or object.status == "r" or object.status == "u" %}
-      <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+      <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
       {% endif %}
       {{ object.get_status_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/job/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/job/list.html
@@ -58,16 +58,16 @@
         <td>{{ job.threads_per_rank }}</td>
         <td>
           {% if job.status == "p" or job.status == "q" or job.status == "d" or job.status == "r" or job.status == "u" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if job.status == "e" %}
-          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="Error">
+          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="">
           {% endif %}
           {% if job.status == "c" %}
-          <img src="/static/img/status-completed.png" style="width:22px;height:32px;" alt="Completed">
+          <img src="/static/img/status-completed.png" style="width:22px;height:32px;" alt="">
           {% endif %}
           {% if job.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
           {% endif %}
           {{ job.get_status_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/job/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/job/list.html
@@ -58,16 +58,16 @@
         <td>{{ job.threads_per_rank }}</td>
         <td>
           {% if job.status == "p" or job.status == "q" or job.status == "d" or job.status == "r" or job.status == "u" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
           {% endif %}
           {% if job.status == "e" %}
-          <img src="/static/img/status-error.png" style="width:32px;height:20px;">
+          <img src="/static/img/status-error.png" style="width:32px;height:20px;" alt="Error">
           {% endif %}
           {% if job.status == "c" %}
-          <img src="/static/img/status-completed.png" style="width:22px;height:32px;">
+          <img src="/static/img/status-completed.png" style="width:22px;height:32px;" alt="Completed">
           {% endif %}
           {% if job.status == "n" %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
           {% endif %}
           {{ job.get_status_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/_container_rows.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/_container_rows.html
@@ -23,13 +23,13 @@
         {% for build in image.builds %}
             <div id="build-status-{{ build.build_id }}">
                 {% if build.status == "n" %}
-                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
                 {% elif build.status == "i" %}
-                    <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
                 {% elif build.status == "s" %}
-                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
                 {% elif build.status == "f" %}
-                    <img src="/static/img/status-error.png" style="width:30px;height:20px;">
+                    <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="Error">
                 {% endif %}
                 {{ build.status|friendly_build_status }} ({{ build.build_id|slice:":8" }})
             </div>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/_container_rows.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/_container_rows.html
@@ -23,13 +23,13 @@
         {% for build in image.builds %}
             <div id="build-status-{{ build.build_id }}">
                 {% if build.status == "n" %}
-                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
                 {% elif build.status == "i" %}
-                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
                 {% elif build.status == "s" %}
-                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
                 {% elif build.status == "f" %}
-                    <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="Error">
+                    <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="">
                 {% endif %}
                 {{ build.status|friendly_build_status }} ({{ build.build_id|slice:":8" }})
             </div>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/detail.html
@@ -90,13 +90,13 @@
                 {% for build in image.builds %}
                     <div id="build-status-{{ build.build_id }}">
                         {% if build.status == "n" %}
-                            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+                            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
                         {% elif build.status == "i" %}
-                            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+                            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
                         {% elif build.status == "s" %}
-                            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+                            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
                         {% elif build.status == "f" %}
-                            <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="Error">
+                            <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="">
                         {% endif %}
                         {{ build.status|friendly_build_status }} ({{ build.build_id|slice:":8" }})
                     </div>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/detail.html
@@ -90,13 +90,13 @@
                 {% for build in image.builds %}
                     <div id="build-status-{{ build.build_id }}">
                         {% if build.status == "n" %}
-                            <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+                            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
                         {% elif build.status == "i" %}
-                            <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+                            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
                         {% elif build.status == "s" %}
-                            <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+                            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
                         {% elif build.status == "f" %}
-                            <img src="/static/img/status-error.png" style="width:30px;height:20px;">
+                            <img src="/static/img/status-error.png" style="width:30px;height:20px;" alt="Error">
                         {% endif %}
                         {{ build.status|friendly_build_status }} ({{ build.build_id|slice:":8" }})
                     </div>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
@@ -92,13 +92,13 @@
                 <td>{{ registry.get_repo_mode_display }}</td>
                 <td>
                     {% if registry.status == "i" %}
-                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
                     {% elif registry.status == "r" %}
-                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
                     {% elif registry.status == "n" %}
-                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
                     {% elif registry.status == "d" %}
-                    <img src="/static/img/status-deleted.png" style="width:30px;height:32px;" alt="Deleted">
+                    <img src="/static/img/status-deleted.png" style="width:30px;height:32px;" alt="">
                     {% endif %}
                     {{ registry.get_status_display }}
                 </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
@@ -92,13 +92,13 @@
                 <td>{{ registry.get_repo_mode_display }}</td>
                 <td>
                     {% if registry.status == "i" %}
-                    <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+                    <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
                     {% elif registry.status == "r" %}
-                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+                    <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
                     {% elif registry.status == "n" %}
-                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+                    <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
                     {% elif registry.status == "d" %}
-                    <img src="/static/img/status-deleted.png" style="width:30px;height:32px;">
+                    <img src="/static/img/status-deleted.png" style="width:30px;height:32px;" alt="Deleted">
                     {% endif %}
                     {{ registry.get_status_display }}
                 </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/detail.html
@@ -34,10 +34,10 @@
     <p>
       <b>Status:</b>
       {% if "c" in object.cloud_state or "d" in object.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
       {% endif %}
       {% if object.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
       {% endif %}
       {{ object.get_cloud_state_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/detail.html
@@ -34,10 +34,10 @@
     <p>
       <b>Status:</b>
       {% if "c" in object.cloud_state or "d" in object.cloud_state %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
       {% endif %}
       {% if object.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
       {% endif %}
       {{ object.get_cloud_state_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
@@ -48,17 +48,17 @@
         <td><a href="{% url 'vpc-detail' vpc.id %}">{{ vpc.name }}</a></td>
         <td>{{ vpc.cloud_id }}</td>
         <td>
-          {% if "c" in vpc.cloud_state == "c" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          {% if "c" in vpc.cloud_state %}
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if "i" in vpc.cloud_state or vpc.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
           {% endif %}
           {% if "n" in vpc.cloud_state %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
           {% endif %}
           {% if "d" in vpc.cloud_state %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="">
           {% endif %}
           {{ vpc.get_cloud_state_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
@@ -49,16 +49,16 @@
         <td>{{ vpc.cloud_id }}</td>
         <td>
           {% if "c" in vpc.cloud_state == "c" %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
           {% endif %}
           {% if "i" in vpc.cloud_state or vpc.cloud_state == "m" %}
-          <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+          <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
           {% endif %}
           {% if "n" in vpc.cloud_state %}
-          <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+          <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
           {% endif %}
           {% if "d" in vpc.cloud_state %}
-          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;">
+          <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
           {% endif %}
           {{ vpc.get_cloud_state_display }}
         </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/detail.html
@@ -36,7 +36,7 @@
     <p>
       <b>Status:</b>
       {% if workbench.status == "c" or workbench.status == "i" or workbench.status  == "t"  %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
       {% endif %}
       {{ object.get_status_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/detail.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/detail.html
@@ -36,7 +36,7 @@
     <p>
       <b>Status:</b>
       {% if workbench.status == "c" or workbench.status == "i" or workbench.status  == "t"  %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
       {% endif %}
       {{ object.get_status_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
@@ -53,19 +53,19 @@
           <td>{{ workbench.cloud_zone }}</td>
           <td>
             {% if workbench.status == "c" or workbench.status == "i" or workbench.status == "t" %}
-            <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
             {% endif %}
             {% if workbench.status == "r" %}
-            <img src="/static/img/status-ready.png" style="width:32px;height:32px;">
+            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
             {% endif %}
             {% if workbench.status == "n" %}
-            <img src="/static/img/status-configured.png" style="width:30px;height:32px;">
+            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
             {% endif %}
             {% if workbench.status == "d" %}
-            <img src="/static/img/status-deleted.png" style="width:29px;height:32px;">
+            <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
             {% endif %}
             {% if workbench.status == "s" %}
-            <img src="/static/img/status-paused.png" style="width:32px;height:32px;">
+            <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="Paused">
             {% endif %}
             {{ workbench.get_status_display }}
           </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
@@ -53,19 +53,19 @@
           <td>{{ workbench.cloud_zone }}</td>
           <td>
             {% if workbench.status == "c" or workbench.status == "i" or workbench.status == "t" %}
-            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+            <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
             {% endif %}
             {% if workbench.status == "r" %}
-            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="Ready">
+            <img src="/static/img/status-ready.png" style="width:32px;height:32px;" alt="">
             {% endif %}
             {% if workbench.status == "n" %}
-            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="Configured">
+            <img src="/static/img/status-configured.png" style="width:30px;height:32px;" alt="">
             {% endif %}
             {% if workbench.status == "d" %}
-            <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="Deleted">
+            <img src="/static/img/status-deleted.png" style="width:29px;height:32px;" alt="">
             {% endif %}
             {% if workbench.status == "s" %}
-            <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="Paused">
+            <img src="/static/img/status-paused.png" style="width:32px;height:32px;" alt="">
             {% endif %}
             {{ workbench.get_status_display }}
           </td>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/update.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/update.html
@@ -25,7 +25,7 @@
 
       <b>Status:</b>
       {% if workbench.status == "c" or workbench.status == "i" or workbench.status  == "t"  %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
       {% endif %}
       {{ object.get_status_display }}
     </p>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/update.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/update.html
@@ -25,7 +25,7 @@
 
       <b>Status:</b>
       {% if workbench.status == "c" or workbench.status == "i" or workbench.status  == "t"  %}
-          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="Loading">
+          <img src="/static/img/loading.gif" style="width:32px;height:32px;" alt="">
       {% endif %}
       {{ object.get_status_display }}
     </p>


### PR DESCRIPTION
### Description

The Open Front End (OFE) Django templates rendered every `<img>` without an
`alt` attribute. Assistive technologies therefore announced nothing — or the
raw image file name — for status icons, navigation icons, user avatars and the
GCP logo. This is a [WCAG 2.1 SC 1.1.1 (Non-text Content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
failure.

This change adds `alt` text to all 77 affected images across 23 templates:

- **Status icons** (`loading`, `ready`, `configured`, `deleted`, `paused`,
  `error`, `completed`) get descriptive `alt` text matching the status they
  convey.
- **Avatars** get `alt="User avatar"`; the GCP credential logo gets a
  descriptive `alt`.
- **Decorative navigation icons** that sit next to a visible text label get
  `alt=""`, so screen readers skip them instead of announcing the label twice.

The change is markup-only — no behavioral or visual change. It follows the
convention already used in `index.html` and `credential/select_form.html`,
which already set `alt` on their images.

### Verification

- No `<img>` left without `alt` (82 images total across the templates).
- Django `{% %}` / `{{ }}` tag balance unchanged; no duplicate `alt` attributes.
- Only `<img>` lines are touched (confirmed via diff).

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] Markup-only change verified as above.
- [ ] N/A — no unit tests apply to static template markup, and no Go/Terraform/Python logic is changed.
