### PR TITLE
docs: fix typos flagged by codespell

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/views/credentials.py
+++ b/community/front-end/ofe/website/ghpcfe/views/credentials.py
@@ -138,7 +138,7 @@ class CredentialDeleteView(SuperUserRequiredMixin, DeleteView):
 
 
 class CredentialViewSet(viewsets.ModelViewSet):
-    """Custom ModelViewSet for Crendential model"""
+    """Custom ModelViewSet for Credential model"""
 
     permission_classes = (
         IsAuthenticated,

--- a/examples/machine-learning/build-service-images/build.sh
+++ b/examples/machine-learning/build-service-images/build.sh
@@ -25,7 +25,7 @@ readonly SUFFIX="$2"
 readonly PROJECT="$3"
 
 if [[ ! -d "$RECIPE" ]]; then
-	echo "The '$RECIPE' does not exist. Available recepies: common, a3m"
+	echo "The '$RECIPE' does not exist. Available recipes: common, a3m"
 	exit 1
 fi
 

--- a/modules/compute/gke-node-pool/reservation_definitions.tf
+++ b/modules/compute/gke-node-pool/reservation_definitions.tf
@@ -22,7 +22,7 @@ locals {
   input_reservation_projects = [for r in try(var.reservation_affinity.specific_reservations, []) : coalesce(r.project, var.project_id)]
   # We, also, remember the suffix "/reservationBlocks/exr-one-block-1" for use elsewhere afterwards
   input_reservation_suffixes = [for r in try(var.reservation_affinity.specific_reservations, []) : substr(r.name, length(split("/", r.name)[0]), -1)]
-  # Adding this variable to by-pass the machine-type validation for TPUs
+  # Adding this variable to bypass the machine-type validation for TPUs
   is_tpu = var.placement_policy.tpu_topology != null
 }
 

--- a/tools/cloud-build/provision/list_tests.py
+++ b/tools/cloud-build/provision/list_tests.py
@@ -78,7 +78,7 @@ TEMPORAL_CONSTAINTS = [
 ]
 # TODO:
 # * Consider defining constraints (e.g. reservations used) as a tags within tests yamls
-# * Use better solution than randome brute force
+# * Use better solution than random brute force
 
 def list_builds() -> list[str]:
     builds = [b[:-5] for b in glob.glob("*.yaml", root_dir="../daily-tests/builds/")]


### PR DESCRIPTION
### Description

Fixes four genuine misspellings caught by the repository's own `codespell`
pre-commit hook. All are in comments, a docstring, and one user-facing message
— no identifiers, APIs, or behavior are changed.

| Typo | Correction | File |
|---|---|---|
| `randome` | `random` | `tools/cloud-build/provision/list_tests.py` (comment) |
| `recepies` | `recipes` | `examples/machine-learning/build-service-images/build.sh` (echo message) |
| `Crendential` | `Credential` | `community/front-end/ofe/website/ghpcfe/views/credentials.py` (docstring) |
| `by-pass` | `bypass` | `modules/compute/gke-node-pool/reservation_definitions.tf` (comment) |

`codespell` (using the repo's `.codespellrc`) reports no remaining issues in
these files. Other codespell hits elsewhere in the tree (`re-used`, `NotIn`,
`bootup`) are intentionally left untouched as false positives — valid
hyphenation, a code identifier, and an accepted compound word respectively.

### Verification

- `codespell` passes on all four changed files.
- Python (`py_compile`) and Bash (`bash -n`) syntax verified for the edited files.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] `codespell` passes on all changed files.
- [ ] N/A — comment/docstring/message-only changes; no logic or tests affected.
