### PR TITLE
fix(ofe): close malformed </table> tags in image/list.html

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/templates/image/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/image/list.html
@@ -60,7 +60,7 @@
       </tr>
     {% endfor %}
     </tbody>
-  </table
+  </table>
   </div>
   {% else %}
     <p>You have not created a startup script yet. Create one!</p>
@@ -113,7 +113,7 @@
       </tr>
     {% endfor %}
     </tbody>
-  </table
+  </table>
   </div>
   {% else %}
     <p>You have not created an image yet. Create or import one!</p>


### PR DESCRIPTION
### Description

Both tables in `community/front-end/ofe/website/ghpcfe/templates/image/list.html` closed with `</table` (missing the `>`) at lines 63 and 116. Every other list template in the OFE uses a well-formed `</table>`. Browsers recover from the malformed tag, but it is invalid HTML. This adds the missing `>` to both.

### Verification

- `grep` confirms no `</table` (without `>`) remains in the file.
- Markup-only change; no behavioral or visual difference.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [ ] N/A — markup-only fix; no logic or tests affected.