### PR TITLE
refactor(cmd): move expand helpers from create.go to expand.go

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,12 +20,10 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/modulewriter"
-	"hpc-toolkit/pkg/validators"
 	"os"
 	"os/exec"
 	"os/user"
@@ -34,8 +32,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/zclconf/go-cty/cty"
-	"gopkg.in/yaml.v3"
 )
 
 func addCreateFlags(c *cobra.Command) *cobra.Command {
@@ -183,82 +179,6 @@ func expandOrDie(cmd *cobra.Command, path string) (config.Blueprint, *config.Yam
 	return bp, ctx
 }
 
-// TODO: move to expand.go
-func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
-	err := validators.Execute(bp)
-	if err == nil {
-		return
-	}
-	logging.Error("%s", renderError(err, ctx))
-
-	const errorMsg = `One or more blueprint validators has failed. See messages above for suggested
-actions. General troubleshooting guidance and instructions for configuring validators are shown below.
-
-- https://goo.gle/hpc-toolkit-troubleshooting
-- https://goo.gle/hpc-toolkit-validation
-
-Validators can be silenced or treated as warnings or errors:
-
-- https://goo.gle/hpc-toolkit-validation-levels
-`
-	logging.Error("%s", errorMsg)
-
-	switch bp.ValidationLevel {
-	case config.ValidationWarning:
-		{
-			logging.Error("%s\n", boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
-		}
-	case config.ValidationError:
-		{
-			logging.Fatal("%s", boldRed("Validation failed due to the issues listed above"))
-		}
-	}
-}
-
-// TODO: move to expand.go
-func setCLIVariables(ds *config.DeploymentSettings, s []string) error {
-	for _, cliVar := range s {
-		arr := strings.SplitN(cliVar, "=", 2)
-
-		if len(arr) != 2 {
-			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", cliVar)
-		}
-		// Convert the variable's string literal to its equivalent default type.
-		key := arr[0]
-		var v config.YamlValue
-		if err := yaml.Unmarshal([]byte(arr[1]), &v); err != nil {
-			return fmt.Errorf("invalid input: unable to convert '%s' value '%s' to known type", key, arr[1])
-		}
-		ds.Vars = ds.Vars.With(key, v.Unwrap())
-	}
-	return nil
-}
-
-// TODO: move to expand.go
-func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
-	if len(s) == 0 {
-		return nil // no op
-	}
-	be := config.TerraformBackend{Type: "gcs"}
-	for _, config := range s {
-		arr := strings.SplitN(config, "=", 2)
-
-		if len(arr) != 2 {
-			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", config)
-		}
-
-		key, value := arr[0], arr[1]
-		switch key {
-		case "type":
-			be.Type = value
-		default:
-			be.Configuration = be.Configuration.With(key, cty.StringVal(value))
-		}
-	}
-	ds.TerraformBackendDefaults = be
-	return nil
-}
-
 func mergeDeploymentSettings(bp *config.Blueprint, ds config.DeploymentSettings) error {
 	for k, v := range ds.Vars.Items() {
 		bp.Vars = bp.Vars.With(k, v)
@@ -267,29 +187,6 @@ func mergeDeploymentSettings(bp *config.Blueprint, ds config.DeploymentSettings)
 		bp.TerraformBackendDefaults = ds.TerraformBackendDefaults
 	}
 	return nil
-}
-
-// SetValidationLevel allows command-line tools to set the validation level
-// TODO: move to expand.go
-func setValidationLevel(bp *config.Blueprint, s string) error {
-	switch s {
-	case "ERROR":
-		bp.ValidationLevel = config.ValidationError
-	case "WARNING":
-		bp.ValidationLevel = config.ValidationWarning
-	case "IGNORE":
-		bp.ValidationLevel = config.ValidationIgnore
-	default:
-		return errors.New("invalid validation level (\"ERROR\", \"WARNING\", \"IGNORE\")")
-	}
-	return nil
-}
-
-// TODO: move to expand.go
-func skipValidators(bp *config.Blueprint) {
-	for _, v := range expandFlags.validatorsToSkip {
-		bp.SkipValidator(v)
-	}
 }
 
 func forceErr(err error) error {

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -24,84 +24,6 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *MySuite) TestSetCLIVariables(c *C) {
-	ds := config.DeploymentSettings{
-		Vars: config.Dict{}.
-			With("deployment_name", cty.StringVal("bush"))}
-
-	vars := []string{
-		"project_id=cli_test_project_id",
-		"deployment_name=cli_deployment_name",
-		"region=cli_region",
-		"zone=cli_zone",
-		"kv=key=val",
-		"keyBool=true",
-		"keyInt=15",
-		"keyFloat=15.43",
-		"keyMap={bar: baz, qux: 1}",
-		"keyArray=[1, 2, 3]",
-		"keyArrayOfMaps=[foo, {bar: baz, qux: 1}]",
-		"keyMapOfArrays={foo: [1, 2, 3], bar: [a, b, c]}",
-	}
-	c.Assert(setCLIVariables(&ds, vars), IsNil)
-	c.Check(
-		ds.Vars.Items(), DeepEquals, map[string]cty.Value{
-			"project_id":      cty.StringVal("cli_test_project_id"),
-			"deployment_name": cty.StringVal("cli_deployment_name"),
-			"region":          cty.StringVal("cli_region"),
-			"zone":            cty.StringVal("cli_zone"),
-			"kv":              cty.StringVal("key=val"),
-			"keyBool":         cty.True,
-			"keyInt":          cty.NumberIntVal(15),
-			"keyFloat":        cty.NumberFloatVal(15.43),
-			"keyMap": cty.ObjectVal(map[string]cty.Value{
-				"bar": cty.StringVal("baz"),
-				"qux": cty.NumberIntVal(1)}),
-			"keyArray": cty.TupleVal([]cty.Value{
-				cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
-			"keyArrayOfMaps": cty.TupleVal([]cty.Value{
-				cty.StringVal("foo"),
-				cty.ObjectVal(map[string]cty.Value{
-					"bar": cty.StringVal("baz"),
-					"qux": cty.NumberIntVal(1)})}),
-			"keyMapOfArrays": cty.ObjectVal(map[string]cty.Value{
-				"foo": cty.TupleVal([]cty.Value{
-					cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
-				"bar": cty.TupleVal([]cty.Value{
-					cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}),
-			}),
-		})
-
-	// Failure: Variable without '='
-	ds = config.DeploymentSettings{}
-	inv := []string{"project_idcli_test_project_id"}
-	c.Check(setCLIVariables(&ds, inv), ErrorMatches, "invalid format: .*")
-
-	// Failure: Unmarshalable value
-	ds = config.DeploymentSettings{}
-	inv = []string{"pyrite={gold"}
-	c.Check(setCLIVariables(&ds, inv), ErrorMatches, ".*unable to convert.*pyrite.*gold.*")
-}
-
-func (s *MySuite) TestSetBackendConfig(c *C) {
-	// Success
-	vars := []string{
-		"taste=sweet",
-		"type=green",
-		"odor=strong",
-	}
-
-	ds := config.DeploymentSettings{}
-	c.Assert(setBackendConfig(&ds, vars), IsNil)
-
-	be := ds.TerraformBackendDefaults
-	c.Check(be.Type, Equals, "green")
-	c.Check(be.Configuration.Items(), DeepEquals, map[string]cty.Value{
-		"taste": cty.StringVal("sweet"),
-		"odor":  cty.StringVal("strong"),
-	})
-}
-
 func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 	ds1 := config.DeploymentSettings{
 		Vars: config.Dict{}.
@@ -164,49 +86,6 @@ func (s *MySuite) TestMergeDeploymentSettings(c *C) {
 			"bucket": cty.StringVal("ds_bucket"),
 		}),
 	})
-}
-
-func (s *MySuite) TestSetBackendConfig_Invalid(c *C) {
-	// Failure: Variable without '='
-	vars := []string{
-		"typegreen",
-	}
-	ds := config.DeploymentSettings{}
-	c.Assert(setBackendConfig(&ds, vars), ErrorMatches, "invalid format: .*")
-}
-
-func (s *MySuite) TestSetBackendConfig_NoOp(c *C) {
-	ds := config.DeploymentSettings{
-		TerraformBackendDefaults: config.TerraformBackend{
-			Type: "green"}}
-
-	c.Assert(setBackendConfig(&ds, []string{}), IsNil)
-	c.Check(ds.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
-		Type: "green"})
-}
-
-func (s *MySuite) TestValidationLevels(c *C) {
-	bp := config.Blueprint{}
-
-	c.Check(setValidationLevel(&bp, "ERROR"), IsNil)
-	c.Check(bp.ValidationLevel, Equals, config.ValidationError)
-
-	c.Check(setValidationLevel(&bp, "WARNING"), IsNil)
-	c.Check(bp.ValidationLevel, Equals, config.ValidationWarning)
-
-	c.Check(setValidationLevel(&bp, "IGNORE"), IsNil)
-	c.Check(bp.ValidationLevel, Equals, config.ValidationIgnore)
-
-	c.Check(setValidationLevel(&bp, "INVALID"), NotNil)
-}
-
-func (s *MySuite) TestValidateMaybeDie(c *C) {
-	bp := config.Blueprint{
-		Validators:      []config.Validator{{Validator: "invalid"}},
-		ValidationLevel: config.ValidationWarning,
-	}
-	ctx, _ := config.NewYamlCtx([]byte{})
-	validateMaybeDie(bp, ctx) // smoke test
 }
 
 func (s *MySuite) TestIsOverwriteAllowed_Absent(c *C) {

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -16,9 +16,16 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
+	"hpc-toolkit/pkg/validators"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/zclconf/go-cty/cty"
+	"gopkg.in/yaml.v3"
 )
 
 func addExpandFlags(c *cobra.Command, addOutFlag bool) *cobra.Command {
@@ -71,4 +78,98 @@ func runExpandCmd(cmd *cobra.Command, args []string) {
 	bp, ctx := expandOrDie(cmd, args[0])
 	checkErr(bp.Export(expandFlags.outputPath), ctx)
 	logging.Info(boldGreen("Expanded Environment Definition created successfully, saved as %s."), expandFlags.outputPath)
+}
+
+func validateMaybeDie(bp config.Blueprint, ctx config.YamlCtx) {
+	err := validators.Execute(bp)
+	if err == nil {
+		return
+	}
+	logging.Error("%s", renderError(err, ctx))
+
+	const errorMsg = `One or more blueprint validators has failed. See messages above for suggested
+actions. General troubleshooting guidance and instructions for configuring validators are shown below.
+
+- https://goo.gle/hpc-toolkit-troubleshooting
+- https://goo.gle/hpc-toolkit-validation
+
+Validators can be silenced or treated as warnings or errors:
+
+- https://goo.gle/hpc-toolkit-validation-levels
+`
+	logging.Error("%s", errorMsg)
+
+	switch bp.ValidationLevel {
+	case config.ValidationWarning:
+		{
+			logging.Error("%s\n", boldYellow("Validation failures were treated as a warning, continuing to create blueprint."))
+		}
+	case config.ValidationError:
+		{
+			logging.Fatal("%s", boldRed("Validation failed due to the issues listed above"))
+		}
+	}
+}
+
+func setCLIVariables(ds *config.DeploymentSettings, s []string) error {
+	for _, cliVar := range s {
+		arr := strings.SplitN(cliVar, "=", 2)
+
+		if len(arr) != 2 {
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", cliVar)
+		}
+		// Convert the variable's string literal to its equivalent default type.
+		key := arr[0]
+		var v config.YamlValue
+		if err := yaml.Unmarshal([]byte(arr[1]), &v); err != nil {
+			return fmt.Errorf("invalid input: unable to convert '%s' value '%s' to known type", key, arr[1])
+		}
+		ds.Vars = ds.Vars.With(key, v.Unwrap())
+	}
+	return nil
+}
+
+func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
+	if len(s) == 0 {
+		return nil // no op
+	}
+	be := config.TerraformBackend{Type: "gcs"}
+	for _, config := range s {
+		arr := strings.SplitN(config, "=", 2)
+
+		if len(arr) != 2 {
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", config)
+		}
+
+		key, value := arr[0], arr[1]
+		switch key {
+		case "type":
+			be.Type = value
+		default:
+			be.Configuration = be.Configuration.With(key, cty.StringVal(value))
+		}
+	}
+	ds.TerraformBackendDefaults = be
+	return nil
+}
+
+// SetValidationLevel allows command-line tools to set the validation level
+func setValidationLevel(bp *config.Blueprint, s string) error {
+	switch s {
+	case "ERROR":
+		bp.ValidationLevel = config.ValidationError
+	case "WARNING":
+		bp.ValidationLevel = config.ValidationWarning
+	case "IGNORE":
+		bp.ValidationLevel = config.ValidationIgnore
+	default:
+		return errors.New("invalid validation level (\"ERROR\", \"WARNING\", \"IGNORE\")")
+	}
+	return nil
+}
+
+func skipValidators(bp *config.Blueprint) {
+	for _, v := range expandFlags.validatorsToSkip {
+		bp.SkipValidator(v)
+	}
 }

--- a/cmd/expand.go
+++ b/cmd/expand.go
@@ -134,11 +134,11 @@ func setBackendConfig(ds *config.DeploymentSettings, s []string) error {
 		return nil // no op
 	}
 	be := config.TerraformBackend{Type: "gcs"}
-	for _, config := range s {
-		arr := strings.SplitN(config, "=", 2)
+	for _, cfg := range s {
+		arr := strings.SplitN(cfg, "=", 2)
 
 		if len(arr) != 2 {
-			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", config)
+			return fmt.Errorf("invalid format: '%s' should follow the 'name=value' format", cfg)
 		}
 
 		key, value := arr[0], arr[1]

--- a/cmd/expand_test.go
+++ b/cmd/expand_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"hpc-toolkit/pkg/config"
+
+	"github.com/zclconf/go-cty/cty"
+	. "gopkg.in/check.v1"
+)
+
+func (s *MySuite) TestSetCLIVariables(c *C) {
+	ds := config.DeploymentSettings{
+		Vars: config.Dict{}.
+			With("deployment_name", cty.StringVal("bush"))}
+
+	vars := []string{
+		"project_id=cli_test_project_id",
+		"deployment_name=cli_deployment_name",
+		"region=cli_region",
+		"zone=cli_zone",
+		"kv=key=val",
+		"keyBool=true",
+		"keyInt=15",
+		"keyFloat=15.43",
+		"keyMap={bar: baz, qux: 1}",
+		"keyArray=[1, 2, 3]",
+		"keyArrayOfMaps=[foo, {bar: baz, qux: 1}]",
+		"keyMapOfArrays={foo: [1, 2, 3], bar: [a, b, c]}",
+	}
+	c.Assert(setCLIVariables(&ds, vars), IsNil)
+	c.Check(
+		ds.Vars.Items(), DeepEquals, map[string]cty.Value{
+			"project_id":      cty.StringVal("cli_test_project_id"),
+			"deployment_name": cty.StringVal("cli_deployment_name"),
+			"region":          cty.StringVal("cli_region"),
+			"zone":            cty.StringVal("cli_zone"),
+			"kv":              cty.StringVal("key=val"),
+			"keyBool":         cty.True,
+			"keyInt":          cty.NumberIntVal(15),
+			"keyFloat":        cty.NumberFloatVal(15.43),
+			"keyMap": cty.ObjectVal(map[string]cty.Value{
+				"bar": cty.StringVal("baz"),
+				"qux": cty.NumberIntVal(1)}),
+			"keyArray": cty.TupleVal([]cty.Value{
+				cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
+			"keyArrayOfMaps": cty.TupleVal([]cty.Value{
+				cty.StringVal("foo"),
+				cty.ObjectVal(map[string]cty.Value{
+					"bar": cty.StringVal("baz"),
+					"qux": cty.NumberIntVal(1)})}),
+			"keyMapOfArrays": cty.ObjectVal(map[string]cty.Value{
+				"foo": cty.TupleVal([]cty.Value{
+					cty.NumberIntVal(1), cty.NumberIntVal(2), cty.NumberIntVal(3)}),
+				"bar": cty.TupleVal([]cty.Value{
+					cty.StringVal("a"), cty.StringVal("b"), cty.StringVal("c")}),
+			}),
+		})
+
+	// Failure: Variable without '='
+	ds = config.DeploymentSettings{}
+	inv := []string{"project_idcli_test_project_id"}
+	c.Check(setCLIVariables(&ds, inv), ErrorMatches, "invalid format: .*")
+
+	// Failure: Unmarshalable value
+	ds = config.DeploymentSettings{}
+	inv = []string{"pyrite={gold"}
+	c.Check(setCLIVariables(&ds, inv), ErrorMatches, ".*unable to convert.*pyrite.*gold.*")
+}
+
+func (s *MySuite) TestSetBackendConfig(c *C) {
+	// Success
+	vars := []string{
+		"taste=sweet",
+		"type=green",
+		"odor=strong",
+	}
+
+	ds := config.DeploymentSettings{}
+	c.Assert(setBackendConfig(&ds, vars), IsNil)
+
+	be := ds.TerraformBackendDefaults
+	c.Check(be.Type, Equals, "green")
+	c.Check(be.Configuration.Items(), DeepEquals, map[string]cty.Value{
+		"taste": cty.StringVal("sweet"),
+		"odor":  cty.StringVal("strong"),
+	})
+}
+
+func (s *MySuite) TestSetBackendConfig_Invalid(c *C) {
+	// Failure: Variable without '='
+	vars := []string{
+		"typegreen",
+	}
+	ds := config.DeploymentSettings{}
+	c.Assert(setBackendConfig(&ds, vars), ErrorMatches, "invalid format: .*")
+}
+
+func (s *MySuite) TestSetBackendConfig_NoOp(c *C) {
+	ds := config.DeploymentSettings{
+		TerraformBackendDefaults: config.TerraformBackend{
+			Type: "green"}}
+
+	c.Assert(setBackendConfig(&ds, []string{}), IsNil)
+	c.Check(ds.TerraformBackendDefaults, DeepEquals, config.TerraformBackend{
+		Type: "green"})
+}
+
+func (s *MySuite) TestValidationLevels(c *C) {
+	bp := config.Blueprint{}
+
+	c.Check(setValidationLevel(&bp, "ERROR"), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationError)
+
+	c.Check(setValidationLevel(&bp, "WARNING"), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationWarning)
+
+	c.Check(setValidationLevel(&bp, "IGNORE"), IsNil)
+	c.Check(bp.ValidationLevel, Equals, config.ValidationIgnore)
+
+	c.Check(setValidationLevel(&bp, "INVALID"), NotNil)
+}
+
+func (s *MySuite) TestValidateMaybeDie(c *C) {
+	bp := config.Blueprint{
+		Validators:      []config.Validator{{Validator: "invalid"}},
+		ValidationLevel: config.ValidationWarning,
+	}
+	ctx, _ := config.NewYamlCtx([]byte{})
+	validateMaybeDie(bp, ctx) // smoke test
+}


### PR DESCRIPTION
### Description

Five helper functions in `cmd/create.go` were annotated `// TODO: move to expand.go`:

- `validateMaybeDie`
- `setCLIVariables`
- `setBackendConfig`
- `setValidationLevel`
- `skipValidators`

They all support blueprint *expansion* (validation level, validator skipping, CLI variable / backend overrides, and post-expand validation) and are called from `expandOrDie`, which both the `create` and `expand` commands use. This PR resolves the TODOs by moving the five functions to `cmd/expand.go` and dropping the now-unused imports (`errors`, `validators`, `go-cty/cty`, `yaml.v3`) from `create.go`.

This is a **pure relocation with no behavior change** — both files remain in package `cmd`, so all call sites are unaffected.

### Verification

- `go build ./...` — passes
- `go vet ./cmd/...` — passes
- `gofmt -l` — clean
- `go test ./cmd/...` — all pass

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] `go test ./cmd/...` passes.
- [x] No behavior change (functions relocated within the same package).