### PR TITLE
fix(ofe): associate form labels and fix empty link for accessibility

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
@@ -161,6 +161,7 @@ function filterTable() {
 }
 function setupFilter() {
     var toggle = document.getElementById("id_show_destroyed");
+    if (!toggle) return;
     toggle_cookie = ($.cookie("cluster_list_show_destroyed") != "false");
     if ( toggle_cookie ) {
         toggle.checked = true;

--- a/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/cluster/list.html
@@ -129,7 +129,7 @@
     </tbody>
   </table>
   {% if admin_view == 1 %}
-  <input type="checkbox" id="id_show_destroyed"/> Show Destroyed Clusters
+  <input type="checkbox" id="id_show_destroyed"/> <label for="id_show_destroyed">Show Destroyed Clusters</label>
   {% endif %}
   </div>
   {% else %}

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
@@ -89,7 +89,7 @@
     {% endfor %}
     </tbody>
   </table>
-  <input type="checkbox" id="id_show_destroyed"/> Show Destroyed Filesystems
+  <input type="checkbox" id="id_show_destroyed"/> <label for="id_show_destroyed">Show Destroyed Filesystems</label>
   </div>
   {% else %}
     <p>This is no record of any Filesystem in this system. Create one!</p>

--- a/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/filesystem/list.html
@@ -120,6 +120,7 @@ function filterTable() {
 }
 function setupFilter() {
     var toggle = document.getElementById("id_show_destroyed");
+    if (!toggle) return;
     toggle_cookie = ($.cookie("fs_list_show_destroyed") != "false");
     if ( toggle_cookie ) {
         toggle.checked = true;

--- a/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/registry/list.html
@@ -112,7 +112,7 @@
     </tbody>
 </table>
 {% else %}
-<p>No registries found. You can deploy an <a href="https://cloud.google.com/artifact-registry/docs"></a>Artifact Registry</a> when you create a cluster.</p>
+<p>No registries found. You can deploy an <a href="https://cloud.google.com/artifact-registry/docs">Artifact Registry</a> when you create a cluster.</p>
 {% endif %}
 
 {% endblock %}

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
@@ -124,6 +124,7 @@ function filterTable() {
 }
 function setupFilter() {
     var toggle = document.getElementById("id_show_destroyed");
+    if (!toggle) return;
     toggle_cookie = ($.cookie("vpc_list_show_destroyed") != "false");
     if ( toggle_cookie ) {
         toggle.checked = true;

--- a/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/vpc/list.html
@@ -93,7 +93,7 @@
     {% endfor %}
     </tbody>
   </table>
-  <input type="checkbox" id="id_show_destroyed"/> Show Destroyed VPCs
+  <input type="checkbox" id="id_show_destroyed"/> <label for="id_show_destroyed">Show Destroyed VPCs</label>
   </div>
   {% else %}
     <p>This is no record of any VPC in this system. Create one!</p>

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
@@ -145,6 +145,7 @@ function filterTable() {
 }
 function setupFilter() {
     var toggle = document.getElementById("id_show_destroyed");
+    if (!toggle) return;
     toggle_cookie = ($.cookie("workbench_list_show_destroyed") != "false");
     if ( toggle_cookie ) {
         toggle.checked = true;

--- a/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
+++ b/community/front-end/ofe/website/ghpcfe/templates/workbench/list.html
@@ -111,7 +111,7 @@
     {% endfor %}
     </tbody>
   </table>
-  <input type="checkbox" id="id_show_destroyed"/> Show Destroyed workbenches
+  <input type="checkbox" id="id_show_destroyed"/> <label for="id_show_destroyed">Show Destroyed workbenches</label>
   </div>
   {% else %}
     {% if normaluser or admin %}


### PR DESCRIPTION
### Description

Two accessibility fixes in the Open Front End templates:

1. **Unlabeled "Show Destroyed …" checkboxes.** On the cluster, filesystem, workbench and VPC list pages, the toggle text sat next to `<input type="checkbox" id="id_show_destroyed">` but was not programmatically associated with it. Screen readers announced an unlabeled checkbox, and the text was not a click target. Wrapped the text in `<label for="id_show_destroyed">`. The input keeps its `id`, so the existing filter JavaScript (`getElementById("id_show_destroyed")`) is unaffected.

2. **Empty anchor in `registry/list.html`.** The empty-state text read `<a href="…/artifact-registry/docs"></a>Artifact Registry</a>` — an anchor with no accessible name plus a stray closing `</a>`. Moved "Artifact Registry" inside the anchor so the link has text.

### Verification

- All four checkboxes now have a `<label for="id_show_destroyed">`.
- The filter JS still resolves the checkbox by `id` — no behavior change.
- Markup-only change.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [ ] N/A — markup-only accessibility fix; no logic or tests affected.