### PR TITLE
Fix(community/slinky): add missing instructions output variable

### DIFF
--- a/community/examples/slurm-gke/slurm-gke.yaml
+++ b/community/examples/slurm-gke/slurm-gke.yaml
@@ -139,6 +139,7 @@ deployment_groups:
       slurm_operator_namespace: $(vars.slurm_namespace)
       install_slurm_operator_chart: true
       install_slurm_chart: false
+    outputs: [instructions]
 
   - id: gke_compute_nodeset
     source: community/modules/compute/gke-nodeset

--- a/community/modules/scheduler/slinky/README.md
+++ b/community/modules/scheduler/slinky/README.md
@@ -167,6 +167,7 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_instructions"></a> [instructions](#output\_instructions) | Instructions on how to connect to the cluster and run basic Slurm commands. |
 | <a name="output_slurm_namespace"></a> [slurm\_namespace](#output\_slurm\_namespace) | namespace for the slurm chart |
 | <a name="output_slurm_operator_namespace"></a> [slurm\_operator\_namespace](#output\_slurm\_operator\_namespace) | namespace for the slinky operator chart |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/scheduler/slinky/outputs.tf
+++ b/community/modules/scheduler/slinky/outputs.tf
@@ -58,6 +58,9 @@ output "instructions" {
       srun hostname
   EOT
   depends_on = [
-    helm_release.slurm
+    helm_release.cert_manager,
+    helm_release.slurm_operator,
+    helm_release.slurm,
+    helm_release.prometheus
   ]
 }

--- a/community/modules/scheduler/slinky/outputs.tf
+++ b/community/modules/scheduler/slinky/outputs.tf
@@ -46,11 +46,18 @@ output "instructions" {
       kubectl exec -it statefulsets/slurm-controller --namespace=${var.slurm_namespace} -- bash --login
 
     Connect to the login node (if enabled):
+      (Note: It may take a few minutes for the LoadBalancer IP to become available)
       SLURM_LOGIN_IP="$(kubectl get services -n ${var.slurm_namespace} -l app.kubernetes.io/instance=slurm,app.kubernetes.io/name=login -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")"
+      # If using root with SSH authorized keys:
       ssh -p 2222 root@$${SLURM_LOGIN_IP}
+      # Or if SSSD/LDAP is configured:
+      ssh -p 2222 $${USER}@$${SLURM_LOGIN_IP}
 
     Once connected, you can run:
       sinfo
       srun hostname
   EOT
+  depends_on = [
+    helm_release.slurm
+  ]
 }

--- a/community/modules/scheduler/slinky/outputs.tf
+++ b/community/modules/scheduler/slinky/outputs.tf
@@ -33,3 +33,24 @@ output "slurm_operator_namespace" {
     helm_release.prometheus
   ]
 }
+
+output "instructions" {
+  description = "Instructions on how to connect to the cluster and run basic Slurm commands."
+  value       = <<-EOT
+    To test Slurm functionality, connect to the controller or the login node and use Slurm client commands.
+
+    First, get cluster credentials:
+      gcloud container clusters get-credentials ${local.cluster_name} --location ${local.cluster_location} --project ${local.project_id}
+
+    Connect to the controller:
+      kubectl exec -it statefulsets/slurm-controller --namespace=${var.slurm_namespace} -- bash --login
+
+    Connect to the login node (if enabled):
+      SLURM_LOGIN_IP="$(kubectl get services -n ${var.slurm_namespace} -l app.kubernetes.io/instance=slurm,app.kubernetes.io/name=login -o jsonpath="{.items[0].status.loadBalancer.ingress[0].ip}")"
+      ssh -p 2222 root@$${SLURM_LOGIN_IP}
+
+    Once connected, you can run:
+      sinfo
+      srun hostname
+  EOT
+}


### PR DESCRIPTION
This PR fixes a validation error in the community module `hpc-slinky` blueprint (`hpc-slinky.yaml`). The blueprint expects an `instructions` output variable to be exported by the `slinky` module to display post-deployment steps, but that variable was missing from `community/modules/scheduler/slinky/outputs.tf`.
