### PR TITLE
Upgrade GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v10
       with:
         days-before-issue-stale: 30
         days-before-issue-close: 14

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,6 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout Repository'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: 'Dependency Review'
-      uses: actions/dependency-review-action@v2
+      uses: actions/dependency-review-action@v4

--- a/.github/workflows/inactive-pr.yml
+++ b/.github/workflows/inactive-pr.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read # Needed to checkout the repository
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Run inactivity script
       env:

--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Add external label only for develop PRs
       env:

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Check PR description
       env:
         PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -32,7 +32,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
@@ -41,22 +41,22 @@ jobs:
         dotnet: true
         haskell: true
         large-packages: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         # internal Python tests require Python 3.12
         python-version: '3.12'
         check-latest: true
         cache: 'pip'
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
         check-latest: true
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: "1.12.2"
         terraform_wrapper: false
     - run: make install-dev-deps
-    - uses: terraform-linters/setup-tflint@v4
+    - uses: terraform-linters/setup-tflint@v6
       with:
         tflint_version: v0.49.0
     - run: tflint --init
@@ -69,7 +69,7 @@ jobs:
   pre-commit-highest-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@main
       with:
@@ -78,23 +78,23 @@ jobs:
         dotnet: true
         haskell: true
         large-packages: true
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v6
       with:
         # the slurm-files Python requirements.txt requires updating
         # to enable 3.12+ compatibility
         python-version: '3.11'
         check-latest: true
         cache: 'pip'
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.24'
         check-latest: true
-    - uses: hashicorp/setup-terraform@v3
+    - uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: "1.12.2"
         terraform_wrapper: false
     - run: make install-dev-deps
-    - uses: terraform-linters/setup-tflint@v4
+    - uses: terraform-linters/setup-tflint@v6
       with:
         tflint_version: v0.49.0
     - run: tflint --init

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -49,7 +49,7 @@ jobs:
         cache: 'pip'
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         check-latest: true
     - uses: hashicorp/setup-terraform@v4
       with:
@@ -87,7 +87,7 @@ jobs:
         cache: 'pip'
     - uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         check-latest: true
     - uses: hashicorp/setup-terraform@v4
       with:


### PR DESCRIPTION
Upgraded various GitHub Actions in workflows to versions compatible with Node 24 to address the deprecation of Node 20.

Actions upgraded:
- actions/checkout to v6
- actions/dependency-review-action to v4
- actions/stale to v10
- actions/setup-python to v6
- actions/setup-go to v6
- hashicorp/setup-terraform to v4
- terraform-linters/setup-tflint to v6

**Note:**
No updates are needed for customer environments. The GitHub warning about Node 20 deprecation is strictly a CI/CD infrastructure concern for this repository's development pipeline.
* The `cluster-toolkit` itself is compiled into Go binaries, Python scripts, and Terraform modules. It does not run Node.js in the deployed customer environments.
* The Node.js runtime is only used by the GitHub Actions runners to execute linters, formatting checks, and tests during Pull Request validation.
