### PR TITLE
Slurm ha controller (adoptiong MIGs for controller)

### DIFF
--- a/community/examples/hpc-slurm-ha.yaml
+++ b/community/examples/hpc-slurm-ha.yaml
@@ -161,6 +161,7 @@ deployment_groups:
     use: [debug_partition]
     settings:
       enable_backup_controller: true
+      controller_ha_type: regional
       slurm_cluster_name: hpcslurmha
       backup_zone: us-central1-f
       # Disable PD state disk, rely on /var/spool/slurm filestore share

--- a/community/examples/hpc-slurm-ha.yaml
+++ b/community/examples/hpc-slurm-ha.yaml
@@ -21,6 +21,7 @@ vars:
   deployment_name: hpcslurmha
   region: us-central1
   zone: us-central1-a
+  enable_slurm_auth: true
 
 terraform_backend_defaults:
   type: gcs

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -88,6 +88,7 @@ To enable High Availability:
    Filestore, NFS) that is mounted on both controllers at `/var/spool/slurm`.
 4. Configure the Managed Instance Group distribution type using `controller_ha_type`
    (set to either `"zonal"` or `"regional"`, defaults to `"zonal"`).
+5. Provide at least two static IP addresses in `static_ips` (one for the primary controller and one for the backup controller).
 
 > **CRITICAL**: The `StateSaveLocation` MUST be a shared network filesystem
 > (like Filestore or NFS) that supports simultaneous read/write access from both
@@ -107,6 +108,9 @@ To enable High Availability:
     enable_backup_controller: true
     controller_ha_type: regional
     controller_state_disk: null
+    static_ips:
+    - 10.80.0.10
+    - 10.80.0.11
     network_storage:
     - server_ip: $(controller_fs.network_storage.server_ip)
       remote_mount: $(controller_fs.network_storage.remote_mount)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -89,6 +89,7 @@ To enable High Availability:
 4. Configure the Managed Instance Group distribution type using `controller_ha_type`
    (set to either `"zonal"` or `"regional"`, defaults to `"zonal"`).
 5. Provide at least two static IP addresses in `static_ips` (one for the primary controller and one for the backup controller).
+6. Configure an external database (`cloudsql`) to manage Slurm accounting and state across the controllers.
 
 > **CRITICAL**: The `StateSaveLocation` MUST be a shared network filesystem
 > (like Filestore or NFS) that supports simultaneous read/write access from both
@@ -111,6 +112,11 @@ To enable High Availability:
     static_ips:
     - 10.80.0.10
     - 10.80.0.11
+    cloudsql:
+      server_ip: $(slurm_db.cloudsql.server_ip)
+      user: $(slurm_db.cloudsql.user)
+      password: $(slurm_db.cloudsql.password)
+      db_name: $(slurm_db.cloudsql.db_name)
     network_storage:
     - server_ip: $(controller_fs.network_storage.server_ip)
       remote_mount: $(controller_fs.network_storage.remote_mount)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -61,7 +61,10 @@ The following are examples of updates that can be made to a running cluster:
 
 The `schedmd-slurm-gcp-v6-controller` module supports High Availability (HA) for
 the Slurm controller. This feature deploys a secondary "Backup" controller that
-allows the cluster to continue operating if the primary controller fails.
+allows the cluster to continue operating if the primary controller fails. The module
+manages these controllers using a Google Compute Managed Instance Group (MIG).
+By default, the MIG is **zonal** but can be configured as **regional** to increase
+fault tolerance across multiple zones.
 
 ### Architecture
 
@@ -83,6 +86,8 @@ To enable High Availability:
    disk.
 3. Ensure `StateSaveLocation` points to a shared network mount (e.g.,
    Filestore, NFS) that is mounted on both controllers at `/var/spool/slurm`.
+4. Configure the Managed Instance Group distribution type using `controller_ha_type`
+   (set to either `"zonal"` or `"regional"`, defaults to `"zonal"`).
 
 > **CRITICAL**: The `StateSaveLocation` MUST be a shared network filesystem
 > (like Filestore or NFS) that supports simultaneous read/write access from both
@@ -100,7 +105,7 @@ To enable High Availability:
   - homefs
   settings:
     enable_backup_controller: true
-    backup_machine_type: c2-standard-8
+    controller_ha_type: regional
     controller_state_disk: null
     network_storage:
     - server_ip: $(controller_fs.network_storage.server_ip)
@@ -343,7 +348,6 @@ limitations under the License.
 | <a name="module_login"></a> [login](#module\_login) | ../../internal/slurm-gcp/login | n/a |
 | <a name="module_nodeset_cleanup"></a> [nodeset\_cleanup](#module\_nodeset\_cleanup) | ./modules/cleanup_compute | n/a |
 | <a name="module_nodeset_cleanup_tpu"></a> [nodeset\_cleanup\_tpu](#module\_nodeset\_cleanup\_tpu) | ./modules/cleanup_tpu | n/a |
-| <a name="module_slurm_backup_controller_template"></a> [slurm\_backup\_controller\_template](#module\_slurm\_backup\_controller\_template) | ../../internal/slurm-gcp/instance_template | n/a |
 | <a name="module_slurm_controller_template"></a> [slurm\_controller\_template](#module\_slurm\_controller\_template) | ../../internal/slurm-gcp/instance_template | n/a |
 | <a name="module_slurm_files"></a> [slurm\_files](#module\_slurm\_files) | ./modules/slurm_files | n/a |
 | <a name="module_slurm_nodeset_template"></a> [slurm\_nodeset\_template](#module\_slurm\_nodeset\_template) | ../../internal/slurm-gcp/instance_template | n/a |
@@ -353,9 +357,13 @@ limitations under the License.
 
 | Name | Type |
 | ---- | ---- |
-| [google-beta_google_compute_instance_from_template.backup_controller](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_from_template) | resource |
 | [google-beta_google_compute_instance_from_template.controller](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_from_template) | resource |
+| [google_compute_address.controller_ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_disk.controller_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_instance_group_manager.controller_zonal_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
+| [google_compute_per_instance_config.controller_zonal_stateful_ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
+| [google_compute_region_instance_group_manager.controller_regional_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
+| [google_compute_region_per_instance_config.controller_regional_stateful_ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_per_instance_config) | resource |
 | [google_secret_manager_secret.cloudsql](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_iam_member.cloudsql_secret_accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_secret_manager_secret_version.cloudsql_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
@@ -372,7 +380,6 @@ limitations under the License.
 | <a name="input_additional_networks"></a> [additional\_networks](#input\_additional\_networks) | Additional network interface details for the controller, if any. | <pre>list(object({<br/>    access_config = optional(list(object({<br/>      nat_ip       = string<br/>      network_tier = string<br/>    })), [])<br/>    alias_ip_range = optional(list(object({<br/>      ip_cidr_range         = string<br/>      subnetwork_range_name = string<br/>    })), [])<br/>    ipv6_access_config = optional(list(object({<br/>      network_tier = string<br/>    })), [])<br/>    network            = optional(string)<br/>    network_ip         = optional(string, "")<br/>    nic_type           = optional(string)<br/>    queue_count        = optional(number)<br/>    stack_type         = optional(string)<br/>    subnetwork         = optional(string)<br/>    subnetwork_project = optional(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_advanced_machine_features"></a> [advanced\_machine\_features](#input\_advanced\_machine\_features) | See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#nested_advanced_machine_features | <pre>object({<br/>    enable_nested_virtualization = optional(bool)<br/>    threads_per_core             = optional(number)<br/>    turbo_mode                   = optional(string)<br/>    visible_core_count           = optional(number)<br/>    performance_monitoring_unit  = optional(string)<br/>    enable_uefi_networking       = optional(bool)<br/>  })</pre> | <pre>{<br/>  "threads_per_core": 1<br/>}</pre> | no |
 | <a name="input_allow_automatic_updates"></a> [allow\_automatic\_updates](#input\_allow\_automatic\_updates) | If false, disables automatic system package updates on the created instances.  This feature is<br/>only available on supported images (or images derived from them).  For more details, see<br/>https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates | `bool` | `true` | no |
-| <a name="input_backup_machine_type"></a> [backup\_machine\_type](#input\_backup\_machine\_type) | Machine type for the backup controller. If null, uses the same as the primary controller. | `string` | `null` | no |
 | <a name="input_backup_zone"></a> [backup\_zone](#input\_backup\_zone) | Zone for the backup controller. If null, it will be placed in the same region, potentially different zone. | `string` | `null` | no |
 | <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Configures the network interface card and the maximum egress bandwidth for VMs.<br/>  - Setting `platform_default` respects the Google Cloud Platform API default values for networking.<br/>  - Setting `virtio_enabled` explicitly selects the VirtioNet network adapter.<br/>  - Setting `gvnic_enabled` selects the gVNIC network adapter (without Tier 1 high bandwidth).<br/>  - Setting `tier_1_enabled` selects both the gVNIC adapter and Tier 1 high bandwidth networking.<br/>  - Note: both gVNIC and Tier 1 networking require a VM image with gVNIC support as well as specific VM families and shapes.<br/>  - See [official docs](https://cloud.google.com/compute/docs/networking/configure-vm-with-high-bandwidth-configuration) for more details. | `string` | `"platform_default"` | no |
 | <a name="input_bucket_dir"></a> [bucket\_dir](#input\_bucket\_dir) | Bucket directory for cluster files to be put into. If not specified, then one will be chosen based on slurm\_cluster\_name. | `string` | `null` | no |
@@ -383,6 +390,7 @@ limitations under the License.
 | <a name="input_cloudsql"></a> [cloudsql](#input\_cloudsql) | Use this database instead of the one on the controller.<br/>  server\_ip : Address of the database server.<br/>  user      : The user to access the database as.<br/>  password  : The password, given the user, to access the given database. (sensitive)<br/>  db\_name   : The database to access.<br/>  user\_managed\_replication : The list of location and (optional) kms\_key\_name for secret | <pre>object({<br/>    server_ip = string<br/>    user      = string<br/>    password  = string # sensitive<br/>    db_name   = string<br/>    user_managed_replication = optional(list(object({<br/>      location     = string<br/>      kms_key_name = optional(string)<br/>    })), [])<br/>  })</pre> | `null` | no |
 | <a name="input_compute_startup_script"></a> [compute\_startup\_script](#input\_compute\_startup\_script) | DEPRECATED: `compute_startup_script` has been deprecated.<br/>Use `startup_script` of nodeset module instead. | `any` | `null` | no |
 | <a name="input_compute_startup_scripts_timeout"></a> [compute\_startup\_scripts\_timeout](#input\_compute\_startup\_scripts\_timeout) | The timeout (seconds) applied to each startup script in compute nodes. If<br/>any script exceeds this timeout, then the instance setup process is considered<br/>failed and handled accordingly.<br/><br/>NOTE: When set to 0, the timeout is considered infinite and thus disabled. | `number` | `300` | no |
+| <a name="input_controller_ha_type"></a> [controller\_ha\_type](#input\_controller\_ha\_type) | Type of Managed Instance Group for controllers: 'zonal' or 'regional'. | `string` | `"zonal"` | no |
 | <a name="input_controller_network_attachment"></a> [controller\_network\_attachment](#input\_controller\_network\_attachment) | SelfLink for NetworkAttachment to be attached to the controller, if any. | `string` | `null` | no |
 | <a name="input_controller_project_id"></a> [controller\_project\_id](#input\_controller\_project\_id) | Optionally. Provision controller and config bucket in the different project | `string` | `null` | no |
 | <a name="input_controller_startup_script"></a> [controller\_startup\_script](#input\_controller\_startup\_script) | Startup script used by the controller VM. | `string` | `"# no-op"` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -269,6 +269,10 @@ resource "google_compute_region_instance_group_manager" "controller_regional_mig
     ignore_changes = [
       target_size,
     ]
+    precondition {
+      condition     = var.controller_ha_type != "regional" || var.zone != local.backup_zone
+      error_message = "For a regional controller HA deployment, 'zone' and 'backup_zone' must be different."
+    }
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -57,29 +57,20 @@ locals {
   controller_project_id = coalesce(var.controller_project_id, var.project_id)
 
   # HA Locals
-  backup_machine_type          = coalesce(var.backup_machine_type, var.machine_type)
   backup_zone                  = coalesce(var.backup_zone, var.zone)
-  slurm_backup_controller_name = var.enable_backup_controller ? "${local.slurm_cluster_name}-backup-controller" : ""
+  slurm_backup_controller_name = var.enable_backup_controller ? "${local.slurm_cluster_name}-controller-1" : ""
 
   # Merge HA metadata
   metadata = merge(
     local.disable_automatic_updates_metadata,
     var.metadata,
     local.universe_domain,
-    {
-      slurm_ha_role                = "primary"
+    var.enable_backup_controller ? {
+      slurm_ha_role                = "dynamic"
       slurm_backup_controller_name = local.slurm_backup_controller_name
-    }
-  )
-
-  backup_metadata = merge(
-    local.disable_automatic_updates_metadata,
-    var.metadata,
-    local.universe_domain,
-    {
-      slurm_ha_role       = "backup"
-      slurm_cluster_name  = local.slurm_cluster_name
-      slurm_instance_role = "controller"
+      } : {
+      slurm_ha_role                = "primary"
+      slurm_backup_controller_name = ""
     }
   )
 }
@@ -160,6 +151,7 @@ module "slurm_controller_template" {
 # INSTANCE
 resource "google_compute_instance_from_template" "controller" {
   provider = google-beta
+  count    = var.enable_backup_controller ? 0 : 1
 
   name                     = "${local.slurm_cluster_name}-controller"
   project                  = local.controller_project_id
@@ -226,83 +218,112 @@ resource "google_compute_instance_from_template" "controller" {
   }
 }
 
-# BACKUP CONTROLLER TEMPLATE
-module "slurm_backup_controller_template" {
-  source = "../../internal/slurm-gcp/instance_template"
-  count  = var.enable_backup_controller ? 1 : 0
-
-  project_id          = local.controller_project_id
-  region              = var.region
-  slurm_instance_role = "controller"
-  slurm_cluster_name  = local.slurm_cluster_name
-  labels              = local.labels
-
-  disk_auto_delete           = var.disk_auto_delete
-  disk_labels                = merge(var.disk_labels, local.labels)
-  disk_size_gb               = var.disk_size_gb
-  disk_type                  = var.disk_type
-  disk_resource_manager_tags = var.disk_resource_manager_tags
-  additional_disks           = local.additional_disks
-  bandwidth_tier             = var.bandwidth_tier
-  slurm_bucket_path          = module.slurm_files.slurm_bucket_path
-  can_ip_forward             = var.can_ip_forward
-  advanced_machine_features  = var.advanced_machine_features
-  resource_manager_tags      = var.resource_manager_tags
-
-  enable_confidential_vm   = var.enable_confidential_vm
-  enable_oslogin           = var.enable_oslogin
-  enable_shielded_vm       = var.enable_shielded_vm
-  shielded_instance_config = var.shielded_instance_config
-
-  gpu = one(module.gpu.guest_accelerator)
-
-  machine_type     = local.backup_machine_type
-  metadata         = local.backup_metadata
-  min_cpu_platform = var.min_cpu_platform
-
-  on_host_maintenance = var.on_host_maintenance
-  preemptible         = var.preemptible
-  service_account     = local.service_account
-
-  source_image_family  = local.source_image_family
-  source_image_project = local.source_image_project_normalized
-  source_image         = local.source_image
-
-  subnetwork = var.subnetwork_self_link
-
-  tags = concat([local.slurm_cluster_name], var.tags)
-}
-
-# BACKUP INSTANCE
-resource "google_compute_instance_from_template" "backup_controller" {
-  provider = google-beta
-  count    = var.enable_backup_controller ? 1 : 0
-
-  name                     = local.slurm_backup_controller_name
-  project                  = local.controller_project_id
-  zone                     = local.backup_zone
-  source_instance_template = module.slurm_backup_controller_template[0].self_link
-  labels                   = module.slurm_backup_controller_template[0].labels
-
-  allow_stopping_for_update = true
-
-  network_interface {
-    dynamic "access_config" {
-      for_each = var.enable_controller_public_ips ? ["unit"] : []
-      content {
-        nat_ip       = null
-        network_tier = null
-      }
-    }
-    network_ip = length(var.static_ips) >= 2 ? var.static_ips[1] : ""
-    subnetwork = var.subnetwork_self_link
-    stack_type = var.subnetwork_stack_type
+# ZONAL INSTANCE GROUP MANAGER (deployed if ha_type is zonal)
+resource "google_compute_instance_group_manager" "controller_zonal_mig" {
+  count              = (var.enable_backup_controller && var.controller_ha_type == "zonal") ? 1 : 0
+  name               = "${local.slurm_cluster_name}-controller-mig"
+  base_instance_name = "${local.slurm_cluster_name}-controller"
+  zone               = var.zone
+  project            = local.controller_project_id
+  target_size        = 0
+  version {
+    instance_template = module.slurm_controller_template.self_link
+  }
+  update_policy {
+    type                  = "PROACTIVE"
+    minimal_action        = "REPLACE"
+    replacement_method    = "RECREATE"
+    max_surge_fixed       = 0
+    max_unavailable_fixed = 1
   }
 
-  dynamic "network_interface" {
-    for_each = var.controller_network_attachment != null ? [1] : []
-    content {
-      network_attachment = var.controller_network_attachment
+  lifecycle {
+    ignore_changes = [
+      target_size,
+    ]
+  }
+}
+
+# REGIONAL INSTANCE GROUP MANAGER (deployed if ha_type is regional)
+resource "google_compute_region_instance_group_manager" "controller_regional_mig" {
+  count                     = (var.enable_backup_controller && var.controller_ha_type == "regional") ? 1 : 0
+  name                      = "${local.slurm_cluster_name}-controller-mig"
+  base_instance_name        = "${local.slurm_cluster_name}-controller"
+  region                    = var.region
+  project                   = local.controller_project_id
+  distribution_policy_zones = [var.zone, local.backup_zone]
+  target_size               = 0
+  version {
+    instance_template = module.slurm_controller_template.self_link
+  }
+  update_policy {
+    type                         = "PROACTIVE"
+    minimal_action               = "REPLACE"
+    replacement_method           = "RECREATE"
+    instance_redistribution_type = "NONE"
+    max_surge_fixed              = 0
+    max_unavailable_fixed        = 2
+  }
+
+  lifecycle {
+    ignore_changes = [
+      target_size,
+    ]
+  }
+}
+
+resource "google_compute_address" "controller_ips" {
+  for_each     = var.enable_backup_controller ? toset(var.static_ips) : []
+  project      = local.controller_project_id
+  name         = "${local.slurm_cluster_name}-controller-ip-${replace(each.value, ".", "-")}"
+  address_type = "INTERNAL"
+  subnetwork   = var.subnetwork_self_link
+  address      = each.value
+  region       = var.region
+}
+
+locals {
+  # Maps pre-allocated static IPs to instance suffixes (e.g. 0 and 1)
+  mig_instances = var.enable_backup_controller ? {
+    "${local.slurm_cluster_name}-controller-0" = var.static_ips[0]
+    "${local.slurm_cluster_name}-controller-1" = var.static_ips[1]
+  } : {}
+}
+
+# STATEFUL PER-INSTANCE IP CONFIGURATION (ZONAL)
+resource "google_compute_per_instance_config" "controller_zonal_stateful_ips" {
+  for_each               = (var.enable_backup_controller && var.controller_ha_type == "zonal") ? local.mig_instances : {}
+  project                = local.controller_project_id
+  instance_group_manager = google_compute_instance_group_manager.controller_zonal_mig[0].name
+  zone                   = var.zone
+  name                   = each.key
+
+  preserved_state {
+    internal_ip {
+      interface_name = "nic0"
+      auto_delete    = "NEVER"
+      ip_address {
+        address = google_compute_address.controller_ips[each.value].self_link
+      }
+    }
+  }
+}
+
+# STATEFUL PER-INSTANCE IP CONFIGURATION (REGIONAL)
+resource "google_compute_region_per_instance_config" "controller_regional_stateful_ips" {
+  for_each                      = (var.enable_backup_controller && var.controller_ha_type == "regional") ? local.mig_instances : {}
+  project                       = local.controller_project_id
+  region_instance_group_manager = google_compute_region_instance_group_manager.controller_regional_mig[0].name
+  region                        = var.region
+  name                          = each.key
+
+  preserved_state {
+    internal_ip {
+      interface_name = "nic0"
+      auto_delete    = "NEVER"
+      ip_address {
+        address = google_compute_address.controller_ips[each.value].self_link
+      }
     }
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -46,5 +46,5 @@ module "login" {
 
   # trigger replacement of login nodes when the controller instance is replaced
   # Needed for re-mounting volumes hosted on controller
-  replace_trigger = google_compute_instance_from_template.controller.self_link
+  replace_trigger = var.enable_backup_controller ? module.slurm_controller_template.self_link : google_compute_instance_from_template.controller[0].self_link
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/login.tf
@@ -46,5 +46,5 @@ module "login" {
 
   # trigger replacement of login nodes when the controller instance is replaced
   # Needed for re-mounting volumes hosted on controller
-  replace_trigger = var.enable_backup_controller ? module.slurm_controller_template.self_link : google_compute_instance_from_template.controller[0].self_link
+  replace_trigger = var.enable_backup_controller ? module.slurm_controller_template.self_link : one(google_compute_instance_from_template.controller[*].self_link)
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -79,9 +79,9 @@ locals {
     google_app_cred_path          = var.enable_hybrid ? local.google_app_cred_path : null
     output_dir                    = var.enable_hybrid ? local.output_dir : null
     install_dir                   = var.enable_hybrid ? local.install_dir : null
-    slurm_control_host            = var.slurm_control_host != null ? var.slurm_control_host : (var.enable_hybrid ? var.slurm_control_host : null)
+    slurm_control_host            = var.slurm_control_host
     slurm_control_host_port       = var.enable_hybrid ? local.slurm_control_host_port : null
-    slurm_control_addr            = var.slurm_control_addr != null ? var.slurm_control_addr : (var.enable_hybrid ? var.slurm_control_addr : null)
+    slurm_control_addr            = var.slurm_control_addr
     slurm_bin_dir                 = var.enable_hybrid ? local.slurm_bin_dir : null
     slurm_log_dir                 = var.enable_hybrid ? local.slurm_log_dir : null
     controller_network_attachment = var.controller_network_attachment

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -80,7 +80,7 @@ locals {
     output_dir                    = var.enable_hybrid ? local.output_dir : null
     install_dir                   = var.enable_hybrid ? local.install_dir : null
     slurm_control_host            = var.slurm_control_host
-    slurm_control_host_port       = var.enable_hybrid ? local.slurm_control_host_port : null
+    slurm_control_host_port       = local.slurm_control_host_port
     slurm_control_addr            = var.slurm_control_addr
     slurm_bin_dir                 = var.enable_hybrid ? local.slurm_bin_dir : null
     slurm_log_dir                 = var.enable_hybrid ? local.slurm_log_dir : null

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/main.tf
@@ -79,9 +79,9 @@ locals {
     google_app_cred_path          = var.enable_hybrid ? local.google_app_cred_path : null
     output_dir                    = var.enable_hybrid ? local.output_dir : null
     install_dir                   = var.enable_hybrid ? local.install_dir : null
-    slurm_control_host            = var.enable_hybrid ? var.slurm_control_host : null
+    slurm_control_host            = var.slurm_control_host != null ? var.slurm_control_host : (var.enable_hybrid ? var.slurm_control_host : null)
     slurm_control_host_port       = var.enable_hybrid ? local.slurm_control_host_port : null
-    slurm_control_addr            = var.enable_hybrid ? var.slurm_control_addr : null
+    slurm_control_addr            = var.slurm_control_addr != null ? var.slurm_control_addr : (var.enable_hybrid ? var.slurm_control_addr : null)
     slurm_bin_dir                 = var.enable_hybrid ? local.slurm_bin_dir : null
     slurm_log_dir                 = var.enable_hybrid ? local.slurm_log_dir : null
     controller_network_attachment = var.controller_network_attachment

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -798,6 +798,14 @@ def main():
                 role = "backup_controller"
     except Exception as e:
         log.warning(f"Failed to read slurm_ha_role metadata: {e}")
+        if lkp.cfg.get("slurm_backup_controller_name"):
+            hostname = socket.gethostname()
+            short_hostname = hostname.split(".")[0]
+            if short_hostname.endswith("-0"):
+                log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
+            else:
+                log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
+                role = "backup_controller"
 
     {
         "controller": lambda: setup_controller(is_primary=True),

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -735,11 +735,16 @@ def populate_etc_hosts(lkp: util.Lookup) -> None:
     new_lines = []
     for line in lines:
         stripped = line.strip()
+        if stripped == "# Added by Slurm HA Setup":
+            continue
         if not stripped or stripped.startswith("#"):
             new_lines.append(line)
             continue
         parts = stripped.split()
-        if len(parts) > 1 and any(name in parts[1:] for name in names_to_remove):
+        if len(parts) > 1 and any(
+            any(p == name or p.startswith(f"{name}.") for p in parts[1:])
+            for name in names_to_remove
+        ):
             continue
         new_lines.append(line)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -25,6 +25,7 @@ import time
 import yaml
 from pathlib import Path
 import functools
+import socket
 
 import util
 from util import (
@@ -492,6 +493,19 @@ def setup_controller(is_primary: bool):
     if not lkp.cfg.cloudsql_secret:
         configure_mysql(lkp)
 
+    if not is_primary:
+        db_sentinel = Path(slurmdirs.state / "db_initialized")
+        timeout = 300
+        snooze = 10
+        retries = int(timeout / snooze)
+        log.info("Waiting for database initialization to complete on primary...")
+        for _ in range(retries):
+            if db_sentinel.exists():
+                break
+            time.sleep(snooze)
+        if not db_sentinel.exists():
+            log.warning("Timed out waiting for database initialization sentinel on primary. Proceeding anyway.")
+
     run("systemctl enable slurmdbd", timeout=30)
     run("systemctl restart slurmdbd", timeout=30)
 
@@ -514,6 +528,14 @@ def setup_controller(is_primary: bool):
     if clustername_file.exists():
         log.info(f"Removing {clustername_file} to prevent cluster ID mismatch")
         clustername_file.unlink()
+
+    if is_primary:
+        db_sentinel = Path(slurmdirs.state / "db_initialized")
+        try:
+            db_sentinel.touch()
+            util.chown_slurm(db_sentinel)
+        except Exception as e:
+            log.warning(f"Failed to create database initialization sentinel: {e}")
 
     run("systemctl enable slurmctld", timeout=30)
     run("systemctl restart slurmctld", timeout=30)
@@ -690,6 +712,36 @@ def setup_cloud_ops() -> None:
             raise
 
 
+def populate_etc_hosts(lkp: util.Lookup) -> None:
+    """Populate static IP mappings for controllers in /etc/hosts to bypass DNS propagation latency."""
+    log.info("Populating /etc/hosts with controller IP mappings")
+    primary_name = lkp.cfg.get("slurm_control_host")
+    primary_ip = lkp.cfg.get("slurm_control_addr")
+    backup_name = lkp.cfg.get("slurm_backup_controller_name")
+    backup_ip = lkp.cfg.get("slurm_backup_controller_ip")
+
+    hosts_path = Path("/etc/hosts")
+    if not hosts_path.exists():
+        log.warning("/etc/hosts does not exist, skipping population")
+        return
+
+    hosts_content = hosts_path.read_text()
+    new_entries = []
+
+    if primary_ip and primary_name and primary_ip not in hosts_content:
+        new_entries.append(f"{primary_ip} {primary_name}")
+    if backup_ip and backup_name and backup_ip not in hosts_content:
+        new_entries.append(f"{backup_ip} {backup_name}")
+
+    if new_entries:
+        try:
+            with open(hosts_path, "a") as f:
+                f.write("\n# Added by Slurm HA Setup\n" + "\n".join(new_entries) + "\n")
+            log.info(f"Added controller hosts mapping to /etc/hosts: {new_entries}")
+        except Exception as e:
+            log.error(f"Failed to write to /etc/hosts: {e}")
+
+
 def main():
     start_motd()
 
@@ -706,6 +758,8 @@ def main():
             log.exception(f"unexpected error while fetching config, sleeping for {sleep_seconds}s")
         time.sleep(sleep_seconds)
     log.info("Config fetched")
+    lkp = lookup()
+    populate_etc_hosts(lkp)
     setup_cloud_ops()
     configure_dirs()
     # call the setup function for the instance type
@@ -714,8 +768,15 @@ def main():
         ha_role = util.instance_metadata("attributes/slurm_ha_role", silent=True)
         if ha_role == "backup":
             role = "backup_controller"
-    except:
-        pass
+        elif ha_role == "dynamic":
+            hostname = socket.gethostname()
+            if hostname.endswith("-0"):
+                log.info(f"Dynamic HA: Hostname '{hostname}' ends with '-0'. Assuming Primary role.")
+            else:
+                log.info(f"Dynamic HA: Hostname '{hostname}' does not end with '-0'. Assuming Standby Backup role.")
+                role = "backup_controller"
+    except Exception as e:
+        log.warning(f"Failed to read slurm_ha_role metadata: {e}")
 
     {
         "controller": lambda: setup_controller(is_primary=True),

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -784,28 +784,29 @@ def main():
     configure_dirs()
     # call the setup function for the instance type
     role = lookup().instance_role
-    try:
-        ha_role = util.instance_metadata("attributes/slurm_ha_role", silent=True)
-        if ha_role == "backup":
-            role = "backup_controller"
-        elif ha_role == "dynamic":
-            hostname = socket.gethostname()
-            short_hostname = hostname.split(".")[0]
-            if short_hostname.endswith("-0"):
-                log.info(f"Dynamic HA: Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
-            else:
-                log.info(f"Dynamic HA: Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
+    if role == "controller":
+        try:
+            ha_role = util.instance_metadata("attributes/slurm_ha_role", silent=True)
+            if ha_role == "backup":
                 role = "backup_controller"
-    except Exception as e:
-        log.warning(f"Failed to read slurm_ha_role metadata: {e}")
-        if lkp.cfg.get("slurm_backup_controller_name"):
-            hostname = socket.gethostname()
-            short_hostname = hostname.split(".")[0]
-            if short_hostname.endswith("-0"):
-                log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
-            else:
-                log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
-                role = "backup_controller"
+            elif ha_role == "dynamic":
+                hostname = socket.gethostname()
+                short_hostname = hostname.split(".")[0]
+                if short_hostname.endswith("-0"):
+                    log.info(f"Dynamic HA: Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
+                else:
+                    log.info(f"Dynamic HA: Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
+                    role = "backup_controller"
+        except Exception as e:
+            log.warning(f"Failed to read slurm_ha_role metadata: {e}")
+            if lkp.cfg.get("slurm_backup_controller_name"):
+                hostname = socket.gethostname()
+                short_hostname = hostname.split(".")[0]
+                if short_hostname.endswith("-0"):
+                    log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
+                else:
+                    log.info(f"Dynamic HA (Fallback): Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
+                    role = "backup_controller"
 
     {
         "controller": lambda: setup_controller(is_primary=True),

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup.py
@@ -725,19 +725,34 @@ def populate_etc_hosts(lkp: util.Lookup) -> None:
         log.warning("/etc/hosts does not exist, skipping population")
         return
 
-    hosts_content = hosts_path.read_text()
-    new_entries = []
+    try:
+        lines = hosts_path.read_text().splitlines()
+    except Exception as e:
+        log.error(f"Failed to read /etc/hosts: {e}")
+        return
 
-    if primary_ip and primary_name and primary_ip not in hosts_content:
+    names_to_remove = {name for name in (primary_name, backup_name) if name}
+    new_lines = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            new_lines.append(line)
+            continue
+        parts = stripped.split()
+        if len(parts) > 1 and any(name in parts[1:] for name in names_to_remove):
+            continue
+        new_lines.append(line)
+
+    new_entries = []
+    if primary_ip and primary_name:
         new_entries.append(f"{primary_ip} {primary_name}")
-    if backup_ip and backup_name and backup_ip not in hosts_content:
+    if backup_ip and backup_name:
         new_entries.append(f"{backup_ip} {backup_name}")
 
     if new_entries:
         try:
-            with open(hosts_path, "a") as f:
-                f.write("\n# Added by Slurm HA Setup\n" + "\n".join(new_entries) + "\n")
-            log.info(f"Added controller hosts mapping to /etc/hosts: {new_entries}")
+            hosts_path.write_text("\n".join(new_lines) + "\n\n# Added by Slurm HA Setup\n" + "\n".join(new_entries) + "\n")
+            log.info(f"Updated /etc/hosts with current controller mappings: {new_entries}")
         except Exception as e:
             log.error(f"Failed to write to /etc/hosts: {e}")
 
@@ -770,10 +785,11 @@ def main():
             role = "backup_controller"
         elif ha_role == "dynamic":
             hostname = socket.gethostname()
-            if hostname.endswith("-0"):
-                log.info(f"Dynamic HA: Hostname '{hostname}' ends with '-0'. Assuming Primary role.")
+            short_hostname = hostname.split(".")[0]
+            if short_hostname.endswith("-0"):
+                log.info(f"Dynamic HA: Hostname '{short_hostname}' ends with '-0'. Assuming Primary role.")
             else:
-                log.info(f"Dynamic HA: Hostname '{hostname}' does not end with '-0'. Assuming Standby Backup role.")
+                log.info(f"Dynamic HA: Hostname '{short_hostname}' does not end with '-0'. Assuming Standby Backup role.")
                 role = "backup_controller"
     except Exception as e:
         log.warning(f"Failed to read slurm_ha_role metadata: {e}")

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -57,7 +57,7 @@ output "instructions" {
   value       = <<-EOT
     ${var.enable_slurm_auth ? "" : "DEPRECATION NOTICE: Support for MUNGE-based authentication is DEPRECATING and scheduled for complete removal on July 31, 2026. Please migrate to Slurm Native Authentication by setting enable_slurm_auth: true.\n"}
     To SSH to the controller (may need to add '--tunnel-through-iap'):
-      gcloud compute ssh ${var.enable_backup_controller ? "projects/${local.controller_project_id}/zones/${var.zone}/instances/${local.slurm_cluster_name}-controller-0" : google_compute_instance_from_template.controller[0].self_link}
+      gcloud compute ssh ${var.enable_backup_controller ? "${local.slurm_cluster_name}-controller-0" : google_compute_instance_from_template.controller[0].self_link}
     
     If you are using cloud ops agent with this deployment,
     you can use the following command to see the logs for the entire cluster or any particular VM host:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -19,7 +19,7 @@ output "slurm_cluster_name" {
 
 output "slurm_controller_instance" {
   description = "Compute instance of controller node"
-  value       = google_compute_instance_from_template.controller
+  value       = var.enable_backup_controller ? null : google_compute_instance_from_template.controller[0]
 }
 
 output "slurm_login_instances" {
@@ -57,7 +57,7 @@ output "instructions" {
   value       = <<-EOT
     ${var.enable_slurm_auth ? "" : "DEPRECATION NOTICE: Support for MUNGE-based authentication is DEPRECATING and scheduled for complete removal on July 31, 2026. Please migrate to Slurm Native Authentication by setting enable_slurm_auth: true.\n"}
     To SSH to the controller (may need to add '--tunnel-through-iap'):
-      gcloud compute ssh ${google_compute_instance_from_template.controller.self_link}
+      gcloud compute ssh ${var.enable_backup_controller ? "projects/${local.controller_project_id}/zones/${var.zone}/instances/${local.slurm_cluster_name}-controller-0" : google_compute_instance_from_template.controller[0].self_link}
     
     If you are using cloud ops agent with this deployment,
     you can use the following command to see the logs for the entire cluster or any particular VM host:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/outputs.tf
@@ -19,7 +19,7 @@ output "slurm_cluster_name" {
 
 output "slurm_controller_instance" {
   description = "Compute instance of controller node"
-  value       = var.enable_backup_controller ? null : google_compute_instance_from_template.controller[0]
+  value       = one(google_compute_instance_from_template.controller)
 }
 
 output "slurm_login_instances" {
@@ -57,7 +57,7 @@ output "instructions" {
   value       = <<-EOT
     ${var.enable_slurm_auth ? "" : "DEPRECATION NOTICE: Support for MUNGE-based authentication is DEPRECATING and scheduled for complete removal on July 31, 2026. Please migrate to Slurm Native Authentication by setting enable_slurm_auth: true.\n"}
     To SSH to the controller (may need to add '--tunnel-through-iap'):
-      gcloud compute ssh ${var.enable_backup_controller ? "${local.slurm_cluster_name}-controller-0" : google_compute_instance_from_template.controller[0].self_link}
+      gcloud compute ssh ${var.enable_backup_controller ? "${local.slurm_cluster_name}-controller-0" : one(google_compute_instance_from_template.controller[*].self_link)}
     
     If you are using cloud ops agent with this deployment,
     you can use the following command to see the logs for the entire cluster or any particular VM host:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/slurm_files.tf
@@ -156,6 +156,8 @@ module "slurm_files" {
 
   project_id                    = var.project_id
   slurm_cluster_name            = local.slurm_cluster_name
+  slurm_control_host            = var.enable_backup_controller ? "${local.slurm_cluster_name}-controller-0" : null
+  slurm_control_addr            = var.enable_backup_controller && length(var.static_ips) >= 1 ? var.static_ips[0] : null
   slurm_backup_controller_name  = var.enable_backup_controller ? local.slurm_backup_controller_name : null
   slurm_backup_controller_ip    = var.enable_backup_controller && length(var.static_ips) >= 2 ? var.static_ips[1] : null
   bucket_dir                    = var.bucket_dir

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -92,8 +92,8 @@ variable "enable_backup_controller" {
   type        = bool
   default     = false
   validation {
-    condition     = var.enable_backup_controller == false || (anytrue([for s in var.network_storage : s.local_mount == "/var/spool/slurm"]) && var.controller_state_disk == null && length(var.static_ips) >= 2)
-    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null, network_storage must contain a shared mount for '/var/spool/slurm' to sync state, and at least 2 static_ips must be provided."
+    condition     = var.enable_backup_controller == false || (anytrue([for s in var.network_storage : s.local_mount == "/var/spool/slurm"]) && var.controller_state_disk == null && length(var.static_ips) >= 2 && var.cloudsql != null)
+    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null, network_storage must contain a shared mount for '/var/spool/slurm' to sync state, at least 2 static_ips must be provided, and an external database (cloudsql) must be configured."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -92,8 +92,8 @@ variable "enable_backup_controller" {
   type        = bool
   default     = false
   validation {
-    condition     = var.enable_backup_controller == false || (anytrue([for s in var.network_storage : s.local_mount == "/var/spool/slurm"]) && var.controller_state_disk == null)
-    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null and network_storage must contain a shared mount for '/var/spool/slurm' to sync state."
+    condition     = var.enable_backup_controller == false || (anytrue([for s in var.network_storage : s.local_mount == "/var/spool/slurm"]) && var.controller_state_disk == null && length(var.static_ips) >= 2)
+    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null, network_storage must contain a shared mount for '/var/spool/slurm' to sync state, and at least 2 static_ips must be provided."
   }
 }
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables.tf
@@ -92,15 +92,19 @@ variable "enable_backup_controller" {
   type        = bool
   default     = false
   validation {
-    condition     = var.enable_backup_controller == false || (length(var.network_storage) > 0 && var.controller_state_disk == null)
-    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null and network_storage must be provided (non-empty) to share state."
+    condition     = var.enable_backup_controller == false || (anytrue([for s in var.network_storage : s.local_mount == "/var/spool/slurm"]) && var.controller_state_disk == null)
+    error_message = "When enable_backup_controller is true, controller_state_disk must be set to null and network_storage must contain a shared mount for '/var/spool/slurm' to sync state."
   }
 }
 
-variable "backup_machine_type" {
-  description = "Machine type for the backup controller. If null, uses the same as the primary controller."
+variable "controller_ha_type" {
   type        = string
-  default     = null
+  default     = "zonal"
+  description = "Type of Managed Instance Group for controllers: 'zonal' or 'regional'."
+  validation {
+    condition     = contains(["zonal", "regional"], var.controller_ha_type)
+    error_message = "The controller_ha_type must be either 'zonal' or 'regional'."
+  }
 }
 
 variable "backup_zone" {


### PR DESCRIPTION
1. Control Plane Architecture (MIG Integration)
Zonal & Regional Schedulers: Introduced support for both zonal and regional HA deployments controlled via the controller_ha_type variable. Schedulers are distributed across zones to protect against single-zone outages.
Stateful IP Preservation: Integrated google_compute_per_instance_config (zonal) and google_compute_region_per_instance_config (regional). On VM recreation or auto-healing events, GCE automatically preserves the exact static IP bindings (controller-0 and controller-1) and persistent stateful templates.
Init Target Size: Configured target_size = 0 during MIG resource definition. This ensures instances are exclusively provisioned using the explicit per-instance config rules, preventing the generation of random-suffix helper VMs.


2. Networking & Host Resolution
FQDN Support: Refactored boot-time hostname checks in setup.py to isolate the short hostname before resolving node roles, ensuring compatibility with corporate DNS suffixes and FQDN networks.
Self-Cleaning /etc/hosts: Added intelligent regex cleanup logic to standard setup scripts. Reboots and VM recreations dynamically purge stale local hostname entries and update DNS entries cleanly without duplicate headers.
GCE Metadata Fallback: Added a local configuration checking safety fallback to setup.py. If the GCE Metadata Server is slow or rate-limiting on startup, the system extracts roles based on local configs and hostname endings, completely preventing split-brain database states.


3. Safety & Configuration Constraints
Upgrade Safety (MIG Update Policy):
Zonal MIG: Set max_unavailable_fixed = 1 for zero-downtime rolling upgrades.
Regional MIG: Configured max_unavailable_fixed = 2 to satisfy the GCP regional MIG API validation check requiring max_unavailable to be at least equal to the number of zones when using RECREATE.
Database & IP Validations: Enforced compile-time validation checks requiring var.cloudsql != null (external DB connection parameters) and at least 2 static IPs when enable_backup_controller is true.
Default Port Configuration: Assured slurm_control_host_port is always populated (defaulting to "6818"), eliminating potential null-parsing issues across client nodes.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
