### PR TITLE
docs: fix broken and malformed documentation links

### DIFF
--- a/community/cos-nvidia-bug-report/README.md
+++ b/community/cos-nvidia-bug-report/README.md
@@ -97,7 +97,7 @@ Before running the script, ensure you have:
 
 2. The GPU driver is installed on the GCE VM instance.
    * Please refer to
-        [COS's official documentation page](\(https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install\))
+        [COS's official documentation page](https://cloud.google.com/container-optimized-os/docs/how-to/run-gpus#install)
         for more detail.
    * Sample commands to install the GPU driver and verify the installation:
    * ***NOTE:*** For GKE the driver is already installed. Unless opted for [manual driver installation](https://cloud.google.com/kubernetes-engine/docs/how-to/gpus#create-gpu-pool-auto-drivers)

--- a/community/examples/eda/README.md
+++ b/community/examples/eda/README.md
@@ -226,7 +226,7 @@ Depending on the software you want to use, different installation paths may be r
   ```
 
   where you can follow the installation steps manually. Or using the toolkit's
-  [startup-script](../../modules/scripts/startup-scripts/README.md) module, the process
+  [startup-script](../../../modules/scripts/startup-script/README.md) module, the process
   can be automated.
 
   Once that is completed, the software will persist on the NetApp Volumes share for as long as you

--- a/examples/cae/README.md
+++ b/examples/cae/README.md
@@ -222,7 +222,7 @@ Depending on the software you want to use, different installation paths may be r
   ```
 
   where you can follow the installation steps manually. Or using the toolkit's
-  [startup-script](../../modules/scripts/startup-scripts/README.md) module, the process
+  [startup-script](../../modules/scripts/startup-script/README.md) module, the process
   can be automated.
 
   Once that is completed, the software will persist on the NFS Filestore share for as long as you

--- a/examples/science/af3-slurm/README.md
+++ b/examples/science/af3-slurm/README.md
@@ -313,7 +313,7 @@ This solution uses various GCS buckets to store required persistent information:
    This bucket is expected to contain a copy of the AlphaFold 3 weights as provided by the process
    described in section [AlphaFold 3 Model Weights](#alphafold-3-model-weights).
 
-   You can use [Google Cloud Console](htpps://console.cloud.google.com) to upload the
+   You can use [Google Cloud Console](https://console.cloud.google.com) to upload the
    uncompressed `af3.bin` weights file. Alternatively, you can execute on a shell where you have the weights and gcloud commands installed:
 
    ```bash


### PR DESCRIPTION
### Description

Fixes four broken or malformed Markdown links in documentation. No auto-generated files are touched (none of these READMEs contain `BEGIN_TF_DOCS` markers).

- `examples/science/af3-slurm/README.md` — `htpps://` → `https://` in the Google Cloud Console link.
- `community/cos-nvidia-bug-report/README.md` — removed stray escaped parens around the COS docs URL: `](\(https://…\))` → `](https://…)`.
- `examples/cae/README.md` — broken link to the startup-script module README: the directory is `startup-script` (singular), not `startup-scripts`.
- `community/examples/eda/README.md` — same `startup-scripts` → `startup-script` fix; this link also needed one more `../` to reach the top-level `modules/` directory.

### Verification

All four corrected relative links now resolve to existing files, and the two external links use the correct scheme/format.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] N/A — documentation-only change; no code or tests affected.
