### PR TITLE
docs: fix more broken and malformed documentation links

### DIFF
--- a/docs/slurm-troubleshooting.md
+++ b/docs/slurm-troubleshooting.md
@@ -85,7 +85,7 @@ to `false` on the partition in question.
 If VMs get stuck in `status: staging` when using the `vm-instance` module with
 placement enabled, it may be because you need to allow terraform to make more
 concurrent requests. See
-[this note](modules/compute/vm-instance/README.md#placement) in the vm-instance
+[this note](../modules/compute/vm-instance/README.md#placement) in the vm-instance
 README.
 
 #### Insufficient Service Account Permissions

--- a/docs/videos/build-your-own-blueprint/README.md
+++ b/docs/videos/build-your-own-blueprint/README.md
@@ -4,4 +4,4 @@ The [blueprint in this folder](./batch-high-io.yaml) was produced as part of a
 training video on how to build your own blueprint from scratch. Watch the
 YouTube video [here](https://youtu.be/Mb7aOmCdKZU).
 
-Note: The DDN-EXAScaler file system referenced in the video is no longer supported. For reference, please use alternate supported file system, like **[Managed-Lustre](../../../modules/file-system/managed-lustre)**.
+Note: The DDN-EXAScaler file system referenced in the video is no longer supported. For reference, please use alternate supported file system, like **[Managed-Lustre](../../../modules/file-system/managed-lustre/README.md)**.

--- a/docs/videos/build-your-own-blueprint/README.md
+++ b/docs/videos/build-your-own-blueprint/README.md
@@ -4,4 +4,4 @@ The [blueprint in this folder](./batch-high-io.yaml) was produced as part of a
 training video on how to build your own blueprint from scratch. Watch the
 YouTube video [here](https://youtu.be/Mb7aOmCdKZU).
 
-Note: The DDN-EXAScaler file system referenced in the video is no longer supported. For reference, please use alternate supported file system, like **[Managed-Lustre](modules/file-system/managed-lustre)**.
+Note: The DDN-EXAScaler file system referenced in the video is no longer supported. For reference, please use alternate supported file system, like **[Managed-Lustre](../../../modules/file-system/managed-lustre)**.

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -97,7 +97,7 @@ gcloud compute images create <new_image_name> --project=<your project> --source-
 
 Alternatively, a user can specify a family of images you wish to pull from (i.e.
 `--source-image-family` instead of `--source-image`). See more on
-[gcloud compute images create](gcloud-compute-images).
+[gcloud compute images create][gcloud-compute-images].
 
 Once the image has been created or copied, the user can specify their own
 project and the new image name in the `instance_image` field discussed in

--- a/examples/gke-consumption-options/dws-calendar.md
+++ b/examples/gke-consumption-options/dws-calendar.md
@@ -6,7 +6,7 @@ With Calendar mode, you will be able to request GPU capacity in fixed duration c
 
 ## Create an A3 Ultra cluster
 
-The [gke-a3-ultragpu](./examples/gke-a3-ultragpu) example can be used to create an A3 Ultra cluster using a DWS Calendar reservation. The `reservation` variable under `vars` in the [-deployment.yaml](examples/gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml) should be updated to the DWS Calendar reservation name.
+The [gke-a3-ultragpu](../gke-a3-ultragpu) example can be used to create an A3 Ultra cluster using a DWS Calendar reservation. The `reservation` variable under `vars` in the [-deployment.yaml](../gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml) should be updated to the DWS Calendar reservation name.
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 

--- a/examples/gke-consumption-options/dws-calendar.md
+++ b/examples/gke-consumption-options/dws-calendar.md
@@ -6,7 +6,7 @@ With Calendar mode, you will be able to request GPU capacity in fixed duration c
 
 ## Create an A3 Ultra cluster
 
-The [gke-a3-ultragpu](../gke-a3-ultragpu) example can be used to create an A3 Ultra cluster using a DWS Calendar reservation. The `reservation` variable under `vars` in the [-deployment.yaml](../gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml) should be updated to the DWS Calendar reservation name.
+The [gke-a3-ultragpu](../gke-a3-ultragpu/README.md) example can be used to create an A3 Ultra cluster using a DWS Calendar reservation. The reservation variable under vars in the [-deployment.yaml](../gke-a3-ultragpu/gke-a3-ultragpu-deployment.yaml) should be updated to the DWS Calendar reservation name.
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 

--- a/examples/gke-tpu-v6e/ml-diagnostics-sample-workload-test/README.md
+++ b/examples/gke-tpu-v6e/ml-diagnostics-sample-workload-test/README.md
@@ -10,8 +10,8 @@ To run a sample job, you need a GKE TPU cluster with ML Diagnostics enabled:
 
 1. Deploy a GKE TPU blueprint (e.g., v6e or 7x) with ML Diagnostics features enabled. Instructions can be found in the respective READMEs:
 
-   - [GKE TPU v6e README](../../examples/gke-tpu-v6e/README.md#understanding-ml-diagnostics-integration)
-   - [GKE TPU 7x README](../../examples/gke-tpu-7x/README.md#understanding-ml-diagnostics-integration)
+   - [GKE TPU v6e README](../README.md#understanding-ml-diagnostics-integration)
+   - [GKE TPU 7x README](../../gke-tpu-7x/README.md#understanding-ml-diagnostics-integration)
 
 2. Verify the cluster and ML Diagnostics components are correctly configured by following the "Testing ML Diagnostics Cluster Configuration" section in the blueprint's README.
 


### PR DESCRIPTION
### Description

Fixes more broken / malformed Markdown links in hand-written documentation (no auto-generated files touched). All corrected relative links were verified to resolve to existing files.

- `docs/slurm-troubleshooting.md` — the vm-instance module link needed a leading `../` (the page lives under `docs/`).
- `docs/videos/build-your-own-blueprint/README.md` — the Managed-Lustre link needed the correct `../../../` depth to reach `modules/`.
- `docs/vm-images.md` — converted the "gcloud compute images create" inline link `](gcloud-compute-images)` to a reference link `][gcloud-compute-images]`, so it uses the URL already defined at the bottom of the file (previously unused).
- `examples/gke-consumption-options/dws-calendar.md` — two links assumed a repo-root path; corrected to `../gke-a3-ultragpu…`.
- `examples/gke-tpu-v6e/ml-diagnostics-sample-workload-test/README.md` — two links had the wrong relative depth (`../../examples/…`); corrected to `../README.md` and `../../gke-tpu-7x/README.md`.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [ ] N/A — documentation-only change; no code or tests affected.
