### PR TITLE
chore: remove unused imports and fix f-strings without placeholders

### DIFF
--- a/community/modules/files/fsi-montecarlo-on-batch/mc_run.tpl.py
+++ b/community/modules/files/fsi-montecarlo-on-batch/mc_run.tpl.py
@@ -19,17 +19,16 @@ Run MC simulation for VaR portfolio risk
 
 import avro.schema
 import io
-import google.auth
 import numpy
 import time
 import yfinance as yf
 
 from absl import app
 from absl import flags
-from avro.io import DatumWriter, BinaryEncoder, BinaryDecoder, DatumReader
+from avro.io import DatumWriter, BinaryEncoder
 from datetime import datetime
 from datetime import timedelta
-from google.cloud import pubsub_v1, bigquery
+from google.cloud import pubsub_v1
 from google.cloud.pubsub import SchemaServiceClient
 
 PROJECT_ID = '${project_id}'

--- a/community/modules/scripts/htcondor-install/files/autoscaler.py
+++ b/community/modules/scripts/htcondor-install/files/autoscaler.py
@@ -18,8 +18,6 @@
 # Script for resizing managed instance group (MIG) cluster size based
 # on the number of jobs in the Condor Queue.
 
-from absl import app
-from absl import flags
 from collections import OrderedDict
 from datetime import datetime
 from pprint import pprint
@@ -27,9 +25,7 @@ from googleapiclient import discovery
 from oauth2client.client import GoogleCredentials
 
 import argparse
-import os
 import math
-import time
 import htcondor
 import classad
 
@@ -222,7 +218,7 @@ class AutoScaler:
             exit()
         last_negotiation_cycle_time = negotiator_ad[0].get(LAST_CYCLE_ATTRIBUTE)
         if not last_negotiation_cycle_time:
-            print(f"The negotiator has not yet started a match cycle. Exiting auto-scaling.")
+            print("The negotiator has not yet started a match cycle. Exiting auto-scaling.")
             exit()
 
         print(f"Last negotiation cycle occurred at: {datetime.fromtimestamp(last_negotiation_cycle_time)}")
@@ -267,8 +263,8 @@ class AutoScaler:
 
         # Find VMs that are idle (no dynamic slots created from partitionable
         # slots) in the MIG handled by this autoscaler
-        filter_idle_vms = classad.ExprTree(f"PartitionableSlot && NumDynamicSlots==0")
-        filter_claimed_vms = classad.ExprTree(f"PartitionableSlot && NumDynamicSlots>0")
+        filter_idle_vms = classad.ExprTree("PartitionableSlot && NumDynamicSlots==0")
+        filter_claimed_vms = classad.ExprTree("PartitionableSlot && NumDynamicSlots>0")
         filter_mig = classad.ExprTree(f"regexp(\".*/{self.instance_group_manager}$\", CloudCreatedBy)")
         # A full list of Machine (StartD) ClassAd attributes can be found at
         # https://htcondor.readthedocs.io/en/latest/classad-attributes/machine-classad-attributes.html

--- a/tools/python-integration-tests/slurm_topology.py
+++ b/tools/python-integration-tests/slurm_topology.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ssh import SSHManager
 from deployment import Deployment
 from collections import defaultdict
 import logging


### PR DESCRIPTION
### Description

Removes dead code flagged by `pyflakes` in non-vendored Python files. No behavior change; `py_compile` passes for all three files.

- `community/modules/scripts/htcondor-install/files/autoscaler.py` — remove unused imports (`absl.app`, `absl.flags`, `os`, `time`) and drop the `f` prefix from three f-strings that contain no placeholders.
- `community/modules/files/fsi-montecarlo-on-batch/mc_run.tpl.py` — remove unused imports (`google.auth`, `avro.io.BinaryDecoder`, `avro.io.DatumReader`, `google.cloud.bigquery`).
- `tools/python-integration-tests/slurm_topology.py` — remove the unused `from ssh import SSHManager`.

Two unused *local variables* that pyflakes also flagged were intentionally left untouched, since their right-hand side could have side effects.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] `py_compile` passes; `pyflakes` no longer reports unused-import / f-string issues in these files.
