### PR TITLE
fix(job):improve kueue reinstallation and dry-run directory handling

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -18,10 +18,12 @@ import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"os"
+	"path/filepath"
 	"slices"
 	"time"
 
 	"hpc-toolkit/pkg/orchestrator"
+	"hpc-toolkit/pkg/shell"
 
 	"strings"
 
@@ -82,6 +84,10 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 	RunE: runSubmitCmd,
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		if len(workloadName) > 28 {
+			return fmt.Errorf("workload name %q cannot exceed 28 characters (got %d)", workloadName, len(workloadName))
+		}
+
 		if err := validateImageFlags(); err != nil {
 			return err
 		}
@@ -139,7 +145,7 @@ func init() {
 	SubmitCmd.Flags().StringVar(&gkeScheduler, "gke-scheduler", "", "Kubernetes Scheduler name (e.g., gke.io/topology-aware-auto).")
 	SubmitCmd.Flags().BoolVar(&awaitJobCompletion, "await-job-completion", false, "If true, gcluster will wait for the submitted job to complete.")
 	SubmitCmd.Flags().StringVar(&timeoutStr, "timeout", "-1s", "Time to wait for job in seconds or string format (e.g. 1h, 10m). Default is max timeout (-1s).")
-	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "medium", "A priority, one of `very-low`, `low`, `medium`, `high` or `very-high`. Defaults to `medium`.")
+	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "", "A priority, one of `very-low`, `low`, `medium`, `high` or `very-high`. If empty, the cluster's default priority class will be used.")
 	SubmitCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging for the workload (TPUs and GPUs).")
 	SubmitCmd.Flags().StringVar(&gkeNapProvisioning, "gke-nap-provisioning", "", "Compute provisioning model for GKE NAP. Allowed values: on-demand, spot, reservation.")
 	SubmitCmd.Flags().StringVar(&gkeNapReservation, "gke-nap-reservation", "", "Name of the Google Cloud Reservation for GKE NAP (required if --gke-nap-provisioning=reservation).")
@@ -164,6 +170,12 @@ func init() {
 }
 
 func runSubmitCmd(cmd *cobra.Command, args []string) error {
+	if dryRunManifest != "" {
+		if err := ensureDryRunDir(dryRunManifest); err != nil {
+			return err
+		}
+	}
+
 	ttlSeconds, err := parseDurationToSeconds(ttlAfterFinished, "--gke-ttl-after-finished")
 	if err != nil {
 		return err
@@ -385,6 +397,32 @@ func validateGKENAPFlags() error {
 	}
 	if gkeNapProvisioning != "reservation" && gkeNapReservation != "" {
 		return fmt.Errorf("--gke-nap-reservation should only be provided when --gke-nap-provisioning=reservation")
+	}
+	return nil
+}
+
+func ensureDryRunDir(path string) error {
+	if len(path) > 0 && os.IsPathSeparator(path[len(path)-1]) {
+		return fmt.Errorf("the dry-run-out path %q must be a file path, not a directory path", path)
+	}
+
+	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
+		return fmt.Errorf("the dry-run-out path %q must be a file path, not a directory path", path)
+	}
+
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); err != nil {
+		if os.IsNotExist(err) {
+			prompt := fmt.Sprintf("Directory %q does not exist. Would you like to create it?", dir)
+			if shell.PromptYesNo(prompt) {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					return fmt.Errorf("failed to create directory %s: %w", dir, err)
+				}
+				return nil
+			}
+			return fmt.Errorf("directory %q does not exist. Please check your path for typos or create the directory manually", dir)
+		}
+		return fmt.Errorf("failed to check directory %s: %w", dir, err)
 	}
 	return nil
 }

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -85,7 +85,7 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if len(workloadName) > 28 {
-			return fmt.Errorf("workload name %q cannot exceed 28 characters (got %d)", workloadName, len(workloadName))
+			return fmt.Errorf("workload name cannot exceed 28 characters due to Kubernetes/GCE resource name limits. The provided name %q has %d characters", workloadName, len(workloadName))
 		}
 
 		if err := validateImageFlags(); err != nil {
@@ -105,10 +105,6 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 		}
 
 		priorityClassName = strings.ToLower(priorityClassName)
-		if priorityClassName != "" && !slices.Contains(orchestrator.ValidPriorityClasses, priorityClassName) {
-			return fmt.Errorf("invalid value for --priority: %s. Allowed values are: %s",
-				priorityClassName, strings.Join(orchestrator.ValidPriorityClasses, ", "))
-		}
 
 		return nil
 	},
@@ -145,7 +141,7 @@ func init() {
 	SubmitCmd.Flags().StringVar(&gkeScheduler, "gke-scheduler", "", "Kubernetes Scheduler name (e.g., gke.io/topology-aware-auto).")
 	SubmitCmd.Flags().BoolVar(&awaitJobCompletion, "await-job-completion", false, "If true, gcluster will wait for the submitted job to complete.")
 	SubmitCmd.Flags().StringVar(&timeoutStr, "timeout", "-1s", "Time to wait for job in seconds or string format (e.g. 1h, 10m). Default is max timeout (-1s).")
-	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "", "A priority, one of `very-low`, `low`, `medium`, `high` or `very-high`. If empty, the cluster's default priority class will be used.")
+	SubmitCmd.Flags().StringVar(&priorityClassName, "priority", "", "A priority class name (e.g., low, medium, high, or any custom PriorityClass defined in the cluster). If empty, the cluster's default priority class will be used.")
 	SubmitCmd.Flags().BoolVar(&verbose, "verbose", false, "Enable verbose logging for the workload (TPUs and GPUs).")
 	SubmitCmd.Flags().StringVar(&gkeNapProvisioning, "gke-nap-provisioning", "", "Compute provisioning model for GKE NAP. Allowed values: on-demand, spot, reservation.")
 	SubmitCmd.Flags().StringVar(&gkeNapReservation, "gke-nap-reservation", "", "Name of the Google Cloud Reservation for GKE NAP (required if --gke-nap-provisioning=reservation).")

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -17,7 +17,9 @@ package job
 import (
 	"bytes"
 	"hpc-toolkit/pkg/orchestrator"
+	"hpc-toolkit/pkg/shell"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -215,6 +217,38 @@ func TestSubmitCmd_TPUWithNumNodes_Fails(t *testing.T) {
 	expectedErr := "--num-nodes cannot be used with TPU jobs"
 	if !strings.Contains(output, expectedErr) && !strings.Contains(err.Error(), expectedErr) {
 		t.Errorf("expected error message to contain %q, got output: %q, err: %v", expectedErr, output, err)
+	}
+}
+
+func TestSubmitCmd_LongWorkloadName_Fails(t *testing.T) {
+	resetSubmitCmdFlags()
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+		},
+	}
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "a-very-long-workload-name-that-exceeds-28-characters",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--cluster", "test-cluster",
+		"--location", "us-central1-a",
+		"--project", "test-project",
+		"--compute-type", "n2-standard-4",
+	)
+
+	if err == nil {
+		t.Fatalf("expected error when passing long workload name, but got nil")
+	}
+
+	expectedErr := "cannot exceed 28 characters"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error message to contain %q, got: %v", expectedErr, err)
 	}
 }
 
@@ -599,5 +633,170 @@ func TestSubmitCmd_NonReservationModelWithName_Fails(t *testing.T) {
 	expectedErr := "--gke-nap-reservation should only be provided when --gke-nap-provisioning=reservation"
 	if !strings.Contains(output, expectedErr) && !strings.Contains(err.Error(), expectedErr) {
 		t.Errorf("expected error message to contain %q, got output: %q, err: %v", expectedErr, output, err)
+	}
+}
+
+func TestSubmitCmd_DryRunMissingDir_Approved(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gcluster-submit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	missingDirPath := filepath.Join(tmpDir, "non-existent-sub-dir", "manifest.yaml")
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	oldPrompt := shell.PromptYesNo
+	defer func() { shell.PromptYesNo = oldPrompt }()
+	shell.PromptYesNo = func(prompt string) bool { return true }
+
+	resetSubmitCmdFlags()
+
+	_, err = executeCommand(JobCmd,
+		"submit",
+		"--name", "dry-run-missing-dir-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--dry-run-out", missingDirPath,
+	)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Dir(missingDirPath)); err != nil {
+		t.Errorf("expected directory %q to exist, got error: %v", filepath.Dir(missingDirPath), err)
+	}
+
+	if _, err := os.Stat(missingDirPath); err != nil {
+		t.Errorf("expected file %q to exist, got error: %v", missingDirPath, err)
+	}
+}
+
+func TestSubmitCmd_DryRunMissingDir_Rejected(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gcluster-submit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	missingDirPath := filepath.Join(tmpDir, "non-existent-sub-dir", "manifest.yaml")
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	oldPrompt := shell.PromptYesNo
+	defer func() { shell.PromptYesNo = oldPrompt }()
+	shell.PromptYesNo = func(prompt string) bool { return false }
+
+	resetSubmitCmdFlags()
+
+	output, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "dry-run-missing-dir-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--dry-run-out", missingDirPath,
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "directory \"" + filepath.Dir(missingDirPath) + "\" does not exist"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v, output: %s", expectedErr, err, output)
+	}
+
+	if _, err := os.Stat(filepath.Dir(missingDirPath)); !os.IsNotExist(err) {
+		t.Errorf("expected directory %q to not exist, but it does", filepath.Dir(missingDirPath))
+	}
+}
+
+func TestSubmitCmd_DryRunIsDir_Existing(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gcluster-submit-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
+
+	resetSubmitCmdFlags()
+
+	_, err = executeCommand(JobCmd,
+		"submit",
+		"--name", "dry-run-dir-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--dry-run-out", tmpDir,
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "must be a file path, not a directory path"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}
+
+func TestSubmitCmd_DryRunIsDir_TrailingSlash(t *testing.T) {
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
+
+	resetSubmitCmdFlags()
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "dry-run-dir-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--dry-run-out", "/some/random/dir/path/",
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "must be a file path, not a directory path"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
 	}
 }

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -1033,7 +1033,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | Flag | Type | Description |
 | :--- | :--- | :--- |
 | `-q, --queue` | `string` | Name of the Kueue `LocalQueue` to submit the job to (Auto-discovered by default). |
-| `--priority` | `string` | Priority class or level assigned to the job queue (e.g., `low`, `medium`, `high`). If empty, the cluster's default priority class will be used. |
+| `--priority` | `string` | Priority class name assigned to the job queue (supports default classes like `low`, `medium`, `high`, or any custom PriorityClass defined in the cluster). If empty, the cluster's default priority class will be used. |
 | `--gke-ttl-after-finished` | `string` | Time duration to retain the JobSet resources after completion (Default: `1h`). |
 | `--grace-period` | `string` | Buffer period given to pods to save checkpoints before forced termination (Default: `30s`). |
 | `--node-constraint` | `string` | Maps to Kubernetes node labels to target specific hardware instance types. Supports pipe separator (`|`) for multiple values. |

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -983,14 +983,14 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 
 | Flag | Type | Description |
 | :--- | :--- | :--- |
-| `-n, --name` | `string` | Name of the job (JobSet) to create. Used for Kubernetes resources. *(Required)* |
+| `-n, --name` | `string` | Name of the job (JobSet) to create. Used for Kubernetes resources. Maximum of 28 characters. *(Required)* |
 | `-e, --command` | `string` | Command to execute inside the container (e.g., `'python app.py'`). *(Required)* |
 | `--compute-type` | `string` | The hardware target for the job. Accepts a full GCE machine type (e.g., 'n2-standard-32'), a GKE accelerator type (e.g., 'nvidia-l4'), or a TPU shorthand string representing total chips/cores (e.g., 'v6e-8'). *(Required)* The tool will automatically resolve the machine type, calculate num-nodes, and deduce the correct TPU topology if needed. |
 | `-i, --image` | `string` | Full registry path of a pre-built container image to run. |
 | `-B, --base-image` | `string` | Name of the base container image to build upon (e.g., `python:3.9-slim`). |
 | `-b, --build-context` | `string` | Path to the local build context directory for on-the-fly image builds. |
 | `-f, --platform` | `string` | Target platform architecture for the image build (Default: `linux/amd64`). |
-| `-o, --dry-run-out` | `string` | Local path to save the generated Kubernetes manifest instead of applying it. |
+| `-o, --dry-run-out` | `string` | Local file path to save the generated Kubernetes manifest instead of applying it (must specify a file path, not a directory). |
 | `--num-slices` | `int` | Number of independent groups/slices to use (Default: `1`). |
 | `--num-nodes` | `int` | Number of nodes to use per group/slice (Default: `1`). Auto-calculated for TPUs based on topology. |
 | `--restarts` | `int` | Maximum number of restarts allowed for the JobSet before marked as failed (Default: `1`). |
@@ -1033,7 +1033,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | Flag | Type | Description |
 | :--- | :--- | :--- |
 | `-q, --queue` | `string` | Name of the Kueue `LocalQueue` to submit the job to (Auto-discovered by default). |
-| `--priority` | `string` | Priority class or level assigned to the job queue (e.g., `low`, `medium`, `high`). |
+| `--priority` | `string` | Priority class or level assigned to the job queue (e.g., `low`, `medium`, `high`). If empty, the cluster's default priority class will be used. |
 | `--gke-ttl-after-finished` | `string` | Time duration to retain the JobSet resources after completion (Default: `1h`). |
 | `--grace-period` | `string` | Buffer period given to pods to save checkpoints before forced termination (Default: `30s`). |
 | `--node-constraint` | `string` | Maps to Kubernetes node labels to target specific hardware instance types. Supports pipe separator (`|`) for multiple values. |

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -42,7 +42,7 @@ var templatesFS embed.FS
 // defaultKueueVersion is the fallback version of Kueue to install.
 // ATTENTION: If you update this version, please also update the corresponding
 // default version in modules/management/kubectl-apply/variables.tf.
-const defaultKueueVersion = "v0.17.1"
+const defaultKueueVersion = "v0.15.2"
 const defaultJobSetVersion = "v0.10.1"
 
 func (g *GKEOrchestrator) checkAndInstallJobSetCRD() error {
@@ -93,9 +93,12 @@ func (g *GKEOrchestrator) CheckAndInstallKueue(version string, clusterName strin
 	}
 
 	if needReinstall {
-		isDynamicSlicing, _ := g.checkDynamicSlicingViaGKE(clusterName, clusterLocation)
-		if isDynamicSlicing {
+		if g.checkDynamicSlicingViaGKE() {
 			return fmt.Errorf("automatic Kueue installation blocked: we detected that cluster %s is set up for Dynamic-slicing (found 'PROVISION_ONLY' in the node pool's placementPolicy). Wiping Kueue would corrupt your custom topology configurations. Please install Kueue and the required custom CRDs manually", clusterName)
+		}
+
+		if err := g.checkKueueInstallPermissions(version); err != nil {
+			return err
 		}
 
 		if err := g.handleKueueReinstallation(version, reinstallReason); err != nil {
@@ -108,18 +111,17 @@ func (g *GKEOrchestrator) CheckAndInstallKueue(version string, clusterName strin
 }
 
 func (g *GKEOrchestrator) ensurePriorityClassesInstalled() error {
-	priorityClassesInstalled, err := g.arePriorityClassesInstalled()
+	hasUserClasses, err := g.hasUserPriorityClasses()
 	if err != nil {
 		return err
 	}
 
-	if !priorityClassesInstalled {
-		logging.Info("Required PriorityClasses not found. Installing them...")
-		return g.installPriorityClasses()
+	if hasUserClasses {
+		return nil // Skip installation entirely
 	}
 
-	logging.Info("The required PriorityClasses are already installed.")
-	return nil
+	logging.Info("No user-defined PriorityClasses found. Installing defaults...")
+	return g.installPriorityClasses()
 }
 
 func (g *GKEOrchestrator) handleKueueReinstallation(targetVersion string, reason string) error {
@@ -223,17 +225,21 @@ func (g *GKEOrchestrator) GetKueueVersion() (string, error) {
 	return version, nil
 }
 
-func (g *GKEOrchestrator) arePriorityClassesInstalled() (bool, error) {
-	args := []string{"get", "priorityclass"}
-	args = append(args, orchestrator.ValidPriorityClasses...)
-	args = append(args, "-o", "name")
-
-	res := g.executor.ExecuteCommand("kubectl", args...)
+func (g *GKEOrchestrator) hasUserPriorityClasses() (bool, error) {
+	res := g.executor.ExecuteCommand("kubectl", "get", "priorityclass", "-o", "jsonpath={.items[*].metadata.name}")
 	if res.ExitCode != 0 {
-		logging.Info("One or more PriorityClasses not found.")
-		return false, nil
+		return false, fmt.Errorf("failed to list priority classes: %s", res.Stderr)
 	}
-	return true, nil
+
+	existing := strings.Fields(res.Stdout)
+	for _, name := range existing {
+		if strings.HasPrefix(name, "system-") || strings.HasPrefix(name, "gke-") {
+			continue
+		}
+		logging.Info("Pre-existing PriorityClass '%s' found. Skipping default PriorityClass installation.", name)
+		return true, nil
+	}
+	return false, nil
 }
 
 func (g *GKEOrchestrator) installKueue(version string) error {
@@ -278,8 +284,14 @@ func (g *GKEOrchestrator) installPriorityClasses() error {
 func (g *GKEOrchestrator) installKueueResources(cqName string, lqName string) error {
 	logging.Info("Installing Kueue resources (ClusterQueue, LocalQueue)...")
 
-	if err := g.installPriorityClasses(); err != nil {
+	hasUserClasses, err := g.hasUserPriorityClasses()
+	if err != nil {
 		return err
+	}
+	if !hasUserClasses {
+		if err := g.installPriorityClasses(); err != nil {
+			return err
+		}
 	}
 
 	// Install ClusterQueue
@@ -610,7 +622,11 @@ func parseVersion(v string) (int, int, int) {
 		minor, _ = strconv.Atoi(parts[1])
 	}
 	if len(parts) > 2 {
-		patch, _ = strconv.Atoi(parts[2])
+		patchStr := parts[2]
+		// Strip pre-release and build metadata
+		patchStr = strings.Split(patchStr, "-")[0]
+		patchStr = strings.Split(patchStr, "+")[0]
+		patch, _ = strconv.Atoi(patchStr)
 	}
 	return major, minor, patch
 }
@@ -971,24 +987,40 @@ func (g *GKEOrchestrator) checkClusterConnectivity() error {
 	return nil
 }
 
-func (g *GKEOrchestrator) checkDynamicSlicingViaGKE(clusterName, clusterLocation string) (bool, error) {
-	poolName := os.Getenv("GKE_NODE_POOL_NAME")
-	if poolName == "" {
-		return false, nil
-	}
-
-	result := g.executor.ExecuteCommand("gcloud", "container", "node-pools", "describe", poolName, "--cluster="+clusterName, "--location="+clusterLocation, "--format=json(placementPolicy)")
-	if result.ExitCode != 0 {
-		return false, fmt.Errorf("failed to describe node pool: %s", result.Stderr)
-	}
-
-	var policy map[string]interface{}
-	if err := json.Unmarshal([]byte(result.Stdout), &policy); err == nil {
-		if placement, ok := policy["placementPolicy"].(map[string]interface{}); ok {
-			if mode, ok := placement["acceleratorTopologyMode"].(string); ok && mode == "PROVISION_ONLY" {
-				return true, nil
+func (g *GKEOrchestrator) checkDynamicSlicingViaGKE() bool {
+	for _, np := range g.clusterDesc.NodePools {
+		if np.PlacementPolicy != nil {
+			mode := np.PlacementPolicy.AcceleratorTopologyMode
+			if mode == "PROVISION_ONLY" {
+				return true
 			}
 		}
 	}
-	return false, nil
+	return false
+}
+
+func (g *GKEOrchestrator) checkKueueInstallPermissions(version string) error {
+	logging.Info("Verifying cluster permissions for Kueue installation...")
+	checks := []struct {
+		verb     string
+		resource string
+		group    string
+	}{
+		{"create", "namespaces", ""},
+		{"create", "customresourcedefinitions", "apiextensions.k8s.io"},
+		{"create", "clusterroles", "rbac.authorization.k8s.io"},
+		{"create", "clusterrolebindings", "rbac.authorization.k8s.io"},
+	}
+
+	for _, c := range checks {
+		args := []string{"auth", "can-i", c.verb, c.resource}
+		if c.group != "" {
+			args = append(args, "--group="+c.group)
+		}
+		res := g.executor.ExecuteCommand("kubectl", args...)
+		if res.ExitCode != 0 || strings.TrimSpace(res.Stdout) != "yes" {
+			return fmt.Errorf("unable to re-install kueue to version %s, this could be a permission issue. Please contact your cluster administrator for updating KUEUE settings", version)
+		}
+	}
+	return nil
 }

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -40,8 +41,8 @@ import (
 var templatesFS embed.FS
 
 // defaultKueueVersion is the fallback version of Kueue to install.
-// ATTENTION: If you update this version, please also update the corresponding
-// default version in modules/management/kubectl-apply/variables.tf.
+// ATTENTION: For cluster creation the corresponding default version
+// is in modules/management/kubectl-apply/variables.tf.
 const defaultKueueVersion = "v0.15.2"
 const defaultJobSetVersion = "v0.10.1"
 
@@ -225,13 +226,20 @@ func (g *GKEOrchestrator) GetKueueVersion() (string, error) {
 	return version, nil
 }
 
-func (g *GKEOrchestrator) hasUserPriorityClasses() (bool, error) {
+func (g *GKEOrchestrator) getClusterPriorityClasses() ([]string, error) {
 	res := g.executor.ExecuteCommand("kubectl", "get", "priorityclass", "-o", "jsonpath={.items[*].metadata.name}")
 	if res.ExitCode != 0 {
-		return false, fmt.Errorf("failed to list priority classes: %s", res.Stderr)
+		return nil, fmt.Errorf("failed to list priority classes: %s", res.Stderr)
+	}
+	return strings.Fields(res.Stdout), nil
+}
+
+func (g *GKEOrchestrator) hasUserPriorityClasses() (bool, error) {
+	existing, err := g.getClusterPriorityClasses()
+	if err != nil {
+		return false, err
 	}
 
-	existing := strings.Fields(res.Stdout)
 	for _, name := range existing {
 		if strings.HasPrefix(name, "system-") || strings.HasPrefix(name, "gke-") {
 			continue
@@ -964,6 +972,7 @@ func (g *GKEOrchestrator) ValidateClusterState(job *orchestrator.JobDefinition) 
 		g.checkClusterConnectivity,
 		func() error { return g.CheckAndInstallKueue("", job.ClusterName, job.ClusterLocation) },
 		func() error { return g.ensurePriorityClassesInstalled() },
+		func() error { return g.validatePriorityClass(job.PriorityClassName) },
 		g.checkAndInstallJobSetCRD,
 	}
 
@@ -1004,23 +1013,34 @@ func (g *GKEOrchestrator) checkKueueInstallPermissions(version string) error {
 	checks := []struct {
 		verb     string
 		resource string
-		group    string
 	}{
-		{"create", "namespaces", ""},
-		{"create", "customresourcedefinitions", "apiextensions.k8s.io"},
-		{"create", "clusterroles", "rbac.authorization.k8s.io"},
-		{"create", "clusterrolebindings", "rbac.authorization.k8s.io"},
+		{"create", "namespaces"},
+		{"create", "customresourcedefinitions.apiextensions.k8s.io"},
+		{"create", "clusterroles.rbac.authorization.k8s.io"},
+		{"create", "clusterrolebindings.rbac.authorization.k8s.io"},
 	}
 
 	for _, c := range checks {
-		args := []string{"auth", "can-i", c.verb, c.resource}
-		if c.group != "" {
-			args = append(args, "--group="+c.group)
-		}
-		res := g.executor.ExecuteCommand("kubectl", args...)
+		res := g.executor.ExecuteCommand("kubectl", "auth", "can-i", c.verb, c.resource)
 		if res.ExitCode != 0 || strings.TrimSpace(res.Stdout) != "yes" {
 			return fmt.Errorf("unable to re-install kueue to version %s, this could be a permission issue. Please contact your cluster administrator for updating KUEUE settings", version)
 		}
+	}
+	return nil
+}
+
+func (g *GKEOrchestrator) validatePriorityClass(requestedPriority string) error {
+	if requestedPriority == "" {
+		return nil
+	}
+
+	existing, err := g.getClusterPriorityClasses()
+	if err != nil {
+		return err
+	}
+
+	if !slices.Contains(existing, requestedPriority) {
+		return fmt.Errorf("priority class %q does not exist in the cluster. Available priority classes are: %v", requestedPriority, existing)
 	}
 	return nil
 }

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -241,6 +241,9 @@ func TestParseVersion(t *testing.T) {
 		{"v0.6.3", 0, 6, 3},
 		{"1.2.3", 1, 2, 3},
 		{"v1.2", 1, 2, 0},
+		{"v0.16.6-some-random-suffix", 0, 16, 6},
+		{"v0.16.6+build123", 0, 16, 6},
+		{"v0.16.6-rc1+build123", 0, 16, 6},
 		{"invalid", 0, 0, 0},
 	}
 
@@ -265,6 +268,7 @@ func TestCheckAndInstallKueue_ReinstallNeeded_LowVersion(t *testing.T) {
 		action  func()
 	}{
 		{pattern: "kubectl delete crd", action: func() { deleteCalled = true }, res: shell.CommandResult{ExitCode: 0}},
+		{pattern: "auth can-i", res: shell.CommandResult{ExitCode: 0, Stdout: "yes"}},
 		{pattern: "kubectl get crd", res: shell.CommandResult{ExitCode: 0, Stdout: "clusterqueues.kueue.x-k8s.io found"}},
 		{pattern: "jsonpath", res: shell.CommandResult{ExitCode: 0, Stdout: "registry.k8s.io/kueue/kueue:v0.12.0"}},
 		{pattern: "kubectl get deployment", res: shell.CommandResult{ExitCode: 0, Stdout: "kueue-controller-manager found"}},
@@ -310,8 +314,8 @@ func TestEnsurePriorityClassesInstalled_Missing(t *testing.T) {
 		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
 			fullCmd := name + " " + strings.Join(args, " ")
 			if strings.Contains(fullCmd, "kubectl get priorityclass") {
-				// Return failure with "not found" to simulate missing priority classes
-				return shell.CommandResult{ExitCode: 1, Stderr: "Error from server (NotFound): priorityclass \"very-low\" not found"}
+				// Return only system priority classes to simulate no user priority classes
+				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical system-node-critical"}
 			}
 			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "priority-classes.yaml") {
 				applyCalled = true
@@ -341,8 +345,8 @@ func TestEnsurePriorityClassesInstalled_Present(t *testing.T) {
 		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
 			fullCmd := name + " " + strings.Join(args, " ")
 			if strings.Contains(fullCmd, "kubectl get priorityclass") {
-				// Return success to simulate all are present
-				return shell.CommandResult{ExitCode: 0}
+				// Return system classes and at least one user class (e.g. 'low') to simulate pre-existing classes
+				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical system-node-critical low"}
 			}
 			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "priority-classes.yaml") {
 				applyCalled = true
@@ -420,5 +424,89 @@ func TestRenderClusterQueue_NAP(t *testing.T) {
 	}
 	if !strings.Contains(output, "nominalQuota: 80") { // GPU limit from napLimits
 		t.Errorf("expected nominalQuota: 80 for GPU, got %s", output)
+	}
+}
+
+func TestCheckAndInstallKueue_PermissionDenied(t *testing.T) {
+	mock := &mockExecutor{
+		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
+			fullCmd := name + " " + strings.Join(args, " ")
+			if strings.Contains(fullCmd, "auth can-i") {
+				if strings.Contains(fullCmd, "clusterroles") {
+					return shell.CommandResult{ExitCode: 0, Stdout: "no"}
+				}
+				return shell.CommandResult{ExitCode: 0, Stdout: "yes"}
+			}
+			if strings.Contains(fullCmd, "kubectl get crd") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "clusterqueues.kueue.x-k8s.io found"}
+			}
+			if strings.Contains(fullCmd, "jsonpath") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "registry.k8s.io/kueue/kueue:v0.12.0"}
+			}
+			if strings.Contains(fullCmd, "kubectl get deployment") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "kueue-controller-manager found"}
+			}
+			return shell.CommandResult{ExitCode: 0}
+		},
+	}
+
+	orc := &GKEOrchestrator{
+		executor: mock,
+	}
+
+	err := orc.CheckAndInstallKueue("", "test-cluster", "us-central1-a")
+	if err == nil {
+		t.Fatal("expected error due to insufficient permissions, got nil")
+	}
+
+	expectedErr := "unable to re-install kueue to version"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}
+
+func TestCheckAndInstallKueue_PermissionGranted(t *testing.T) {
+	deleteCalled := false
+	mock := &mockExecutor{
+		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
+			fullCmd := name + " " + strings.Join(args, " ")
+			if strings.Contains(fullCmd, "auth can-i") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "yes"}
+			}
+			if strings.Contains(fullCmd, "kubectl delete crd") {
+				deleteCalled = true
+				return shell.CommandResult{ExitCode: 0}
+			}
+			if strings.Contains(fullCmd, "kubectl get crd") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "clusterqueues.kueue.x-k8s.io found"}
+			}
+			if strings.Contains(fullCmd, "jsonpath") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "registry.k8s.io/kueue/kueue:v0.12.0"}
+			}
+			if strings.Contains(fullCmd, "kubectl get deployment") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "kueue-controller-manager found"}
+			}
+			if strings.Contains(fullCmd, "kubectl get endpoints") || strings.Contains(fullCmd, "kubectl get endpointslice") {
+				return shell.CommandResult{ExitCode: 0, Stdout: `{"subsets": [{"addresses": [{"ip": "10.0.0.1"}]}]}`}
+			}
+			return shell.CommandResult{ExitCode: 0}
+		},
+	}
+
+	origPrompt := shell.PromptYesNo
+	defer func() { shell.PromptYesNo = origPrompt }()
+	shell.PromptYesNo = func(prompt string) bool { return true }
+
+	orc := &GKEOrchestrator{
+		executor: mock,
+	}
+
+	err := orc.CheckAndInstallKueue("", "test-cluster", "us-central1-a")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	if !deleteCalled {
+		t.Errorf("expected DeleteAllKueueResources to be called, but it wasn't")
 	}
 }

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -510,3 +510,47 @@ func TestCheckAndInstallKueue_PermissionGranted(t *testing.T) {
 		t.Errorf("expected DeleteAllKueueResources to be called, but it wasn't")
 	}
 }
+
+func TestValidatePriorityClass_Empty(t *testing.T) {
+	orc := &GKEOrchestrator{}
+	err := orc.validatePriorityClass("")
+	if err != nil {
+		t.Fatalf("expected no error for empty priority, got %v", err)
+	}
+}
+
+func TestValidatePriorityClass_Exists(t *testing.T) {
+	mock := &mockExecutor{
+		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
+			if strings.Contains(name+" "+strings.Join(args, " "), "kubectl get priorityclass") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical low medium high"}
+			}
+			return shell.CommandResult{ExitCode: 0}
+		},
+	}
+	orc := &GKEOrchestrator{executor: mock}
+	err := orc.validatePriorityClass("medium")
+	if err != nil {
+		t.Fatalf("expected no error for existing priority, got %v", err)
+	}
+}
+
+func TestValidatePriorityClass_NotExist(t *testing.T) {
+	mock := &mockExecutor{
+		executeCommandFunc: func(name string, args ...string) shell.CommandResult {
+			if strings.Contains(name+" "+strings.Join(args, " "), "kubectl get priorityclass") {
+				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical low high"}
+			}
+			return shell.CommandResult{ExitCode: 0}
+		},
+	}
+	orc := &GKEOrchestrator{executor: mock}
+	err := orc.validatePriorityClass("medium")
+	if err == nil {
+		t.Fatal("expected error for non-existing priority, got nil")
+	}
+	expected := `priority class "medium" does not exist in the cluster`
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("expected error to contain %q, got %v", expected, err)
+	}
+}


### PR DESCRIPTION
* Workload Name Validation: Added a validation check to ensure workload names do not exceed 28 characters, preventing potential issues with Kubernetes resource naming.
* Dry-Run Directory Handling: Implemented robust directory validation and creation logic for the --dry-run-out flag, ensuring the target path is a file and creating parent directories if confirmed by the user.
* Kueue Reinstallation Improvements: Updated Kueue reinstallation logic to include permission checks (via 'kubectl auth can-i') and smarter detection of user-defined PriorityClasses to avoid unnecessary overwrites.
* Version Parsing Robustness: Improved version string parsing to correctly handle custom and build metadata suffixes.