### PR TITLE
managed-luster updating zone from us-central1-c to us-central1-a

### DIFF
--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -21,7 +21,7 @@ vars:
   # The GCP Region used for this deployment.
   region: us-central1
   # The GCP Zone used for this deployment.
-  zone: us-central1-c
+  zone: us-central1-a
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
   authorized_cidr: <your-ip-address>/32

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -15,7 +15,7 @@
 test_name: gke-managed-lustre
 deployment_name: gke-ml-{{ build }}
 region: us-central1
-zone: us-central1-c
+zone: us-central1-a
 lustre_instance_id: "{{ deployment_name }}-lstr"
 size_gib: 36000
 per_unit_storage_throughput: 500


### PR DESCRIPTION
The enough resources available to fulfill the request in us-central1-c got exhausted and changed to us-central1-a zone
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
