### PR TITLE
fix(ofe): import RestrictedError and remove duplicate dict keys

### DIFF
--- a/community/front-end/ofe/website/ghpcfe/cluster_manager/cloud_info.py
+++ b/community/front-end/ofe/website/ghpcfe/cluster_manager/cloud_info.py
@@ -49,7 +49,6 @@ gcp_machine_table = defaultdict(
         "t2d": defaultdict(lambda: "zen2"),  # TODO: Should also be zen3
         "h3": defaultdict(lambda: "sapphirerapids"),
         # Memory Optimized
-        "m2": defaultdict(lambda: "icelake"),
         "m2": defaultdict(lambda: "cascadelake"),
         "m1": defaultdict(
             lambda: "broadwell",
@@ -201,10 +200,6 @@ def _get_gcp_machine_types(
         "n2d-": [
             "pd-extreme", "hyperdisk-ml", "hyperdisk-balanced",
             "hyperdisk-extreme"
-        ],
-        "n1-": [
-            "pd-extreme", "hyperdisk-extreme", "hyperdisk-ml",
-            "hyperdisk-throughput", "hyperdisk-balanced"
         ],
         "t2d-": [
             "pd-extreme", "local-ssd", "hyperdisk-balanced",

--- a/community/front-end/ofe/website/ghpcfe/views/credentials.py
+++ b/community/front-end/ofe/website/ghpcfe/views/credentials.py
@@ -18,6 +18,7 @@ from django.urls import reverse, reverse_lazy
 from django.views import generic
 from django.views.generic.edit import CreateView, UpdateView, DeleteView
 from django.contrib import messages
+from django.db.models import RestrictedError
 from rest_framework import viewsets
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
@@ -124,7 +125,7 @@ class CredentialDeleteView(SuperUserRequiredMixin, DeleteView):
     def post(self, request, *args, **kwargs):
         try:
             delete_request = super().delete(request, *args, **kwargs)
-            messages.success(self.request, f"Credential successfully deleted.")
+            messages.success(self.request, "Credential successfully deleted.")
             return delete_request
         except RestrictedError:
             msg = """Credential deletion failed due to a foreign key constraint.


### PR DESCRIPTION
### Description

Three real bugs in the Open Front End backend:

1. **Latent crash on a restricted credential delete** (`views/credentials.py`) — `CredentialDeleteView.post` catches `RestrictedError`, but the name was never imported, so the `except` clause itself raised `NameError` instead of showing the intended friendly message. The foreign keys referencing `Credential` use `on_delete=models.RESTRICT`, so `RestrictedError` is the correct exception — added `from django.db.models import RestrictedError`. Also dropped the `f` prefix from a placeholder-less success message in the same method.

2. **Duplicate dict key `"m2"`** (`cluster_manager/cloud_info.py`) — `"m2"` was defined twice in `gcp_machine_table` (`icelake`, then `cascadelake`); Python silently keeps the last, so the first was dead code. Removed the dead `icelake` entry.

3. **Duplicate dict key `"n1-"`** (`cluster_manager/cloud_info.py`) — `"n1-"` was defined twice with different disk-type lists; Python keeps the later one, so the earlier was dead. Removed the dead earlier entry.

For (2) and (3) I kept the value Python was already using, so **runtime behaviour is unchanged** — only the silently-shadowed duplicate is removed. If the intended surviving value should differ, happy to adjust.

### Verification

- `pyflakes`: no more undefined-name / duplicate-dict-key / placeholder-less f-string findings in the edited files.
- `python -m py_compile` passes for both files.

### Submission Checklist

- [x] PR branched from the `develop` branch.
- [x] Verified with `pyflakes` + `py_compile`; (2) and (3) are behaviour-preserving.
