### PR TITLE
Remove addict dependency and replace with custom AttrDict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,7 +100,7 @@ repos:
     - requests
     - httplib2
     - more-executors
-    - addict
+
     - google-cloud-tpu
     types: [python]
     pass_filenames: false
@@ -122,7 +122,7 @@ repos:
     - pytest
     - pytest-unordered
     - more-executors
-    - addict
+
     - google-cloud-tpu
     types: [python]
     pass_filenames: false

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/c2_daemon/tasks/main.yaml
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/clusters/ansible_setup/roles/c2_daemon/tasks/main.yaml
@@ -42,7 +42,7 @@
     - pexpect
     - google-cloud-storage
     - google-cloud-pubsub
-    - addict
+
     - google-api-python-client
     - google-cloud-secret-manager
     - prometheus_client

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -112,7 +112,7 @@ python3.12 -m ensurepip --upgrade
 pip3.12 install google-api-python-client \
 	google-cloud-secret-manager \
 	google.cloud.pubsub \
-	pyyaml addict httplib2
+	pyyaml httplib2
 
 # Set Python3.12 as default Python3
 echo '2' | update-alternatives --config python3

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf.py
@@ -26,7 +26,7 @@ import uuid
 import util
 from util import dirs, slurmdirs
 import tpu
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 import yaml
 import socket
 import time

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf_v2411.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/conf_v2411.py
@@ -23,7 +23,7 @@ import conf
 from pathlib import Path
 import util
 from util import dirs, slurmdirs
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 
 FILE_PREAMBLE = """
 # Warning:

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/mig_flex.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/mig_flex.py
@@ -16,7 +16,7 @@ from typing import List, Optional
 
 import util
 import uuid
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 from datetime import datetime, timedelta
 from collections import defaultdict
 import logging

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/requirements.txt
@@ -1,4 +1,4 @@
-addict==2.4.0
+
 google-api-core==2.19.0
 google-api-python-client==2.93.0
 google-auth==2.40.3

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/resume.py
@@ -26,7 +26,7 @@ import yaml
 import collections
 from pathlib import Path
 from dataclasses import dataclass
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 
 import util
 from util import (

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/setup_network_storage.py
@@ -27,7 +27,7 @@ import uuid
 import shutil
 from pathlib import Path
 from concurrent.futures import as_completed
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 
 import util
 from util import NSMount, lookup, run, dirs, separate

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf.py
@@ -16,7 +16,7 @@ import pytest
 import mock
 from common import TstNodeset, TstCfg, TstMachineConf, TstTemplateInfo, Placeholder
 
-import addict # type: ignore
+from util import NSDict
 import conf
 import util
 
@@ -200,7 +200,7 @@ def test_conflines(cfg, want):
     lkp.template_info = mock.Mock(return_value=TstTemplateInfo(gpu=None))
     assert conf.conflines(lkp) == want
 
-    cfg.cloud_parameters = addict.Dict(cfg.cloud_parameters)
+    cfg.cloud_parameters = NSDict(cfg.cloud_parameters)
     lkp = util.Lookup(cfg)
     lkp.template_info = mock.Mock(return_value=TstTemplateInfo(gpu=None))
     assert conf.conflines(lkp) == want

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf_v2411.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_conf_v2411.py
@@ -16,7 +16,7 @@ import pytest
 from mock import Mock
 from common import TstNodeset, TstCfg, TstMachineConf, TstTemplateInfo, Placeholder
 
-import addict # type: ignore
+from util import NSDict
 from conf import conflines
 import util
 
@@ -138,7 +138,7 @@ def test_conflines(cfg, want):
     lkp.template_info = Mock(return_value=TstTemplateInfo(gpu=None))
     assert conflines(lkp) == want
 
-    cfg.cloud_parameters = addict.Dict(cfg.cloud_parameters)
+    cfg.cloud_parameters = NSDict(cfg.cloud_parameters)
     lkp = util.Lookup(cfg)
     lkp.cfg.slurm_version = "24.11"
     lkp.template_info = Mock(return_value=TstTemplateInfo(gpu=None))

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -24,7 +24,7 @@ import util
 from util import NodeState, MachineType, AcceleratorInfo, UpcomingMaintenance, InstanceResourceStatus, FutureReservation, ReservationDetails
 from google.api_core.client_options import ClientOptions  # noqa: E402
 from googleapiclient.errors import HttpError # type: ignore
-from addict import Dict as NSDict # type: ignore
+from util import NSDict
 
 # Note: need to install pytest-mock
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -60,7 +60,54 @@ import google.api_core.exceptions as gExceptions
 import requests as requests_lib
 
 import yaml
-from addict import Dict as NSDict # type: ignore
+class AttrDict(dict):
+    """A dict subclass that allows attribute access to keys, with auto-expansion.
+    
+    This replaces the external 'addict' dependency.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+        self.update(*args, **kwargs)
+
+    def __getattr__(self, key):
+        if key not in self:
+            self[key] = AttrDict()
+        return self[key]
+
+    def __setattr__(self, key, value):
+        self[key] = value
+
+    def __delattr__(self, key):
+        try:
+            del self[key]
+        except KeyError as e:
+            raise AttributeError(e) from e
+
+    def __setitem__(self, key, value):
+        if isinstance(value, dict) and not isinstance(value, AttrDict):
+            value = AttrDict(value)
+        elif isinstance(value, list):
+            value = [AttrDict(x) if isinstance(x, dict) and not isinstance(x, AttrDict) else x for x in value]
+        super().__setitem__(key, value)
+
+    def update(self, *args, **kwargs):
+        for k, v in dict(*args, **kwargs).items():
+            self[k] = v
+
+    def to_dict(self):
+        """Recursively convert the AttrDict and its nested structures back to standard dicts."""
+        d = {}
+        for k, v in self.items():
+            if isinstance(v, AttrDict):
+                d[k] = v.to_dict()
+            elif isinstance(v, list):
+                d[k] = [x.to_dict() if isinstance(x, AttrDict) else x for x in v]
+            else:
+                d[k] = v
+        return d
+
+NSDict = AttrDict
 import file_cache
 
 USER_AGENT = "Slurm_GCP_Scripts/1.5 (GPN:SchedMD)"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -71,6 +71,8 @@ class AttrDict(dict):
         self.update(*args, **kwargs)
 
     def __getattr__(self, key):
+        if key.startswith('__') and key.endswith('__'):
+            raise AttributeError(key)
         if key not in self:
             self[key] = AttrDict()
         return self[key]
@@ -85,11 +87,16 @@ class AttrDict(dict):
             raise AttributeError(e) from e
 
     def __setitem__(self, key, value):
+        super().__setitem__(key, self._convert(value))
+
+    def _convert(self, value):
         if isinstance(value, dict) and not isinstance(value, AttrDict):
-            value = AttrDict(value)
-        elif isinstance(value, list):
-            value = [AttrDict(x) if isinstance(x, dict) and not isinstance(x, AttrDict) else x for x in value]
-        super().__setitem__(key, value)
+            return AttrDict(value)
+        if isinstance(value, list):
+            return [self._convert(x) for x in value]
+        if isinstance(value, tuple):
+            return tuple(self._convert(x) for x in value)
+        return value
 
     def update(self, *args, **kwargs):
         for k, v in dict(*args, **kwargs).items():
@@ -97,15 +104,18 @@ class AttrDict(dict):
 
     def to_dict(self):
         """Recursively convert the AttrDict and its nested structures back to standard dicts."""
-        d = {}
-        for k, v in self.items():
-            if isinstance(v, AttrDict):
-                d[k] = v.to_dict()
-            elif isinstance(v, list):
-                d[k] = [x.to_dict() if isinstance(x, AttrDict) else x for x in v]
-            else:
-                d[k] = v
-        return d
+        return self._to_dict_helper(self)
+
+    def _to_dict_helper(self, value):
+        if isinstance(value, AttrDict):
+            return {k: self._to_dict_helper(v) for k, v in value.items()}
+        if isinstance(value, dict):
+            return {k: self._to_dict_helper(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._to_dict_helper(x) for x in value]
+        if isinstance(value, tuple):
+            return tuple(self._to_dict_helper(x) for x in value)
+        return value
 
 NSDict = AttrDict
 import file_cache
@@ -818,7 +828,7 @@ def _fetch_config(old_hash: Optional[str]) -> Optional[Tuple[NSDict, str]]:
         login_groups=_download(blobs.login_group),
     ), blobs.hash
 
-def _fetch_mounted_config() -> Optional[Tuple[NSDict, str]]:
+def _fetch_mounted_config() -> NSDict:
     if not dirs.slurm_bucket_mount.is_mount():
         raise Exception(f"{dirs.slurm_bucket_mount} is not mounted")
 
@@ -2015,7 +2025,7 @@ class Lookup:
             delete_at_time=parse_gcp_timestamp(reservation.get("deleteAtTime")) if reservation.get("deleteAtTime") else None,
             bulk_insert_name=bulk_insert_name)
 
-    def nodeset_reservation(self, nodeset: NSDict) -> Optional[ReservationDetails]:
+    def nodeset_reservation(self, nodeset: Any) -> Optional[ReservationDetails]:
         if not nodeset.reservation_name:
             return None
 
@@ -2032,7 +2042,7 @@ class Lookup:
         project, name = match.group("project", "reservation")
         return self.get_reservation_details(project, zone, name, nodeset.reservation_name)
 
-    def future_reservation(self, nodeset: NSDict) -> Optional[FutureReservation]:
+    def future_reservation(self, nodeset: Any) -> Optional[FutureReservation]:
         if not nodeset.future_reservation:
             return None
 

--- a/docs/hybrid-slurm-cluster/requirements.in
+++ b/docs/hybrid-slurm-cluster/requirements.in
@@ -1,4 +1,4 @@
-addict~=2.0
+
 google-cloud-pubsub~=2.0
 google-api-python-client==2.61.0
 httplib2==0.20.4

--- a/docs/hybrid-slurm-cluster/requirements.txt
+++ b/docs/hybrid-slurm-cluster/requirements.txt
@@ -4,10 +4,7 @@
 #
 #    pip-compile --generate-hashes docs/hybrid-slurm-cluster/requirements.in
 #
-addict==2.4.0 \
-    --hash=sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc \
-    --hash=sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494
-    # via -r docs/hybrid-slurm-cluster/requirements.in
+
 certifi==2024.7.4 \
     --hash=sha256:5a1e7645bc0ec61a09e26c36f6106dd4cf40c6db3a1fb6352b0244e7fb057c7b \
     --hash=sha256:c198e21b1289c2ab85ee4e67bb4b4ef3ead0892059901a8d5b622f24a1101e90

--- a/tools/cloud-workstations/requirements.in
+++ b/tools/cloud-workstations/requirements.in
@@ -1,4 +1,4 @@
-addict==2.4.0
+
 backcall==0.2.0
 cachetools==5.3.1
 certifi==2024.7.4

--- a/tools/cloud-workstations/requirements.txt
+++ b/tools/cloud-workstations/requirements.txt
@@ -4,10 +4,7 @@
 #
 #    pip-compile --generate-hashes tools/cloud-workstations/requirements.in
 #
-addict==2.4.0 \
-    --hash=sha256:249bb56bbfd3cdc2a004ea0ff4c2b6ddc84d53bc2194761636eb314d5cfa5dfc \
-    --hash=sha256:b3b2210e0e067a281f5646c8c5db92e99b7231ea8b0eb5f74dbdf9e259d4e494
-    # via -r tools/cloud-workstations/requirements.in
+
 asttokens==3.0.1 \
     --hash=sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a \
     --hash=sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7


### PR DESCRIPTION
### Summary
Removes the external Python dependency `addict` and replaces it with a lightweight, custom `AttrDict` class in `util.py` (aliased as `NSDict`). This preserves the existing attribute-access and nested auto-expansion syntax used throughout the Slurm provider scripts without relying on an external package.

### Why
Unblocks **PR #5801** (supply chain security). The `dependency-review` CI job failed because `pip/addict` has an **OpenSSF Scorecard score of 2.8** (below the 3.0 threshold) due to repository stagnation. Replacing it with an internal implementation resolves this security compliance blocker.

### Key Changes
* **Implemented `AttrDict`** in `util.py` to mimic `addict.Dict` (attribute access, auto-expansion, recursive dict/list conversion, `to_dict()`).
* **Updated imports** in 9 Slurm scripts and unit tests to use `from util import NSDict` instead of `addict`.
* **Removed `addict`** from all `requirements.txt`/`.in` files, Ansible roles, startup scripts, and `.pre-commit-config.yaml`.

### Verification
* **Syntax Check:** Ran `py_compile` on all modified Python files (**passed with 0 errors**).
* **Behavioral Check:** Verified `AttrDict` behavior (attribute read/write, auto-expansion, recursion, serialization) via local prototype tests (**all passed**).