### PR TITLE
feat(job): Enable jobs to schedule on autoscaling clusters

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -909,7 +909,7 @@ func (g *GKEOrchestrator) resolveTopology(job *orchestrator.JobDefinition) (stri
 
 	logging.Info("Auto-discovering Topology for %s...", job.MachineType)
 	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
-	output, err := g.queryDiscoveredTopologies(accelLabel)
+	output, err := g.queryDiscoveredTopologies(accelLabel, job.MachineType)
 	if err != nil {
 		return "", false, err
 	}
@@ -1047,8 +1047,17 @@ func (g *GKEOrchestrator) parseTopologies(output string) map[string]bool {
 	return topologies
 }
 
-func (g *GKEOrchestrator) queryDiscoveredTopologies(accelLabel string) (string, error) {
+func (g *GKEOrchestrator) queryDiscoveredTopologies(accelLabel string, machineType string) (string, error) {
 	selector := fmt.Sprintf("cloud.google.com/gke-tpu-accelerator=%s", accelLabel)
+
+	var nodePoolTopologies []string
+	for _, np := range g.clusterDesc.NodePools {
+		if strings.EqualFold(np.Config.MachineType, machineType) {
+			if np.PlacementPolicy != nil && np.PlacementPolicy.TpuTopology != "" {
+				nodePoolTopologies = append(nodePoolTopologies, np.PlacementPolicy.TpuTopology)
+			}
+		}
+	}
 
 	res := g.executor.ExecuteCommand("kubectl", "get", "resourceflavors.kueue.x-k8s.io", "-o", "jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}", "-l", selector)
 	output := strings.TrimSpace(res.Stdout)
@@ -1060,7 +1069,11 @@ func (g *GKEOrchestrator) queryDiscoveredTopologies(accelLabel string) (string, 
 		}
 		output = strings.TrimSpace(res.Stdout)
 	}
-	return output, nil
+
+	if len(nodePoolTopologies) > 0 {
+		output = strings.Join(nodePoolTopologies, "\n") + "\n" + output
+	}
+	return strings.TrimSpace(output), nil
 }
 
 func (g *GKEOrchestrator) BuildContainerImage(job orchestrator.JobDefinition) (string, error) {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -168,7 +168,7 @@ func (g *GKEOrchestrator) verifyStaticSlicingActive(job *orchestrator.JobDefinit
 	}
 
 	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
-	output, err := g.queryDiscoveredTopologies(accelLabel)
+	output, err := g.queryDiscoveredTopologies(accelLabel, job.MachineType)
 	if err != nil {
 		return false, fmt.Errorf("failed to discover topologies for static sub-slicing check: %w", err)
 	}

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -386,6 +386,7 @@ func TestVerifyStaticSlicingActive(t *testing.T) {
 		machineType    string
 		requestedTopo  string
 		mockResponses  map[string][]shell.CommandResult
+		nodePools      []gkeJobNodePool
 		wantActive     bool
 		wantErr        bool
 		verifyCacheHit bool
@@ -473,12 +474,43 @@ func TestVerifyStaticSlicingActive(t *testing.T) {
 			},
 			wantActive: false,
 		},
+		{
+			name:          "Static sub-slicing active (discovered from scaled-to-0 node pool)",
+			machineType:   "ct6e-standard-8t",
+			requestedTopo: "2x2",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get topologies.kueue.x-k8s.io -o json": {
+					{ExitCode: 0, Stdout: `{"items":[{"metadata":{"name":"tpu-topology"}}]}`},
+				},
+				"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+					{ExitCode: 0, Stdout: ""},
+				},
+				"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+					{ExitCode: 0, Stdout: ""},
+				},
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "tpu-pool-4x4",
+					Config: gkeNodePoolConfig{
+						MachineType: "ct6e-standard-8t",
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						TpuTopology: "4x4",
+					},
+				},
+			},
+			wantActive: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockExec := NewMockExecutor(tt.mockResponses)
 			orc := newTestGKEOrchestrator(mockExec)
+			if len(tt.nodePools) > 0 {
+				orc.clusterDesc.NodePools = tt.nodePools
+			}
 
 			job := &orchestrator.JobDefinition{
 				MachineType: tt.machineType,

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -249,6 +249,7 @@ type gkeAutoscaling struct {
 type gkePlacementPolicy struct {
 	AcceleratorTopologyMode string `json:"acceleratorTopologyMode"`
 	Type                    string `json:"type"`
+	TpuTopology             string `json:"tpuTopology"`
 }
 
 type gkeJobNodePool struct {


### PR DESCRIPTION
 By incorporating topology information directly from the cluster's node pool configuration, the system can now correctly resolve topologies even when node pools are scaled to zero
 
* TPU Topology Discovery: Updated the GKE orchestrator to discover TPU topologies from node pool configurations, enabling support for clusters that have scaled to zero.
* Placement Policy Update: Added TpuTopology field to the gkePlacementPolicy struct to capture topology information from cluster descriptions.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
