### PR TITLE
fix(job): restrict TPU topology node constraints & deprecated rbac-proxy images

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -195,6 +195,8 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--num-nodes cannot be used with TPU jobs (it is calculated automatically from topology)")
 	}
 
+	jobTopology := strings.ToLower(strings.TrimSpace(topology))
+
 	jobDef := orchestrator.JobDefinition{
 		ImageName:                     imageName,
 		BaseImage:                     baseImage,
@@ -219,7 +221,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		RestartOnExitCodes:            restartOnExitCodes,
 		ImagePullSecrets:              imagePullSecrets,
 		ServiceAccountName:            serviceAccountName,
-		Topology:                      topology,
+		Topology:                      jobTopology,
 		GKEScheduler:                  gkeScheduler,
 		AwaitJobCompletion:            awaitJobCompletion,
 		UseParallelContainers:         !gkeDisableParallelContainers,

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -259,29 +259,41 @@ Use `--node-constraint` to target a specific node pool. This maps to node labels
   --node-constraint "cloud.google.com/gke-nodepool=my-custom-nodepool"
 ```
 
-**Example 2: Target Multiple Topologies (Dynamic Routing)**
-Use a pipe separator (`|`) in `--node-constraint` to specify multiple allowed values for a constraint. This generates a `nodeAffinity` block instead of a strict `nodeSelector`, allowing the workload to fall back to other pools if the preferred one is full.
+**Example 2: Target Multiple Node Pools (Fallback Scheduling)**
+Use a pipe separator (`|`) in `--node-constraint` to specify multiple allowed values for standard constraints. This generates a `nodeAffinity` block instead of a strict `nodeSelector`, allowing the workload to schedule on any of the specified pools.
 
 ```bash
 ./gcluster job submit \
   --name my-fallback-job \
   --command "python app.py" \
-  --compute-type v6e-4 \
-  --node-constraint "cloud.google.com/gke-tpu-topology=2x2|4x4"
+  --compute-type c2-standard-60 \
+  --node-constraint "cloud.google.com/gke-nodepool=nodepool-a|nodepool-b"
 ```
 
 > [!CAUTION]
-> **Dynamic Slicing Interaction:**
+> **TPU Topology Constraints (GKE Warden Limitation):**
 >
-> When using GKE Dynamic Slicing, be careful setting topology constraints in `--node-constraint`.
+> GKE clusters run a validating webhook (GKE Warden) that rejects any pod template where the affinity list for `cloud.google.com/gke-tpu-topology` contains **more than one unique value**.
 >
-> GKE labels nodes with their *physical* pool topology (e.g., `4x4`). If you request a smaller slice (e.g., `2x2`) via `--topology`, GKE handles the placement via annotations automatically.
+> Consequently, passing multiple values separated by a pipe for TPU topology (e.g., `"2x2|4x4"`) is **strictly blocked** by `gcluster` client-side validation to avoid GKE admission rejection.
 >
-> However, if you also pass `--node-constraint "cloud.google.com/gke-tpu-topology=2x2"`, you are forcing strict Node Affinity. The scheduler will only look for nodes physically labeled `2x2` and will **refuse to schedule** on the `4x4` pool, defeating Dynamic Slicing.
->
-> To avoid this, either omit the topology from `--node-constraint` when using Dynamic Slicing, or explicitly include the larger pool topologies in the pipe-separated list (e.g., `"2x2|4x4"`).
+> **Best Practice (Queue-Based Fallback):**
+> If you leave `--node-constraint` empty for TPU topology, GKE Kueue's `tryNextFlavor` cascading mechanism takes over automatically. Kueue will dynamically attempt to admit and schedule the job across all compatible resource pools (flavors) configured in the queue, mutating the pod template to target the single correct physical topology at admission time.
 
-**Example 3: Use Placement Policy**
+**Example 3: TPU Sub-Slicing**
+If you want to schedule a job with a smaller TPU topology on a node pool with larger TPU slices (e.g., running a logical `2x2` workload on a physical `4x4` node pool):
+* Specify the logical slice size in the `--topology` flag: `--topology 2x2` (or let it auto-discover from shorthand labels like `--compute-type v6e-4`)
+* Specify the single physical topology size of the target node pool in `--node-constraint`: `--node-constraint "cloud.google.com/gke-tpu-topology=4x4"`
+
+```bash
+./gcluster job submit \
+  --name my-subslicing-job \
+  --command "python app.py" \
+  --compute-type v6e-4 \
+  --node-constraint "cloud.google.com/gke-tpu-topology=4x4"
+```
+
+**Example 4: Use Placement Policy**
 Use `--placement-policy` to specify a GCE Placement Policy (e.g., for compact placement to reduce latency).
 
 ```bash
@@ -293,7 +305,7 @@ Use `--placement-policy` to specify a GCE Placement Policy (e.g., for compact pl
 
 *(Note: requires a `PlacementPolicy` resource named `compact-placement` to exist on the cluster)*
 
-**Example 4: Pod Failure Policy**
+**Example 5: Pod Failure Policy**
 Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (these do not count against the `restarts` budget).
 
 ```bash
@@ -303,7 +315,7 @@ Use `--restart-on-exit-codes` to specify retriable exit codes at the pod level (
   --restart-on-exit-codes 1,137
 ```
 
-**Example 5: Private Registry & Service Account**
+**Example 6: Private Registry & Service Account**
 Use `--image-pull-secret` and `--service-account` for secure jobs.
 
 ```bash
@@ -314,7 +326,7 @@ Use `--image-pull-secret` and `--service-account` for secure jobs.
   --service-account "my-workload-sa"
 ```
 
-**Example 6: Explicit Kueue Queue Selection**
+**Example 7: Explicit Kueue Queue Selection**
 Use `--queue` to submit the job to a specific Kueue LocalQueue.
 
 ```bash
@@ -329,7 +341,7 @@ Use `--queue` to submit the job to a specific Kueue LocalQueue.
 
 (Note: You would need to ensure a Kueue `LocalQueue` named `my-local-queue` is configured on your cluster.)
 
-### Example 7: Targeting Provisioning Models (Spot/Reservation) on GKE NAP Clusters
+### Example 8: Targeting Provisioning Models (Spot/Reservation) on GKE NAP Clusters
 
 > [!NOTE]
 > The `--gke-nap-provisioning` and `--gke-nap-reservation` flags are supported **only** on GKE clusters with Node Auto-Provisioning (NAP) enabled. They cannot be used on static GKE clusters where NAP is disabled, and doing so will result in an immediate pre-flight validation error.

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1744,10 +1744,12 @@ func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, sched
 
 func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isCPUMachine bool) (string, error) {
 	nodeSelector := make(map[string]string)
-	if existing := GetNodeSelector(schedOpts); existing != nil {
-		for k, v := range existing {
-			nodeSelector[k] = v
-		}
+	existing, err := getNodeSelector(schedOpts)
+	if err != nil {
+		return "", err
+	}
+	for k, v := range existing {
+		nodeSelector[k] = v
 	}
 
 	// Inject unified consumption options

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -908,6 +908,8 @@ func (g *GKEOrchestrator) injectTolerationsAndLabels(data map[interface{}]interf
 		podSpec["tolerations"] = tolerations
 	}
 
+	replaceDeprecatedRbacProxyImage(podSpec)
+
 	if podMeta, ok := template["metadata"].(map[interface{}]interface{}); ok {
 		labels, ok := podMeta["labels"].(map[interface{}]interface{})
 		if !ok {
@@ -919,6 +921,37 @@ func (g *GKEOrchestrator) injectTolerationsAndLabels(data map[interface{}]interf
 		labels["control-plane"] = "controller-manager"
 		labels["app.kubernetes.io/component"] = "controller-manager"
 	}
+}
+
+// replaceDeprecatedRbacProxyImage replaces the deprecated image "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1"
+// with "quay.io/brancz/kube-rbac-proxy:v0.13.1" in the JobSet controller pods to avoid deployment failures
+// due to GCR container registry deprecation.
+//
+// TODO: Remove this helper function once the default JobSet version/manifest is upgraded.
+func replaceDeprecatedRbacProxyImage(podSpec map[interface{}]interface{}) {
+	replaceInContainerList := func(containerKey string) {
+		containers, ok := podSpec[containerKey].([]interface{})
+		if !ok {
+			return
+		}
+		for _, c := range containers {
+			containerMap, ok := c.(map[interface{}]interface{})
+			if !ok {
+				continue
+			}
+			img, ok := containerMap["image"].(string)
+			const deprecatedProxyPrefix = "gcr.io/kubebuilder/kube-rbac-proxy"
+			if ok && (img == deprecatedProxyPrefix || strings.HasPrefix(img, deprecatedProxyPrefix+":") || strings.HasPrefix(img, deprecatedProxyPrefix+"@")) {
+				suffix := strings.TrimPrefix(img, deprecatedProxyPrefix)
+				newImg := "quay.io/brancz/kube-rbac-proxy" + suffix
+				containerMap["image"] = newImg
+				logging.Info("Replaced deprecated image %s with %s in %s", img, newImg, containerKey)
+			}
+		}
+	}
+
+	replaceInContainerList("containers")
+	replaceInContainerList("initContainers")
 }
 
 func (g *GKEOrchestrator) applyManifests(manifests []byte, filename string) error {

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -554,3 +554,126 @@ func TestValidatePriorityClass_NotExist(t *testing.T) {
 		t.Errorf("expected error to contain %q, got %v", expected, err)
 	}
 }
+
+func TestReplaceDeprecatedRbacProxyImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		podSpec  map[interface{}]interface{}
+		wantSpec map[interface{}]interface{}
+	}{
+		{
+			name: "replaces v0.13.1 image",
+			podSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy",
+						"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1",
+					},
+					map[interface{}]interface{}{
+						"name":  "other-container",
+						"image": "nginx:latest",
+					},
+				},
+			},
+			wantSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy",
+						"image": "quay.io/brancz/kube-rbac-proxy:v0.13.1",
+					},
+					map[interface{}]interface{}{
+						"name":  "other-container",
+						"image": "nginx:latest",
+					},
+				},
+			},
+		},
+		{
+			name: "replaces v0.14.0 image dynamically",
+			podSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy",
+						"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0",
+					},
+				},
+			},
+			wantSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy",
+						"image": "quay.io/brancz/kube-rbac-proxy:v0.14.0",
+					},
+				},
+			},
+		},
+		{
+			name: "ignores unrelated images",
+			podSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "main",
+						"image": "gcr.io/my-project/my-image:latest",
+					},
+				},
+			},
+			wantSpec: map[interface{}]interface{}{
+				"containers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "main",
+						"image": "gcr.io/my-project/my-image:latest",
+					},
+				},
+			},
+		},
+		{
+			name: "replaces image in initContainers",
+			podSpec: map[interface{}]interface{}{
+				"initContainers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy-init",
+						"image": "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1",
+					},
+				},
+			},
+			wantSpec: map[interface{}]interface{}{
+				"initContainers": []interface{}{
+					map[interface{}]interface{}{
+						"name":  "kube-rbac-proxy-init",
+						"image": "quay.io/brancz/kube-rbac-proxy:v0.13.1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			replaceDeprecatedRbacProxyImage(tt.podSpec)
+
+			checkContainers := func(key string) {
+				containers, ok1 := tt.podSpec[key].([]interface{})
+				wantContainers, ok2 := tt.wantSpec[key].([]interface{})
+				if ok1 != ok2 {
+					t.Fatalf("mismatch in %s presence: got %v, want %v", key, ok1, ok2)
+				}
+				if !ok1 {
+					return
+				}
+				if len(containers) != len(wantContainers) {
+					t.Fatalf("length mismatch for %s: got %d, want %d", key, len(containers), len(wantContainers))
+				}
+				for i := range containers {
+					c := containers[i].(map[interface{}]interface{})
+					w := wantContainers[i].(map[interface{}]interface{})
+					if c["image"] != w["image"] {
+						t.Errorf("image mismatch in %s: got %q, want %q", key, c["image"], w["image"])
+					}
+				}
+			}
+
+			checkContainers("containers")
+			checkContainers("initContainers")
+		})
+	}
+}

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -33,7 +33,7 @@ type SchedulingOptions struct {
 	IsStaticSlicing    bool
 }
 
-func GetNodeSelector(opts SchedulingOptions) map[string]string {
+func getNodeSelector(opts SchedulingOptions) (map[string]string, error) {
 	nodeSelector := make(map[string]string)
 
 	if opts.PlacementPolicy != "" {
@@ -45,17 +45,22 @@ func GetNodeSelector(opts SchedulingOptions) map[string]string {
 		if strings.Contains(v, "|") {
 			continue
 		}
-		// Skip if it's topology (will go to affinity)
+		// Validate topology format
 		if k == tpuTopologyLabel {
+			trimmed := strings.ToLower(strings.TrimSpace(v))
+			if !config.TopologyRegex.MatchString(trimmed) {
+				return nil, fmt.Errorf("invalid topology format %q for key %s", v, k)
+			}
+			nodeSelector[k] = trimmed
 			continue
 		}
 		nodeSelector[k] = v
 	}
 
 	if len(nodeSelector) == 0 {
-		return nil
+		return nil, nil
 	}
-	return nodeSelector
+	return nodeSelector, nil
 }
 
 func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
@@ -89,14 +94,13 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 
 	for _, k := range keys {
 		v := opts.NodeAffinityLabels[k]
-		isTopologyMerge := (k == tpuTopologyLabel) && (opts.Topology != "") && !(opts.IsDynamicSlicing || opts.IsStaticSlicing)
 		hasPipe := strings.Contains(v, "|")
 
-		if !hasPipe && k != tpuTopologyLabel {
+		if !hasPipe {
 			continue
 		}
 
-		values, err := parseAffinityValues(k, v, opts.Topology, isTopologyMerge)
+		values, err := parseAffinityValues(k, v)
 		if err != nil {
 			return nil, err
 		}
@@ -117,28 +121,23 @@ func GetAffinity(opts SchedulingOptions) (*corev1.Affinity, error) {
 	return affinity, nil
 }
 
-func parseAffinityValues(k string, v string, topology string, isTopologyMerge bool) ([]string, error) {
-	if v == "" && !isTopologyMerge {
+func parseAffinityValues(k string, v string) ([]string, error) {
+	if v == "" {
 		return nil, nil
 	}
 
-	var values []string
-	if isTopologyMerge {
-		values = append(values, topology)
+	if k == tpuTopologyLabel && strings.Contains(v, "|") {
+		return nil, fmt.Errorf("multiple topologies in node constraints are not supported for key %s: got %q. GKE Warden validation rejects templates targeting multiple topologies", k, v)
 	}
 
-	if v != "" {
-		for _, val := range strings.Split(v, "|") {
-			trimmed := strings.TrimSpace(val)
-			if trimmed == "" {
-				return nil, fmt.Errorf("invalid node constraint for key %s: empty element in %q", k, v)
-			}
-			if k == tpuTopologyLabel && !config.TopologyRegex.MatchString(trimmed) {
-				return nil, fmt.Errorf("invalid topology format %q for key %s", trimmed, k)
-			}
-			if !slices.Contains(values, trimmed) {
-				values = append(values, trimmed)
-			}
+	var values []string
+	for _, val := range strings.Split(v, "|") {
+		trimmed := strings.TrimSpace(val)
+		if trimmed == "" {
+			return nil, fmt.Errorf("invalid node constraint for key %s: empty element in %q", k, v)
+		}
+		if !slices.Contains(values, trimmed) {
+			values = append(values, trimmed)
 		}
 	}
 

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -22,16 +22,91 @@ import (
 )
 
 func TestGetNodeSelector(t *testing.T) {
-	opts := SchedulingOptions{
-		PlacementPolicy:    "compact-placement",
-		NodeAffinityLabels: map[string]string{"key": "value"},
+	tests := []struct {
+		name      string
+		opts      SchedulingOptions
+		wantKey   string
+		wantValue string
+		wantErr   bool
+	}{
+		{
+			name: "basic labels inclusion",
+			opts: SchedulingOptions{
+				PlacementPolicy: "compact-placement",
+				NodeAffinityLabels: map[string]string{
+					"key": "value",
+				},
+			},
+			wantKey:   "key",
+			wantValue: "value",
+		},
+		{
+			name: "skip pipe separated values (goes to affinity)",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"pipe-key": "val1|val2",
+				},
+			},
+			wantKey: "pipe-key",
+		},
+		{
+			name: "single value topology inclusion",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "4x4",
+				},
+			},
+			wantKey:   "cloud.google.com/gke-tpu-topology",
+			wantValue: "4x4",
+		},
+		{
+			name: "case insensitivity canonicalization",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "4X4",
+				},
+			},
+			wantKey:   "cloud.google.com/gke-tpu-topology",
+			wantValue: "4x4",
+		},
+		{
+			name: "invalid topology format fails",
+			opts: SchedulingOptions{
+				NodeAffinityLabels: map[string]string{
+					"cloud.google.com/gke-tpu-topology": "invalid",
+				},
+			},
+			wantErr: true,
+		},
 	}
-	selector := GetNodeSelector(opts)
-	if selector["cloud.google.com/gke-placement-group"] != "compact-placement" {
-		t.Errorf("Expected placement policy label, got %v", selector["cloud.google.com/gke-placement-group"])
-	}
-	if selector["key"] != "value" {
-		t.Errorf("Expected user label, got %v", selector["key"])
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selector, err := getNodeSelector(tt.opts)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.wantValue == "" {
+				if selector != nil {
+					if _, exists := selector[tt.wantKey]; exists {
+						t.Errorf("Expected key %s to be excluded from nodeSelector", tt.wantKey)
+					}
+				}
+			} else {
+				if selector == nil {
+					t.Fatal("Expected selector, got nil")
+				}
+				if val := selector[tt.wantKey]; val != tt.wantValue {
+					t.Errorf("Expected key %s value to be %q, got %q", tt.wantKey, tt.wantValue, val)
+				}
+			}
+		})
 	}
 }
 
@@ -176,7 +251,10 @@ func TestGetNodeSelector_DynamicTopology(t *testing.T) {
 		},
 		Topology: "2x2",
 	}
-	selector := GetNodeSelector(opts)
+	selector, err := getNodeSelector(opts)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if selector["normal-key"] != "value" {
 		t.Errorf("Expected normal-key to be 'value', got %v", selector["normal-key"])
@@ -184,8 +262,8 @@ func TestGetNodeSelector_DynamicTopology(t *testing.T) {
 	if _, exists := selector["pipe-key"]; exists {
 		t.Errorf("Expected pipe-key to be excluded from nodeSelector")
 	}
-	if _, exists := selector["cloud.google.com/gke-tpu-topology"]; exists {
-		t.Errorf("Expected cloud.google.com/gke-tpu-topology to be excluded from nodeSelector due to smart merging")
+	if selector["cloud.google.com/gke-tpu-topology"] != "2x2" {
+		t.Errorf("Expected cloud.google.com/gke-tpu-topology to be '2x2', got %v", selector["cloud.google.com/gke-tpu-topology"])
 	}
 }
 
@@ -208,26 +286,14 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 			wantValues: []string{"val1", "val2"},
 		},
 		{
-			name: "smart merging (legacy case)",
-			opts: SchedulingOptions{
-				Topology: "2x2",
-				NodeAffinityLabels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "4x4",
-				},
-			},
-			wantKey:    "cloud.google.com/gke-tpu-topology",
-			wantValues: []string{"2x2", "4x4"},
-		},
-		{
-			name: "prioritize baseline and deduplicate",
+			name: "multiple topologies in constraint fails",
 			opts: SchedulingOptions{
 				Topology: "2x2x1",
 				NodeAffinityLabels: map[string]string{
 					"cloud.google.com/gke-tpu-topology": "2x2x2|2x2x1",
 				},
 			},
-			wantKey:    "cloud.google.com/gke-tpu-topology",
-			wantValues: []string{"2x2x1", "2x2x2"},
+			wantErr: true,
 		},
 		{
 			name: "null safety with whitespace (now fails)",
@@ -235,38 +301,6 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 				Topology: "2x2x1",
 				NodeAffinityLabels: map[string]string{
 					"cloud.google.com/gke-tpu-topology": " | ",
-				},
-			},
-			wantErr: true,
-		},
-		{
-			name: "null safety with empty string",
-			opts: SchedulingOptions{
-				Topology: "2x2x1",
-				NodeAffinityLabels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "",
-				},
-			},
-			wantKey:    "cloud.google.com/gke-tpu-topology",
-			wantValues: []string{"2x2x1"},
-		},
-		{
-			name: "skip baseline for dynamic slicing",
-			opts: SchedulingOptions{
-				Topology: "2x2x1",
-				NodeAffinityLabels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "2x2x2",
-				},
-				IsDynamicSlicing: true,
-			},
-			wantKey:    "cloud.google.com/gke-tpu-topology",
-			wantValues: []string{"2x2x2"},
-		},
-		{
-			name: "invalid topology format",
-			opts: SchedulingOptions{
-				NodeAffinityLabels: map[string]string{
-					"cloud.google.com/gke-tpu-topology": "invalid",
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION

## Key Changes

### 1. TPU Topology Validation & Restrictions

* **GKE Warden Compliance**: The toolkit now strictly blocks the use of multiple values (via the pipe | operator) in `--node-constraints` for the `cloud.google.com/gke-tpu-topology` label. This prevents GKE clusters from rejecting pod templates that target multiple physical topologies.

* **Removal of "Smart Merging"**: Automatic merging of the `--topology` flag value into the node affinity constraints has been removed to ensure scheduling logic is explicit and predictable.

* **Case Insensitivity**: All TPU topology values are now canonicalized to lowercase at the point of submission and within scheduling logic to ensure case-insensitive matching with node labels.

### 2. Dynamic Image Replacement

* **GCR Deprecation Fix**: Implemented a dynamic helper function that replaces deprecated gcr.io/kubebuilder/kube-rbac-proxy images with the supported quay.io/brancz/kube-rbac-proxy versions in JobSet manifests.

### 3. Documentation Updates

* **Scheduling Guidance**: Updated docs/gcluster_job_guide.md with new examples for TPU sub-slicing and fallback scheduling.

* **Best Practices**: Added instructions on leveraging GKE Kueue’s tryNextFlavor mechanism for dynamic resource allocation when topology constraints are omitted.
