### PR TITLE
Fixing A3H Issue

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
@@ -191,10 +191,10 @@ deployment_groups:
               package_filename: /tmp/{{ package_url | basename }}
               nvidia_packages:
               - cuda-toolkit-12-8
-              - nvidia-dkms-570-server-open
-              - nvidia-driver-570-server-open
+              - nvidia-dkms-580-server-open
+              - nvidia-driver-580-server-open
               - datacenter-gpu-manager
-              - libnvidia-nscq-570
+              - libnvidia-nscq-580
               - nvidia-container-toolkit
             tasks:
             - name: Download NVIDIA repository package

--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
@@ -193,7 +193,7 @@ deployment_groups:
               - cuda-toolkit-12-8
               - nvidia-dkms-580-server-open
               - nvidia-driver-580-server-open
-              - datacenter-gpu-manager
+              - datacenter-gpu-manager-4-cuda13
               - libnvidia-nscq-580
               - nvidia-container-toolkit
             tasks:

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -43,7 +43,7 @@ steps:
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"
   - "MACHINE_TYPE=a3-highgpu-8g"
-  - "NUM_NODES=4"
+  - "NUM_NODES=2"
   - "INSTANCE_PREFIX=a3hsp"
   - "PROJECT_ID=$PROJECT_ID"
   - "BUILD_ID=$BUILD_ID"


### PR DESCRIPTION
This PR resolves an issue where A3 High compute nodes in the Slurm cluster consistently entered a `DRAIN` state immediately after job execution, which prevented multi-node workloads and NCCL tests from running. 

The root cause was an API version mismatch between the NVIDIA Driver 580 (CUDA 13.0) and the legacy Datacenter GPU Manager (DCGM) v3.3.9 package. The unversioned `datacenter-gpu-manager` dependency resolved to an older version that is incompatible with CUDA 13, causing Slurm's mandatory post-job health check (`gpu-test` epilog) to fail.

This PR implements the permanent fix by explicitly pairing the Driver 580 upgrade with the CUDA 13-compatible DCGM v4 package (`datacenter-gpu-manager-4-cuda13`). 

Additionally, it updates the daily cloud build tests to run with 2 nodes instead of 4