### PR TITLE
Fix(validators): Support shared reservations in blueprint validation

### DIFF
--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -408,42 +408,90 @@ func TestReservationExists(ctx context.Context, reservationProjectID string, zon
 	return fmt.Errorf("reservation %q was not found in any zone of project %q", reservationName, reservationProjectID)
 }
 
+// findReservationOwnerProject scans the blueprint's modules to see if a specific
+// reservation is configured as a shared reservation (meaning it has an explicit
+// 'project' field defined in its 'reservation_affinity' settings).
+// If found, it returns the owner project ID; otherwise, it returns an empty string.
 func findReservationOwnerProject(bp config.Blueprint, reservationName string) string {
 	var ownerProject string
+	// Walk through all modules in the blueprint to inspect their settings
 	bp.WalkModulesSafe(func(_ config.ModulePath, m *config.Module) {
+		// Short-circuit if we already found the owner project in a previous module
 		if ownerProject != "" {
 			return
 		}
-		settings := m.Settings
-		if settings.Has("reservation_affinity") {
-			val := settings.Get("reservation_affinity")
-			v, err := bp.Eval(val)
-			if err != nil || !v.Type().IsObjectType() {
-				return
-			}
-			attrs := v.AsValueMap()
-			if specRes, ok := attrs["specific_reservations"]; ok && specRes.Type().IsListType() {
-				iterator := specRes.ElementIterator()
-				for iterator.Next() {
-					_, resVal := iterator.Element()
-					if !resVal.Type().IsObjectType() {
-						continue
-					}
-					resAttrs := resVal.AsValueMap()
-					nameVal, hasName := resAttrs["name"]
-					projectVal, hasProject := resAttrs["project"]
-
-					if hasName && nameVal.Type() == cty.String && !nameVal.IsNull() && nameVal.AsString() == reservationName {
-						if hasProject && projectVal.Type() == cty.String && !projectVal.IsNull() && projectVal.AsString() != "" {
-							ownerProject = projectVal.AsString()
-							return
-						}
-					}
-				}
-			}
-		}
+		ownerProject = extractOwnerProjectFromModule(bp, m, reservationName)
 	})
 	return ownerProject
+}
+
+// extractOwnerProjectFromModule evaluates the 'reservation_affinity' setting of a module
+// and attempts to extract the owner project if it matches the target reservation.
+func extractOwnerProjectFromModule(bp config.Blueprint, m *config.Module, reservationName string) string {
+	settings := m.Settings
+	if !settings.Has("reservation_affinity") {
+		return ""
+	}
+	val := settings.Get("reservation_affinity")
+	v, err := bp.Eval(val)
+	if err != nil || v.IsNull() {
+		return ""
+	}
+	v, _ = v.Unmark()
+	if !v.IsKnown() || !v.Type().IsObjectType() {
+		return ""
+	}
+	attrs := v.AsValueMap()
+	specRes, ok := attrs["specific_reservations"]
+	if !ok {
+		return ""
+	}
+	return findProjectInSpecificReservations(specRes, reservationName)
+}
+
+// findProjectInSpecificReservations iterates over the 'specific_reservations' list
+// to find a reservation matching the target name and returns its owner project.
+func findProjectInSpecificReservations(specRes cty.Value, reservationName string) string {
+	specRes, _ = specRes.Unmark()
+	if specRes.IsNull() || !specRes.IsKnown() || !specRes.Type().IsListType() {
+		return ""
+	}
+	iterator := specRes.ElementIterator()
+	for iterator.Next() {
+		_, resVal := iterator.Element()
+		if proj := getProjectIfReservationMatches(resVal, reservationName); proj != "" {
+			return proj
+		}
+	}
+	return ""
+}
+
+// getProjectIfReservationMatches checks if a single reservation object matches the
+// target name and returns its owner project if specified.
+func getProjectIfReservationMatches(resVal cty.Value, reservationName string) string {
+	resVal, _ = resVal.Unmark()
+	if resVal.IsNull() || !resVal.IsKnown() || !resVal.Type().IsObjectType() {
+		return ""
+	}
+	resAttrs := resVal.AsValueMap()
+	if getSafeString(resAttrs, "name") != reservationName {
+		return ""
+	}
+	return getSafeString(resAttrs, "project")
+}
+
+// getSafeString extracts a string value from a cty.Value map by key, returning
+// an empty string if the key is missing, null, or not of type string.
+func getSafeString(attrs map[string]cty.Value, key string) string {
+	val, ok := attrs[key]
+	if !ok {
+		return ""
+	}
+	val, _ = val.Unmark()
+	if val.Type() != cty.String || val.IsNull() || !val.IsKnown() {
+		return ""
+	}
+	return val.AsString()
 }
 
 func testReservationExists(bp config.Blueprint, inputs config.Dict) error {

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -23,6 +23,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	compute "google.golang.org/api/compute/v1"
@@ -34,6 +35,10 @@ import (
 
 var reservationNameRegex = regexp.MustCompile(`^projects/([^/]+)/reservations/([^/]+)$`)
 var resKeyRegex = regexp.MustCompile(`^(.*_)?reservation(_name)?$`)
+
+var newComputeService = func(ctx context.Context) (*compute.Service, error) {
+	return compute.NewService(ctx)
+}
 
 const gcsFuseProfileUserRole = "gke.gcsfuse.profileUser"
 
@@ -335,7 +340,7 @@ func TestReservationExists(ctx context.Context, reservationProjectID string, zon
 		return nil
 	}
 
-	s, err := compute.NewService(ctx)
+	s, err := newComputeService(ctx)
 	if err != nil {
 		return handleClientError(err)
 	}
@@ -403,6 +408,44 @@ func TestReservationExists(ctx context.Context, reservationProjectID string, zon
 	return fmt.Errorf("reservation %q was not found in any zone of project %q", reservationName, reservationProjectID)
 }
 
+func findReservationOwnerProject(bp config.Blueprint, reservationName string) string {
+	var ownerProject string
+	bp.WalkModulesSafe(func(_ config.ModulePath, m *config.Module) {
+		if ownerProject != "" {
+			return
+		}
+		settings := m.Settings
+		if settings.Has("reservation_affinity") {
+			val := settings.Get("reservation_affinity")
+			v, err := bp.Eval(val)
+			if err != nil || !v.Type().IsObjectType() {
+				return
+			}
+			attrs := v.AsValueMap()
+			if specRes, ok := attrs["specific_reservations"]; ok && specRes.Type().IsListType() {
+				iterator := specRes.ElementIterator()
+				for iterator.Next() {
+					_, resVal := iterator.Element()
+					if !resVal.Type().IsObjectType() {
+						continue
+					}
+					resAttrs := resVal.AsValueMap()
+					nameVal, hasName := resAttrs["name"]
+					projectVal, hasProject := resAttrs["project"]
+
+					if hasName && nameVal.Type() == cty.String && !nameVal.IsNull() && nameVal.AsString() == reservationName {
+						if hasProject && projectVal.Type() == cty.String && !projectVal.IsNull() && projectVal.AsString() != "" {
+							ownerProject = projectVal.AsString()
+							return
+						}
+					}
+				}
+			}
+		}
+	})
+	return ownerProject
+}
+
 func testReservationExists(bp config.Blueprint, inputs config.Dict) error {
 	if err := checkInputs(inputs, []string{"project_id", "zone", "reservation_name"}); err != nil {
 		return err
@@ -434,6 +477,11 @@ func testReservationExists(bp config.Blueprint, inputs config.Dict) error {
 		// Use the project ID extracted from the path instead of the deployment project.
 		reservationProjectID = matches[1]
 		targetName = matches[2]
+	} else {
+		// It's a simple name. Check if we can find an owner project in the blueprint modules.
+		if ownerProj := findReservationOwnerProject(bp, resInput); ownerProj != "" {
+			reservationProjectID = ownerProj
+		}
 	}
 
 	// Pass context from the caller to ensure cancellation/timeouts are respected

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -606,3 +606,95 @@ func (s *MySuite) TestReservationExistsValidatorWithSharedReservation_NotFound(c
 	c.Assert(err, NotNil) // Use Assert to stop execution if nil, avoiding panic on next line
 	c.Check(err.Error(), Matches, ".*was not found in any zone of project.*")
 }
+
+func (s *MySuite) TestReservationExistsValidatorWithSharedReservation_UnknownAndMarked(c *C) {
+	// 1. Mock the compute service to return success ONLY for the resolved owner-proj
+	oldCreator := newComputeService
+	defer func() { newComputeService = oldCreator }()
+	apiCalled := false
+	newComputeService = func(ctx context.Context) (*compute.Service, error) {
+		return mockComputeService(func(w http.ResponseWriter, r *http.Request) {
+			path := r.URL.Path
+			// Verify the API call is routed to the owner project resolved from the marked setting
+			if strings.Contains(path, "owner-proj") && strings.Contains(path, "us-central1-a") && strings.Contains(path, "my-shared-res") {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"name": "my-shared-res", "status": "READY"}`))
+				apiCalled = true
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}), nil
+	}
+
+	// 2. Create a marked reservation_affinity value (simulating sensitive or module-passed values)
+	markedAffinity := cty.ObjectVal(map[string]cty.Value{
+		"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+		"specific_reservations": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"name":    cty.StringVal("my-shared-res"),
+				"project": cty.StringVal("owner-proj"),
+			}),
+		}),
+	}).Mark("sensitive-metadata") // Mark the entire object
+
+	// 3. Set up a blueprint containing:
+	//    - A module with a MARKED reservation_affinity
+	//    - A module with an UNKNOWN reservation_affinity (simulating unresolved module outputs)
+	//    - A module with a list containing an UNKNOWN reservation element
+	bp := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{
+			"project_id":       cty.StringVal("consumer-proj"),
+			"zone":             cty.StringVal("us-central1-a"),
+			"reservation_name": cty.StringVal("my-shared-res"),
+		}),
+		Groups: []config.Group{
+			{
+				Modules: []config.Module{
+					{
+						ID: "module_with_marked_affinity",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": markedAffinity,
+						}),
+					},
+					{
+						ID: "module_with_unknown_affinity",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": cty.UnknownVal(cty.Object(map[string]cty.Type{
+								"consume_reservation_type": cty.String,
+							})),
+						}),
+					},
+					{
+						ID: "module_with_unknown_element",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+								"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+								"specific_reservations": cty.ListVal([]cty.Value{
+									cty.UnknownVal(cty.Object(map[string]cty.Type{
+										"name":    cty.String,
+										"project": cty.String,
+									})),
+								}),
+							}),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	// 4. Run the validator
+	inputs := config.NewDict(map[string]cty.Value{
+		"project_id":       cty.StringVal("consumer-proj"),
+		"zone":             cty.StringVal("us-central1-a"),
+		"reservation_name": cty.StringVal("my-shared-res"),
+	})
+
+	// Execution should NOT panic. It should safely skip unknown values,
+	// unmark the marked value, resolve "owner-proj", and succeed.
+	err := testReservationExists(bp, inputs)
+
+	// 5. Assertions
+	c.Assert(err, IsNil)
+	c.Check(apiCalled, Equals, true)
+}

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -19,6 +19,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/zclconf/go-cty/cty"
@@ -296,4 +297,312 @@ func (s *MySuite) TestValidateDiskTypeInZone(c *C) {
 
 		c.Check(err.Error(), Matches, ".*disk type.*invalid-disk.*not available.*")
 	}
+}
+
+func (s *MySuite) TestFindReservationOwnerProject(c *C) {
+	// Case 1: No reservation_affinity in blueprint
+	{
+		bp := config.Blueprint{
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID:       "m1",
+							Settings: config.NewDict(nil),
+						},
+					},
+				},
+			},
+		}
+		proj := findReservationOwnerProject(bp, "my-res")
+		c.Check(proj, Equals, "")
+	}
+
+	// Case 2: reservation_affinity present but type is not SPECIFIC_RESERVATION
+	{
+		bp := config.Blueprint{
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID: "m1",
+							Settings: config.NewDict(map[string]cty.Value{
+								"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+									"consume_reservation_type": cty.StringVal("ANY_RESERVATION"),
+								}),
+							}),
+						},
+					},
+				},
+			},
+		}
+		proj := findReservationOwnerProject(bp, "my-res")
+		c.Check(proj, Equals, "")
+	}
+
+	// Case 3: SPECIFIC_RESERVATION present, but name doesn't match
+	{
+		bp := config.Blueprint{
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID: "m1",
+							Settings: config.NewDict(map[string]cty.Value{
+								"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+									"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+									"specific_reservations": cty.ListVal([]cty.Value{
+										cty.ObjectVal(map[string]cty.Value{
+											"name":    cty.StringVal("other-res"),
+											"project": cty.StringVal("owner-proj"),
+										}),
+									}),
+								}),
+							}),
+						},
+					},
+				},
+			},
+		}
+		proj := findReservationOwnerProject(bp, "my-res")
+		c.Check(proj, Equals, "")
+	}
+
+	// Case 4: SPECIFIC_RESERVATION present, name matches, project is set
+	{
+		bp := config.Blueprint{
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID: "m1",
+							Settings: config.NewDict(map[string]cty.Value{
+								"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+									"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+									"specific_reservations": cty.ListVal([]cty.Value{
+										cty.ObjectVal(map[string]cty.Value{
+											"name":    cty.StringVal("my-res"),
+											"project": cty.StringVal("owner-proj"),
+										}),
+									}),
+								}),
+							}),
+						},
+					},
+				},
+			},
+		}
+		proj := findReservationOwnerProject(bp, "my-res")
+		c.Check(proj, Equals, "owner-proj")
+	}
+
+	// Case 5: SPECIFIC_RESERVATION present, name matches, project is NOT set (optional field)
+	{
+		bp := config.Blueprint{
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID: "m1",
+							Settings: config.NewDict(map[string]cty.Value{
+								"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+									"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+									"specific_reservations": cty.ListVal([]cty.Value{
+										cty.ObjectVal(map[string]cty.Value{
+											"name":    cty.StringVal("my-res"),
+											"project": cty.NullVal(cty.String),
+										}),
+									}),
+								}),
+							}),
+						},
+					},
+				},
+			},
+		}
+		proj := findReservationOwnerProject(bp, "my-res")
+		c.Check(proj, Equals, "")
+	}
+}
+
+func (s *MySuite) TestReservationExistsValidatorWithSharedReservation(c *C) {
+	var capturedProject string
+	var capturedZone string
+	var capturedName string
+
+	// 1. Mock the compute service
+	oldCreator := newComputeService
+	defer func() { newComputeService = oldCreator }()
+	newComputeService = func(ctx context.Context) (*compute.Service, error) {
+		return mockComputeService(func(w http.ResponseWriter, r *http.Request) {
+			// URL format: /projects/{project}/zones/{zone}/reservations/{reservation}
+			path := r.URL.Path
+			parts := strings.Split(path, "/")
+			if len(parts) >= 7 && parts[1] == "projects" && parts[3] == "zones" && parts[5] == "reservations" {
+				capturedProject = parts[2]
+				capturedZone = parts[4]
+				capturedName = parts[6]
+			}
+			// Return a dummy reservation to simulate success
+			_, _ = w.Write([]byte(`{"name": "my-shared-res", "status": "READY"}`))
+		}), nil
+	}
+
+	// 2. Set up a blueprint with a shared reservation in a module's reservation_affinity
+	bp := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{
+			"project_id":       cty.StringVal("consumer-proj"),
+			"zone":             cty.StringVal("us-central1-a"),
+			"reservation_name": cty.StringVal("my-shared-res"),
+		}),
+		Groups: []config.Group{
+			{
+				Modules: []config.Module{
+					{
+						ID: "gke_node_pool",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+								"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+								"specific_reservations": cty.ListVal([]cty.Value{
+									cty.ObjectVal(map[string]cty.Value{
+										"name":    cty.StringVal("my-shared-res"),
+										"project": cty.StringVal("owner-proj"),
+									}),
+								}),
+							}),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	// 3. Run the validator
+	inputs := config.NewDict(map[string]cty.Value{
+		"project_id":       cty.StringVal("consumer-proj"),
+		"zone":             cty.StringVal("us-central1-a"),
+		"reservation_name": cty.StringVal("my-shared-res"),
+	})
+
+	err := testReservationExists(bp, inputs)
+
+	// 4. Assertions
+	c.Check(err, IsNil)                            // Should succeed because mock returned 200 OK
+	c.Check(capturedProject, Equals, "owner-proj") // CRITICAL: Must be owner-proj, not consumer-proj!
+	c.Check(capturedZone, Equals, "us-central1-a")
+	c.Check(capturedName, Equals, "my-shared-res")
+}
+
+func (s *MySuite) TestReservationExistsValidatorWithSharedReservation_PermissionDenied(c *C) {
+	// 1. Mock the compute service to return 403 Forbidden
+	oldCreator := newComputeService
+	defer func() { newComputeService = oldCreator }()
+	newComputeService = func(ctx context.Context) (*compute.Service, error) {
+		return mockComputeService(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte(`{"error": {"code": 403, "message": "Identity lacks permission to get reservation"}}`))
+		}), nil
+	}
+
+	// 2. Set up a blueprint with a shared reservation in a module's reservation_affinity
+	bp := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{
+			"project_id":       cty.StringVal("consumer-proj"),
+			"zone":             cty.StringVal("us-central1-a"),
+			"reservation_name": cty.StringVal("my-shared-res"),
+		}),
+		Groups: []config.Group{
+			{
+				Modules: []config.Module{
+					{
+						ID: "gke_node_pool",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+								"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+								"specific_reservations": cty.ListVal([]cty.Value{
+									cty.ObjectVal(map[string]cty.Value{
+										"name":    cty.StringVal("my-shared-res"),
+										"project": cty.StringVal("owner-proj"),
+									}),
+								}),
+							}),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	// 3. Run the validator
+	inputs := config.NewDict(map[string]cty.Value{
+		"project_id":       cty.StringVal("consumer-proj"),
+		"zone":             cty.StringVal("us-central1-a"),
+		"reservation_name": cty.StringVal("my-shared-res"),
+	})
+
+	err := testReservationExists(bp, inputs)
+
+	// 4. Assertion: Should succeed (return nil) despite 403, because it's handled as a soft warning
+	c.Check(err, IsNil)
+}
+
+func (s *MySuite) TestReservationExistsValidatorWithSharedReservation_NotFound(c *C) {
+	// 1. Mock the compute service
+	oldCreator := newComputeService
+	defer func() { newComputeService = oldCreator }()
+	newComputeService = func(ctx context.Context) (*compute.Service, error) {
+		return mockComputeService(func(w http.ResponseWriter, r *http.Request) {
+			path := r.URL.Path
+			if strings.Contains(path, "aggregated") {
+				// Discovery/List succeeds but returns empty list of reservations
+				_, _ = w.Write([]byte(`{"items": {}}`))
+				return
+			}
+			// Direct check fails with 404
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte(`{"error": {"code": 404, "message": "Reservation not found"}}`))
+		}), nil
+	}
+
+	// 2. Set up a blueprint with a shared reservation in a module's reservation_affinity
+	bp := config.Blueprint{
+		Vars: config.NewDict(map[string]cty.Value{
+			"project_id":       cty.StringVal("consumer-proj"),
+			"zone":             cty.StringVal("us-central1-a"),
+			"reservation_name": cty.StringVal("my-shared-res"),
+		}),
+		Groups: []config.Group{
+			{
+				Modules: []config.Module{
+					{
+						ID: "gke_node_pool",
+						Settings: config.NewDict(map[string]cty.Value{
+							"reservation_affinity": cty.ObjectVal(map[string]cty.Value{
+								"consume_reservation_type": cty.StringVal("SPECIFIC_RESERVATION"),
+								"specific_reservations": cty.ListVal([]cty.Value{
+									cty.ObjectVal(map[string]cty.Value{
+										"name":    cty.StringVal("my-shared-res"),
+										"project": cty.StringVal("owner-proj"),
+									}),
+								}),
+							}),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	// 3. Run the validator
+	inputs := config.NewDict(map[string]cty.Value{
+		"project_id":       cty.StringVal("consumer-proj"),
+		"zone":             cty.StringVal("us-central1-a"),
+		"reservation_name": cty.StringVal("my-shared-res"),
+	})
+
+	err := testReservationExists(bp, inputs)
+
+	// 4. Assertion: Should FAIL (return error) because it's 404 and not found anywhere
+	c.Assert(err, NotNil) // Use Assert to stop execution if nil, avoiding panic on next line
+	c.Check(err.Error(), Matches, ".*was not found in any zone of project.*")
 }


### PR DESCRIPTION
Resolve owner project for shared reservations defined in modules.

When validating if a reservation exists, the validator previously only looked at the global 'project_id'. If a shared reservation was defined inside a module's 'reservation_affinity' setting with a specific 'project' field, the validator would fail to find it because it searched in the deployment project.

This CL adds a helper 'findReservationOwnerProject' that scans the blueprint modules for 'reservation_affinity' settings matching the reservation name. If a specific owner project is defined, it uses that project for the validation.