### PR TITLE
Fix(gke): Support shared reservations in job submission

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1756,6 +1756,30 @@ func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, sched
 	return nil
 }
 
+func injectProvisioningLabels(nodeSelector map[string]string, provisioning string, reservation string) {
+	switch strings.ToLower(provisioning) {
+	case "spot":
+		nodeSelector["cloud.google.com/gke-provisioning"] = "spot"
+	case "on-demand":
+		nodeSelector["cloud.google.com/gke-provisioning"] = "standard"
+	case "reservation":
+		res := parseReservationURI(reservation)
+		if res.Name != "" {
+			nodeSelector["cloud.google.com/reservation-name"] = res.Name
+			nodeSelector["cloud.google.com/reservation-affinity"] = "specific"
+		}
+		if res.Project != "" {
+			nodeSelector["cloud.google.com/reservation-project"] = res.Project
+		}
+		if res.Block != "" {
+			nodeSelector["cloud.google.com/reservation-blocks"] = res.Block
+		}
+		if res.Subblock != "" {
+			nodeSelector["cloud.google.com/reservation-subblocks"] = res.Subblock
+		}
+	}
+}
+
 func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orchestrator.JobDefinition, isCPUMachine bool) (string, error) {
 	nodeSelector := make(map[string]string)
 	existing, err := getNodeSelector(schedOpts)
@@ -1767,14 +1791,7 @@ func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orc
 	}
 
 	// Inject unified consumption options
-	switch job.GKENAPProvisioning {
-	case "spot":
-		nodeSelector["cloud.google.com/gke-provisioning"] = "spot"
-	case "on-demand":
-		nodeSelector["cloud.google.com/gke-provisioning"] = "standard"
-	case "reservation":
-		nodeSelector["cloud.google.com/reservation-name"] = extractShortReservationName(job.GKENAPReservation)
-	}
+	injectProvisioningLabels(nodeSelector, job.GKENAPProvisioning, job.GKENAPReservation)
 
 	cap, err := g.FetchMachineCapabilities(job.MachineType, job.ClusterLocation)
 	if err != nil {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2498,3 +2498,130 @@ func TestPrepareManifestOptions_PathwaysPlatform(t *testing.T) {
 		})
 	}
 }
+
+func TestSharedReservationManifestGeneration(t *testing.T) {
+	orc := NewGKEOrchestrator()
+	orc.projectID = "my-consumer-project"
+	orc.clusterDesc = gkeCluster{
+		Locations: []string{"us-central1-a"},
+	}
+	orc.napEnabled = true
+	orc.napLimits = map[string]int64{
+		"nvidia.com/gpu": 100,
+	}
+	// Mock machine capabilities fetcher to avoid actual API calls
+	orc.machineCapCache = map[string]MachineTypeCap{
+		"a3-highgpu-8g:us-central1-a": {
+			GuestCpus: 208,
+			MemoryMb:  1884160,
+			Accelerators: []struct {
+				Count int    `json:"guestAcceleratorCount"`
+				Type  string `json:"guestAcceleratorType"`
+			}{
+				{Count: 8, Type: "nvidia-h100-80gb"},
+			},
+		},
+	}
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:       "shared-res-job",
+		MachineType:        "a3-highgpu-8g",
+		ComputeType:        "a3-highgpu-8g",
+		ClusterLocation:    "us-central1-a",
+		GKENAPProvisioning: "reservation",
+		GKENAPReservation:  "projects/my-owner-project/reservations/my-shared-res",
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Verify that the manifest contains the correct node selector labels
+	expectedLabels := []string{
+		"cloud.google.com/reservation-name: my-shared-res",
+		"cloud.google.com/reservation-project: my-owner-project",
+		"cloud.google.com/reservation-affinity: specific",
+	}
+
+	for _, label := range expectedLabels {
+		if !strings.Contains(manifest, label) {
+			t.Errorf("Expected manifest to contain nodeSelector label %q, but it was missing.\nManifest:\n%s", label, manifest)
+		}
+	}
+}
+
+func TestSharedReservationSubblockManifestGeneration(t *testing.T) {
+	orc := NewGKEOrchestrator()
+	orc.projectID = "my-consumer-project"
+	orc.clusterDesc = gkeCluster{
+		Locations: []string{"us-central1-a"},
+	}
+	orc.napEnabled = true
+	orc.napLimits = map[string]int64{
+		"nvidia.com/gpu": 100,
+	}
+	// Mock machine capabilities fetcher to avoid actual API calls
+	orc.machineCapCache = map[string]MachineTypeCap{
+		"a3-highgpu-8g:us-central1-a": {
+			GuestCpus: 208,
+			MemoryMb:  1884160,
+			Accelerators: []struct {
+				Count int    `json:"guestAcceleratorCount"`
+				Type  string `json:"guestAcceleratorType"`
+			}{
+				{Count: 8, Type: "nvidia-h100-80gb"},
+			},
+		},
+	}
+
+	job := orchestrator.JobDefinition{
+		WorkloadName:       "shared-res-subblock-job",
+		MachineType:        "a3-highgpu-8g",
+		ComputeType:        "a3-highgpu-8g",
+		ClusterLocation:    "us-central1-a",
+		GKENAPProvisioning: "reservation",
+		GKENAPReservation:  "projects/my-owner-project/reservations/my-shared-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2",
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	// Verify that the manifest contains the correct node selector labels, including subblock
+	expectedLabels := []string{
+		"cloud.google.com/reservation-name: my-shared-res",
+		"cloud.google.com/reservation-project: my-owner-project",
+		"cloud.google.com/reservation-blocks: block-1",
+		"cloud.google.com/reservation-subblocks: subblock-2",
+		"cloud.google.com/reservation-affinity: specific",
+	}
+
+	for _, label := range expectedLabels {
+		if !strings.Contains(manifest, label) {
+			t.Errorf("Expected manifest to contain nodeSelector label %q, but it was missing.\nManifest:\n%s", label, manifest)
+		}
+
+	}
+}

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -225,11 +225,12 @@ func (g *GKEOrchestrator) fillManifestStrings(opts *ManifestOptions, schedOpts S
 
 func (g *GKEOrchestrator) resolveReservationTolerations(machineType, reservationName string) []corev1.Toleration {
 	var tolerations []corev1.Toleration
+	res := parseReservationURI(reservationName)
 	// Always add the standard GKE reservation toleration to support NAP where the node pool may not exist yet
 	tolerations = append(tolerations, corev1.Toleration{
 		Key:      "cloud.google.com/reservation-name",
 		Operator: corev1.TolerationOpEqual,
-		Value:    extractShortReservationName(reservationName),
+		Value:    res.Name,
 		Effect:   corev1.TaintEffectNoSchedule,
 	})
 
@@ -237,14 +238,15 @@ func (g *GKEOrchestrator) resolveReservationTolerations(machineType, reservation
 		"cloud.google.com/reservation-name": true,
 	}
 
-	shortResName := extractShortReservationName(reservationName)
+	shortResName := res.Name
 	for _, np := range g.clusterDesc.NodePools {
 		lblVal := np.Config.Labels["cloud.google.com/reservation-name"]
 		if lblVal == "" {
 			continue
 		}
-		if strings.EqualFold(np.Config.MachineType, machineType) && strings.EqualFold(extractShortReservationName(lblVal), shortResName) {
-			tolerations[0].Value = extractShortReservationName(lblVal)
+		parsedLbl := parseReservationURI(lblVal)
+		if strings.EqualFold(np.Config.MachineType, machineType) && parsedLbl.Name == shortResName {
+			tolerations[0].Value = parsedLbl.Name
 			for _, t := range np.Config.Taints {
 				// Avoid duplicate tolerations
 				if seenTaints[t.Key] {

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -119,37 +119,53 @@ func (g *GKEOrchestrator) validateConsumptionForStaticCluster(job *orchestrator.
 	return nil
 }
 
-// extractShortReservationName extracts the reservation name from a GCE reservation resource URI or reservation path.
-// It handles standard URIs, simple names, and paths containing reservationBlocks/reservationSubBlocks.
-// E.g.,
-// - "my-res" -> "my-res"
-// - "projects/my-project/reservations/my-res" -> "my-res"
-// - "projects/my-project/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2" -> "my-res"
-// - "my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2" -> "my-res"
-func extractShortReservationName(resName string) string {
-	resName = strings.TrimSuffix(resName, "/")
-	if !strings.Contains(resName, "/") {
-		return resName
+// resolveFallbackName returns a fallback reservation name from the URI parts.
+func resolveFallbackName(parts []string) string {
+	if len(parts) == 0 {
+		return ""
 	}
-
-	parts := strings.Split(resName, "/")
-
-	// Case 1: Full GCP URI containing ".../reservations/RESERVATION_NAME/..."
-	for i, part := range parts {
-		if part == "reservations" && i+1 < len(parts) {
-			return parts[i+1]
-		}
-	}
-
-	// Case 2: Path containing ".../reservationBlocks/..." but not "reservations" prefix
+	// If it has reservationBlocks, the name is the one before it
 	for i, part := range parts {
 		if part == "reservationBlocks" && i > 0 {
 			return parts[i-1]
 		}
 	}
-
-	// Fallback: Return the last segment
+	// Fallback to last element
 	return parts[len(parts)-1]
+}
+
+// parseReservationURI parses a GCE reservation resource URI or reservation path into its components.
+// E.g.,
+// - "my-res" -> Name: "my-res"
+// - "projects/my-project/reservations/my-res" -> Project: "my-project", Name: "my-res"
+// - "projects/my-project/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2" -> Project: "my-project", Name: "my-res", Block: "block-1", Subblock: "subblock-2"
+func parseReservationURI(resName string) parsedReservation {
+	resName = strings.TrimSuffix(resName, "/")
+	var parsed parsedReservation
+	if !strings.Contains(resName, "/") {
+		parsed.Name = strings.ToLower(resName)
+		return parsed
+	}
+
+	parts := strings.Split(resName, "/")
+	for i := 0; i < len(parts)-1; i++ {
+		switch parts[i] {
+		case "projects":
+			parsed.Project = strings.ToLower(parts[i+1])
+		case "reservations":
+			parsed.Name = strings.ToLower(parts[i+1])
+		case "reservationBlocks":
+			parsed.Block = strings.ToLower(parts[i+1])
+		case "reservationSubBlocks":
+			parsed.Subblock = strings.ToLower(parts[i+1])
+		}
+	}
+
+	if parsed.Name == "" {
+		parsed.Name = strings.ToLower(resolveFallbackName(parts))
+	}
+
+	return parsed
 }
 
 func isSpecificGPUKey(key string) bool {

--- a/pkg/orchestrator/gke/nap_test.go
+++ b/pkg/orchestrator/gke/nap_test.go
@@ -338,50 +338,102 @@ func TestResolveTolerationsDoesNotMutateSharedArray(t *testing.T) {
 	}
 }
 
-func TestExtractShortReservationName(t *testing.T) {
+func TestParseReservationURI(t *testing.T) {
 	tests := []struct {
 		input string
-		want  string
+		want  parsedReservation
 	}{
 		{
 			input: "my-res",
-			want:  "my-res",
+			want: parsedReservation{
+				Name: "my-res",
+			},
 		},
 		{
 			input: "projects/my-project/reservations/my-res",
-			want:  "my-res",
+			want: parsedReservation{
+				Project: "my-project",
+				Name:    "my-res",
+			},
 		},
 		{
 			input: "projects/my-project/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2",
-			want:  "my-res",
+			want: parsedReservation{
+				Project:  "my-project",
+				Name:     "my-res",
+				Block:    "block-1",
+				Subblock: "subblock-2",
+			},
 		},
 		{
 			input: "my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2",
-			want:  "my-res",
+			want: parsedReservation{
+				Name:     "my-res",
+				Block:    "block-1",
+				Subblock: "subblock-2",
+			},
 		},
 		{
 			input: "nvidia-gb300-1elqwl23xva0f/reservationBlocks/nvidia-gb300-1elqwl23xva0f-block-0001/reservationSubBlocks/nvidia-gb300-1elqwl23xva0f-block-0001-subblock-0002",
-			want:  "nvidia-gb300-1elqwl23xva0f",
+			want: parsedReservation{
+				Name:     "nvidia-gb300-1elqwl23xva0f",
+				Block:    "nvidia-gb300-1elqwl23xva0f-block-0001",
+				Subblock: "nvidia-gb300-1elqwl23xva0f-block-0001-subblock-0002",
+			},
+		},
+		{
+			input: "projects/my-project/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2/",
+			want: parsedReservation{
+				Project:  "my-project",
+				Name:     "my-res",
+				Block:    "block-1",
+				Subblock: "subblock-2",
+			},
+		},
+		{
+			input: "projects/my-project/reservations/my-res/reservationBlocks/block-1",
+			want: parsedReservation{
+				Project: "my-project",
+				Name:    "my-res",
+				Block:   "block-1",
+			},
+		},
+		{
+			input: "projects/123456789/reservations/my-res",
+			want: parsedReservation{
+				Project: "123456789",
+				Name:    "my-res",
+			},
+		},
+		{
+			input: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-res",
+			want: parsedReservation{
+				Project: "my-project",
+				Name:    "my-res",
+			},
 		},
 		{
 			input: "folders/my-folder/my-res",
-			want:  "my-res",
+			want: parsedReservation{
+				Name: "my-res",
+			},
 		},
 		{
-			input: "my-res/",
-			want:  "my-res",
-		},
-		{
-			input: "projects/my-project/reservations/my-res/",
-			want:  "my-res",
+			input: "projects/My-Project/reservations/My-Res/reservationBlocks/Block-1/reservationSubBlocks/Subblock-2",
+			want: parsedReservation{
+				Project:  "my-project",
+				Name:     "my-res",
+				Block:    "block-1",
+				Subblock: "subblock-2",
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
-			got := extractShortReservationName(tt.input)
+			got := parseReservationURI(tt.input)
 			if got != tt.want {
-				t.Errorf("extractShortReservationName(%q) = %q, want %q", tt.input, got, tt.want)
+				t.Errorf("parseReservationURI(%q) = %+v, want %+v", tt.input, got, tt.want)
 			}
 		})
 	}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -351,3 +351,11 @@ type jobSetTemplateData struct {
 	IsTPU                         bool
 	IsGPU                         bool
 }
+
+// parsedReservation holds the extracted components of a GCE reservation URI/path.
+type parsedReservation struct {
+	Project  string
+	Name     string
+	Block    string
+	Subblock string
+}


### PR DESCRIPTION
Extract and inject the reservation owner project when submitting a job with a shared reservation.

GKE requires 'cloud.google.com/reservation-owner-project' to be specified in the nodeSelector to correctly consume shared reservations owned by a different project. This CL extracts the owner project from the reservation URI (if provided) and injects it into the generated manifest's nodeSelector.