### PR TITLE
feat(slurm): add health check and autohealing to HA controller MIGs

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -125,6 +125,29 @@ To enable High Availability:
       mount_options: _netdev,hard,intr
 ```
 
+### Health Checks and Autohealing
+
+When `enable_backup_controller` is `true`, instances are managed by a Managed Instance Group (MIG) with an autohealing policy using a Google Compute Health Check. By default, a TCP health check probes port `6818` with `initial_delay_sec = 900` to allow time for controller startup.
+
+You can customize this configuration using the `health_check` settings block.
+
+#### Tuning Guidelines
+* **Slow Startup (large state/long startup scripts)**: Increase `initial_delay_sec` (e.g. `1200+`) to prevent premature restarts.
+* **Fast Failover**: Lower `initial_delay_sec` (e.g. `600`), `check_interval_sec`, and `timeout_sec`. Note: `timeout_sec` must be $\le$ `check_interval_sec`.
+* **Shared VPC**: The health check firewall rule must be created in the host project. If permissions are restricted or rules are pre-configured, set `create_firewall_rule` to `false` to disable automatic creation. If configuring firewall rules manually, you must allow ingress traffic from GCP health check prober IP ranges (`35.191.0.0/16` and `130.211.0.0/22`) to the controllers on the health check port.
+* **HTTP Health Checks**: Set `type` to `"http"` and configure `request_path` (e.g. `"/healthz"`) to check slurmctld endpoints. See [slurmctld HTTP server](https://slurm.schedmd.com/slurmctld.html#SECTION_HTTP-server) for more details.
+
+Example configuration overrides:
+
+```yaml
+    health_check:
+      type: "tcp"
+      initial_delay_sec: 1200
+      check_interval_sec: 20
+      timeout_sec: 10
+      create_firewall_rule: true
+```
+
 ### Backward Compatibility
 
 The HA feature is **opt-in**. If `enable_backup_controller` is set to `false`
@@ -370,6 +393,8 @@ limitations under the License.
 | [google-beta_google_compute_instance_from_template.controller](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_instance_from_template) | resource |
 | [google_compute_address.controller_ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
 | [google_compute_disk.controller_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
+| [google_compute_firewall.health_check_firewall_rule](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+| [google_compute_health_check.controller_health_check](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check) | resource |
 | [google_compute_instance_group_manager.controller_zonal_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_group_manager) | resource |
 | [google_compute_per_instance_config.controller_zonal_stateful_ips](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_per_instance_config) | resource |
 | [google_compute_region_instance_group_manager.controller_regional_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
@@ -380,6 +405,7 @@ limitations under the License.
 | [google_storage_bucket_iam_member.legacy_readers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_object.partition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_compute_subnetwork.controller_subnetwork](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_subnetwork) | data source |
 | [google_project.controller_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
@@ -439,6 +465,7 @@ limitations under the License.
 | <a name="input_extra_logging_flags"></a> [extra\_logging\_flags](#input\_extra\_logging\_flags) | The only available flag is `trace_api` | `map(bool)` | `{}` | no |
 | <a name="input_gcloud_path_override"></a> [gcloud\_path\_override](#input\_gcloud\_path\_override) | Directory of the gcloud executable to be used during cleanup | `string` | `""` | no |
 | <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br/>    type  = string,<br/>    count = number<br/>  }))</pre> | `[]` | no |
+| <a name="input_health_check"></a> [health\_check](#input\_health\_check) | Health check and autohealing configuration for controller HA instance groups. | <pre>object({<br/>    type                 = optional(string, "tcp")<br/>    port                 = optional(number, 6818)<br/>    initial_delay_sec    = optional(number, 900)<br/>    check_interval_sec   = optional(number, 60)<br/>    timeout_sec          = optional(number, 10)<br/>    healthy_threshold    = optional(number, 2)<br/>    unhealthy_threshold  = optional(number, 5)<br/>    enable_logging       = optional(bool, true)<br/>    request_path         = optional(string, "/healthz")<br/>    create_firewall_rule = optional(bool, true)<br/>    port_name            = optional(string, "slurmctld")<br/>  })</pre> | `{}` | no |
 | <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Defines the image that will be used in the Slurm controller VM instance.<br/><br/>Expected Fields:<br/>name: The name of the image. Mutually exclusive with family.<br/>family: The image family to use. Mutually exclusive with name.<br/>project: The project where the image is hosted.<br/><br/>For more information on creating custom images that comply with Slurm on GCP<br/>see the "Slurm on GCP Custom Images" section in docs/vm-images.md. | `map(string)` | <pre>{<br/>  "family": "slurm-gcp-6-12-hpc-rocky-linux-9",<br/>  "project": "schedmd-slurm-public"<br/>}</pre> | no |
 | <a name="input_instance_image_custom"></a> [instance\_image\_custom](#input\_instance\_image\_custom) | A flag that designates that the user is aware that they are requesting<br/>to use a custom and potentially incompatible image for this Slurm on<br/>GCP module.<br/><br/>If the field is set to false, only the compatible families and project<br/>names will be accepted.  The deployment will fail with any other image<br/>family or name.  If set to true, no checks will be done.<br/><br/>See: https://goo.gle/hpc-slurm-images | `bool` | `false` | no |
 | <a name="input_instance_template"></a> [instance\_template](#input\_instance\_template) | DEPRECATED: Instance template can not be specified for controller. | `string` | `null` | no |

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/controller.tf
@@ -144,7 +144,7 @@ module "slurm_controller_template" {
 
   subnetwork = var.subnetwork_self_link
 
-  tags = concat([local.slurm_cluster_name], var.tags)
+  tags = concat([local.slurm_cluster_name], ["${local.slurm_cluster_name}-controller"], var.tags)
   # termination_action = TODO: add support for termination_action (?)
 }
 
@@ -218,6 +218,67 @@ resource "google_compute_instance_from_template" "controller" {
   }
 }
 
+data "google_compute_subnetwork" "controller_subnetwork" {
+  count     = var.enable_backup_controller ? 1 : 0
+  self_link = var.subnetwork_self_link
+}
+
+# HEALTH CHECK FIREWALL RULE (Allow GCP probers to reach controller MIG)
+resource "google_compute_firewall" "health_check_firewall_rule" {
+  count       = (var.enable_backup_controller && var.health_check.create_firewall_rule) ? 1 : 0
+  name        = "allow-health-check-${local.slurm_cluster_name}"
+  description = "Allow Managed Instance Group Health Checks for Slurm Controller VMs"
+  project     = one(data.google_compute_subnetwork.controller_subnetwork[*].project)
+  network     = one(data.google_compute_subnetwork.controller_subnetwork[*].network)
+
+  direction = "INGRESS"
+  source_ranges = [
+    "130.211.0.0/22",
+    "35.191.0.0/16",
+  ]
+  target_tags = ["${local.slurm_cluster_name}-controller"]
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.health_check.port)]
+  }
+}
+
+# CONTROLLER HEALTH CHECK (for HA autohealing)
+resource "google_compute_health_check" "controller_health_check" {
+  count       = var.enable_backup_controller ? 1 : 0
+  name        = "${local.slurm_cluster_name}-controller-hc"
+  description = "Health check for Slurm Controller HA instance group autohealing"
+  project     = local.controller_project_id
+
+  check_interval_sec  = var.health_check.check_interval_sec
+  timeout_sec         = var.health_check.timeout_sec
+  healthy_threshold   = var.health_check.healthy_threshold
+  unhealthy_threshold = var.health_check.unhealthy_threshold
+
+  dynamic "log_config" {
+    for_each = var.health_check.enable_logging ? [1] : []
+    content {
+      enable = true
+    }
+  }
+
+  dynamic "tcp_health_check" {
+    for_each = var.health_check.type == "tcp" ? [1] : []
+    content {
+      port = var.health_check.port
+    }
+  }
+
+  dynamic "http_health_check" {
+    for_each = var.health_check.type == "http" ? [1] : []
+    content {
+      port         = var.health_check.port
+      request_path = var.health_check.request_path
+    }
+  }
+}
+
 # ZONAL INSTANCE GROUP MANAGER (deployed if ha_type is zonal)
 resource "google_compute_instance_group_manager" "controller_zonal_mig" {
   count              = (var.enable_backup_controller && var.controller_ha_type == "zonal") ? 1 : 0
@@ -226,9 +287,21 @@ resource "google_compute_instance_group_manager" "controller_zonal_mig" {
   zone               = var.zone
   project            = local.controller_project_id
   target_size        = 0
+
+  named_port {
+    name = var.health_check.port_name
+    port = var.health_check.port
+  }
+
   version {
     instance_template = module.slurm_controller_template.self_link
   }
+
+  auto_healing_policies {
+    health_check      = one(google_compute_health_check.controller_health_check[*].id)
+    initial_delay_sec = var.health_check.initial_delay_sec
+  }
+
   update_policy {
     type                  = "PROACTIVE"
     minimal_action        = "REPLACE"
@@ -253,9 +326,21 @@ resource "google_compute_region_instance_group_manager" "controller_regional_mig
   project                   = local.controller_project_id
   distribution_policy_zones = [var.zone, local.backup_zone]
   target_size               = 0
+
+  named_port {
+    name = var.health_check.port_name
+    port = var.health_check.port
+  }
+
   version {
     instance_template = module.slurm_controller_template.self_link
   }
+
+  auto_healing_policies {
+    health_check      = one(google_compute_health_check.controller_health_check[*].id)
+    initial_delay_sec = var.health_check.initial_delay_sec
+  }
+
   update_policy {
     type                         = "PROACTIVE"
     minimal_action               = "REPLACE"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/variables_controller_instance.tf
@@ -459,3 +459,32 @@ variable "slurm_key_mount" {
   })
   default = null
 }
+
+variable "health_check" {
+  description = "Health check and autohealing configuration for controller HA instance groups."
+  type = object({
+    type                 = optional(string, "tcp")
+    port                 = optional(number, 6818)
+    initial_delay_sec    = optional(number, 900)
+    check_interval_sec   = optional(number, 60)
+    timeout_sec          = optional(number, 10)
+    healthy_threshold    = optional(number, 2)
+    unhealthy_threshold  = optional(number, 5)
+    enable_logging       = optional(bool, true)
+    request_path         = optional(string, "/healthz")
+    create_firewall_rule = optional(bool, true)
+    port_name            = optional(string, "slurmctld")
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["tcp", "http"], var.health_check.type)
+    error_message = "The health_check.type must be either 'tcp' or 'http'."
+  }
+
+  validation {
+    condition     = var.health_check.timeout_sec <= var.health_check.check_interval_sec
+    error_message = "The health_check.timeout_sec must be less than or equal to health_check.check_interval_sec."
+  }
+}


### PR DESCRIPTION
Implement GCP Compute Engine health checks, firewall rules, and autohealing policies for High Availability (HA) controller Managed Instance Groups (MIGs).

- Add configurable `var.health_check` object variable in `variables_controller_instance.tf` supporting customizable TCP and HTTP health checks.
- Add `google_compute_health_check.controller_health_check` in `controller.tf` configured for MIG autohealing with logging and threshold settings.
- Add `google_compute_firewall.health_check_firewall_rule` to allow Google Cloud health check prober IP ranges (`130.211.0.0/22`, `35.191.0.0/16`) to reach controller instances.
- Attach `auto_healing_policies` and `named_port` configurations to both zonal and regional controller MIGs.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
