### PR TITLE
Fix(validators): support tuple types in shared reservation check

### DIFF
--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -453,7 +453,10 @@ func extractOwnerProjectFromModule(bp config.Blueprint, m *config.Module, reserv
 // to find a reservation matching the target name and returns its owner project.
 func findProjectInSpecificReservations(specRes cty.Value, reservationName string) string {
 	specRes, _ = specRes.Unmark()
-	if specRes.IsNull() || !specRes.IsKnown() || !specRes.Type().IsListType() {
+	if specRes.IsNull() || !specRes.IsKnown() {
+		return ""
+	}
+	if !specRes.Type().IsListType() && !specRes.Type().IsTupleType() {
 		return ""
 	}
 	iterator := specRes.ElementIterator()


### PR DESCRIPTION
The specific_reservations block under reservation_affinity can be parsed as a cty.Type of tuple instead of list depending on the blueprint structure. Update findProjectInSpecificReservations to support both List and Tuple types when scanning for the owner project of a shared reservation.