### PR TITLE
Fix: update inconsistent metadata validators

### DIFF
--- a/community/modules/compute/gke-nodeset/metadata.yaml
+++ b/community/modules/compute/gke-nodeset/metadata.yaml
@@ -23,8 +23,8 @@ ghpc:
   - validator: regex
     inputs:
       vars: [slurm_cluster_name]
-      pattern: "^[a-z](?:[a-z0-9]{0,9})$"
-    error_message: "'slurm_cluster_name' must contain only lowercase letters and numbers, start with a letter, and be 1-10 characters long."
+      pattern: "^[a-z]([-a-z0-9]{0,19})$"
+    error_message: "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   - validator: range
     inputs:
       vars: [network_storage]

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/metadata.yaml
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/metadata.yaml
@@ -30,8 +30,8 @@ ghpc:
   - validator: regex
     inputs:
       vars: [slurm_cluster_name]
-      pattern: "^[a-z](?:[a-z0-9]{0,9})$"
-    error_message: "'slurm_cluster_name' must contain only lowercase letters and numbers, start with a letter, and be 1-10 characters long."
+      pattern: "^[a-z]([-a-z0-9]{0,19})$"
+    error_message: "Variable 'slurm_cluster_name' must be a match of regex '^[a-z]([-a-z0-9]{0,19})$'."
   - validator: exclusive
     inputs:
       vars: [instance_image.name, instance_image.family]


### PR DESCRIPTION
Updated the regex metadata validators for variable `slurm_cluster_name` to match pre-conditional validator (in variables.tf).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
