### PR TITLE
Fix: update inconsistent metadata validators

### DIFF
--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/metadata.yaml
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/metadata.yaml
@@ -22,8 +22,8 @@ ghpc:
   - validator: regex
     inputs:
       vars: [partition_name]
-      pattern: "^[a-z](?:[a-z0-9]*)$"
-    error_message: "'partition_name' must start with a lowercase letter and can only contain lowercase letters and numbers."
+      pattern: "^[a-z](?:[a-z0-9-]*)$"
+    error_message: "'partition_name' must start with a lowercase letter and can only contain lowercase letters, numbers, and hyphens."
   - validator: exclusive
     inputs:
       vars: [nodeset, nodeset_dyn, nodeset_tpu]


### PR DESCRIPTION
Follow up to PR [#5832](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/5832)
Found similar inconsistency in validations with `partition_name`. 
This PR updates `partition_name` metadata validation to match its pre-conditional validator (in [variables.tf](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/8982f94c4ac16589c1fa455d18fb11c588e48a12/community/modules/compute/schedmd-slurm-gcp-v6-partition/variables.tf#L20)).