### PR TITLE
Fix(subnetwork_project): subnetwork_project was missing from local block in htcondor-execute-point module

### DIFF
--- a/community/modules/compute/htcondor-execute-point/README.md
+++ b/community/modules/compute/htcondor-execute-point/README.md
@@ -196,7 +196,7 @@ limitations under the License.
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.0 |
@@ -204,14 +204,14 @@ limitations under the License.
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 4.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_execute_point_instance_template"></a> [execute\_point\_instance\_template](#module\_execute\_point\_instance\_template) | terraform-google-modules/vm/google//modules/instance_template | ~> 14.0 |
 | <a name="module_gpu"></a> [gpu](#module\_gpu) | ../../../../modules/internal/gpu-definition | n/a |
 | <a name="module_mig"></a> [mig](#module\_mig) | terraform-google-modules/vm/google//modules/mig | ~> 14.0 |
@@ -220,7 +220,7 @@ limitations under the License.
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google_storage_bucket_object.execute_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [null_resource.execute_config](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [google_compute_image.compute_image](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_image) | data source |
@@ -229,7 +229,7 @@ limitations under the License.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_allow_automatic_updates"></a> [allow\_automatic\_updates](#input\_allow\_automatic\_updates) | If false, disables automatic system package updates on the created instances.  This feature is<br/>only available on supported images (or images derived from them).  For more details, see<br/>https://cloud.google.com/compute/docs/instances/create-hpc-vm#disable_automatic_updates | `bool` | `true` | no |
 | <a name="input_central_manager_ips"></a> [central\_manager\_ips](#input\_central\_manager\_ips) | List of IP addresses of HTCondor Central Managers | `list(string)` | n/a | yes |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Cluster Toolkit deployment name. HTCondor cloud resource names will include this value. | `string` | n/a | yes |
@@ -266,7 +266,7 @@ limitations under the License.
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_autoscaler_runner"></a> [autoscaler\_runner](#output\_autoscaler\_runner) | Toolkit runner to configure the HTCondor autoscaler |
 | <a name="output_mig_id"></a> [mig\_id](#output\_mig\_id) | ID of the managed instance group containing the execute points |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -184,11 +184,12 @@ module "execute_point_instance_template" {
   source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "~> 14.0"
 
-  name_prefix = local.name_prefix
-  project_id  = var.project_id
-  region      = var.region
-  network     = local.network_interfaces[0].network
-  subnetwork  = local.network_interfaces[0].subnetwork
+  name_prefix        = local.name_prefix
+  project_id         = var.project_id
+  region             = var.region
+  network            = local.network_interfaces[0].network
+  subnetwork         = local.network_interfaces[0].subnetwork
+  subnetwork_project = local.network_interfaces[0].subnetwork_project
 
   additional_networks = [
     for network_interface in slice(local.network_interfaces, 1, length(local.network_interfaces)) : {

--- a/community/modules/compute/htcondor-execute-point/main.tf
+++ b/community/modules/compute/htcondor-execute-point/main.tf
@@ -125,6 +125,7 @@ locals {
       for ni in var.network_interfaces : {
         network            = ni.network
         subnetwork         = ni.subnetwork
+        subnetwork_project = ni.subnetwork_project
         nic_type           = ni.nic_type
         stack_type         = ni.stack_type
         network_ip         = ni.network_ip
@@ -138,6 +139,7 @@ locals {
       {
         network            = var.network_self_link
         subnetwork         = var.subnetwork_self_link
+        subnetwork_project = null
         nic_type           = null
         stack_type         = null
         network_ip         = ""


### PR DESCRIPTION
This pull request addresses a bug in the `htcondor-execute-point` module where the `subnetwork_project` property was missing from the local network interface configuration. By including this field, the module now correctly handles subnetwork project specifications, ensuring consistent network resource deployment.

### Highlights

* **Network Configuration Fix**: Added the missing `subnetwork_project` field to the local block in the `htcondor-execute-point` module to ensure proper network interface configuration.
* **Documentation Update**: Updated the `README.md` file to refresh the Terraform documentation tables.
