### PR TITLE
Fix(kueue): Unify Kueue resource groups for Pathways workloads

### DIFF
--- a/modules/management/kubectl-apply/README.md
+++ b/modules/management/kubectl-apply/README.md
@@ -75,6 +75,24 @@ The `config_path` field in `kueue` installation accepts a template file, too. Yo
         install: true
 ```
 
+### TPU Flavor Quotas Override (Pathways active)
+
+When Pathways is active, the TPU worker pods request both TPU and CPU/Memory resources. To prevent Kueue from blocking these pods, the default configuration uses high "unlimited" defaults (`999999` and `999999T`) for CPU and Memory quotas on the TPU flavor.
+
+If you want to enforce strict capacity sharing on the TPU pool, you can override these defaults by specifying `tpu_flavor_cpu_quota` and `tpu_flavor_memory_quota` inside `config_template_vars`:
+
+```yaml
+  - id: workload_component_install
+    source: modules/management/kubectl-apply
+    use: [gke_cluster]
+    settings:
+      kueue:
+        install: true
+        config_template_vars:
+          tpu_flavor_cpu_quota: 1024
+          tpu_flavor_memory_quota: "4096G"
+```
+
 You can specify a particular kueue version that you would like to use using the `version` flag. By default, we recommend customers to [use v0.17.1](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L126). You can find the list of supported kueue versions [here](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/modules/management/kubectl-apply/variables.tf#L24).
 
 ```yaml

--- a/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing-pathways.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing-pathways.yaml.tftpl
@@ -48,16 +48,20 @@ spec:
   admissionChecks:
   - dynamic-slicing-ac
   resourceGroups:
-  - coveredResources: ["google.com/tpu"]
+  - coveredResources: ["google.com/tpu", "cpu", "memory"]
     flavors:
     - name: "tpu-flavor"
       resources:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
-  - coveredResources: ["cpu", "memory"]
-    flavors:
+      - name: "cpu"
+        nominalQuota: ${tpu_flavor_cpu_quota} # High default to avoid limiting TPU pods by CPU
+      - name: "memory"
+        nominalQuota: ${tpu_flavor_memory_quota} # High default to avoid limiting TPU pods by Memory
     - name: pathways-flavor
       resources:
+      - name: "google.com/tpu"
+        nominalQuota: "0"
       - name: cpu
         nominalQuota: ${pathways_cpu_quota}
       - name: memory

--- a/modules/management/kubectl-apply/kueue/kueue-configuration-pathways.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/kueue-configuration-pathways.yaml.tftpl
@@ -28,16 +28,20 @@ spec:
     withinClusterQueue: LowerPriority
   namespaceSelector: {} # match all.
   resourceGroups:
-  - coveredResources: ["google.com/tpu"]
+  - coveredResources: ["google.com/tpu", "cpu", "memory"]
     flavors:
     - name: "tpu-flavor"
       resources:
       - name: "google.com/tpu"
         nominalQuota: ${tpu_quota}
-  - coveredResources: ["cpu", "memory"]
-    flavors:
+      - name: "cpu"
+        nominalQuota: ${tpu_flavor_cpu_quota} # High default to avoid limiting TPU pods by CPU
+      - name: "memory"
+        nominalQuota: ${tpu_flavor_memory_quota} # High default to avoid limiting TPU pods by Memory
     - name: pathways-flavor
       resources:
+      - name: "google.com/tpu"
+        nominalQuota: "0"
       - name: cpu
         nominalQuota: ${pathways_cpu_quota}
       - name: memory

--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -31,9 +31,11 @@ locals {
 
   kueue_config_template_vars = merge(
     {
-      pathways_cpu_quota    = 480
-      pathways_memory_quota = "2000G"
-      tpu_quota             = "999999" # Default high value if not set
+      pathways_cpu_quota      = 480
+      pathways_memory_quota   = "2000G"
+      tpu_flavor_cpu_quota    = "999999" # High default to avoid limiting TPU pods by CPU
+      tpu_flavor_memory_quota = "999999T"
+      tpu_quota               = "999999" # Default high value if not set
     },
     var.kueue.config_template_vars != null ? var.kueue.config_template_vars : {}
   )

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -435,6 +435,18 @@ func (g *GKEOrchestrator) getNominalQuota(resName string, fc FlavorCapacity, fna
 func (g *GKEOrchestrator) renderClusterQueue(name string) ([]byte, error) {
 	mainCoveredResourcesMap, pathwaysCoveredResourcesMap := g.calculateCoveredResources()
 
+	_, hasPathways := g.capacity.Flavors["pathways-flavor"]
+
+	// If pathways is active, we unify the resource groups to prevent Kueue from
+	// merging incompatible node selectors for TPU worker pods (which request both
+	// TPU and CPU/Memory).
+	if hasPathways {
+		for res := range pathwaysCoveredResourcesMap {
+			mainCoveredResourcesMap[res] = true
+		}
+		pathwaysCoveredResourcesMap = make(map[string]bool) // Clear to prevent second group generation
+	}
+
 	// Pass 2: Build flavor lists with matched resources
 	var mainFlavors []map[string]interface{}
 	var pathwaysFlavors []map[string]interface{}
@@ -448,31 +460,19 @@ func (g *GKEOrchestrator) renderClusterQueue(name string) ([]byte, error) {
 	for _, fname := range fnames {
 		fc := g.capacity.Flavors[fname]
 		isPathways := (fname == "pathways-flavor")
-		var resources []map[string]interface{}
 
 		coveredMap := mainCoveredResourcesMap
-		if isPathways {
+		if isPathways && !hasPathways {
 			coveredMap = pathwaysCoveredResourcesMap
 		}
 
-		for res := range coveredMap {
-			resources = append(resources, map[string]interface{}{
-				"name":         res,
-				"nominalQuota": g.getNominalQuota(res, fc, fname),
-			})
-		}
-
+		resources := g.buildFlavorResources(coveredMap, fc, fname)
 		if len(resources) > 0 {
-			// Sort resources alphabetically by name
-			sort.Slice(resources, func(i, j int) bool {
-				return resources[i]["name"].(string) < resources[j]["name"].(string)
-			})
-
 			flavor := map[string]interface{}{
 				"name":      fname,
 				"resources": resources,
 			}
-			if isPathways {
+			if isPathways && !hasPathways {
 				pathwaysFlavors = append(pathwaysFlavors, flavor)
 			} else {
 				mainFlavors = append(mainFlavors, flavor)
@@ -481,29 +481,11 @@ func (g *GKEOrchestrator) renderClusterQueue(name string) ([]byte, error) {
 	}
 
 	var resourceGroups []map[string]interface{}
-
-	var mainCoveredResources []string
-	for res := range mainCoveredResourcesMap {
-		mainCoveredResources = append(mainCoveredResources, res)
+	if rg := buildResourceGroup(mainCoveredResourcesMap, mainFlavors); rg != nil {
+		resourceGroups = append(resourceGroups, rg)
 	}
-	sort.Strings(mainCoveredResources)
-	if len(mainCoveredResources) > 0 {
-		resourceGroups = append(resourceGroups, map[string]interface{}{
-			"coveredResources": mainCoveredResources,
-			"flavors":          mainFlavors,
-		})
-	}
-
-	var pathwaysCoveredResources []string
-	for res := range pathwaysCoveredResourcesMap {
-		pathwaysCoveredResources = append(pathwaysCoveredResources, res)
-	}
-	sort.Strings(pathwaysCoveredResources)
-	if len(pathwaysCoveredResources) > 0 {
-		resourceGroups = append(resourceGroups, map[string]interface{}{
-			"coveredResources": pathwaysCoveredResources,
-			"flavors":          pathwaysFlavors,
-		})
+	if rg := buildResourceGroup(pathwaysCoveredResourcesMap, pathwaysFlavors); rg != nil {
+		resourceGroups = append(resourceGroups, rg)
 	}
 
 	cqMap := map[string]interface{}{
@@ -525,6 +507,45 @@ func (g *GKEOrchestrator) renderClusterQueue(name string) ([]byte, error) {
 	}
 
 	return cqBytes, nil
+}
+
+func (g *GKEOrchestrator) buildFlavorResources(coveredMap map[string]bool, fc FlavorCapacity, fname string) []map[string]interface{} {
+	var resources []map[string]interface{}
+	_, hasPathways := g.capacity.Flavors["pathways-flavor"]
+	for res := range coveredMap {
+		var quota = g.getNominalQuota(res, fc, fname)
+		if hasPathways && isTPUFlavor(fname) {
+			switch res {
+			case "cpu":
+				quota = "999999"
+			case "memory":
+				quota = "999999T"
+			}
+		}
+		resources = append(resources, map[string]interface{}{
+			"name":         res,
+			"nominalQuota": quota,
+		})
+	}
+	sort.Slice(resources, func(i, j int) bool {
+		return resources[i]["name"].(string) < resources[j]["name"].(string)
+	})
+	return resources
+}
+
+func buildResourceGroup(coveredMap map[string]bool, flavors []map[string]interface{}) map[string]interface{} {
+	var coveredResources []string
+	for res := range coveredMap {
+		coveredResources = append(coveredResources, res)
+	}
+	sort.Strings(coveredResources)
+	if len(coveredResources) == 0 {
+		return nil
+	}
+	return map[string]interface{}{
+		"coveredResources": coveredResources,
+		"flavors":          flavors,
+	}
 }
 
 func (g *GKEOrchestrator) renderResourceFlavor(name string, nodeLabels map[string]string) ([]byte, error) {

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -68,10 +68,12 @@ func TestRenderClusterQueue_Pathways(t *testing.T) {
 				"flavor-tpu": { // TPU flavor (name contains 'tpu')
 					CPUs:     100,
 					MemoryGi: 400,
+					TPUs:     8, // Physical TPU capacity
 				},
-				"pathways-flavor": { // Pathways flavor
+				"pathways-flavor": { // Pathways flavor (CPU-only)
 					CPUs:     480,
 					MemoryGi: 2000,
+					TPUs:     0, // No TPUs
 				},
 			},
 		},
@@ -86,18 +88,27 @@ func TestRenderClusterQueue_Pathways(t *testing.T) {
 
 	// Verify quotas are rendered correctly
 	// The TPU flavor (flavor-tpu) CPU/Memory must be overridden to the high defaults (999999 / 999999T)
+	// The TPU nominal quota should match physical capacity (8)
 	if !strings.Contains(output, "nominalQuota: \"999999\"") {
 		t.Errorf("expected nominalQuota: \"999999\" for TPU flavor CPU, got %s", output)
 	}
 	if !strings.Contains(output, "nominalQuota: 999999T") {
 		t.Errorf("expected nominalQuota: 999999T for TPU flavor Memory, got %s", output)
 	}
+	if !strings.Contains(output, "nominalQuota: 8") {
+		t.Errorf("expected nominalQuota: 8 for TPU flavor TPUs, got %s", output)
+	}
+
 	// The Pathways flavor CPU/Memory should remain at their physical/mocked values
+	// The TPU nominal quota for Pathways flavor must be successfully injected as 0
 	if !strings.Contains(output, "nominalQuota: 480") {
 		t.Errorf("expected nominalQuota: 480 for Pathways flavor CPU, got %s", output)
 	}
 	if !strings.Contains(output, "nominalQuota: 2000Gi") {
 		t.Errorf("expected nominalQuota: 2000Gi for Pathways flavor Memory, got %s", output)
+	}
+	if !strings.Contains(output, "nominalQuota: 0") {
+		t.Errorf("expected nominalQuota: 0 for Pathways flavor TPUs, got %s", output)
 	}
 
 	// Verify SINGLE resource group (unified when Pathways is active)

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -65,7 +65,7 @@ func TestRenderClusterQueue_Pathways(t *testing.T) {
 	orc := &GKEOrchestrator{
 		capacity: ClusterCapacity{
 			Flavors: map[string]FlavorCapacity{
-				"flavor-default": {
+				"flavor-tpu": { // TPU flavor (name contains 'tpu')
 					CPUs:     100,
 					MemoryGi: 400,
 				},
@@ -85,17 +85,33 @@ func TestRenderClusterQueue_Pathways(t *testing.T) {
 	output := string(bytes)
 
 	// Verify quotas are rendered correctly
-	if !strings.Contains(output, "nominalQuota: 100") {
-		t.Errorf("expected nominalQuota: 100 for CPU, got %s", output)
+	// The TPU flavor (flavor-tpu) CPU/Memory must be overridden to the high defaults (999999 / 999999T)
+	if !strings.Contains(output, "nominalQuota: \"999999\"") {
+		t.Errorf("expected nominalQuota: \"999999\" for TPU flavor CPU, got %s", output)
 	}
+	if !strings.Contains(output, "nominalQuota: 999999T") {
+		t.Errorf("expected nominalQuota: 999999T for TPU flavor Memory, got %s", output)
+	}
+	// The Pathways flavor CPU/Memory should remain at their physical/mocked values
 	if !strings.Contains(output, "nominalQuota: 480") {
-		t.Errorf("expected nominalQuota: 480 for CPU, got %s", output)
+		t.Errorf("expected nominalQuota: 480 for Pathways flavor CPU, got %s", output)
+	}
+	if !strings.Contains(output, "nominalQuota: 2000Gi") {
+		t.Errorf("expected nominalQuota: 2000Gi for Pathways flavor Memory, got %s", output)
 	}
 
-	// Verify TWO resource groups
+	// Verify SINGLE resource group (unified when Pathways is active)
 	count := strings.Count(output, "coveredResources:")
-	if count != 2 {
-		t.Errorf("expected 2 coveredResources blocks for Pathways case, got %d. Output: %s", count, output)
+	if count != 1 {
+		t.Errorf("expected 1 coveredResources block for Pathways case (unified), got %d. Output: %s", count, output)
+	}
+
+	// Verify both flavors are present in the output
+	if !strings.Contains(output, "name: flavor-tpu") {
+		t.Errorf("expected flavor-tpu in output, got %s", output)
+	}
+	if !strings.Contains(output, "name: pathways-flavor") {
+		t.Errorf("expected pathways-flavor in output, got %s", output)
 	}
 }
 


### PR DESCRIPTION
Unifies the Kueue ClusterQueue resource groups when Pathways is active. This prevents Kueue from merging incompatible node selectors (TPU nodes vs CPU nodes) for TPU worker pods, which request both TPU and CPU/Memory resources.

Specifically:
- Updated Terraform templates to use a single unified resource group covering ["google.com/tpu", "cpu", "memory"] and aligned both flavors.
- Added default high CPU/Memory quotas for the TPU flavor in main.tf.
- Updated the Go orchestrator (infra_manager.go) to programmatically detect Pathways and unify the resource groups at runtime.
- Updated GKE orchestrator tests to assert the unified queue behavior.

Resolves scheduling conflicts for Pathways workloads on GKE.