### PR TITLE
cleanup(gke): remove redundant switch in GenerateGKENodeSelectorLabel

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1141,7 +1141,6 @@ func (g *GKEOrchestrator) generateAndApplyManifest(opts ManifestOptions, profile
 	return g.ApplyManifest(gkeManifestContent, outputManifestPath, opts.WorkloadName)
 }
 
-// TODO Use a map
 var machineFamilyToLabelMap = map[string]string{
 	"g2-standard":   "nvidia-l4",
 	"a3-highgpu":    "nvidia-h100-80gb",

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1170,12 +1170,6 @@ var machineFamilyToLabelMap = map[string]string{
 func (g *GKEOrchestrator) GenerateGKENodeSelectorLabel(acceleratorType string) string {
 	resolvedLower := strings.ToLower(acceleratorType)
 
-	// Fallback for direct values
-	switch resolvedLower {
-	case "nvidia-tesla-a100", "tpu-v4-podslice", "tpu-v6e-slice", "tpu-v5p-slice", "tpu-v5-lite-podslice":
-		return acceleratorType
-	}
-
 	parts := strings.Split(resolvedLower, "-")
 
 	// Try matching first two parts (e.g., "g2-standard")

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2259,3 +2259,48 @@ func TestPopulateNAPFlavors(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateGKENodeSelectorLabel(t *testing.T) {
+	orc := &GKEOrchestrator{}
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Mapped families (2 parts)
+		{"g2-standard-48", "nvidia-l4"},
+		{"a3-highgpu-8g", "nvidia-h100-80gb"},
+		{"a2-highgpu-1g", "nvidia-tesla-a100"},
+		{"g4-standard-4", "nvidia-rtx-pro-6000"},
+		{"ct6e-standard-8t", "tpu-v6e-slice"},
+
+		// Mapped families (1 part)
+		{"v6e-standard", "tpu-v6e-slice"},
+		{"v5litepod-slice", "tpu-v5-lite-podslice"},
+		{"v4-podslice", "tpu-v4-podslice"},
+		{"l4-standard", "nvidia-l4"},
+
+		// Old switch fallbacks (unmapped directly, but should return as is)
+		{"nvidia-tesla-a100", "nvidia-tesla-a100"},
+		{"tpu-v4-podslice", "tpu-v4-podslice"},
+		{"tpu-v6e-slice", "tpu-v6e-slice"},
+		{"tpu-v5p-slice", "tpu-v5p-slice"},
+		{"tpu-v5-lite-podslice", "tpu-v5-lite-podslice"},
+
+		// Unmapped values
+		{"unknown-accelerator", "unknown-accelerator"},
+		{"h100", "h100"},
+
+		// Case insensitivity
+		{"G2-STANDARD-48", "nvidia-l4"},
+		{"NVIDIA-TESLA-A100", "NVIDIA-TESLA-A100"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := orc.GenerateGKENodeSelectorLabel(tc.input)
+			if got != tc.want {
+				t.Errorf("GenerateGKENodeSelectorLabel(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Simplify `GenerateGKENodeSelectorLabel` by Removing Redundant Switch.

#### The Problem
The `GenerateGKENodeSelectorLabel` function maps accelerator types to GKE node selector labels. It contains a hardcoded fallback switch statement for "direct values":
```go
// Fallback for direct values
switch resolvedLower {
case "nvidia-tesla-a100", "tpu-v4-podslice", "tpu-v6e-slice", "tpu-v5p-slice", "tpu-v5-lite-podslice":
    return acceleratorType
}
```
This switch statement is **completely redundant**. If any of these values (or their prefixes) are passed to the function, they do not match any keys in the `machineFamilyToLabelMap`. As a result, the function naturally falls through all checks and returns `acceleratorType` unmodified at the end of the function anyway. 

Maintaining this hardcoded list of direct values in a switch statement in addition to the map increases maintenance overhead and leads to duplication.

#### The Solution
Remove the redundant `switch` block entirely. Let the function rely on its natural fall-through behavior, which already returns the input string if no map keys match.

#### The Impact
*   **Code Simplicity**: Reduces the size and complexity of the function, making it easier to read and maintain.
*   **Maintainability**: Eliminates the risk of developers forgetting to keep the switch statement in sync with the map when adding new accelerators.