### PR TITLE
feat(packer): restore packer-manifest.json state across blueprint regenerations

### DIFF
--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -179,6 +179,44 @@ func (s *zeroSuite) TestRestoreTfState(c *C) {
 	c.Check(err, IsNil)
 }
 
+func (s *zeroSuite) TestRestorePackerState(c *C) {
+	// set up dir structure
+	//
+	// └── test_dir
+	//    ├── .ghpc
+	//       └── previous_deployment_groups
+	//          └── packer_group
+	//             └── image
+	//                └── packer-manifest.json
+	//    └── packer_group
+	//       └── image
+	depDir := c.MkDir()
+	groupName := "packer_group"
+	subPath := "image"
+	manifestContent := `{"builds": [{"artifact_id": "my-image"}]}`
+
+	prevGroup := filepath.Join(HiddenGhpcDir(depDir), prevGroupDirName, groupName, subPath)
+	curGroup := filepath.Join(depDir, groupName, subPath)
+	prevManifest := filepath.Join(prevGroup, packerManifestFileName)
+
+	c.Assert(os.MkdirAll(prevGroup, 0755), IsNil)
+	c.Assert(os.MkdirAll(curGroup, 0755), IsNil)
+	c.Assert(os.WriteFile(prevManifest, []byte(manifestContent), 0644), IsNil)
+
+	testWriter := PackerWriter{}
+	c.Check(testWriter.restoreState(depDir), IsNil)
+
+	// check manifest file was copied to current resource group dir
+	curManifest := filepath.Join(curGroup, packerManifestFileName)
+	_, err := os.Stat(curManifest)
+	c.Check(err, IsNil)
+
+	// check content is identical
+	gotContent, err := os.ReadFile(curManifest)
+	c.Check(err, IsNil)
+	c.Check(string(gotContent), Equals, manifestContent)
+}
+
 func TestGetTypeTokensRelaxed(t *testing.T) {
 	type test struct {
 		input cty.Type

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -114,17 +114,23 @@ func (w PackerWriter) restoreState(deploymentDir string) error {
 		dest := filepath.Join(deploymentDir, relPath)
 
 		// Ensure the destination directory exists before writing (it should have been created by writeGroup).
-		if _, err := os.Stat(filepath.Dir(dest)); err == nil {
-			bytesRead, err := os.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("failed to read previous packer manifest %s: %w", path, err)
+		_, err = os.Stat(filepath.Dir(dest))
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
 			}
-			err = os.WriteFile(dest, bytesRead, 0644)
-			if err != nil {
-				return fmt.Errorf("failed to write previous packer manifest %s: %w", dest, err)
-			}
-			logging.Info("Restored packer manifest to %s", dest)
+			return fmt.Errorf("failed to stat destination directory %s: %w", filepath.Dir(dest), err)
 		}
+
+		bytesRead, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read previous packer manifest %s: %w", path, err)
+		}
+		err = os.WriteFile(dest, bytesRead, 0644)
+		if err != nil {
+			return fmt.Errorf("failed to write previous packer manifest %s: %w", dest, err)
+		}
+		logging.Info("Restored packer manifest to %s", dest)
 
 		return nil
 	})

--- a/pkg/modulewriter/packerwriter.go
+++ b/pkg/modulewriter/packerwriter.go
@@ -19,9 +19,11 @@ package modulewriter
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 
 	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
 
 	"github.com/zclconf/go-cty/cty"
 )
@@ -85,8 +87,52 @@ func (w PackerWriter) writeGroup(
 	return nil
 }
 
+const packerManifestFileName = "packer-manifest.json"
+
 func (w PackerWriter) restoreState(deploymentDir string) error {
-	// TODO: restore packer-manifest.json if it exists
+	prevGroupPath := filepath.Join(HiddenGhpcDir(deploymentDir), prevGroupDirName)
+
+	// If the previous deployment groups directory doesn't exist, there is nothing to restore.
+	if _, err := os.Stat(prevGroupPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	err := filepath.WalkDir(prevGroupPath, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != packerManifestFileName {
+			return nil
+		}
+
+		// Found a packer-manifest.json. Determine its relative path from prevGroupPath.
+		relPath, err := filepath.Rel(prevGroupPath, path)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path for %s: %w", path, err)
+		}
+
+		dest := filepath.Join(deploymentDir, relPath)
+
+		// Ensure the destination directory exists before writing (it should have been created by writeGroup).
+		if _, err := os.Stat(filepath.Dir(dest)); err == nil {
+			bytesRead, err := os.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf("failed to read previous packer manifest %s: %w", path, err)
+			}
+			err = os.WriteFile(dest, bytesRead, 0644)
+			if err != nil {
+				return fmt.Errorf("failed to write previous packer manifest %s: %w", dest, err)
+			}
+			logging.Info("Restored packer manifest to %s", dest)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("error trying to restore packer manifests: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
### Implement State Restoration for Packer Images (`restoreState`)

#### The Problem
The `moduleWriter` interface defines a `restoreState` method, which is intended to transfer state files from a previous deployment run when a user regenerates their blueprint (preventing state loss). 

While `TFWriter.restoreState` is fully implemented and restores `.tfstate` and `.tfstate.backup` files, `PackerWriter.restoreState` is currently a no-op:
```go
func (w PackerWriter) restoreState(deploymentDir string) error {
	// TODO: restore packer-manifest.json if it exists
	return nil
}
```
When a user modifies their blueprint and runs `ghpc create` again, the toolkit rewrites the deployment directories. Because Packer's state (`packer-manifest.json`, which tracks built image IDs) is not restored, the toolkit loses track of the images built in the previous run. This forces the toolkit to rebuild the Packer images from scratch, even if their configuration did not change.

#### The Solution
Implement `PackerWriter.restoreState` to copy the `packer-manifest.json` file from the backup directory (`.ghpc/previous_system/` or equivalent) into the newly generated Packer deployment directory.

#### The Impact
*   **Developer Experience**: Avoids extremely time-consuming, redundant VM image builds when iterating on blueprints.
*   **Efficiency**: Saves compute resources and time by preserving the cache of already-built Packer images across blueprint updates.
