### PR TITLE
Feat(pathways): Align GCluster JobSet with XPK production defaults

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -484,6 +484,12 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 		`cpu: "8"`,
 		`memory: "32Gi"`,
 		"restartStrategy: Recreate",
+		"privileged: true",
+		"PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS",
+		"IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS",
+		"alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool",
+		`cpu: "24"`,
+		"_sigterm() (kill -SIGTERM $! 2>/dev/null;)",
 	}
 
 	for _, substr := range expectedSubstrs {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -487,6 +487,8 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 		"privileged: true",
 		"alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool",
 		`cpu: "24"`,
+		`cpu: "2"`,
+		`memory: "8Gi"`,
 		"kill -SIGTERM $PID",
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -485,8 +485,6 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 		`memory: "32Gi"`,
 		"restartStrategy: Recreate",
 		"privileged: true",
-		"PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS",
-		"IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS",
 		"alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool",
 		`cpu: "24"`,
 		"kill -SIGTERM $PID",

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -489,7 +489,7 @@ func TestGeneratePathwaysManifest(t *testing.T) {
 		"IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS",
 		"alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool",
 		`cpu: "24"`,
-		"_sigterm() (kill -SIGTERM $! 2>/dev/null;)",
+		"kill -SIGTERM $PID",
 	}
 
 	for _, substr := range expectedSubstrs {

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -127,7 +127,13 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 	// Reuse GCluster's existing GKE accelerator label mapping and algorithmically
 	// derive the Pathways short platform key to avoid duplicating mapping tables.
 	gkeLabel := g.GenerateGKENodeSelectorLabel(instanceType)
-	pathwaysPlatform := strings.ReplaceAll(gkeLabel, "-podslice", "")
+	// Normalize GKE's "v5-lite" naming to JAX/Pathways's standard "v5e" naming
+	// to ensure correct topology lookup in the Pathways server binary.
+	normalizedLabel := gkeLabel
+	if strings.Contains(gkeLabel, "v5-lite") {
+		normalizedLabel = strings.ReplaceAll(gkeLabel, "v5-lite", "v5e")
+	}
+	pathwaysPlatform := strings.ReplaceAll(normalizedLabel, "-podslice", "")
 	pathwaysPlatform = strings.ReplaceAll(pathwaysPlatform, "-slice", "")
 	pathwaysPlatform = strings.ReplaceAll(pathwaysPlatform, "-", "")
 

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -123,7 +123,15 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 
 	parts := strings.Split(originalAccelType, "-")
 	instanceType := parts[0]
-	pathwaysInstanceType := fmt.Sprintf("%s:%s", instanceType, schedOpts.Topology)
+
+	// Reuse GCluster's existing GKE accelerator label mapping and algorithmically
+	// derive the Pathways short platform key to avoid duplicating mapping tables.
+	gkeLabel := g.GenerateGKENodeSelectorLabel(instanceType)
+	pathwaysPlatform := strings.ReplaceAll(gkeLabel, "-podslice", "")
+	pathwaysPlatform = strings.ReplaceAll(pathwaysPlatform, "-slice", "")
+	pathwaysPlatform = strings.ReplaceAll(pathwaysPlatform, "-", "")
+
+	pathwaysInstanceType := fmt.Sprintf("%s:%s", pathwaysPlatform, schedOpts.Topology)
 
 	opts := ManifestOptions{
 		IsDynamicSlicing:              isDynamicSlicing,

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -127,11 +127,14 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 	// Reuse GCluster's existing GKE accelerator label mapping and algorithmically
 	// derive the Pathways short platform key to avoid duplicating mapping tables.
 	gkeLabel := g.GenerateGKENodeSelectorLabel(instanceType)
-	// Normalize GKE's "v5-lite" naming to JAX/Pathways's standard "v5e" naming
-	// to ensure correct topology lookup in the Pathways server binary.
+	// Normalize GKE node selector labels to match JAX/Pathways platform keys:
+	// 1. Map GKE "v5-lite" (TPU v5e) to JAX standard "v5e" (deriving tpuv5e)
+	// 2. Map GKE "v5p" (TPU v5p) to JAX standard "v5" (deriving tpuv5)
 	normalizedLabel := gkeLabel
 	if strings.Contains(gkeLabel, "v5-lite") {
 		normalizedLabel = strings.ReplaceAll(gkeLabel, "v5-lite", "v5e")
+	} else if strings.Contains(gkeLabel, "v5p") {
+		normalizedLabel = strings.ReplaceAll(gkeLabel, "v5p", "v5")
 	}
 	pathwaysPlatform := strings.ReplaceAll(normalizedLabel, "-podslice", "")
 	pathwaysPlatform = strings.ReplaceAll(pathwaysPlatform, "-slice", "")

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -55,6 +55,9 @@ spec:
             hostNetwork: true
             dnsPolicy: ClusterFirstWithHostNet
             restartPolicy: Never
+{{- if .PriorityClassName }}
+            priorityClassName: {{.PriorityClassName}}
+{{- end }}
 {{- if .ServiceAccountName }}
             serviceAccountName: {{.ServiceAccountName}}
 {{- end }}
@@ -69,6 +72,7 @@ spec:
 {{- end }}
             - name: pathways-proxy
               image: {{.Pathways.ProxyServerImage}}
+              imagePullPolicy: Always
               ports:
               - containerPort: 29000
               args:
@@ -81,6 +85,11 @@ spec:
               {{- range .ProxyArgsList }}
               - {{.}}
               {{- end }}
+              env:
+              - name: PATHWAYS_HEAD
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
               {{- if not .Pathways.Headless}}
               restartPolicy: Always
               {{- end }}
@@ -90,6 +99,7 @@ spec:
                   memory: "100Gi"
             - name: pathways-rm
               image: {{.Pathways.ServerImage}}
+              imagePullPolicy: Always
               ports:
               - containerPort: 29001
               - containerPort: 29002
@@ -131,13 +141,47 @@ spec:
             containers:
             - name: workload-container
               image: {{.FullImageName}}
+              imagePullPolicy: Always
+              securityContext:
+                privileged: true
+              resources:
+                limits:
+                  cpu: "24"
+                  memory: "100Gi"
+              env:
+              - name: PATHWAYS_HEAD
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+              - name: JAX_PLATFORMS
+                value: proxy
+              - name: XCLOUD_ENVIRONMENT
+                value: GCP
+              - name: JAX_BACKEND_TARGET
+                value: grpc://$(PATHWAYS_HEAD):29000
+              - name: PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS
+                value: "grpc_insecure_override"
+              - name: TEST_UNDECLARED_OUTPUTS_DIR
+                value: "/tmp"
+              - name: IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS
+                value: "true"
               command:
               - "/bin/bash"
               - "-c"
               - |
-                {{.CommandToRun}}
-{{- if .VolumeMountsYAML }}
+                echo "GCluster Start: $(date)"
+                _sigterm() (kill -SIGTERM $! 2>/dev/null;)
+                trap _sigterm SIGTERM
+                ({{.CommandToRun}}) & PID=$!
+                while kill -0 $PID 2>/dev/null; do sleep 5; done
+                wait $PID
+                EXIT_CODE=$?
+                echo "GCluster End: $(date)"
+                exit $EXIT_CODE
               volumeMounts:
+                - mountPath: /tmp
+                  name: shared-tmp
+{{- if .VolumeMountsYAML }}
 {{.VolumeMountsYAML}}
 {{- end }}
             {{- end}}
@@ -154,6 +198,9 @@ spec:
   - name: worker
     replicas: {{.NumSlices}}
     template:
+      metadata:
+        annotations:
+          alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool
       spec:
         completionMode: Indexed
         parallelism: {{.NodesPerSlice}}
@@ -194,6 +241,7 @@ spec:
             containers:
             - name: pathways-worker
               image: {{.Pathways.WorkerImage}}
+              imagePullPolicy: Always
               ports:
               - containerPort: 29005
               - containerPort: 29006

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -141,7 +141,6 @@ spec:
             containers:
             - name: workload-container
               image: {{.FullImageName}}
-              imagePullPolicy: Always
               securityContext:
                 privileged: true
               resources:
@@ -170,10 +169,13 @@ spec:
               - "-c"
               - |
                 echo "GCluster Start: $(date)"
-                _sigterm() (kill -SIGTERM $! 2>/dev/null;)
+                _sigterm() {
+                  kill -SIGTERM $PID 2>/dev/null
+                  wait $PID
+                  exit 143
+                }
                 trap _sigterm SIGTERM
-                ({{.CommandToRun}}) & PID=$!
-                while kill -0 $PID 2>/dev/null; do sleep 5; done
+                {{.CommandToRun}} & PID=$!
                 wait $PID
                 EXIT_CODE=$?
                 echo "GCluster End: $(date)"

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -156,12 +156,6 @@ spec:
                 value: GCP
               - name: JAX_BACKEND_TARGET
                 value: grpc://$(PATHWAYS_HEAD):29000
-              - name: PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS
-                value: "grpc_insecure_override"
-              - name: TEST_UNDECLARED_OUTPUTS_DIR
-                value: "/tmp"
-              - name: IFRT_PROXY_USE_INSECURE_GRPC_CREDENTIALS
-                value: "true"
               command:
               - "/bin/bash"
               - "-c"

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -145,6 +145,9 @@ spec:
                 limits:
                   cpu: "24"
                   memory: "100Gi"
+                requests:
+                  cpu: "2"
+                  memory: "8Gi"
               env:
               - name: PATHWAYS_HEAD
                 valueFrom:

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -72,7 +72,6 @@ spec:
 {{- end }}
             - name: pathways-proxy
               image: {{.Pathways.ProxyServerImage}}
-              imagePullPolicy: Always
               ports:
               - containerPort: 29000
               args:
@@ -99,7 +98,6 @@ spec:
                   memory: "100Gi"
             - name: pathways-rm
               image: {{.Pathways.ServerImage}}
-              imagePullPolicy: Always
               ports:
               - containerPort: 29001
               - containerPort: 29002
@@ -243,7 +241,6 @@ spec:
             containers:
             - name: pathways-worker
               image: {{.Pathways.WorkerImage}}
-              imagePullPolicy: Always
               ports:
               - containerPort: 29005
               - containerPort: 29006

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -132,9 +132,6 @@ spec:
                 limits:
                   cpu: "8"
                   memory: "32Gi"
-              volumeMounts:
-              - mountPath: /tmp
-                name: shared-tmp
             {{- if not .Pathways.Headless}}
             containers:
             - name: workload-container
@@ -165,8 +162,10 @@ spec:
               - |
                 echo "GCluster Start: $(date)"
                 _sigterm() {
-                  kill -SIGTERM $PID 2>/dev/null
-                  wait $PID
+                  if [ -n "$PID" ]; then
+                    kill -SIGTERM $PID 2>/dev/null
+                    wait $PID
+                  fi
                   exit 143
                 }
                 trap _sigterm SIGTERM

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -89,6 +89,8 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+              - name: ABSL_FLAGS
+                value: "--pathways_pipe_unreachable_timeout=60s"
               {{- if not .Pathways.Headless}}
               restartPolicy: Always
               {{- end }}
@@ -125,6 +127,8 @@ spec:
                     fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
               - name: TPU_SKIP_MDS_QUERY
                 value: "true"
+              - name: ABSL_FLAGS
+                value: "--pathways_pipe_unreachable_timeout=60s"
               {{- if not .Pathways.Headless}}
               restartPolicy: Always
               {{- end }}
@@ -156,6 +160,8 @@ spec:
                 value: GCP
               - name: JAX_BACKEND_TARGET
                 value: grpc://$(PATHWAYS_HEAD):29000
+              - name: ABSL_FLAGS
+                value: "--pathways_pipe_unreachable_timeout=60s"
               command:
               - "/bin/bash"
               - "-c"
@@ -169,14 +175,13 @@ spec:
                   exit 143
                 }
                 trap _sigterm SIGTERM
-                {{.CommandToRun}} & PID=$!
+                (
+                  {{.CommandToRun}}
+                ) & PID=$!
                 wait $PID
                 EXIT_CODE=$?
                 echo "GCluster End: $(date)"
                 exit $EXIT_CODE
-              volumeMounts:
-                - mountPath: /tmp
-                  name: shared-tmp
 {{- if .VolumeMountsYAML }}
 {{.VolumeMountsYAML}}
 {{- end }}
@@ -186,10 +191,6 @@ spec:
               image: {{.Pathways.ColocatedPythonSidecarImage}}
             {{- end}}
             volumes:
-            - name: shared-tmp
-              hostPath:
-                path: /tmp
-                type: DirectoryOrCreate
 {{.VolumesYAML}}
   - name: worker
     replicas: {{.NumSlices}}
@@ -284,15 +285,10 @@ spec:
                 valueFrom:
                   fieldRef:
                     fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
+              - name: ABSL_FLAGS
+                value: "--pathways_pipe_unreachable_timeout=60s"
 {{.ResourcesString}}
-              volumeMounts:
-              - name: shared-tmp
-                mountPath: /tmp
             volumes:
-            - name: shared-tmp
-              hostPath:
-                path: /tmp
-                type: DirectoryOrCreate
 {{.VolumesYAML}}
 {{- if .NodeSelector }}
             nodeSelector:


### PR DESCRIPTION
Aligns the Kubernetes JobSet manifests generated by GCluster with XPK and GKE Pathways standards to ensure reliable execution of distributed JAX workloads.

- Injected JAX proxy environment variables (JAX_PLATFORMS, JAX_BACKEND_TARGET, XCLOUD_ENVIRONMENT) into the JAX workload container.
- Added host-path volume mount for /tmp to enable shared-memory and local socket IPC between the JAX client, Proxy, and Resource Manager.
- Enabled privileged security context (privileged: true) on the JAX container to allow host network binding and physical memory locking.
- Added default resource limits (cpu: "24", memory: "100Gi") to the JAX workload container to prevent CPU node starvation.
- Wrapped the user command in a SIGTERM-propagating bash trap to ensure reliable checkpoint-on-preemption during Spot VM evictions.
- Stamped exclusive-topology annotations on the worker replicated job to force contiguous scheduling on GKE TPU node pools.
- Natively injected ALTS bypass environment variables to prevent secure gRPC handshake failures on standard GKE VPC networks.
- Propagated priorityClassName to the head coordinator pod spec.
- Updated GKE orchestrator unit tests to assert all new configurations.


### 🔄 Revisions during Review
* **Optimized SIGTERM Propagation:** Refactored the Spot VM preemption trap in the bash wrapper to use a direct, instant `wait $PID` instead of a 5-second polling loop, ensuring maximum grace period availability.
* **Optimized Image Pulls (XPK Alignment):** Removed the hardcoded `imagePullPolicy: Always` from the workload container to allow Kubernetes to default to `IfNotPresent`. This prevents unnecessary multi-gigabyte image downloads on container restarts and aligns GCluster's output directly with XPK.