### PR TITLE
feat(job): implement custom environment variables (--env flag) support

### DIFF
--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -19,6 +19,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"slices"
 	"time"
@@ -72,8 +73,11 @@ var (
 	gkeNapProvisioning string
 	gkeNapReservation  string
 
-	envVars          []string
-	validEnvKeyRegex = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+	envVars           []string
+	pathwaysProxyEnv  []string
+	pathwaysServerEnv []string
+	pathwaysWorkerEnv []string
+	validEnvKeyRegex  = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 )
 
 var SubmitCmd = &cobra.Command{
@@ -108,8 +112,10 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 			return err
 		}
 
-		if err := validateEnvFlags(envVars); err != nil {
-			return err
+		for _, envs := range [][]string{envVars, pathwaysProxyEnv, pathwaysServerEnv, pathwaysWorkerEnv} {
+			if err := validateEnvFlags(envs); err != nil {
+				return err
+			}
 		}
 
 		priorityClassName = strings.ToLower(priorityClassName)
@@ -166,6 +172,9 @@ func init() {
 	SubmitCmd.Flags().StringVar(&pathways.ProxyArgs, "pathways-proxy-args", "", "Arbitrary additional command-line arguments to pass directly to the `pathways-proxy` executable.")
 	SubmitCmd.Flags().StringVar(&pathways.ServerArgs, "pathways-server-args", "", "Arbitrary additional command-line arguments to pass directly to the `pathways-rm` (resource manager) executable.")
 	SubmitCmd.Flags().StringVar(&pathways.WorkerArgs, "pathways-worker-args", "", "Arbitrary additional command-line arguments to pass directly to the `pathways-worker` executable.")
+	SubmitCmd.Flags().StringArrayVar(&pathwaysProxyEnv, "pathways-proxy-env", []string{}, "Custom environment variables for the Pathways proxy container in KEY=VALUE format. Can be specified multiple times.")
+	SubmitCmd.Flags().StringArrayVar(&pathwaysServerEnv, "pathways-server-env", []string{}, "Custom environment variables for the Pathways server container in KEY=VALUE format. Can be specified multiple times.")
+	SubmitCmd.Flags().StringArrayVar(&pathwaysWorkerEnv, "pathways-worker-env", []string{}, "Custom environment variables for the Pathways worker container in KEY=VALUE format. Can be specified multiple times.")
 	SubmitCmd.Flags().StringVar(&pathways.ColocatedPythonSidecarImage, "pathways-colocated-python-sidecar-image", "", "Image for an optional Python-based sidecar container to run alongside the Pathways head components.")
 	SubmitCmd.Flags().StringVar(&pathways.HeadNodePool, "pathways-head-np", "", "The node pool to use for the Pathways head job. If empty, it will be auto-detected (looking for 'cpu-np' or 'pathways-np').")
 
@@ -205,6 +214,10 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	jobTopology := strings.ToLower(strings.TrimSpace(topology))
+
+	pathways.ProxyEnv = parseEnvFlags(pathwaysProxyEnv)
+	pathways.ServerEnv = parseEnvFlags(pathwaysServerEnv)
+	pathways.WorkerEnv = parseEnvFlags(pathwaysWorkerEnv)
 
 	jobDef := orchestrator.JobDefinition{
 		ImageName:                     imageName,
@@ -300,7 +313,7 @@ func validatePathwaysFlags() error {
 		}
 	} else {
 		// Check if any pathways-specific flag is set without --pathways
-		if pathways != (orchestrator.PathwaysJobDefinition{MaxSliceRestarts: 1}) {
+		if !reflect.DeepEqual(pathways, orchestrator.PathwaysJobDefinition{MaxSliceRestarts: 1}) || len(pathwaysProxyEnv) > 0 || len(pathwaysServerEnv) > 0 || len(pathwaysWorkerEnv) > 0 {
 			return fmt.Errorf("pathways flags specified but --pathways flag is missing")
 		}
 	}

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -19,6 +19,7 @@ import (
 	"hpc-toolkit/pkg/config"
 	"os"
 	"path/filepath"
+	"regexp"
 	"slices"
 	"time"
 
@@ -70,6 +71,9 @@ var (
 
 	gkeNapProvisioning string
 	gkeNapReservation  string
+
+	envVars          []string
+	validEnvKeyRegex = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
 )
 
 var SubmitCmd = &cobra.Command{
@@ -104,6 +108,10 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 			return err
 		}
 
+		if err := validateEnvFlags(envVars); err != nil {
+			return err
+		}
+
 		priorityClassName = strings.ToLower(priorityClassName)
 
 		return nil
@@ -121,6 +129,7 @@ func init() {
 	SubmitCmd.Flags().StringVarP(&platform, "platform", "f", "linux/amd64", "Target platform for the image build (e.g., 'linux/amd64', 'linux/arm64'). Used with --base-image.")
 
 	SubmitCmd.Flags().StringSliceVar(&volumeStr, "mount", nil, "Volumes to mount (format: <src>:<dest>[:<mode>], mode can be 'ro' or 'rw', default 'ro').")
+	SubmitCmd.Flags().StringArrayVar(&envVars, "env", []string{}, "Custom environment variables to pass to the workload container in KEY=VALUE format. Can be specified multiple times.")
 
 	SubmitCmd.Flags().StringVarP(&workloadName, "name", "n", "", "Name of the workload to create. Required.")
 	SubmitCmd.Flags().StringVarP(&kueueQueueName, "queue", "q", "", "Name of the Kueue LocalQueue to submit the workload to. If empty, it will be auto-discovered.")
@@ -232,10 +241,42 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		IsPathwaysJob:                 isPathwaysJob,
 		Pathways:                      pathways,
 		RawMounts:                     volumeStr,
+		Env:                           parseEnvFlags(envVars),
 		Verbose:                       verbose,
 	}
 
 	return orc.SubmitJob(jobDef)
+}
+
+func parseEnvFlags(envs []string) map[string]string {
+	if len(envs) == 0 {
+		return nil
+	}
+	res := make(map[string]string)
+	for _, env := range envs {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			res[parts[0]] = parts[1]
+		}
+	}
+	return res
+}
+
+func validateEnvFlags(envs []string) error {
+	for _, env := range envs {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid environment variable format: %q. Must be in KEY=VALUE format", env)
+		}
+		key := parts[0]
+		if key == "" {
+			return fmt.Errorf("invalid environment variable key in %q: key cannot be empty", env)
+		}
+		if !validEnvKeyRegex.MatchString(key) {
+			return fmt.Errorf("invalid environment variable name: %q. Must conform to POSIX environment variable naming rules (letters, numbers, and underscores, cannot start with a digit)", key)
+		}
+	}
+	return nil
 }
 
 func parseDurationToSeconds(dStr string, flagName string) (int, error) {

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -285,6 +285,9 @@ func resetSubmitCmdFlags() {
 	gkeNapProvisioning = ""
 	gkeNapReservation = ""
 	envVars = nil
+	pathwaysProxyEnv = nil
+	pathwaysServerEnv = nil
+	pathwaysWorkerEnv = nil
 }
 
 type mockOrchestrator struct {
@@ -779,6 +782,97 @@ func TestSubmitCmd_InvalidEnvFormat_Fails(t *testing.T) {
 		"--location", "test-location",
 		"--project", "test-project",
 		"--env", "INVALID_ENV",
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "invalid environment variable format"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}
+
+func TestSubmitCmd_PathwaysEnv_Success(t *testing.T) {
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+			LastCheckedProjectID: "test-project",
+			GCloudSDKInstalled:   true,
+			GCloudAuthenticated:  true,
+			ADCConfigured:        true,
+			KubectlInstalled:     true,
+		},
+	}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	resetSubmitCmdFlags()
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--pathways",
+		"--pathways-gcs-location", "gs://foo",
+		"--name", "pathways-env-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--pathways-proxy-env", "PROXY_VAR=value",
+		"--pathways-server-env", "SERVER_VAR=foo=bar",
+		"--pathways-worker-env", "WORKER_VAR=baz",
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSubmitCmd_PathwaysEnv_InvalidFormat_Fails(t *testing.T) {
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+			LastCheckedProjectID: "test-project",
+			GCloudSDKInstalled:   true,
+			GCloudAuthenticated:  true,
+			ADCConfigured:        true,
+			KubectlInstalled:     true,
+		},
+	}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	resetSubmitCmdFlags()
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--pathways",
+		"--pathways-gcs-location", "gs://foo",
+		"--name", "pathways-env-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--pathways-server-env", "INVALID_ENV",
 	)
 
 	if err == nil {

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -284,6 +284,7 @@ func resetSubmitCmdFlags() {
 	pathways = orchestrator.PathwaysJobDefinition{MaxSliceRestarts: 1}
 	gkeNapProvisioning = ""
 	gkeNapReservation = ""
+	envVars = nil
 }
 
 type mockOrchestrator struct {
@@ -709,5 +710,146 @@ func TestSubmitCmd_DryRunIsDir_TrailingSlash(t *testing.T) {
 	expectedErr := "must be a file path, not a directory path"
 	if !strings.Contains(err.Error(), expectedErr) {
 		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}
+
+func TestSubmitCmd_ValidEnvVars(t *testing.T) {
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+			LastCheckedProjectID: "test-project",
+			GCloudSDKInstalled:   true,
+			GCloudAuthenticated:  true,
+			ADCConfigured:        true,
+			KubectlInstalled:     true,
+		},
+	}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	resetSubmitCmdFlags()
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "env-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--env", "MY_VAR=value",
+		"--env", "ANOTHER_VAR=foo=bar", // handles multiple '='
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSubmitCmd_InvalidEnvFormat_Fails(t *testing.T) {
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+			LastCheckedProjectID: "test-project",
+			GCloudSDKInstalled:   true,
+			GCloudAuthenticated:  true,
+			ADCConfigured:        true,
+			KubectlInstalled:     true,
+		},
+	}
+
+	resetSubmitCmdFlags()
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "env-test",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--env", "INVALID_ENV",
+	)
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	expectedErr := "invalid environment variable format"
+	if !strings.Contains(err.Error(), expectedErr) {
+		t.Errorf("expected error containing %q, got: %v", expectedErr, err)
+	}
+}
+
+func TestSubmitCmd_InvalidEnvKey_Fails(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         string
+		expectedErr string
+	}{
+		{
+			name:        "Starts with digit",
+			env:         "1VAR=value",
+			expectedErr: "invalid environment variable name",
+		},
+		{
+			name:        "Empty key",
+			env:         "=value",
+			expectedErr: "invalid environment variable key",
+		},
+		{
+			name:        "Special characters in key",
+			env:         "MY-VAR=value",
+			expectedErr: "invalid environment variable name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oldStore := store
+			defer func() { store = oldStore }()
+			store = &MockPrereqStore{
+				State: PrereqState{
+					LastCheckedTimestamp: time.Now(),
+					LastCheckedProjectID: "test-project",
+					GCloudSDKInstalled:   true,
+					GCloudAuthenticated:  true,
+					ADCConfigured:        true,
+					KubectlInstalled:     true,
+				},
+			}
+
+			resetSubmitCmdFlags()
+
+			_, err := executeCommand(JobCmd,
+				"submit",
+				"--name", "env-test",
+				"--image", "busybox",
+				"--command", "echo hello",
+				"--compute-type", "n2-standard-4",
+				"--cluster", "test-cluster",
+				"--location", "test-location",
+				"--project", "test-project",
+				"--env", tt.env,
+			)
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+
+			if !strings.Contains(err.Error(), tt.expectedErr) {
+				t.Errorf("expected error containing %q, got: %v", tt.expectedErr, err)
+			}
+		})
 	}
 }

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -202,6 +202,21 @@ Mounting an existing PVC named `lustre-pvc` (read-only):
   --mount "lustre-pvc:/data"
 ```
 
+### 4.5 Example: Submit Job with Custom Environment Variables
+
+You can pass custom environment variables to the container using the `--env` flag:
+
+```bash
+./gcluster job submit \
+  --name my-env-job \
+  --command "python app.py" \
+  --compute-type n2-standard-32 \
+  --base-image python:3.9-slim \
+  --build-context job_details \
+  --env "TRAINING_EPOCHS=10" \
+  --env "DEBUG=true"
+```
+
 ## 5. Verify the Job
 
 Verify that the Kubernetes JobSet ran successfully on your GKE cluster.
@@ -1038,6 +1053,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--num-nodes` | `int` | Number of nodes to use per group/slice (Default: `1`). Auto-calculated for TPUs based on topology. |
 | `--restarts` | `int` | Maximum number of restarts allowed for the JobSet before marked as failed (Default: `1`). |
 | `--mount` | `stringArray` | Mount storage volumes, buckets, filestore instances, or PVCs using the `<src>:<dest>[:<mode>]` format. Examples of `<src>`: `gs://my-bucket`, `filestore://my-instance/share`, `my-pvc` (for Lustre/etc), or `/host/path`. |
+| `--env` | `stringArray` | Custom environment variables to pass to the workload container in KEY=VALUE format (e.g. `--env KEY=VALUE`). Can be specified multiple times. |
 | `--await-job-completion` | `bool` | If true, the CLI waits for the job to complete before exiting. |
 | `--timeout` | `string` | Time to wait for job completion (e.g., `1h`, `10m`). Used with `--await-job-completion`. |
 | `--verbose` | `bool` | Enable verbose logging for the workload. |

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -1053,7 +1053,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--num-nodes` | `int` | Number of nodes to use per group/slice (Default: `1`). Auto-calculated for TPUs based on topology. |
 | `--restarts` | `int` | Maximum number of restarts allowed for the JobSet before marked as failed (Default: `1`). |
 | `--mount` | `stringArray` | Mount storage volumes, buckets, filestore instances, or PVCs using the `<src>:<dest>[:<mode>]` format. Examples of `<src>`: `gs://my-bucket`, `filestore://my-instance/share`, `my-pvc` (for Lustre/etc), or `/host/path`. |
-| `--env` | `stringArray` | Custom environment variables to pass to the workload container in KEY=VALUE format (e.g. `--env KEY=VALUE`). Can be specified multiple times. |
+| `--env` | `stringArray` | Custom environment variables to pass exclusively to the user's workload container in KEY=VALUE format (e.g. `--env KEY=VALUE`). Applies to both standard and Pathways workloads. Can be specified multiple times. |
 | `--await-job-completion` | `bool` | If true, the CLI waits for the job to complete before exiting. |
 | `--timeout` | `string` | Time to wait for job completion (e.g., `1h`, `10m`). Used with `--await-job-completion`. |
 | `--verbose` | `bool` | Enable verbose logging for the workload. |
@@ -1077,6 +1077,9 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--pathways-proxy-args` | `string` | Arbitrary additional command-line arguments passed to `pathways-proxy`. |
 | `--pathways-server-args` | `string` | Arbitrary additional command-line arguments passed to `pathways-rm`. |
 | `--pathways-worker-args` | `string` | Arbitrary additional command-line arguments passed to `pathways-worker`. |
+| `--pathways-proxy-env` | `stringArray` | Custom environment variables injected specifically into the Pathways proxy container (KEY=VALUE). |
+| `--pathways-server-env` | `stringArray` | Custom environment variables injected specifically into the Pathways server container (KEY=VALUE). |
+| `--pathways-worker-env` | `stringArray` | Custom environment variables injected specifically into the Pathways worker containers (KEY=VALUE). |
 | `--pathways-colocated-python-sidecar-image` | `string` | Image for an optional Python-based sidecar container running alongside workers. |
 | `--pathways-head-np` | `string` | The node pool name to target for the Pathways head job. |
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1270,24 +1270,29 @@ func (g *GKEOrchestrator) prepareJobSetTemplateData(opts ManifestOptions, comman
 		Pathways:                      opts.Pathways,
 		ExclusiveTopologyAnnotation:   exclusiveTopology,
 		Verbose:                       opts.Verbose,
-		Env: func() []struct{ Name, Value string } {
-			if len(opts.Env) == 0 {
-				return nil
-			}
-			envKeys := make([]string, 0, len(opts.Env))
-			for k := range opts.Env {
-				envKeys = append(envKeys, k)
-			}
-			slices.Sort(envKeys)
-			res := make([]struct{ Name, Value string }, len(envKeys))
-			for i, k := range envKeys {
-				res[i] = struct{ Name, Value string }{Name: k, Value: opts.Env[k]}
-			}
-			return res
-		}(),
-		IsTPU: isTPU,
-		IsGPU: isGPU,
+		Env:                           sortedEnvVars(opts.Env),
+		PathwaysProxyEnv:              sortedEnvVars(opts.Pathways.ProxyEnv),
+		PathwaysServerEnv:             sortedEnvVars(opts.Pathways.ServerEnv),
+		PathwaysWorkerEnv:             sortedEnvVars(opts.Pathways.WorkerEnv),
+		IsTPU:                         isTPU,
+		IsGPU:                         isGPU,
 	}
+}
+
+func sortedEnvVars(envMap map[string]string) []EnvVar {
+	if len(envMap) == 0 {
+		return nil
+	}
+	envKeys := make([]string, 0, len(envMap))
+	for k := range envMap {
+		envKeys = append(envKeys, k)
+	}
+	slices.Sort(envKeys)
+	res := make([]EnvVar, len(envKeys))
+	for i, k := range envKeys {
+		res[i] = EnvVar{Name: k, Value: envMap[k]}
+	}
+	return res
 }
 
 func (g *GKEOrchestrator) determineIfCPUMachine(job *orchestrator.JobDefinition) (bool, int, error) {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -27,6 +27,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"slices"
 	"strconv"
 	"strings"
 	"text/template"
@@ -1269,8 +1270,23 @@ func (g *GKEOrchestrator) prepareJobSetTemplateData(opts ManifestOptions, comman
 		Pathways:                      opts.Pathways,
 		ExclusiveTopologyAnnotation:   exclusiveTopology,
 		Verbose:                       opts.Verbose,
-		IsTPU:                         isTPU,
-		IsGPU:                         isGPU,
+		Env: func() []struct{ Name, Value string } {
+			if len(opts.Env) == 0 {
+				return nil
+			}
+			envKeys := make([]string, 0, len(opts.Env))
+			for k := range opts.Env {
+				envKeys = append(envKeys, k)
+			}
+			slices.Sort(envKeys)
+			res := make([]struct{ Name, Value string }, len(envKeys))
+			for i, k := range envKeys {
+				res[i] = struct{ Name, Value string }{Name: k, Value: opts.Env[k]}
+			}
+			return res
+		}(),
+		IsTPU: isTPU,
+		IsGPU: isGPU,
 	}
 }
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2311,3 +2311,110 @@ func TestGenerateGKENodeSelectorLabel(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateGKEManifest_CustomEnv(t *testing.T) {
+	setupMockMachineConfig(t)
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "env-test-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "n2-standard-2",
+		ClusterLocation: "us-central1-a",
+		Env: map[string]string{
+			"MY_CUSTOM_VAR": "some-value",
+			"ANOTHER_VAR":   "another=value",
+		},
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"gcloud compute machine-types describe n2-standard-2 --zone=us-central1-a --format=json": {{ExitCode: 0, Stdout: `{"guestCpus": 2}`}},
+	}
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "n2-standard-2"}},
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	expectedLines := []string{
+		`- name: MY_CUSTOM_VAR`,
+		`  value: "some-value"`,
+		`- name: ANOTHER_VAR`,
+		`  value: "another=value"`,
+	}
+	for _, line := range expectedLines {
+		if !strings.Contains(manifest, line) {
+			t.Errorf("manifest does not contain expected line %q. Got manifest:\n%s", line, manifest)
+		}
+	}
+}
+
+func TestGeneratePathwaysManifest_CustomEnv(t *testing.T) {
+	setupMockMachineConfig(t)
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "pathways-env-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "tpu-v5-lite-podslice",
+		ClusterLocation: "us-central1-a",
+		IsPathwaysJob:   true,
+		Pathways: orchestrator.PathwaysJobDefinition{
+			ProxyServerImage: "proxy:latest",
+			ServerImage:      "server:latest",
+			WorkerImage:      "worker:latest",
+			GCSLocation:      "gs://my-bucket",
+		},
+		Env: map[string]string{
+			"PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS": "grpc_insecure_override",
+		},
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "16x16"}},
+		"gcloud compute machine-types describe tpu-v5-lite-podslice --zone=us-central1-a --format=json":                         {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v5-lite-podslice"}]}`}},
+	}
+	mockExec := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExec)
+	orc.projectID = "mock-project"
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Config: gkeNodePoolConfig{MachineType: "tpu-v5-lite-podslice"}},
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	manifest, err := orc.GeneratePathwaysManifest(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("GeneratePathwaysManifest failed: %v", err)
+	}
+
+	// The custom environment variables must be present only in the workload-container container spec
+	expectedLines := []string{
+		`- name: PATHWAYS_UNSAFE_UNSAFE_OVERRIDE_GRPC_CREDENTIALS`,
+		`  value: "grpc_insecure_override"`,
+	}
+	for _, line := range expectedLines {
+		count := strings.Count(manifest, line)
+		// We expect it to appear exactly once: in the workload-container
+		if count != 1 {
+			t.Errorf("expected line %q to appear exactly 1 time in manifest, got %d. Manifest:\n%s", line, count, manifest)
+		}
+	}
+}

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -166,6 +166,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		PriorityClassName:             job.PriorityClassName,
 		Topology:                      schedOpts.Topology,
 		Verbose:                       job.Verbose,
+		Env:                           job.Env,
 	}
 
 	if err := g.fillManifestStrings(&opts, schedOpts, job, isDynamicSlicing, isStaticSlicing, profile.IsCPUMachine); err != nil {

--- a/pkg/orchestrator/gke/templates/jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/jobset.tmpl
@@ -67,7 +67,12 @@ spec:
                 - {{ printf "%q" . }}
                 {{- end }}
 {{ .ResourcesYAML }}
+                {{- if or $.Env (and $.Verbose (or $.IsTPU $.IsGPU)) }}
                 env:
+                {{- range $.Env }}
+                - name: {{ .Name }}
+                  value: {{ printf "%q" .Value }}
+                {{- end }}
                 {{- if $.Verbose }}
                 {{- if $.IsTPU }}
                 - name: TPU_STDERR_LOG_LEVEL
@@ -81,6 +86,7 @@ spec:
                 {{- else if $.IsGPU }}
                 - name: NCCL_DEBUG
                   value: "INFO"
+                {{- end }}
                 {{- end }}
                 {{- end }}
 {{- if $.VolumeMountsYAML }}

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -91,6 +91,10 @@ spec:
                     fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
               - name: ABSL_FLAGS
                 value: "--pathways_pipe_unreachable_timeout=60s"
+              {{- range $.PathwaysProxyEnv }}
+              - name: {{ .Name }}
+                value: {{ printf "%q" .Value }}
+              {{- end }}
               {{- if not .Pathways.Headless}}
               restartPolicy: Always
               {{- end }}
@@ -129,6 +133,10 @@ spec:
                 value: "true"
               - name: ABSL_FLAGS
                 value: "--pathways_pipe_unreachable_timeout=60s"
+              {{- range $.PathwaysServerEnv }}
+              - name: {{ .Name }}
+                value: {{ printf "%q" .Value }}
+              {{- end }}
               {{- if not .Pathways.Headless}}
               restartPolicy: Always
               {{- end }}
@@ -292,6 +300,10 @@ spec:
                     fieldPath: metadata.labels['jobset.sigs.k8s.io/coordinator']
               - name: ABSL_FLAGS
                 value: "--pathways_pipe_unreachable_timeout=60s"
+              {{- range $.PathwaysWorkerEnv }}
+              - name: {{ .Name }}
+                value: {{ printf "%q" .Value }}
+              {{- end }}
 {{.ResourcesString}}
             volumes:
 {{.VolumesYAML}}

--- a/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
+++ b/pkg/orchestrator/gke/templates/pathways_jobset.tmpl
@@ -162,6 +162,10 @@ spec:
                 value: grpc://$(PATHWAYS_HEAD):29000
               - name: ABSL_FLAGS
                 value: "--pathways_pipe_unreachable_timeout=60s"
+              {{- range $.Env }}
+              - name: {{ .Name }}
+                value: {{ printf "%q" .Value }}
+              {{- end }}
               command:
               - "/bin/bash"
               - "-c"
@@ -183,6 +187,7 @@ spec:
                 echo "GCluster End: $(date)"
                 exit $EXIT_CODE
 {{- if .VolumeMountsYAML }}
+              volumeMounts:
 {{.VolumeMountsYAML}}
 {{- end }}
             {{- end}}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -177,6 +177,7 @@ type ManifestOptions struct {
 	IsCPUMachine                  bool
 	Pathways                      orchestrator.PathwaysJobDefinition
 	Verbose                       bool
+	Env                           map[string]string
 	AdditionalManifests           []string
 }
 
@@ -335,6 +336,7 @@ type jobSetTemplateData struct {
 	Pathways                      orchestrator.PathwaysJobDefinition
 	ExclusiveTopologyAnnotation   string
 	Verbose                       bool
+	Env                           []struct{ Name, Value string }
 	IsTPU                         bool
 	IsGPU                         bool
 }

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -297,6 +297,14 @@ type ContainerData struct {
 	ResourcesYAML string
 }
 
+// EnvVar represents a custom environment variable key-value pair.
+type EnvVar struct {
+	// Name is the environment variable key.
+	Name string
+	// Value is the environment variable value.
+	Value string
+}
+
 type jobSetTemplateData struct {
 	WorkloadName                  string
 	ClusterName                   string
@@ -336,7 +344,10 @@ type jobSetTemplateData struct {
 	Pathways                      orchestrator.PathwaysJobDefinition
 	ExclusiveTopologyAnnotation   string
 	Verbose                       bool
-	Env                           []struct{ Name, Value string }
+	Env                           []EnvVar
+	PathwaysProxyEnv              []EnvVar
+	PathwaysServerEnv             []EnvVar
+	PathwaysWorkerEnv             []EnvVar
 	IsTPU                         bool
 	IsGPU                         bool
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -90,6 +90,7 @@ type JobDefinition struct {
 	Pathways      PathwaysJobDefinition // Embedded struct for Pathways-specific args
 
 	RawMounts []string
+	Env       map[string]string
 
 	Verbose bool
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -33,6 +33,11 @@ type PathwaysJobDefinition struct {
 	ServerArgs string // Default: ""
 	WorkerArgs string // Default: ""
 
+	// Custom Environment Variables for Pathways components
+	ProxyEnv  map[string]string
+	ServerEnv map[string]string
+	WorkerEnv map[string]string
+
 	// Pathways-specific sidecars
 	ColocatedPythonSidecarImage string // Default: ""
 


### PR DESCRIPTION
* **New --env Flags:** Added a new --env flag to the 'gcluster job submit' command to allow users to pass custom environment variables to their workload containers. Also, introduced pathways specific new environment flags in cmd/job/submit.go:
  * --pathways-proxy-env
  * --pathways-server-env
  * --pathways-worker-env

* **Validation Logic:** Implemented validation for environment variable keys to ensure they adhere to POSIX naming conventions (letters, numbers, and underscores, without starting with a digit).

* **Template Updates:** Updated GKE and Pathways JobSet templates to inject the provided environment variables into the container specifications.

* **Testing and Documentation:** Added comprehensive unit tests for flag parsing and validation, and updated the job guide documentation with usage examples.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
