### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 ---
 repos:
 - repo: https://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.86.0
+  rev: v1.108.0
   hooks:
   - id: terraform_fmt
   - id: terraform_tflint
@@ -143,16 +143,16 @@ repos:
 #   hooks:
 #   - id: go-critic
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.4.0
+  rev: v2.12.2
   hooks:
   - id: golangci-lint
 - repo: https://github.com/adrienverge/yamllint
-  rev: v1.34.0
+  rev: v1.38.0
   hooks:
   - id: yamllint
     args: [-c=.yamllint, --no-warnings]
 - repo: https://github.com/jackdewinter/pymarkdown
-  rev: v0.9.17
+  rev: v0.9.38
   hooks:
   - id: pymarkdown
     # Rules at https://github.com/jackdewinter/pymarkdown/tree/main/docs/rules
@@ -174,11 +174,11 @@ repos:
   - id: shfmt
     exclude: ".*tpl|.*unlinted"
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v6.0.0
   hooks:
   - id: end-of-file-fixer
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.2.6
+  rev: v2.4.2
   hooks:
   - id: codespell
     exclude: requirements.txt$|/js/|go.sum$|cluster-toolkit-writers.json$


### PR DESCRIPTION
Update pre-commit config file to use the latest versions for the hooks by running the `pre-commit autoupdate` command. 