### PR TITLE
Add num_node_pools var to GKE A4X Max example

### DIFF
--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm-deployment.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm-deployment.yaml
@@ -45,3 +45,6 @@ vars:
   # To target a BLOCK_NAME, the name of the extended reservation
   # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
   reservation:
+
+  # The number of node pools (num_slices) to be created
+  num_node_pools:

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -38,6 +38,9 @@ vars:
   # The number of nodes to be created
   static_node_count:
 
+  # The number of node pools (num_slices) to be created
+  num_node_pools:
+
   # The name of the compute engine reservation of A4X-Max nodes in the form of
   # <project>/<reservation-name>
   # To target a BLOCK_NAME, the name of the extended reservation
@@ -239,6 +242,7 @@ deployment_groups:
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.a4x_max_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
+      num_node_pools: $(vars.num_node_pools)
       disk_type: hyperdisk-balanced
       guest_accelerator:
       - type: $(vars.accelerator_type)


### PR DESCRIPTION
This PR updates the GKE A4X Max BM blueprint to use num_node_pools vars similar to A4X.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
