### PR TITLE
Fix typo `parition` -> `partition` in `schedmd-slurm-gcp-v6-controller`

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/README.md
@@ -379,7 +379,7 @@ limitations under the License.
 | [google_secret_manager_secret_version.cloudsql_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
 | [google_storage_bucket_iam_member.legacy_readers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
-| [google_storage_bucket_object.parition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
+| [google_storage_bucket_object.partition_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object) | resource |
 | [google_project.controller_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/partition.tf
@@ -162,7 +162,7 @@ module "nodeset_cleanup_tpu" {
   ]
 }
 
-resource "google_storage_bucket_object" "parition_config" {
+resource "google_storage_bucket_object" "partition_config" {
   for_each = { for p in var.partitions : p.partition_name => p }
 
   bucket         = module.slurm_files.bucket_name
@@ -174,4 +174,9 @@ resource "google_storage_bucket_object" "parition_config" {
 moved {
   from = module.slurm_files.google_storage_bucket_object.parition_config
   to   = google_storage_bucket_object.parition_config
+}
+
+moved {
+  from = google_storage_bucket_object.parition_config
+  to   = google_storage_bucket_object.partition_config
 }


### PR DESCRIPTION
Fixes a typo in the resource name google_storage_bucket_object.parition_config -> partition_config inside the `schedmd-slurm-gcp-v6-controller` module.
                                                                                                                                 
To ensure upgrades of existing installs are non-destructive, a Terraform moved block has been added