### PR TITLE
Add MPI operator setup instructions on GKE A4X and A4X Max

### DIFF
--- a/examples/gke-a4x-max-bm/README.md
+++ b/examples/gke-a4x-max-bm/README.md
@@ -157,7 +157,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-launcher
-               image: mpioperator/tensorflow-benchmarks:latest
+               image: mpioperator/mpi-pi:v0.8.0-openmpi
                command:
                - mpirun
                - --allow-run-as-root
@@ -173,7 +173,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-worker
-               image: mpioperator/tensorflow-benchmarks:latest
+               image: mpioperator/mpi-pi:v0.8.0-openmpi
    ```
 
    Submit the job and inspect launcher logs:

--- a/examples/gke-a4x-max-bm/README.md
+++ b/examples/gke-a4x-max-bm/README.md
@@ -120,6 +120,70 @@ This section describes how to run [NCCL/gIB](https://docs.cloud.google.com/ai-hy
     kubectl logs $(kubectl get pods -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}' | grep nccl-all-worker-0-0)
     ```
 
+### Install and Run MPI Operator on GKE Cluster
+
+The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
+
+1. **Deploy MPI Operator (v0.8.0):**
+
+   ```bash
+   kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+   ```
+
+2. **Verify Installation:**
+
+   ```bash
+   kubectl get crd | grep mpijob
+   kubectl get pods -n mpi-operator
+   ```
+
+3. **Run a Sample MPIJob Test:**
+   Create a test manifest `sample-mpijob.yaml`:
+
+   ```yaml
+   apiVersion: kubeflow.org/v2beta1
+   kind: MPIJob
+   metadata:
+     name: sample-mpi-job
+     namespace: default
+   spec:
+     slotsPerWorker: 1
+     runPolicy:
+       cleanPodPolicy: Running
+     mpiReplicaSpecs:
+       Launcher:
+         replicas: 1
+         template:
+           spec:
+             containers:
+             - name: mpi-launcher
+               image: mpioperator/tensorflow-benchmarks:latest
+               command:
+               - mpirun
+               - --allow-run-as-root
+               - -n
+               - "2"
+               - --hostfile
+               - /etc/mpi/hostfile
+               - echo
+               - "Hello World from MPI worker!"
+       Worker:
+         replicas: 2
+         template:
+           spec:
+             containers:
+             - name: mpi-worker
+               image: mpioperator/tensorflow-benchmarks:latest
+   ```
+
+   Submit the job and inspect launcher logs:
+
+   ```bash
+   kubectl apply -f sample-mpijob.yaml
+   kubectl logs -l training.kubeflow.org/job-role=launcher
+   kubectl delete -f sample-mpijob.yaml
+   ```
+
 ### Clean up resources created by Cluster Toolkit
 
 To avoid recurring charges for the resources used, clean up the resources provisioned by Cluster Toolkit, including the VPC networks and GKE cluster:

--- a/examples/gke-a4x-max-bm/README.md
+++ b/examples/gke-a4x-max-bm/README.md
@@ -126,9 +126,23 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
 
 1. **Deploy MPI Operator (v0.8.0):**
 
-   ```bash
-   kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
-   ```
+   * **Automated (During Cluster Creation via Blueprint YAML):** Include the MPI Operator manifest in `apply_manifests` under `kubectl-apply` in your blueprint YAML (`gke-a4x-max-bm.yaml`):
+
+     ```yaml
+       - id: kubectl-apply
+         source: modules/management/kubectl-apply
+         use: [a4x-max-cluster]
+         settings:
+           apply_manifests:
+           - name: mpi-operator
+             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     ```
+
+   * **Manual (After Cluster Deployment via `kubectl`):** Once the cluster is deployed, run the following command against your cluster:
+
+     ```bash
+     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     ```
 
 2. **Verify Installation:**
 

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -5,3 +5,67 @@ This example provides the configuration to deploy a GKE cluster with A4X machine
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A4X cluster.
 
 Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A4X cluster.
+
+## Install and Run MPI Operator on GKE Cluster
+
+The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
+
+1. **Deploy MPI Operator (v0.8.0):**
+
+   ```bash
+   kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+   ```
+
+2. **Verify Installation:**
+
+   ```bash
+   kubectl get crd | grep mpijob
+   kubectl get pods -n mpi-operator
+   ```
+
+3. **Run a Sample MPIJob Test:**
+   Create a test manifest `sample-mpijob.yaml`:
+
+   ```yaml
+   apiVersion: kubeflow.org/v2beta1
+   kind: MPIJob
+   metadata:
+     name: sample-mpi-job
+     namespace: default
+   spec:
+     slotsPerWorker: 1
+     runPolicy:
+       cleanPodPolicy: Running
+     mpiReplicaSpecs:
+       Launcher:
+         replicas: 1
+         template:
+           spec:
+             containers:
+             - name: mpi-launcher
+               image: mpioperator/tensorflow-benchmarks:latest
+               command:
+               - mpirun
+               - --allow-run-as-root
+               - -n
+               - "2"
+               - --hostfile
+               - /etc/mpi/hostfile
+               - echo
+               - "Hello World from MPI worker!"
+       Worker:
+         replicas: 2
+         template:
+           spec:
+             containers:
+             - name: mpi-worker
+               image: mpioperator/tensorflow-benchmarks:latest
+   ```
+
+   Submit the job and inspect launcher logs:
+
+   ```bash
+   kubectl apply -f sample-mpijob.yaml
+   kubectl logs -l training.kubeflow.org/job-role=launcher
+   kubectl delete -f sample-mpijob.yaml
+   ```

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -43,7 +43,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-launcher
-               image: mpioperator/tensorflow-benchmarks:latest
+               image: mpioperator/mpi-pi:v0.8.0-openmpi
                command:
                - mpirun
                - --allow-run-as-root
@@ -59,7 +59,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-worker
-               image: mpioperator/tensorflow-benchmarks:latest
+               image: mpioperator/mpi-pi:v0.8.0-openmpi
    ```
 
    Submit the job and inspect launcher logs:

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -12,9 +12,23 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
 
 1. **Deploy MPI Operator (v0.8.0):**
 
-   ```bash
-   kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
-   ```
+   * **Automated (During Cluster Creation via Blueprint YAML):** Include the MPI Operator manifest in `apply_manifests` under `kubectl-apply` in your blueprint YAML (`gke-a4x.yaml`):
+
+     ```yaml
+       - id: kubectl-apply
+         source: modules/management/kubectl-apply
+         use: [a4x-cluster]
+         settings:
+           apply_manifests:
+           - name: mpi-operator
+             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     ```
+
+   * **Manual (After Cluster Deployment via `kubectl`):** Once the cluster is deployed, run the following command against your cluster:
+
+     ```bash
+     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     ```
 
 2. **Verify Installation:**
 


### PR DESCRIPTION
Added instructions for deploying Kubeflow MPI Operator and running multi-node `MPIJob` tests in `examples/gke-a4x/README.md` and `examples/gke-a4x-max-bm/README.md`.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
