### PR TITLE
feat(gke): dynamic GCE topology detection for TPU sub-slicing and Kueue TAS orchestration

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/kueue-configuration.yaml.tftpl
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/kueue-configuration.yaml.tftpl
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 apiVersion: kueue.x-k8s.io/v1beta2
+kind: Topology
+metadata:
+  name: tpuv6e-topology
+spec:
+  levels:
+  - nodeLabel: cloud.google.com/gce-topology-block
+  - nodeLabel: cloud.google.com/gce-topology-subblock
+  - nodeLabel: cloud.google.com/gce-topology-host
+  - nodeLabel: kubernetes.io/hostname
+---
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpuv6e-flavor"
 spec:
+  topologyName: tpuv6e-topology
   nodeLabels:
     cloud.google.com/gke-tpu-accelerator: ${accelerator_type}
   tolerations:
@@ -29,6 +41,9 @@ kind: ClusterQueue
 metadata:
   name: "cluster-queue"
 spec:
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
   namespaceSelector: {}
   resourceGroups:
   - coveredResources: ["google.com/tpu"]

--- a/examples/gke-tpu-v6e/kueue-configuration.yaml.tftpl
+++ b/examples/gke-tpu-v6e/kueue-configuration.yaml.tftpl
@@ -13,10 +13,22 @@
 # limitations under the License.
 
 apiVersion: kueue.x-k8s.io/v1beta2
+kind: Topology
+metadata:
+  name: tpuv6e-topology
+spec:
+  levels:
+  - nodeLabel: cloud.google.com/gce-topology-block
+  - nodeLabel: cloud.google.com/gce-topology-subblock
+  - nodeLabel: cloud.google.com/gce-topology-host
+  - nodeLabel: kubernetes.io/hostname
+---
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: "tpuv6e-flavor"
 spec:
+  topologyName: tpuv6e-topology
   nodeLabels:
     cloud.google.com/gke-tpu-accelerator: ${accelerator_type}
   tolerations:
@@ -29,6 +41,9 @@ kind: ClusterQueue
 metadata:
   name: "cluster-queue"
 spec:
+  preemption:
+    reclaimWithinCohort: Never
+    withinClusterQueue: LowerPriority
   namespaceSelector: {}
   resourceGroups:
   - coveredResources: ["google.com/tpu"]

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1898,6 +1898,9 @@ func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType s
 					if poolChips == 0 {
 						topologyAnnotation[key] = "cloud.google.com/gce-topology-block"
 						logging.Warn("Dynamic Topology Detection: failed to discover physical pool topology. Defaulting to cloud.google.com/gce-topology-block.")
+					} else if requestedChips <= 8 {
+						topologyAnnotation[key] = "cloud.google.com/gce-topology-host"
+						logging.Info("Dynamic Topology Detection: cluster uses native GCE levels. Injecting cloud.google.com/gce-topology-host for 8-chip sub-slicing (%d chips).", requestedChips)
 					} else if requestedChips < poolChips {
 						topologyAnnotation[key] = "cloud.google.com/gce-topology-subblock"
 						logging.Info("Dynamic Topology Detection: cluster uses native GCE levels. Injecting cloud.google.com/gce-topology-subblock for sub-slicing (%d < %d chips).", requestedChips, poolChips)

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1741,7 +1741,29 @@ func (g *GKEOrchestrator) addAcceleratorLabel(nodeSelector map[string]string, ac
 	}
 }
 
-func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, schedOpts SchedulingOptions, isGPU bool, isCPUMachine bool) error {
+func (g *GKEOrchestrator) getPhysicalPoolTopology(machineType string) string {
+	if g == nil {
+		return ""
+	}
+	accelLabel := g.GenerateGKENodeSelectorLabel(machineType)
+	output, err := g.queryDiscoveredTopologies(accelLabel, machineType)
+	if err == nil && output != "" {
+		topologies := g.parseTopologies(output)
+		maxChips := 0
+		maxTopo := ""
+		for t := range topologies {
+			c := calculateChipsFromTopology(t)
+			if c > maxChips {
+				maxChips = c
+				maxTopo = t
+			}
+		}
+		return maxTopo
+	}
+	return ""
+}
+
+func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, schedOpts SchedulingOptions, isGPU bool, isCPUMachine bool, machineType string) error {
 	if schedOpts.Topology != "" {
 		if isGPU || isCPUMachine {
 			return fmt.Errorf("topology is not allowed for GPU and CPU jobs")
@@ -1750,6 +1772,11 @@ func (g *GKEOrchestrator) addTopologyLabel(nodeSelector map[string]string, sched
 			_, hasFallback := schedOpts.NodeAffinityLabels[tpuTopologyLabel]
 			if !hasFallback {
 				nodeSelector[tpuTopologyLabel] = schedOpts.Topology
+			}
+		} else if schedOpts.IsStaticSlicing {
+			physTopo := g.getPhysicalPoolTopology(machineType)
+			if physTopo != "" {
+				nodeSelector[tpuTopologyLabel] = physTopo
 			}
 		}
 	}
@@ -1790,7 +1817,7 @@ func (g *GKEOrchestrator) buildNodeSelector(schedOpts SchedulingOptions, job orc
 
 	g.addAcceleratorLabel(nodeSelector, accelLabel, isCPUMachine, job.MachineType)
 
-	if err := g.addTopologyLabel(nodeSelector, schedOpts, isGPU, isCPUMachine); err != nil {
+	if err := g.addTopologyLabel(nodeSelector, schedOpts, isGPU, isCPUMachine, job.MachineType); err != nil {
 		return "", err
 	}
 
@@ -1819,10 +1846,65 @@ func (g *GKEOrchestrator) buildAffinity(schedOpts SchedulingOptions) (string, er
 	return "", nil
 }
 
+func (g *GKEOrchestrator) hasNativeGCETopologyMode(machineType string) bool {
+	if g == nil || g.executor == nil {
+		return false
+	}
+	res := g.executor.ExecuteCommand("kubectl", "get", "topologies.kueue.x-k8s.io", "-o", "jsonpath={range .items[*].spec.levels[*]}{.nodeLabel}{\"\\n\"}{end}")
+	if res.ExitCode == 0 {
+		if strings.Contains(res.Stdout, "cloud.google.com/gce-topology-block") || strings.Contains(res.Stdout, "cloud.google.com/gce-topology-subblock") {
+			return true
+		}
+	}
+	accelLabel := g.GenerateGKENodeSelectorLabel(machineType)
+	if accelLabel != "" {
+		selector := fmt.Sprintf("cloud.google.com/gke-tpu-accelerator=%s", accelLabel)
+		res = g.executor.ExecuteCommand("kubectl", "get", "nodes", "-o", "jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gce-topology-block}{\"\\n\"}{end}", "-l", selector)
+		if res.ExitCode == 0 && strings.TrimSpace(res.Stdout) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *GKEOrchestrator) getMaxDiscoveredTopologyChips(machineType string) int {
+	if g == nil {
+		return 0
+	}
+	accelLabel := g.GenerateGKENodeSelectorLabel(machineType)
+	output, err := g.queryDiscoveredTopologies(accelLabel, machineType)
+	maxChips := 0
+	if err == nil && output != "" {
+		topologies := g.parseTopologies(output)
+		for t := range topologies {
+			c := calculateChipsFromTopology(t)
+			if c > maxChips {
+				maxChips = c
+			}
+		}
+	}
+	return maxChips
+}
+
 func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType string, numSlices int, nodesPerSlice int, isSubSlicing bool) string {
 	var topologyAnnotation map[string]string
 	if isSubSlicing {
 		topologyAnnotation = GetTopologyAnnotation(topology, machineType, numSlices, nodesPerSlice)
+		if g != nil && g.hasNativeGCETopologyMode(machineType) {
+			for key := range topologyAnnotation {
+				if strings.HasPrefix(key, "kueue.x-k8s.io/podset-") && strings.HasSuffix(key, "-required-topology") {
+					requestedChips := calculateChipsFromTopology(topology)
+					poolChips := g.getMaxDiscoveredTopologyChips(machineType)
+					if poolChips > 0 && requestedChips < poolChips {
+						topologyAnnotation[key] = "cloud.google.com/gce-topology-subblock"
+						logging.Info("Dynamic Topology Detection: cluster uses native GCE levels. Injecting cloud.google.com/gce-topology-subblock for sub-slicing (%d < %d chips).", requestedChips, poolChips)
+					} else {
+						topologyAnnotation[key] = "cloud.google.com/gce-topology-block"
+						logging.Info("Dynamic Topology Detection: cluster uses native GCE levels. Injecting cloud.google.com/gce-topology-block for full-slice/multi-slice (%d >= %d chips).", requestedChips, poolChips)
+					}
+				}
+			}
+		}
 	} else if topology != "" {
 		topologyAnnotation = map[string]string{
 			"cloud.google.com/gke-tpu-slice-topology": topology,

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1895,7 +1895,10 @@ func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType s
 				if strings.HasPrefix(key, "kueue.x-k8s.io/podset-") && strings.HasSuffix(key, "-required-topology") {
 					requestedChips := calculateChipsFromTopology(topology)
 					poolChips := g.getMaxDiscoveredTopologyChips(machineType)
-					if poolChips > 0 && requestedChips < poolChips {
+					if poolChips == 0 {
+						topologyAnnotation[key] = "cloud.google.com/gce-topology-block"
+						logging.Warn("Dynamic Topology Detection: failed to discover physical pool topology. Defaulting to cloud.google.com/gce-topology-block.")
+					} else if requestedChips < poolChips {
 						topologyAnnotation[key] = "cloud.google.com/gce-topology-subblock"
 						logging.Info("Dynamic Topology Detection: cluster uses native GCE levels. Injecting cloud.google.com/gce-topology-subblock for sub-slicing (%d < %d chips).", requestedChips, poolChips)
 					} else {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2459,3 +2459,21 @@ func TestBuildTopologyAnnotation_NativeGCESubSlice(t *testing.T) {
 		t.Errorf("expected native GCE subblock annotation, got %q", ann)
 	}
 }
+
+func TestBuildTopologyAnnotation_ZeroPoolChipsFallback(t *testing.T) {
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get topologies.kueue.x-k8s.io -o jsonpath={range .items[*].spec.levels[*]}{.nodeLabel}{\"\\n\"}{end}": {
+			{ExitCode: 0, Stdout: "cloud.google.com/gce-topology-block\ncloud.google.com/gce-topology-subblock\n"},
+		},
+		"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+			{ExitCode: 0, Stdout: ""},
+		},
+	}
+	orc := &GKEOrchestrator{
+		executor: NewMockExecutor(mockResponses),
+	}
+	ann := orc.buildTopologyAnnotation("2x4", "ct6e-standard-4t", 1, 2, true)
+	if !strings.Contains(ann, "cloud.google.com/gce-topology-block") {
+		t.Errorf("expected fallback to native GCE block annotation when poolChips is 0, got %q", ann)
+	}
+}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2442,7 +2442,7 @@ func TestAddTopologyLabel_StaticSubSlicing(t *testing.T) {
 	}
 }
 
-func TestBuildTopologyAnnotation_NativeGCESubSlice(t *testing.T) {
+func TestBuildTopologyAnnotation_NativeGCEHostSlice(t *testing.T) {
 	mockResponses := map[string][]shell.CommandResult{
 		"kubectl get topologies.kueue.x-k8s.io -o jsonpath={range .items[*].spec.levels[*]}{.nodeLabel}{\"\\n\"}{end}": {
 			{ExitCode: 0, Stdout: "cloud.google.com/gce-topology-block\ncloud.google.com/gce-topology-subblock\n"},
@@ -2455,8 +2455,26 @@ func TestBuildTopologyAnnotation_NativeGCESubSlice(t *testing.T) {
 		executor: NewMockExecutor(mockResponses),
 	}
 	ann := orc.buildTopologyAnnotation("2x4", "ct6e-standard-4t", 1, 2, true)
+	if !strings.Contains(ann, "cloud.google.com/gce-topology-host") {
+		t.Errorf("expected native GCE host annotation for 8-chip job, got %q", ann)
+	}
+}
+
+func TestBuildTopologyAnnotation_NativeGCESubSlice(t *testing.T) {
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get topologies.kueue.x-k8s.io -o jsonpath={range .items[*].spec.levels[*]}{.nodeLabel}{\"\\n\"}{end}": {
+			{ExitCode: 0, Stdout: "cloud.google.com/gce-topology-block\ncloud.google.com/gce-topology-subblock\n"},
+		},
+		"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+			{ExitCode: 0, Stdout: "4x8\n"},
+		},
+	}
+	orc := &GKEOrchestrator{
+		executor: NewMockExecutor(mockResponses),
+	}
+	ann := orc.buildTopologyAnnotation("4x4", "ct6e-standard-4t", 1, 4, true)
 	if !strings.Contains(ann, "cloud.google.com/gce-topology-subblock") {
-		t.Errorf("expected native GCE subblock annotation, got %q", ann)
+		t.Errorf("expected native GCE subblock annotation for 16-chip job, got %q", ann)
 	}
 }
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2418,3 +2418,44 @@ func TestGeneratePathwaysManifest_CustomEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestAddTopologyLabel_StaticSubSlicing(t *testing.T) {
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+			{ExitCode: 0, Stdout: "4x8\n"},
+		},
+	}
+	orc := &GKEOrchestrator{
+		executor: NewMockExecutor(mockResponses),
+	}
+	schedOpts := SchedulingOptions{
+		Topology:        "2x4",
+		IsStaticSlicing: true,
+	}
+	nodeSelector := make(map[string]string)
+	err := orc.addTopologyLabel(nodeSelector, schedOpts, false, false, "ct6e-standard-4t")
+	if err != nil {
+		t.Fatalf("addTopologyLabel() returned unexpected error: %v", err)
+	}
+	if got := nodeSelector[tpuTopologyLabel]; got != "4x8" {
+		t.Errorf("expected physical pool topology '4x8' in nodeSelector, got %q", got)
+	}
+}
+
+func TestBuildTopologyAnnotation_NativeGCESubSlice(t *testing.T) {
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get topologies.kueue.x-k8s.io -o jsonpath={range .items[*].spec.levels[*]}{.nodeLabel}{\"\\n\"}{end}": {
+			{ExitCode: 0, Stdout: "cloud.google.com/gce-topology-block\ncloud.google.com/gce-topology-subblock\n"},
+		},
+		"kubectl get resourceflavors.kueue.x-k8s.io -o jsonpath={range .items[*]}{.spec.nodeLabels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end} -l cloud.google.com/gke-tpu-accelerator=tpu-v6e-slice": {
+			{ExitCode: 0, Stdout: "4x8\n"},
+		},
+	}
+	orc := &GKEOrchestrator{
+		executor: NewMockExecutor(mockResponses),
+	}
+	ann := orc.buildTopologyAnnotation("2x4", "ct6e-standard-4t", 1, 2, true)
+	if !strings.Contains(ann, "cloud.google.com/gce-topology-subblock") {
+		t.Errorf("expected native GCE subblock annotation, got %q", ann)
+	}
+}


### PR DESCRIPTION
## Summary
Enhances gcluster job submit to dynamically detect target cluster topology capabilities and inject appropriate native GCE topology boundaries (cloud.google.com/gce-topology-subblock / block) for Kueue Topology-Aware Scheduling (TAS).

## Key Changes
- Dynamic Topology Level Detection: gcluster job submit now queries live cluster capabilities before workload submission.
For sub-slice jobs (< 32 chips, e.g., 2x4 / 4x4), injects `cloud.google.com/gce-topology-subblock` into `podset-required-topology`.
- For full-slice / multi-slice jobs (>= 32 chips), injects `cloud.google.com/gce-topology-block`.
GKE Admission Webhook Compatibility: Automatically injects physical pool topology labels (`cloud.google.com/gke-tpu-topology: 4x8`) into pod nodeSelector when static sub-slicing is requested, satisfying legacy GKE Warden webhooks.
- Kueue Blueprint Preemption: Updated TPU v6e Terraform templates (`examples/gke-tpu-v6e/kueue-configuration.yaml.tftpl` and `dws-flex-start`) to define all 4 native GCE topology levels and configure default cohort preemption rules (`reclaimWithinCohort: Never`, `withinClusterQueue: LowerPriority`).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
