### PR TITLE
Fix(gke): use full accelerator type for pathways platform mapping

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2418,3 +2418,83 @@ func TestGeneratePathwaysManifest_CustomEnv(t *testing.T) {
 		}
 	}
 }
+
+func TestPrepareManifestOptions_PathwaysPlatform(t *testing.T) {
+	setupMockMachineConfig(t)
+	tests := []struct {
+		computeType  string
+		topology     string
+		wantPlatform string
+	}{
+		{
+			computeType:  "tpu-v5-lite-podslice",
+			topology:     "16x16",
+			wantPlatform: "tpuv5e:16x16",
+		},
+		{
+			computeType:  "v5litepod",
+			topology:     "8x8",
+			wantPlatform: "tpuv5e:8x8",
+		},
+		{
+			computeType:  "tpu-v6e-slice",
+			topology:     "4x4",
+			wantPlatform: "tpuv6e:4x4",
+		},
+		{
+			computeType:  "v6e",
+			topology:     "4x4",
+			wantPlatform: "tpuv6e:4x4",
+		},
+		{
+			computeType:  "tpu-v5p-slice",
+			topology:     "2x2x2",
+			wantPlatform: "tpuv5:2x2x2",
+		},
+		{
+			computeType:  "v5p",
+			topology:     "2x2x2",
+			wantPlatform: "tpuv5:2x2x2",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.computeType, func(t *testing.T) {
+			job := orchestrator.JobDefinition{
+				WorkloadName:    "pathways-test-job",
+				CommandToRun:    "echo hello",
+				ComputeType:     tc.computeType,
+				ClusterLocation: "us-central1-a",
+				IsPathwaysJob:   true,
+				Topology:        tc.topology,
+			}
+
+			mockResponses := map[string][]shell.CommandResult{
+				"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+				"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: tc.topology}},
+				"gcloud compute machine-types describe " + tc.computeType + " --zone=us-central1-a --format=json":                       {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "` + tc.computeType + `"}]}`}},
+			}
+
+			mockExec := NewMockExecutor(mockResponses)
+			orc := newTestGKEOrchestrator(mockExec)
+			orc.projectID = "mock-project"
+			orc.clusterDesc.NodePools = []gkeJobNodePool{
+				{Config: gkeNodePoolConfig{MachineType: tc.computeType}},
+			}
+
+			profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+			if err != nil {
+				t.Fatalf("resolveHardwareRequirements failed: %v", err)
+			}
+
+			opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+			if err != nil {
+				t.Fatalf("PrepareManifestOptions failed: %v", err)
+			}
+
+			if opts.PathwaysInstanceType != tc.wantPlatform {
+				t.Errorf("PathwaysInstanceType = %q, want %q", opts.PathwaysInstanceType, tc.wantPlatform)
+			}
+		})
+	}
+}

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -121,12 +121,9 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		IsStaticSlicing:    isStaticSlicing,
 	}
 
-	parts := strings.Split(originalAccelType, "-")
-	instanceType := parts[0]
-
 	// Reuse GCluster's existing GKE accelerator label mapping and algorithmically
 	// derive the Pathways short platform key to avoid duplicating mapping tables.
-	gkeLabel := g.GenerateGKENodeSelectorLabel(instanceType)
+	gkeLabel := g.GenerateGKENodeSelectorLabel(originalAccelType)
 	// Normalize GKE node selector labels to match JAX/Pathways platform keys:
 	// 1. Map GKE "v5-lite" (TPU v5e) to JAX standard "v5e" (deriving tpuv5e)
 	// 2. Map GKE "v5p" (TPU v5p) to JAX standard "v5" (deriving tpuv5)


### PR DESCRIPTION
**Problem**: When preparing manifest options for Pathways jobs, the orchestrator was passing a truncated accelerator type (e.g., "tpu" or "v5" extracted by splitting ComputeType by - and taking the first part) to GenerateGKENodeSelectorLabel.

This caused the label resolution to fail to match the full accelerator type (such as tpu-v5-lite-podslice or v5litepod-slice). Consequently, the mapping logic was bypassed, resulting in an incorrect pathwaysPlatform (e.g., "tpu" instead of "tpuv5e"). This led to the Pathways server crashing on container startup due to invalid platform key validation.

**Solution**: Modified PrepareManifestOptions to pass the originalAccelType (the full accelerator type) instead of the truncated instanceType to GenerateGKENodeSelectorLabel. This allows the orchestrator to correctly resolve the machine family and derive the correct JAX/Pathways platform key.

**Testing**
* Added a new unit test TestPrepareManifestOptions_PathwaysPlatform in gke_job_orchestrator_test.go to verify the mapping for various TPU configurations:
   * tpu-v5-lite-podslice -> tpuv5e:16x16
   * v5litepod -> tpuv5e:8x8
   * tpu-v6e-slice -> tpuv6e:4x4
   * v6e -> tpuv6e:4x4
   * tpu-v5p-slice -> tpuv5:2x2x2
   * v5p -> tpuv5:2x2x2
* Ran all unit tests under pkg/ and verified they all pass.