### PR TITLE
Fix(gcluster): enforce strict GKE NAP accelerator validation

### DIFF
--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -30,22 +30,7 @@ func (g *GKEOrchestrator) isNAPEnabledForMachineType(machineType, zone string) (
 	resolvedType := config.ResolveMachineType(machineType)
 
 	if config.IsTPU(resolvedType) {
-		key := strings.ToLower(g.GenerateGKENodeSelectorLabel(resolvedType))
-		if limit, exists := g.napLimits[key]; exists {
-			return limit > 0, nil
-		}
-		// Fallback to generic TPU limit ONLY if no specific TPU limits are configured.
-		hasSpecificTPULimits := false
-		for k := range g.napLimits {
-			if isSpecificTPUKey(k) {
-				hasSpecificTPULimits = true
-				break
-			}
-		}
-		if hasSpecificTPULimits {
-			return false, nil
-		}
-		return g.napLimits["google.com/tpu"] > 0, nil
+		return g.validateTPUNAPLimit(resolvedType)
 	}
 
 	cap, err := g.FetchMachineCapabilities(resolvedType, zone)
@@ -53,31 +38,54 @@ func (g *GKEOrchestrator) isNAPEnabledForMachineType(machineType, zone string) (
 		return false, err
 	}
 	if len(cap.Accelerators) > 0 {
-		key := strings.ToLower(g.GenerateGKENodeSelectorLabel(resolvedType))
-		if strings.EqualFold(key, resolvedType) {
-			key = strings.ToLower(g.GenerateGKENodeSelectorLabel(cap.Accelerators[0].Type))
-		}
-		if !isKnownGKEAccelerator(key) {
-			return false, fmt.Errorf("unknown accelerator label: %q", cap.Accelerators[0].Type)
-		}
-		if limit, exists := g.napLimits[key]; exists {
-			return limit > 0, nil
-		}
-		// Fallback to generic GPU limit ONLY if no specific GPU limits are configured.
-		hasSpecificGPULimits := false
-		for k := range g.napLimits {
-			if isSpecificGPUKey(k) {
-				hasSpecificGPULimits = true
-				break
-			}
-		}
-		if hasSpecificGPULimits {
-			return false, nil
-		}
-		return g.napLimits["nvidia.com/gpu"] > 0, nil
+		return g.validateGPUNAPLimit(resolvedType, cap)
 	}
 
 	return g.napLimits["cpu"] > 0, nil
+}
+
+func (g *GKEOrchestrator) validateTPUNAPLimit(resolvedType string) (bool, error) {
+	key := strings.ToLower(g.GenerateGKENodeSelectorLabel(resolvedType))
+	if limit, exists := g.napLimits[key]; exists {
+		return limit > 0, nil
+	}
+	// Fallback to generic TPU limit ONLY if no specific TPU limits are configured.
+	hasSpecificTPULimits := false
+	for k := range g.napLimits {
+		if isSpecificTPUKey(k) {
+			hasSpecificTPULimits = true
+			break
+		}
+	}
+	if hasSpecificTPULimits {
+		return false, nil
+	}
+	return g.napLimits["google.com/tpu"] > 0, nil
+}
+
+func (g *GKEOrchestrator) validateGPUNAPLimit(resolvedType string, cap MachineTypeCap) (bool, error) {
+	key := strings.ToLower(g.GenerateGKENodeSelectorLabel(resolvedType))
+	if strings.EqualFold(key, resolvedType) {
+		key = strings.ToLower(g.GenerateGKENodeSelectorLabel(cap.Accelerators[0].Type))
+	}
+	if !isKnownGKEAccelerator(key) {
+		return false, fmt.Errorf("unknown accelerator label: %q", cap.Accelerators[0].Type)
+	}
+	if limit, exists := g.napLimits[key]; exists {
+		return limit > 0, nil
+	}
+	// Fallback to generic GPU limit ONLY if no specific GPU limits are configured.
+	hasSpecificGPULimits := false
+	for k := range g.napLimits {
+		if isSpecificGPUKey(k) {
+			hasSpecificGPULimits = true
+			break
+		}
+	}
+	if hasSpecificGPULimits {
+		return false, nil
+	}
+	return g.napLimits["nvidia.com/gpu"] > 0, nil
 }
 
 func (g *GKEOrchestrator) checkNAPFlagsSupported(hasNAPFlags bool, job *orchestrator.JobDefinition) error {
@@ -155,11 +163,11 @@ func extractShortReservationName(resName string) string {
 }
 
 func isSpecificGPUKey(key string) bool {
-	return strings.HasPrefix(key, "nvidia-") && key != "nvidia.com/gpu"
+	return strings.HasPrefix(key, "nvidia-")
 }
 
 func isSpecificTPUKey(key string) bool {
-	return (strings.HasPrefix(key, "tpu-") || strings.HasPrefix(key, "ct")) && key != "google.com/tpu"
+	return strings.HasPrefix(key, "tpu-")
 }
 
 func isKnownGKEAccelerator(key string) bool {

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -31,7 +31,21 @@ func (g *GKEOrchestrator) isNAPEnabledForMachineType(machineType, zone string) (
 
 	if config.IsTPU(resolvedType) {
 		key := strings.ToLower(g.GenerateGKENodeSelectorLabel(resolvedType))
-		return g.napLimits[key] > 0 || g.napLimits["google.com/tpu"] > 0, nil
+		if limit, exists := g.napLimits[key]; exists {
+			return limit > 0, nil
+		}
+		// Fallback to generic TPU limit ONLY if no specific TPU limits are configured.
+		hasSpecificTPULimits := false
+		for k := range g.napLimits {
+			if isSpecificTPUKey(k) {
+				hasSpecificTPULimits = true
+				break
+			}
+		}
+		if hasSpecificTPULimits {
+			return false, nil
+		}
+		return g.napLimits["google.com/tpu"] > 0, nil
 	}
 
 	cap, err := g.FetchMachineCapabilities(resolvedType, zone)
@@ -46,7 +60,21 @@ func (g *GKEOrchestrator) isNAPEnabledForMachineType(machineType, zone string) (
 		if !isKnownGKEAccelerator(key) {
 			return false, fmt.Errorf("unknown accelerator label: %q", cap.Accelerators[0].Type)
 		}
-		return g.napLimits[key] > 0 || g.napLimits["nvidia.com/gpu"] > 0, nil
+		if limit, exists := g.napLimits[key]; exists {
+			return limit > 0, nil
+		}
+		// Fallback to generic GPU limit ONLY if no specific GPU limits are configured.
+		hasSpecificGPULimits := false
+		for k := range g.napLimits {
+			if isSpecificGPUKey(k) {
+				hasSpecificGPULimits = true
+				break
+			}
+		}
+		if hasSpecificGPULimits {
+			return false, nil
+		}
+		return g.napLimits["nvidia.com/gpu"] > 0, nil
 	}
 
 	return g.napLimits["cpu"] > 0, nil
@@ -124,6 +152,14 @@ func extractShortReservationName(resName string) string {
 
 	// Fallback: Return the last segment
 	return parts[len(parts)-1]
+}
+
+func isSpecificGPUKey(key string) bool {
+	return strings.HasPrefix(key, "nvidia-") && key != "nvidia.com/gpu"
+}
+
+func isSpecificTPUKey(key string) bool {
+	return (strings.HasPrefix(key, "tpu-") || strings.HasPrefix(key, "ct")) && key != "google.com/tpu"
 }
 
 func isKnownGKEAccelerator(key string) bool {

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -50,15 +50,10 @@ func (g *GKEOrchestrator) validateTPUNAPLimit(resolvedType string) (bool, error)
 		return limit > 0, nil
 	}
 	// Fallback to generic TPU limit ONLY if no specific TPU limits are configured.
-	hasSpecificTPULimits := false
 	for k := range g.napLimits {
 		if isSpecificTPUKey(k) {
-			hasSpecificTPULimits = true
-			break
+			return false, nil
 		}
-	}
-	if hasSpecificTPULimits {
-		return false, nil
 	}
 	return g.napLimits["google.com/tpu"] > 0, nil
 }
@@ -75,15 +70,10 @@ func (g *GKEOrchestrator) validateGPUNAPLimit(resolvedType string, cap MachineTy
 		return limit > 0, nil
 	}
 	// Fallback to generic GPU limit ONLY if no specific GPU limits are configured.
-	hasSpecificGPULimits := false
 	for k := range g.napLimits {
 		if isSpecificGPUKey(k) {
-			hasSpecificGPULimits = true
-			break
+			return false, nil
 		}
-	}
-	if hasSpecificGPULimits {
-		return false, nil
 	}
 	return g.napLimits["nvidia.com/gpu"] > 0, nil
 }

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -784,6 +784,46 @@ func TestValidateConsumptionForStaticCluster(t *testing.T) {
 			wantErr:     true,
 			expectedErr: "unknown accelerator label: \"unknown-gpu\"",
 		},
+		{
+			name:       "NAP Cluster - TPU: Specific limit configured, requesting different TPU (Should Fail)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"tpu-v6e-slice":  8,
+				"google.com/tpu": 8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "ct5lp-hightpu-4t", // TPU v5e (tpu-v5-lite-podslice)
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - GPU: Specific limit configured, requesting different GPU (Should Fail)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"nvidia-h100-mega-80gb": 8,
+				"nvidia.com/gpu":        8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "g2-standard-12", // L4 GPU (nvidia-l4)
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - GPU: Generic limit only, requesting GPU (Should Pass)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"nvidia.com/gpu": 8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "g2-standard-12",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -807,6 +847,19 @@ func TestValidateConsumptionForStaticCluster(t *testing.T) {
 						{
 							Count: 1,
 							Type:  "unknown-gpu",
+						},
+					},
+				},
+				"g2-standard-12:": {
+					GuestCpus: 12,
+					MemoryMb:  48000,
+					Accelerators: []struct {
+						Count int    `json:"guestAcceleratorCount"`
+						Type  string `json:"guestAcceleratorType"`
+					}{
+						{
+							Count: 1,
+							Type:  "nvidia-l4",
 						},
 					},
 				},


### PR DESCRIPTION
### Problem
GKE Node Auto-Provisioning (NAP) validation in gcluster was too permissive. If a cluster was configured with specific accelerator limits (e.g., H100 only), gcluster would still allow submissions for unconfigured accelerator types (e.g., L4).

This happened because the parser propagated specific limits to the generic `nvidia.com/gpu` and `google.com/tpu` keys in memory. The validator saw these generic limits were greater than zero and incorrectly approved the workload. These jobs were accepted locally but hung in a Pending state indefinitely on GKE because the autoscaler had no authority to provision the unconfigured hardware.

### Solution
Refined the validation logic in `isNAPEnabledForMachineType` (nap.go):

**Strict Matching**: Added helper functions (isSpecificGPUKey and isSpecificTPUKey) to detect if the cluster has opted into specific accelerator limits.
Selective Fallback: If specific limits are configured (e.g., H100), the validator now bypasses the generic nvidia.com/gpu / google.com/tpu fallback for unconfigured types (e.g., L4) and strictly rejects the submission.
**Preserved Propagation**: We preserved the generic limit propagation in parseNAPLimits to ensure that Kueue resource activation and cluster capacity calculations continue to function correctly.

### Verification Results
**Unit Tests**: Ran the GKE orchestrator test suite (go test -v ./pkg/orchestrator/gke/...). All tests passed, including TestPopulateClusterMetadata_NAPLimitsLoopOrder (which verifies generic limit propagation).
**Live Manual Tests**: Verified on the deployed GKE NAP cluster :
* Rejection Test: Requesting an unconfigured L4 GPU (l4-1) was successfully blocked:
text
```
Error: workload submission rejected. Compute type "l4-1" is not configured within your cluster's Node Auto-Provisioning (NAP) limits. Configured limits on cluster: cpu, google.com/tpu, memory, nvidia-h100-mega-80gb, nvidia.com/gpu, tpu-v6e-slice
```
* Acceptance Test: Requesting a configured TPU (v6e-4) was successfully accepted and generated the manifest.