### PR TITLE
packer-unzip-overwrite

### DIFF
--- a/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
+++ b/tools/cloud-build/images/cluster-toolkit-dockerfile/Dockerfile
@@ -41,7 +41,7 @@ RUN wget -q "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terra
 # Install Packer
 ARG PACKER_VERSION=1.15.3
 RUN wget -q "https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip" -O packer.zip && \
-    unzip packer.zip && \
+    unzip -o packer.zip && \
     mv packer /usr/local/bin/ && \
     rm packer.zip
 


### PR DESCRIPTION
During the Docker image build, Terraform extracts a LICENSE.txt file. When the Packer archive is extracted, it also contains a LICENSE.txt file. As a result, unzip prompts for confirmation to replace the existing file:

`replace LICENSE.txt? [y]es, [n]o, [A]ll, [N]one, [r]ename:`

[DAILY-test-gcluster-dockerfile](https://pantheon.corp.google.com/cloud-build/builds;region=global/46cf9a9b-925e-4e97-b4d6-22c7ab26fffe?project=hpc-toolkit-dev)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
