### PR TITLE
fix : use deterministic naming for private service access IP allocations

### DIFF
--- a/modules/network/private-service-access/README.md
+++ b/modules/network/private-service-access/README.md
@@ -77,14 +77,12 @@ limitations under the License.
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.40 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
 | <a name="provider_google"></a> [google](#provider\_google) | >= 6.40 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
 
@@ -97,7 +95,6 @@ No modules.
 | [google_compute_global_address.private_ip_alloc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
 | [google_compute_network_peering_routes_config.private_vpc_peering_routes_gcnv](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network_peering_routes_config) | resource |
 | [google_service_networking_connection.private_vpc_connection](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_networking_connection) | resource |
-| [random_id.resource_name_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 
 ## Inputs
 
@@ -106,6 +103,7 @@ No modules.
 | <a name="input_address"></a> [address](#input\_address) | The IP address or beginning of the address range allocated for the Private Service Access. | `string` | `null` | no |
 | <a name="input_deletion_policy"></a> [deletion\_policy](#input\_deletion\_policy) | The policy to apply when deleting the Private Service Access. Leave empty or use ABANDON. | `string` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to supporting resources. Key-value pairs. | `map(string)` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the global address allocation for Private Service Access. If null, defaults to deterministic naming based on network name. | `string` | `null` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to configure Private Service Access:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
 | <a name="input_prefix_length"></a> [prefix\_length](#input\_prefix\_length) | The prefix length of the IP range allocated for the Private Service Access. | `number` | `16` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which Private Service Access will be created. | `string` | n/a | yes |

--- a/modules/network/private-service-access/main.tf
+++ b/modules/network/private-service-access/main.tf
@@ -27,7 +27,7 @@ locals {
 
 resource "google_compute_global_address" "private_ip_alloc" {
   provider      = google
-  name          = var.name != null ? var.name : "psconnect-${local.network_name}"
+  name          = var.name != null ? var.name : "psconnect-${trimsuffix(substr(local.network_name, 0, 53), "-")}"
   project       = var.project_id
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"

--- a/modules/network/private-service-access/main.tf
+++ b/modules/network/private-service-access/main.tf
@@ -25,13 +25,9 @@ locals {
   network_project  = local.split_network_id[1]
 }
 
-resource "random_id" "resource_name_suffix" {
-  byte_length = 4
-}
-
 resource "google_compute_global_address" "private_ip_alloc" {
   provider      = google
-  name          = "global-psconnect-ip-${random_id.resource_name_suffix.hex}"
+  name          = var.name != null ? var.name : "psconnect-${local.network_name}"
   project       = var.project_id
   purpose       = "VPC_PEERING"
   address_type  = "INTERNAL"

--- a/modules/network/private-service-access/variables.tf
+++ b/modules/network/private-service-access/variables.tf
@@ -57,3 +57,9 @@ variable "deletion_policy" {
   type        = string
   default     = null
 }
+
+variable "name" {
+  description = "Name of the global address allocation for Private Service Access. If null, defaults to deterministic naming based on network name."
+  type        = string
+  default     = null
+}

--- a/modules/network/private-service-access/versions.tf
+++ b/modules/network/private-service-access/versions.tf
@@ -20,10 +20,6 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 6.40"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "~> 3.0"
-    }
   }
   provider_meta "google" {
     module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.96.0"


### PR DESCRIPTION
### Summary of Changes
- **Add optional `name` variable**: Allows blueprints and test runners to explicitly define a static name for the Private Service Access global address allocation.
- **Deterministic default fallback**: When `name` is omitted, the allocation name defaults to `psconnect-${local.network_name}` instead of `global-psconnect-ip-${random_id.resource_name_suffix.hex}`.
- **Remove unused `random_id` resource**: Cleaned up the random ID generator resource.

### Motivation & Root Cause
When automated integration tests (e.g., `slurm-gke`) time out or fail mid-deployment, teardown jobs may delete the VPC network without first calling the Service Networking `DeleteConnection` API. When this happens, GCP Service Networking retains the orphaned tenancy project and allocated IP peering range on its backend.
Previously, because the module generated a new random hex string (`global-psconnect-ip-<random_hex>`) on every run, re-running a test against the same VPC network attempted to allocate a brand new random range. Service Networking rejected this with Error Code 9 (`Cannot modify allocated ranges in CreateConnection... Existing range: <old_range>`).
By using deterministic naming (`psconnect-<network_name>`), test re-runs reference the exact same address allocation name across retries. This allows Service Networking and Terraform to reconcile against existing allocations without failing on conflicting random IP ranges.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
