### PR TITLE
fix: Update managed lustre zone for remote node

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -58,7 +58,7 @@ steps:
     echo '    use: [network]'                      >> $${EXAMPLE_BP}
     echo '    settings:'                           >> $${EXAMPLE_BP}
     echo '      machine_type: e2-standard-2'       >> $${EXAMPLE_BP}
-    echo '      zone: us-central1-c'               >> $${EXAMPLE_BP}
+    echo '      zone: us-central1-a'               >> $${EXAMPLE_BP}
 
     IP=$(curl ifconfig.me)
     sed -i "s/<your-ip-address>/$${IP}/" $${EXAMPLE_BP}


### PR DESCRIPTION
This PR updates the build file of gke-managed-lustre test to use us-central1-a zone instead of us-central1-c to resolve test failure. Because of an explicit setting inside a module overriding the global default, the HPC Toolkit built the VM in zone c, while Ansible was looking for it in zone a.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
