### PR TITLE
fix(Telemetry): Ensure telemetry initialization runs across all subcommands (e.g. `cluster`, `job`)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,10 +81,6 @@ func init() {
 
 	rootCmd.AddCommand(cluster.ClusterCmd)
 	rootCmd.AddCommand(job.JobCmd)
-
-	for _, child := range rootCmd.Commands() {
-		wrapTelemetry(child)
-	}
 }
 
 // Execute the root command
@@ -121,6 +117,10 @@ Commit info: {{index .Annotations "commitInfo"}}
 `
 		}
 		rootCmd.SetVersionTemplate(tmpl)
+	}
+
+	for _, child := range rootCmd.Commands() {
+		wrapTelemetry(child)
 	}
 
 	err := rootCmd.Execute()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,17 +172,28 @@ func initTelemetry(cmd *cobra.Command, args []string) {
 // custom pre-run logic. Commands without their own hook will naturally inherit
 // the wrapped hook of their closest parent.
 func wrapTelemetry(cmd *cobra.Command) {
-	if cmd.PersistentPreRunE != nil {
-		oldPreRunE := cmd.PersistentPreRunE
-		cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
-			initTelemetry(c, args)
-			return oldPreRunE(c, args)
-		}
-	} else if cmd.PersistentPreRun != nil {
-		oldPreRun := cmd.PersistentPreRun
-		cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
-			initTelemetry(c, args)
-			oldPreRun(c, args)
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+
+	if cmd.Annotations["telemetry-wrapped"] != "true" {
+		cmd.Annotations["telemetry-wrapped"] = "true"
+		if cmd.PersistentPreRunE != nil {
+			oldPreRunE := cmd.PersistentPreRunE
+			cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+				err := oldPreRunE(c, args)
+				if err != nil {
+					return err
+				}
+				initTelemetry(c, args)
+				return nil
+			}
+		} else if cmd.PersistentPreRun != nil {
+			oldPreRun := cmd.PersistentPreRun
+			cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+				oldPreRun(c, args)
+				initTelemetry(c, args)
+			}
 		}
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,24 +76,15 @@ func init() {
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		initColor()
 		initDependencies(cmd)
-		if err := config.InitUserConfig(); err == nil {
-			telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
-			userConfigExists = true
-
-			// Register the fatal hook to flush telemetry on hard failures
-			logging.FatalHook = func(exitCode int, e error) {
-				// Ensure telemetry is executed exactly once to prevent re-entrancy and duplicates.
-				if telemetryFlushed.CompareAndSwap(false, true) {
-					if config.IsTelemetryEnabled() && telemetryCollector != nil {
-						telemetryCollector.Execute(exitCode, e)
-					}
-				}
-			}
-		}
+		initTelemetry(cmd, args)
 	}
 
 	rootCmd.AddCommand(cluster.ClusterCmd)
 	rootCmd.AddCommand(job.JobCmd)
+
+	for _, child := range rootCmd.Commands() {
+		wrapTelemetry(child)
+	}
 }
 
 // Execute the root command
@@ -154,6 +145,50 @@ Commit info: {{index .Annotations "commitInfo"}}
 	}
 
 	return err
+}
+
+func initTelemetry(cmd *cobra.Command, args []string) {
+	if err := config.InitUserConfig(); err == nil {
+		telemetryCollector = telemetry.NewCollector(cmd, args, InstallationMode)
+		userConfigExists = true
+
+		// Register the fatal hook to flush telemetry on hard failures
+		logging.FatalHook = func(exitCode int, e error) {
+			// Ensure telemetry is executed exactly once to prevent re-entrancy and duplicates.
+			if telemetryFlushed.CompareAndSwap(false, true) {
+				if config.IsTelemetryEnabled() && telemetryCollector != nil {
+					telemetryCollector.Execute(exitCode, e)
+				}
+			}
+		}
+	}
+}
+
+// wrapTelemetry recursively traverses the command tree and wraps any command
+// that defines its own PersistentPreRun or PersistentPreRunE hook.
+// This is necessary because Cobra does not execute a parent's PersistentPreRun
+// if a child command overrides it. By wrapping these hooks, we ensure telemetry
+// is correctly initialized across all subcommands, while still preserving their
+// custom pre-run logic. Commands without their own hook will naturally inherit
+// the wrapped hook of their closest parent.
+func wrapTelemetry(cmd *cobra.Command) {
+	if cmd.PersistentPreRunE != nil {
+		oldPreRunE := cmd.PersistentPreRunE
+		cmd.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+			initTelemetry(c, args)
+			return oldPreRunE(c, args)
+		}
+	} else if cmd.PersistentPreRun != nil {
+		oldPreRun := cmd.PersistentPreRun
+		cmd.PersistentPreRun = func(c *cobra.Command, args []string) {
+			initTelemetry(c, args)
+			oldPreRun(c, args)
+		}
+	}
+
+	for _, child := range cmd.Commands() {
+		wrapTelemetry(child)
+	}
 }
 
 // checkGitHashMismatch will compare the hash of the git repository vs the git

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -404,3 +404,37 @@ func TestFatalHook_ConcurrencyAndReentrancy(t *testing.T) {
 		t.Errorf("Expected telemetryFlushed to be true after FatalHook execution")
 	}
 }
+
+func TestWrapTelemetryDynamic(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	_ = config.InitUserConfig()
+
+	telemetryCollector = nil
+	userConfigExists = false
+
+	// Create a command with a custom hook
+	customCmd := &cobra.Command{
+		Use: "custom",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	// Wrap it
+	wrapTelemetry(customCmd)
+
+	// Execute the hook
+	err := customCmd.PersistentPreRunE(customCmd, []string{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	// Assert telemetry was initialized
+	if telemetryCollector == nil {
+		t.Errorf("Expected telemetryCollector to be initialized by wrapTelemetry")
+	}
+	if !userConfigExists {
+		t.Errorf("Expected userConfigExists to be true")
+	}
+}


### PR DESCRIPTION
**Problem**
Telemetry initialization was previously tied strictly to the root command's `PersistentPreRun` hook. However, some subcommands like `cluster` and `job` (and their respective configuration subcommands) override `PersistentPreRunE`.
Because of how Cobra's execution model works, when a child command overrides a parent's `PersistentPreRun(E)` hook, Cobra stops traversing the command tree and only executes the child's hook. As a result, the root command's `PersistentPreRun` hook was never being triggered for these subcommands, thereby silently bypassing the telemetry initialization entirely. 

**Analysis**
A naive fix would involve manually calling the root command's hook (`cmd.Root().PersistentPreRun`) from within the subcommands. However, this is unsafe because the root hook also executes global validations (like `initDependencies`), which intentionally should be skipped for certain subcommands like `job config`. Additionally, exporting and explicitly importing a telemetry initialization function from `cmd` to sub-packages like `cmd/cluster` or `cmd/job` introduces an illegal circular package dependency (`cmd` -> `cluster` -> `cmd`).

**Solution**
1. **Extracted Logic**: Separated the telemetry initialization code from `rootCmd.PersistentPreRun` into a standalone, unexported `initTelemetry` method inside `cmd/root.go`.
2. **Dynamic Injection (`wrapTelemetry`)**: Implemented a recursive tree-walking function `wrapTelemetry` which traverses all registered subcommands during `init()`. 
3. **Hook Wrapping**: For any subcommand that overrides `PersistentPreRun` or `PersistentPreRunE`, we dynamically wrap its function to securely inject `initTelemetry` immediately before executing its custom logic. Commands that do not override the hook naturally inherit the initialized state from their parents. 
4. **Unit Tests**: Added `TestWrapTelemetryDynamic` in `cmd/root_test.go` to explicitly verify that any newly added subcommand with a custom hook correctly inherits the telemetry initialization state.