### PR TITLE
Bump mpi-operator version to v0.8.2 to pull in upstream stability bug fixes

### DIFF
--- a/examples/gke-a4x-max-bm/README.md
+++ b/examples/gke-a4x-max-bm/README.md
@@ -124,7 +124,7 @@ This section describes how to run [NCCL/gIB](https://docs.cloud.google.com/ai-hy
 
 The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
 
-1. **Deploy MPI Operator (v0.8.0):**
+1. **Deploy MPI Operator (v0.8.2):**
 
    * **Automated (During Cluster Creation via Blueprint YAML):** Include the MPI Operator manifest in `apply_manifests` under `kubectl-apply` in your blueprint YAML (`gke-a4x-max-bm.yaml`):
 
@@ -135,13 +135,13 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
          settings:
            apply_manifests:
            - name: mpi-operator
-             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.2/deploy/v2beta1/mpi-operator.yaml
      ```
 
    * **Manual (After Cluster Deployment via `kubectl`):** Once the cluster is deployed, run the following command against your cluster:
 
      ```bash
-     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.2/deploy/v2beta1/mpi-operator.yaml
      ```
 
 2. **Verify Installation:**
@@ -171,7 +171,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-launcher
-               image: mpioperator/mpi-pi:v0.8.0-openmpi
+               image: mpioperator/mpi-pi:v0.8.2-openmpi
                command:
                - mpirun
                - --allow-run-as-root
@@ -187,7 +187,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-worker
-               image: mpioperator/mpi-pi:v0.8.0-openmpi
+               image: mpioperator/mpi-pi:v0.8.2-openmpi
    ```
 
    Submit the job and inspect launcher logs:

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -10,7 +10,7 @@ Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https:/
 
 The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
 
-1. **Deploy MPI Operator (v0.8.0):**
+1. **Deploy MPI Operator (v0.8.2):**
 
    * **Automated (During Cluster Creation via Blueprint YAML):** Include the MPI Operator manifest in `apply_manifests` under `kubectl-apply` in your blueprint YAML (`gke-a4x.yaml`):
 
@@ -21,13 +21,13 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
          settings:
            apply_manifests:
            - name: mpi-operator
-             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+             source: https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.2/deploy/v2beta1/mpi-operator.yaml
      ```
 
    * **Manual (After Cluster Deployment via `kubectl`):** Once the cluster is deployed, run the following command against your cluster:
 
      ```bash
-     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.0/deploy/v2beta1/mpi-operator.yaml
+     kubectl apply --server-side -f https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.2/deploy/v2beta1/mpi-operator.yaml
      ```
 
 2. **Verify Installation:**
@@ -57,7 +57,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-launcher
-               image: mpioperator/mpi-pi:v0.8.0-openmpi
+               image: mpioperator/mpi-pi:v0.8.2-openmpi
                command:
                - mpirun
                - --allow-run-as-root
@@ -73,7 +73,7 @@ The Kubeflow MPI Operator manages distributed MPI workloads on GKE.
            spec:
              containers:
              - name: mpi-worker
-               image: mpioperator/mpi-pi:v0.8.0-openmpi
+               image: mpioperator/mpi-pi:v0.8.2-openmpi
    ```
 
    Submit the job and inspect launcher logs:

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -181,7 +181,7 @@ deployment_groups:
       jobset:
         install: true
       apply_manifests:
-      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.7.0/deploy/v2beta1/mpi-operator.yaml"
+      - source: "https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.8.2/deploy/v2beta1/mpi-operator.yaml"
 
   # Filestore
   - id: filestore


### PR DESCRIPTION
This PR updates the recommended mpi-operator version from v0.8.0 to v0.8.2. The v0.8.0 release contains known stability bugs, which are resolved in the [v0.8.2](https://github.com/kubeflow/mpi-operator/issues/820) release.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
