### PR TITLE
fix: add nil check for telemetryCollector

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -148,7 +148,7 @@ Commit info: {{index .Annotations "commitInfo"}}
 
 	// Ensure telemetry is executed exactly once on normal exits to prevent recurrency
 	if telemetryFlushed.CompareAndSwap(false, true) {
-		if config.IsTelemetryEnabled() && userConfigExists {
+		if config.IsTelemetryEnabled() && userConfigExists && telemetryCollector != nil {
 			telemetryCollector.Execute(exitCode, err)
 		}
 	}


### PR DESCRIPTION
The global variable `telemetryCollector` can be nil if the CLI fails or exits early before dependency initialization completes. Calling Execute on a nil pointer will cause a panic, crashing the CLI instead of exiting cleanly. Adding a nil check prevents this panic. Additionally, performing the check for whether telemetry is enabled at the call site avoids redundant checks inside the execution function.