### PR TITLE
Rename ErrTypeFileNotFound to ErrTypeResourceNotFound to broaden scope

### DIFF
--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1749,9 +1749,9 @@ func TestGetErrorType(t *testing.T) {
 			expected: ErrTypePermissionDenied,
 		},
 		{
-			name:     "File Not Exist",
+			name:     "Resource Not Exist",
 			err:      os.ErrNotExist,
-			expected: ErrTypeFileNotFound,
+			expected: ErrTypeResourceNotFound,
 		},
 		{
 			name:     "Context Deadline Exceeded",
@@ -1781,7 +1781,7 @@ func TestGetErrorType(t *testing.T) {
 		{
 			name:     "Text Match Not Found",
 			err:      errors.New("resource not found"),
-			expected: ErrTypeFileNotFound,
+			expected: ErrTypeResourceNotFound,
 		},
 		{
 			name:     "Unknown Error",

--- a/pkg/telemetry/error_categories.go
+++ b/pkg/telemetry/error_categories.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	ErrTypePermissionDenied = "PermissionDenied"
-	ErrTypeFileNotFound     = "FileNotFound"
+	ErrTypeResourceNotFound = "ResourceNotFound"
 	ErrTypeValidation       = "ValidationError"
 	ErrTypeNetwork          = "NetworkError"
 	ErrTypeTimeout          = "TimeoutError"
@@ -40,7 +40,7 @@ var exactErrMatchers = []struct {
 	category string
 }{
 	{os.ErrPermission, ErrTypePermissionDenied},
-	{os.ErrNotExist, ErrTypeFileNotFound},
+	{os.ErrNotExist, ErrTypeResourceNotFound},
 	{context.DeadlineExceeded, ErrTypeTimeout},
 	{context.Canceled, ErrTypeCanceled},
 }
@@ -57,8 +57,8 @@ var substringErrMatchers = []struct {
 	{"permission denied", ErrTypePermissionDenied},
 	{"403 forbidden", ErrTypePermissionDenied},
 	{"access denied", ErrTypePermissionDenied},
-	{"not found", ErrTypeFileNotFound},
-	{"error 404", ErrTypeFileNotFound},
+	{"not found", ErrTypeResourceNotFound},
+	{"error 404", ErrTypeResourceNotFound},
 	{"validation failed", ErrTypeValidation},
 	{"invalid argument", ErrTypeValidation},
 	{"invalid value", ErrTypeValidation},


### PR DESCRIPTION
Rename ErrTypeFileNotFound to ErrTypeResourceNotFound to broaden scope of error to include resource not found failures.