### PR TITLE
feat(job): add regional fallback for GKE cluster metadata queries

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -395,7 +395,27 @@ func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinitio
 		if strings.Contains(res.Stderr, "403") || strings.Contains(strings.ToLower(res.Stderr), "permission denied") {
 			return fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", job.ClusterName, job.ProjectID)
 		}
-		return fmt.Errorf("failed to describe GKE cluster %s: %s", job.ClusterName, res.Stderr)
+		// If the user specified a zone (location with 3 components, e.g. us-central1-a), try to fallback to the region
+		if len(strings.Split(job.ClusterLocation, "-")) == 3 {
+			region := shell.ExtractRegion(job.ClusterLocation)
+			logging.Info("Failed to find cluster in zone %s. Trying fallback to region %s...", job.ClusterLocation, region)
+			fallbackRes := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", job.ClusterName,
+				"--location", region,
+				"--project", job.ProjectID,
+				"--format=json")
+			if fallbackRes.ExitCode == 0 {
+				logging.Warn("Cluster '%s' is a regional cluster in '%s'. Found it by falling back from zone '%s'. "+
+					"Note: This does NOT restrict your job to '%s'. To run specifically in '%s', "+
+					"please use the '--node-constraint topology.kubernetes.io/zone=%s' flag.",
+					job.ClusterName, region, job.ClusterLocation, job.ClusterLocation, job.ClusterLocation, job.ClusterLocation)
+				job.ClusterLocation = region
+				res = fallbackRes
+			} else {
+				return fmt.Errorf("failed to describe GKE cluster %s in zone %s and fallback region %s: %s", job.ClusterName, job.ClusterLocation, region, res.Stderr)
+			}
+		} else {
+			return fmt.Errorf("failed to describe GKE cluster %s: %s", job.ClusterName, res.Stderr)
+		}
 	}
 
 	var clusterDesc gkeCluster

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2194,6 +2194,47 @@ func TestPopulateClusterMetadata_NAPLimitsLoopOrder(t *testing.T) {
 	}
 }
 
+func TestPopulateClusterMetadata_LocationFallback(t *testing.T) {
+	setupMockMachineConfig(t)
+
+	mockDescribeOutput := `{
+		"locations": ["us-central1-a", "us-central1-b"],
+		"nodePools": [],
+		"autoscaling": {}
+	}`
+
+	mockResponses := map[string][]shell.CommandResult{
+		"gcloud container clusters describe my-cluster --location us-central1-a --project my-project --format=json": {
+			{
+				ExitCode: 1,
+				Stderr:   "Resource my-cluster was not found in us-central1-a",
+			},
+		},
+		"gcloud container clusters describe my-cluster --location us-central1 --project my-project --format=json": {
+			{
+				ExitCode: 0,
+				Stdout:   mockDescribeOutput,
+			},
+		},
+	}
+
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	job := &orchestrator.JobDefinition{
+		ProjectID:       "my-project",
+		ClusterName:     "my-cluster",
+		ClusterLocation: "us-central1-a",
+	}
+
+	err := orc.populateClusterMetadata(job)
+	if err != nil {
+		t.Fatalf("populateClusterMetadata failed: %v", err)
+	}
+
+	if job.ClusterLocation != "us-central1" {
+		t.Errorf("Expected job.ClusterLocation to fall back to 'us-central1', got %q", job.ClusterLocation)
+	}
+}
+
 func TestPopulateNAPFlavors(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Problem

When submitting jobs (`gcluster job submit`) to a regional GKE cluster, if a user specifies a zone (e.g., us-central1-a) in the --location flag, initialization queries like gcloud container clusters describe fail. This happens because Google Cloud requires the cluster's exact location (the region, e.g., us-central1) to resolve regional cluster metadata. This causes the job submission flow to fail with a "Resource not found" error, even if the cluster actually has capacity in that zone.

## Solution
Added automatic fallback logic in the GKE orchestrator's populateClusterMetadata method.
If a zonal location is provided and the GKE query fails, the orchestrator extracts the region and retries the query.

On a successful fallback, the orchestrator:
* Logs a warning warning the user that the cluster is regional and guiding them to use `--node-constraint topology.kubernetes.io/zone=...` to target zones for pod scheduling instead.
* Overwrites job.ClusterLocation with the region so that all subsequent commands (like gcloud container clusters get-credentials) succeed automatically.

### Unit test 
Added a corresponding unit test`TestPopulateClusterMetadata_LocationFallback` to verify the fallback functionality.
