### PR TITLE
Chore: strip start_time from indefinite maintenance exclusions in example blueprints

### DIFF
--- a/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
+++ b/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
@@ -67,7 +67,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       enable_filestore_csi: true

--- a/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
@@ -128,7 +128,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2026-04-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -180,7 +180,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -211,7 +211,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -178,7 +178,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -175,7 +175,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
@@ -127,7 +127,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -181,7 +181,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -186,7 +186,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
@@ -148,7 +148,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -180,7 +180,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -185,7 +185,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-g4/gke-g4.yaml
+++ b/examples/gke-g4/gke-g4.yaml
@@ -134,7 +134,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -134,7 +134,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -74,7 +74,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -127,7 +127,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -192,7 +192,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       enable_slice_controller: $(vars.enable_dynamic_slicing_for_tpus)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -135,7 +135,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
       enable_slice_controller: $(vars.enable_dynamic_slicing_for_tpus)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -195,7 +195,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -156,7 +156,6 @@ deployment_groups:
       release_channel: REGULAR
       maintenance_exclusions:
       - name: no-minor-or-node-upgrades-indefinite
-        start_time: "2025-12-01T00:00:00Z"
         exclusion_scope: NO_MINOR_OR_NODE_UPGRADES
         exclusion_end_time_behavior: UNTIL_END_OF_SUPPORT
     outputs: [instructions]

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -19,7 +19,9 @@ locals {
   labels = merge(var.labels, { ghpc_module = "gke-cluster", ghpc_role = "scheduler" })
 }
 
-resource "time_static" "exclusion_start" {}
+resource "time_static" "exclusion_start" {
+  count = length(var.maintenance_exclusions) > 0 ? 1 : 0
+}
 
 locals {
   upgrade_settings = {
@@ -289,7 +291,7 @@ resource "google_container_cluster" "gke_cluster" {
       for_each = var.maintenance_exclusions
       content {
         exclusion_name = maintenance_exclusion.value.name
-        start_time     = coalesce(maintenance_exclusion.value.start_time, time_static.exclusion_start.rfc3339)
+        start_time     = coalesce(maintenance_exclusion.value.start_time, time_static.exclusion_start[0].rfc3339)
         end_time       = maintenance_exclusion.value.end_time
         exclusion_options {
           scope             = maintenance_exclusion.value.exclusion_scope


### PR DESCRIPTION
### Description

Following the updates to the `gke-cluster` module that made the GKE maintenance exclusion `start_time` optional (now defaulting to the cluster creation time), this PR cleans up all GKE blueprint examples. It removes the hardcoded `start_time` field from their indefinite exclusions (`no-minor-or-node-upgrades-indefinite`).

This reduces code duplication and prevents the need to maintain obsolete past timestamps inside blueprints.

### Changes
*   Removed `start_time` from the `no-minor-or-node-upgrades-indefinite` exclusion block across 19 GKE blueprints under `examples/`.
*   Removed `start_time` from the same exclusion block in the `xpk-n2-filestore.yaml` community blueprint under `community/examples/`.

### Verification
*   Verified that compiling `examples/gke-a3-highgpu/gke-a3-highgpu.yaml` using `./gcluster create` generates a Terraform configuration where the `start_time` property is omitted, allowing the module's dynamic defaulting logic to take over.