### PR TITLE
feat(job): add smart main-only logs retrieval for JobSets

### DIFF
--- a/cmd/job/logs.go
+++ b/cmd/job/logs.go
@@ -29,19 +29,27 @@ var LogsCmd = &cobra.Command{
 }
 
 var follow bool
+var mainOnly bool
 
 func init() {
 	LogsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Stream logs continuously")
+	LogsCmd.Flags().BoolVar(&mainOnly, "main-only", false, "Fetch logs only for the main replicated job (main-job or pathways-head)")
 }
 
 func runLogsCmd(cmd *cobra.Command, args []string) error {
 	jobName := args[0]
+
+	var mainOnlyPtr *bool
+	if cmd.Flags().Changed("main-only") {
+		mainOnlyPtr = &mainOnly
+	}
 
 	opts := orchestrator.LogsOptions{
 		ClusterName:     clusterName,
 		ClusterLocation: location,
 		ProjectID:       projectID,
 		Follow:          follow,
+		MainOnly:        mainOnlyPtr,
 	}
 
 	output, err := orc.GetJobLogs(jobName, opts)

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -1121,6 +1121,10 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | Flag | Type | Description |
 | :--- | :--- | :--- |
 | `-f, --follow` | `flag` | Stream logs continuously (like `tail -f`). |
+| `--main-only` | `bool` | Fetch logs only for the coordinator/leader pod (Rank 0) of the main replicated job (e.g. `main-job` or `pathways-head`). |
+
+> [!NOTE]
+> **Smart Logging Defaults**: If a job has more than 5 pods, `gcluster` dynamically defaults to `--main-only=true` to prevent terminal spam from duplicate worker rank logs. You can override this to stream logs from all pods by explicitly passing `--main-only=false`.
 
 ## 10. Troubleshooting: ImagePullBackOff
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -52,6 +52,9 @@ const (
 
 	// kueueAPIVersion is the GVR version used for Kueue resources.
 	kueueAPIVersion = "v1beta2"
+
+	// maxLogRequests is the maximum concurrent log streams allowed by the GKE logs CLI.
+	maxLogRequests = 10
 )
 
 func NewGKEOrchestrator() *GKEOrchestrator {
@@ -209,13 +212,44 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 		return "", err
 	}
 
-	// Retry loop for pulling logs, especially to handle ImagePullBackOff/waiting states
+	selector, mainOnly, podCountForNotice := g.resolveLogsSelector(name, foundNamespace, opts.MainOnly)
+
+	if opts.MainOnly == nil && mainOnly {
+		logging.Info("Job has %d pods (> 5). Defaulting to --main-only logs. To fetch logs from all pods, run with --main-only=false.", podCountForNotice)
+	}
+
+	// Proactively check pod count against GKE logs limits
+	podCount, _ := g.getJobPodCount(foundNamespace, selector)
+	if podCount > maxLogRequests {
+		consoleURL := getCloudConsoleLogsURL(opts.ProjectID, opts.ClusterLocation, opts.ClusterName, foundNamespace, name)
+		return "", fmt.Errorf("job '%s' has %d pods matching logs query, which exceeds the max fetch limit (%d). Please view logs directly in the Google Cloud Console:\n%s", name, podCount, maxLogRequests, consoleURL)
+	}
+
+	if opts.Follow {
+		logging.Info("Streaming logs for job '%s'...", name)
+		err := g.executor.ExecuteCommandStream("kubectl", "logs", "-n", foundNamespace, "-l", selector, "--all-containers", "-f", fmt.Sprintf("--max-log-requests=%d", maxLogRequests))
+		return "", err
+	}
+
+	res, err := g.fetchLogsWithRetry(foundNamespace, selector)
+	if err != nil {
+		return "", err
+	}
+
+	if strings.TrimSpace(res.Stdout) == "" {
+		return "Job exists but has no live logs available (it may have finished or failed to start pods)", nil
+	}
+
+	return res.Stdout, nil
+}
+
+func (g *GKEOrchestrator) fetchLogsWithRetry(ns, selector string) (shell.CommandResult, error) {
 	maxRetries := 12 // 12 * 5s = 1 minute timeout
 	var res shell.CommandResult
 	for i := 0; i < maxRetries; i++ {
-		res = g.executor.ExecuteCommand("kubectl", "logs", "-n", foundNamespace, "-l", fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name), "--all-containers", "--max-log-requests=50")
+		res = g.executor.ExecuteCommand("kubectl", "logs", "-n", ns, "-l", selector, "--all-containers", fmt.Sprintf("--max-log-requests=%d", maxLogRequests))
 		if res.ExitCode == 0 {
-			break
+			return res, nil
 		}
 
 		if strings.Contains(res.Stderr, "is waiting to start") {
@@ -226,24 +260,43 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 			continue
 		}
 
-		return "", fmt.Errorf("failed to get logs: %s\n%s", res.Stderr, res.Stdout)
+		return res, fmt.Errorf("failed to get logs: %s\n%s", res.Stderr, res.Stdout)
 	}
 
+	return res, fmt.Errorf("timed out waiting for job to start; latest error: %s\n%s", res.Stderr, res.Stdout)
+}
+
+func (g *GKEOrchestrator) getJobPodCount(ns, selector string) (int, error) {
+	res := g.executor.ExecuteCommand("kubectl", "get", "pods", "-n", ns, "-l", selector, "--no-headers")
 	if res.ExitCode != 0 {
-		return "", fmt.Errorf("timed out waiting for job to start; latest error: %s\n%s", res.Stderr, res.Stdout)
+		return 0, fmt.Errorf("failed to query pods: %s", res.Stderr)
+	}
+	stdout := strings.TrimSpace(res.Stdout)
+	if stdout == "" {
+		return 0, nil
+	}
+	return len(strings.Split(stdout, "\n")), nil
+}
+
+func (g *GKEOrchestrator) resolveLogsSelector(name, ns string, optsMainOnly *bool) (string, bool, int) {
+	mainOnly := false
+	podCount := 0
+	if optsMainOnly == nil {
+		totalSelector := fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name)
+		var err error
+		podCount, err = g.getJobPodCount(ns, totalSelector)
+		if err == nil && podCount > 5 {
+			mainOnly = true
+		}
+	} else {
+		mainOnly = *optsMainOnly
 	}
 
-	if opts.Follow {
-		logging.Info("Streaming logs for job '%s'...", name)
-		err := g.executor.ExecuteCommandStream("kubectl", "logs", "-n", foundNamespace, "-l", fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name), "--all-containers", "-f", "--max-log-requests=10")
-		return "", err
+	selector := fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name)
+	if mainOnly {
+		selector = fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0", name)
 	}
-
-	if strings.TrimSpace(res.Stdout) == "" {
-		return "Job exists but has no live logs available (it may have finished or failed to start pods)", nil
-	}
-
-	return res.Stdout, nil
+	return selector, mainOnly, podCount
 }
 
 func (g *GKEOrchestrator) generateAndSubmitManifests(job orchestrator.JobDefinition, fullImageName string, profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool) error {
@@ -262,6 +315,20 @@ func (g *GKEOrchestrator) generateAndSubmitManifests(job orchestrator.JobDefinit
 	return g.generateAndApplyManifest(manifestOpts, profile, job.DryRunManifest)
 }
 
+func getCloudConsoleLogsURL(projectID, location, clusterName, namespace, podNamePrefix string) string {
+	query := fmt.Sprintf(`resource.type="k8s_container"
+resource.labels.project_id="%s"
+resource.labels.location="%s"
+resource.labels.cluster_name="%s"
+resource.labels.namespace_name="%s"
+resource.labels.pod_name:"%s-"
+severity>=DEFAULT`, projectID, location, clusterName, namespace, podNamePrefix)
+
+	encodedFilter := url.QueryEscape(query)
+	return fmt.Sprintf("https://console.cloud.google.com/logs/query;query=%s;storageScope=project;duration=P1D?project=%s",
+		encodedFilter, projectID)
+}
+
 func (g *GKEOrchestrator) printConsoleLinks(job orchestrator.JobDefinition) {
 	jobName := job.WorkloadName + "-main-job-0"
 	if job.IsPathwaysJob {
@@ -272,18 +339,7 @@ func (g *GKEOrchestrator) printConsoleLinks(job orchestrator.JobDefinition) {
 
 	logging.Info("Follow your workload details here: %s", gkeLink)
 
-	logFilter := fmt.Sprintf(`resource.type="k8s_container"
-resource.labels.project_id="%s"
-resource.labels.location="%s"
-resource.labels.cluster_name="%s"
-resource.labels.namespace_name="default"
-resource.labels.pod_name:"%s-"
-severity>=DEFAULT`, job.ProjectID, job.ClusterLocation, job.ClusterName, jobName)
-
-	encodedFilter := url.QueryEscape(logFilter)
-	logsLink := fmt.Sprintf("https://console.cloud.google.com/logs/query;query=%s;storageScope=project;duration=P1D?project=%s",
-		encodedFilter, job.ProjectID)
-
+	logsLink := getCloudConsoleLogsURL(job.ProjectID, job.ClusterLocation, job.ClusterName, "default", jobName)
 	logging.Info("View your workload logs in real-time here: %s or use gcluster job logs [job-name] to view logs using kubectl", logsLink)
 }
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -219,10 +219,9 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 	}
 
 	// Proactively check pod count against GKE logs limits
-	podCount, _ := g.getJobPodCount(foundNamespace, selector)
-	if podCount > maxLogRequests {
+	if podCountForNotice > maxLogRequests && !mainOnly {
 		consoleURL := getCloudConsoleLogsURL(opts.ProjectID, opts.ClusterLocation, opts.ClusterName, foundNamespace, name)
-		return "", fmt.Errorf("job '%s' has %d pods matching logs query, which exceeds the max fetch limit (%d). Please view logs directly in the Google Cloud Console:\n%s", name, podCount, maxLogRequests, consoleURL)
+		return "", fmt.Errorf("job '%s' has %d pods matching logs query, which exceeds the max fetch limit (%d). Please view logs directly in the Google Cloud Console:\n%s", name, podCountForNotice, maxLogRequests, consoleURL)
 	}
 
 	if opts.Follow {
@@ -281,21 +280,25 @@ func (g *GKEOrchestrator) getJobPodCount(ns, selector string) (int, error) {
 func (g *GKEOrchestrator) resolveLogsSelector(name, ns string, optsMainOnly *bool) (string, bool, int) {
 	mainOnly := false
 	podCount := 0
-	if optsMainOnly == nil {
-		totalSelector := fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name)
-		var err error
-		podCount, err = g.getJobPodCount(ns, totalSelector)
-		if err == nil && podCount > 5 {
-			mainOnly = true
-		}
-	} else {
+	selector := fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name)
+
+	if optsMainOnly != nil {
 		mainOnly = *optsMainOnly
 	}
 
-	selector := fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s", name)
-	if mainOnly {
-		selector = fmt.Sprintf("jobset.sigs.k8s.io/jobset-name=%s,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0", name)
+	if !mainOnly {
+		var err error
+		podCount, err = g.getJobPodCount(ns, selector)
+
+		if optsMainOnly == nil && err == nil && podCount > 5 {
+			mainOnly = true
+		}
 	}
+
+	if mainOnly {
+		selector = fmt.Sprintf("%s,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0", selector)
+	}
+
 	return selector, mainOnly, podCount
 }
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2544,6 +2544,7 @@ func TestPrepareManifestOptions_PathwaysPlatform(t *testing.T) {
 	}
 }
 
+
 func TestSharedReservationManifestGeneration(t *testing.T) {
 	orc := NewGKEOrchestrator()
 	orc.projectID = "my-consumer-project"
@@ -2667,6 +2668,113 @@ func TestSharedReservationSubblockManifestGeneration(t *testing.T) {
 		if !strings.Contains(manifest, label) {
 			t.Errorf("Expected manifest to contain nodeSelector label %q, but it was missing.\nManifest:\n%s", label, manifest)
 		}
+	}
+}
+func TestGetJobLogs(t *testing.T) {
+	jobName := "test-job"
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		desc               string
+		mainOnly           *bool
+		mockGetPods1Stdout string // response for total count check
+		mockGetPods2Stdout string // response for filtered count check
+		expectedCmdLogsKey string
+		expectErrorContain string
+	}{
+		{
+			desc:               "explicit MainOnly=true uses coordinator-only selector (1 pod, succeeds)",
+			mainOnly:           &trueVal,
+			mockGetPods2Stdout: "pod-main-0-0\n",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+		},
+		{
+			desc:               "explicit MainOnly=false with pods <= 10 uses all-job selector (succeeds)",
+			mainOnly:           &falseVal,
+			mockGetPods2Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\n", // 8 pods
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10",
+		},
+		{
+			desc:               "explicit MainOnly=false with pods > 10 fails proactively with Console URL",
+			mainOnly:           &falseVal,
+			mockGetPods2Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\npod-9\npod-10\npod-11\npod-12\n", // 12 pods
+			expectErrorContain: "exceeds the max fetch limit (10). Please view logs directly in the Google Cloud Console",
+		},
+		{
+			desc:               "implicit MainOnly (nil) with pods <= 5 defaults to all pods (succeeds)",
+			mainOnly:           nil,
+			mockGetPods1Stdout: "pod-1\npod-2\n", // 2 pods (total)
+			mockGetPods2Stdout: "pod-1\npod-2\n", // 2 pods (filtered)
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10",
+		},
+		{
+			desc:               "implicit MainOnly (nil) with pods > 5 defaults to coordinator-only (succeeds)",
+			mainOnly:           nil,
+			mockGetPods1Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\n", // 8 pods total
+			mockGetPods2Stdout: "pod-main-0-0\n",                                           // 1 pod coordinator
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			totalQuery := "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job --no-headers"
+			filteredQuery := "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --no-headers"
+			if tc.mainOnly != nil && !*tc.mainOnly {
+				filteredQuery = "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job --no-headers"
+			}
+
+			mockResponses := map[string][]shell.CommandResult{
+				"gcloud container clusters get-credentials test-cluster --location us-central1-a --project test-project": {{ExitCode: 0, Stdout: ""}},
+				"gcloud container clusters describe": {{ExitCode: 0, Stdout: "description"}},
+			}
+			if totalQuery == filteredQuery {
+				mockResponses[totalQuery] = []shell.CommandResult{{ExitCode: 0, Stdout: tc.mockGetPods2Stdout}}
+			} else {
+				mockResponses[totalQuery] = []shell.CommandResult{{ExitCode: 0, Stdout: tc.mockGetPods1Stdout}, {ExitCode: 0, Stdout: tc.mockGetPods1Stdout}}
+				mockResponses[filteredQuery] = []shell.CommandResult{{ExitCode: 0, Stdout: tc.mockGetPods2Stdout}}
+			}
+			if tc.expectedCmdLogsKey != "" {
+				mockResponses[tc.expectedCmdLogsKey] = []shell.CommandResult{{ExitCode: 0, Stdout: "mock-logs-content"}}
+			}
+
+			mockExec := NewMockExecutor(mockResponses)
+			orc := newTestGKEOrchestrator(mockExec)
+			orc.kubeClient = &MockKubeClient{Namespace: "default"}
+
+			opts := orchestrator.LogsOptions{
+				ClusterName:     "test-cluster",
+				ClusterLocation: "us-central1-a",
+				ProjectID:       "test-project",
+				Follow:          false,
+				MainOnly:        tc.mainOnly,
+			}
+
+			logs, err := orc.GetJobLogs(jobName, opts)
+
+			if tc.expectErrorContain != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.expectErrorContain)
+				}
+				if !strings.Contains(err.Error(), tc.expectErrorContain) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.expectErrorContain)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("GetJobLogs failed: %v", err)
+			}
+
+			if logs != "mock-logs-content" {
+				t.Errorf("expected logs %q, got %q", "mock-logs-content", logs)
+			}
+
+			if mockExec.callCount[tc.expectedCmdLogsKey] != 1 {
+				t.Errorf("expected command %q to be called exactly once, call count: %d", tc.expectedCmdLogsKey, mockExec.callCount[tc.expectedCmdLogsKey])
+			}
+		})
 
 	}
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2544,7 +2544,6 @@ func TestPrepareManifestOptions_PathwaysPlatform(t *testing.T) {
 	}
 }
 
-
 func TestSharedReservationManifestGeneration(t *testing.T) {
 	orc := NewGKEOrchestrator()
 	orc.projectID = "my-consumer-project"
@@ -2687,7 +2686,7 @@ func TestGetJobLogs(t *testing.T) {
 			desc:               "explicit MainOnly=true uses coordinator-only selector (1 pod, succeeds)",
 			mainOnly:           &trueVal,
 			mockGetPods2Stdout: "pod-main-0-0\n",
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
 		},
 		{
 			desc:               "explicit MainOnly=false with pods <= 10 uses all-job selector (succeeds)",
@@ -2713,14 +2712,14 @@ func TestGetJobLogs(t *testing.T) {
 			mainOnly:           nil,
 			mockGetPods1Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\n", // 8 pods total
 			mockGetPods2Stdout: "pod-main-0-0\n",                                           // 1 pod coordinator
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
 			totalQuery := "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job --no-headers"
-			filteredQuery := "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/replicatedjob-name in (main-job, pathways-head),jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --no-headers"
+			filteredQuery := "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --no-headers"
 			if tc.mainOnly != nil && !*tc.mainOnly {
 				filteredQuery = "kubectl get pods -n default -l jobset.sigs.k8s.io/jobset-name=test-job --no-headers"
 			}

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -127,6 +127,7 @@ type LogsOptions struct {
 	ClusterName     string
 	ClusterLocation string
 	Follow          bool
+	MainOnly        *bool
 }
 
 type JobOrchestrator interface {


### PR DESCRIPTION
### Summary of Changes
This pull request improves the GKE job orchestration experience by introducing smarter log retrieval defaults. It addresses issues with terminal noise in large JobSets.

### Highlights
* **Smart Log Retrieval:** Added a `--main-only` flag for JobSet log retrieval, which defaults to true for jobs with more than 5 pods to prevent terminal spam.
* **Proactive Log Limits:** Added a check to prevent exceeding GKE log fetch limits, providing a direct link to the Google Cloud Console when pod counts are too high.
