### PR TITLE
Add Flex Unified support to NetApp Volumes modules

### DIFF
--- a/community/examples/eda/eda-all-on-cloud.yaml
+++ b/community/examples/eda/eda-all-on-cloud.yaml
@@ -83,7 +83,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "toolsfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -98,7 +97,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "libraryfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -113,7 +111,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "homefs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -126,7 +123,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "scratchfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false

--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -5,7 +5,7 @@ storage.
 
 The Toolkit contains modules that will **provision**:
 
-- [Google Cloud NetApp Volumes (GCP managed enterprise NFS and SMB)][netapp-volumes]
+- [Google Cloud NetApp Volumes (GCP managed enterprise NFS)][netapp-volumes]
 - [Filestore (GCP managed NFS)][filestore]
 - [Managed Lustre][managed-lustre]
 - [NFS server (non-GCP managed)][nfs-server]
@@ -18,6 +18,36 @@ with a network storage device that is already set up. The
 - daos
 - managed-lustre
 - gcsfuse
+
+## NetApp Volumes (Default mode)
+
+The [netapp-storage-pool][netapp-storage-pool] and [netapp-volume][netapp-volumes] modules provision NetApp Volumes in Default mode with NFSv3 and NFSv4.1 only. If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and use [pre-existing-network-storage] to mount the NFS export in your blueprint.
+
+### Service levels
+
+1. **STANDARD, PREMIUM, EXTREME** — Regional pools. Set `region` only.
+2. **Flex Unified** — Zonal or regional pools. Set `region` and `zone`; add `replica_zone` for regional pools. Optionally set `total_throughput_mibps` and `total_iops` for custom performance.
+
+### Capacity minimums
+
+Storage pools:
+
+1. STANDARD, PREMIUM, EXTREME — 2048 GiB
+2. Flex Unified — 1024 GiB
+3. Flex Unified large capacity (`SCALE_TYPE_SCALEOUT`) — 6144 GiB
+
+Volumes:
+
+1. STANDARD, PREMIUM, EXTREME (regular) — 100 GiB
+2. STANDARD, PREMIUM, EXTREME (large capacity) — 15 TiB (15360 GiB); set `large_capacity: true`
+3. Flex Unified — 1 GiB
+4. Flex Unified large capacity — 4800 GiB; set `large_capacity_config.constituent_count`
+
+### Not supported by these modules
+
+1. Flex File
+2. ONTAP mode (use [pre-existing-network-storage])
+3. SMB and iSCSI
 
 ## Connecting to Network Storage
 
@@ -128,3 +158,4 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE
 [managed-lustre]: ../modules/file-system/managed-lustre/README.md
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md
 [netapp-volumes]: ../modules/file-system/netapp-volume/README.md
+[netapp-storage-pool]: ../modules/file-system/netapp-storage-pool/README.md

--- a/examples/netapp-volumes.yaml
+++ b/examples/netapp-volumes.yaml
@@ -14,10 +14,9 @@
 
 ---
 
-# This blueprint show how to provision shared file systems with Google Cloud NetApp Volumes.
-# It creates a NetApp storage pool and a volume for use by VM instances.
-# It can be used to build compute clusters on top of it and as a drop-in replacement
-# for Filestore in existing blueprints.
+# This blueprint shows how to provision shared file systems with Google Cloud NetApp Volumes.
+# It creates a Flex Unified SCALEOUT storage pool and one large capacity volume at the
+# minimum supported size. Example VMs mount the volume through the USE directive.
 
 blueprint_name: netapp-volumes
 
@@ -26,7 +25,6 @@ vars:
   deployment_name: netapp-volumes
   region:     ## Set GCP Region Here ##
   zone:       ## Set GCP Zone Here ##
-  pool_service_level: "EXTREME"  # Options: "STANDARD", "PREMIUM", "EXTREME"
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/cluster-toolkit
@@ -53,47 +51,28 @@ deployment_groups:
     use: [network, private_service_access]
     settings:
       pool_name: $(vars.deployment_name)-netapp-pool
-      capacity_gib: 2048
-      service_level: $(vars.pool_service_level)
+      service_level: FLEX
       region: $(vars.region)
-      # allow_auto_tiering: true
+      zone: $(vars.zone)
+      scale_type: SCALE_TYPE_SCALEOUT
+      capacity_gib: 6144
+      total_throughput_mibps: 256
+      total_iops: 4096
 
   - id: homefs
     source: modules/file-system/netapp-volume
-    use: [netapp_pool]             # Create this pool using the netapp-storage-pool module
+    use: [netapp_pool]
     settings:
-      region: $(vars.region)
-      volume_name: $(vars.deployment_name)-homefs
-      capacity_gib: 2048           # Size up to available capacity in the pool
-      large_capacity: false
-      local_mount: "/home"         # Mount point at client when client uses USE directive
-      # mount_options: "..."       # Use custom mount_options for special use cases. Defaults are sane.
-      protocols: ["NFSV3"]         # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
-      unix_permissions: "0777"     # Specify default permissions for root inode owned by root:root
-      # If no export policy is specified, a permissive default policy will be applied, which is:
-      #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
-      #  has_root_access = true      # no_root_squash enabled
-      #  access_type = "READ_WRITE"
-      # export_policy_rules:
-      # - allowed_clients: "10.10.20.8,10.10.20.9"
-      #   has_root_access: true      # no_root_squash enabled
-      #   access_type: "READ_WRITE"
-      #   nfsv3: true
-      #   nfsv4: false
-      # - allowed_clients: "10.0.0.0/8"
-      #   has_root_access: false     # no_root_squash disabled
-      #   access_type: "READ_WRITE"
-      #   nfsv3: true
-      #   nfsv4: false
-      # tiering_policy:              # Enable auto-tiering. Requires auto-tiering enabled storage pool
-      #   tier_action: "ENABLED"
-      #   cooling_threshold_days: 31 # tier data blocks which have not been touched for 31 days
-      # description: "Shared volume for EDA job"
-      # labels:
-      #   department: eda
+      volume_name: homefs
+      capacity_gib: 4800
+      large_capacity_config:
+        constituent_count: 48
+      local_mount: /home
+      protocols: ["NFSV3"]
+      unix_permissions: "0777"
 
   # Example VMs which use homefs
-  - id: gcnv_ubuntu_instances
+  - id: gcnv_instances
     source: modules/compute/vm-instance
     use: [network, homefs]
     settings:
@@ -103,5 +82,5 @@ deployment_groups:
   - id: wait-for-vms
     source: community/modules/scripts/wait-for-startup
     settings:
-      instance_names: $(gcnv_ubuntu_instances.name)
+      instance_names: $(gcnv_instances.name)
       timeout: 7200

--- a/modules/file-system/netapp-storage-pool/README.md
+++ b/modules/file-system/netapp-storage-pool/README.md
@@ -1,34 +1,210 @@
 ## Description
 
-This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
-storage pool.
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview) storage pool.
 
-NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volumes is a first-party Google service that provides NFS shared file systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+
 NetApp Volume provides:
 
-- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
+- support for NFSv3 and NFSv4.1
 - a [rich feature set][service-levels]
 - scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
-- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
-- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+- [FlexCache](https://docs.cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview): Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimize cost
 
 Support for NetApp Volumes is split into two modules.
 
 - **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
-- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume is a file system container shared using NFSv3 or NFSv4.1.
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
 
 ### NetApp storage pool service levels
 
-The netapp-storage-pool module currently supports the following NetApp Volumes [service levels][service-levels]:
+The netapp-storage-pool module supports the following NetApp Volumes [service levels][service-levels]:
 
 - Standard: 16 KiBps throughput per provisioned KiB of volume capacity.
 - Premium: 64 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
 - Extreme: 128 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
+- Flex Unified: Next-generation Flex service level. Supports zonal and regional pools, auto-tiering, and large capacity pools. Flex File and ONTAP mode are not supported by this module.
 
-Check the [service level matrix][service-levels] for additional information on capability differences between service levels. Flex service levels are currently not supported, but you can connect to existing Flex volumes using the [pre-existing-network-storage module][pre-existing].
+Check the [service level matrix][service-levels] for additional information on capability differences between service levels.
+
+### Flex Unified defaults
+
+When `service_level` is `FLEX`, the module sets these values automatically:
+
+1. `mode` = `DEFAULT`
+2. `type` = `UNIFIED`
+
+You do not set `mode` or `type` in your blueprint. Flex File (`type: FILE`) and ONTAP mode are not supported. Use [pre-existing-network-storage][pre-existing] for ONTAP-mode pools.
+
+### Region and zone settings
+
+Always set `region` in your blueprint. Zone settings apply only to Flex Unified pools.
+
+1. **Standard, Premium, and Extreme** — Set `region` only. Blueprint-level `zone` variables used for VMs are ignored.
+2. **Zonal Flex Unified** — Set `region` and `zone`. The module verifies that `zone` is in `region`.
+3. **Regional Flex Unified** — Set `region`, `zone` (active zone), and `replica_zone`. The module verifies that both zones are in `region`.
+4. **Large capacity (SCALE_TYPE_SCALEOUT)** — Zonal Flex Unified only. Set `region` and `zone`. Do not set `replica_zone`.
+
+### Minimum pool capacity
+
+The module enforces these minimum `capacity_gib` values at plan time:
+
+1. **STANDARD, PREMIUM, and EXTREME** — 2048 GiB
+2. **Flex Unified** — 1024 GiB
+3. **Flex Unified large capacity (`scale_type: SCALE_TYPE_SCALEOUT`)** — 6144 GiB
+
+### Flex Unified auto-tiering
+
+When `allow_auto_tiering` is `true` on a Flex Unified pool:
+
+1. Set `hot_tier_size_gib` to the hot-tier capacity in GiB.
+2. Optionally set `enable_hot_tier_auto_resize` to allow the hot tier to grow when it reaches 100%.
+
+When `allow_auto_tiering` is `false` (the default), omit `hot_tier_size_gib` and
+`enable_hot_tier_auto_resize`. The module fails at plan time if either is set.
+
+Volumes in the pool can then enable auto-tiering with `tiering_policy` in the [netapp-volume](../netapp-volume/README.md) module.
+
+### Flex Unified large capacity pools
+
+To host Flex Unified large capacity volumes, create a zonal pool with:
+
+1. `service_level: FLEX`
+2. `region` and `zone` (omit `replica_zone`)
+3. `scale_type: SCALE_TYPE_SCALEOUT`
+4. `capacity_gib` of at least 6144
+
+Pair this pool with volumes that set `large_capacity_config` in the [netapp-volume](../netapp-volume/README.md) module.
+
+### Flex Unified custom performance
+
+Flex Unified pools use custom performance implicitly. You can scale capacity, throughput, and IOPS independently.
+
+1. Each pool includes 64 MiB/s throughput and 1,024 IOPS by default.
+2. Set `total_throughput_mibps` to provision additional throughput in 1 MiB/s increments, up to 5 GiB/s for standard Flex pools.
+3. Set `total_iops` to provision additional IOPS, up to 160,000 per pool. Omit `total_iops` to let Google Cloud calculate IOPS from `total_throughput_mibps` (16 IOPS per additional MiB/s).
+4. All volumes in the pool share the pool throughput and IOPS.
+5. Large capacity pools (`scale_type: SCALE_TYPE_SCALEOUT`) can reach higher throughput limits. See [Volume performance sizing](https://cloud.google.com/netapp/volumes/docs/plan-and-prepare/volume-performance-sizing).
+
+```yaml
+  - id: flex_pool_custom_perf
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool-perf"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      capacity_gib: 5120
+      total_throughput_mibps: 256
+      total_iops: 4096
+```
+
+### Flex Unified zonal and regional pools
+
+Flex Unified pools can be zonal or regional. The module selects the pool type from your zone settings.
+
+#### Zonal vs regional rules
+
+1. **Zonal pool** — Set `region` and `zone`. Omit `replica_zone`. Pool `location` is the zone name.
+2. **Regional pool** — Set `region`, `zone` (active zone), and `replica_zone` (standby zone). Pool `location` is the region name. Volume access is served from the active zone. If the active zone fails, `replica_zone` becomes active.
+3. **`zone` and `replica_zone` must be different** for regional pools.
+4. **`zone` and `replica_zone` must be within `region`.**
+5. **Large capacity pools (`scale_type: SCALE_TYPE_SCALEOUT`) must be zonal.** Set `zone` and omit `replica_zone`.
+6. **Standard, Premium, and Extreme pools use `region` only.** Blueprint-level `zone` values (for example, for VM placement) are ignored and do not block pool creation.
+
+#### Multiple pools in one blueprint
+
+To provision both a zonal and a regional Flex pool, add one `netapp-storage-pool` module per pool. Use a unique module `id` and `pool_name` for each pool. Configure zone settings per module. Attach volumes with `use: [<pool_module_id>]`.
+
+Example:
+
+```yaml
+vars:
+  region: us-east1
+  zone_a: us-east1-b
+  zone_b: us-east1-c
+
+deployment_groups:
+- group: netapp-pools
+  modules:
+  - id: network
+    source: modules/network/pre-existing-vpc
+    settings:
+      region: $(vars.region)
+      network_name: $(vars.network)
+
+  - id: flex_pool_zonal
+    source: modules/file-system/netapp-storage-pool
+    use: [network]
+    settings:
+      pool_name: $(vars.deployment_name)-flex-zonal
+      service_level: FLEX
+      region: $(vars.region)
+      zone: $(vars.zone_a)
+      capacity_gib: 4096
+      total_throughput_mibps: 128
+      total_iops: 2048
+
+  - id: flex_pool_regional
+    source: modules/file-system/netapp-storage-pool
+    use: [network]
+    settings:
+      pool_name: $(vars.deployment_name)-flex-regional
+      service_level: FLEX
+      region: $(vars.region)
+      zone: $(vars.zone_a)
+      replica_zone: $(vars.zone_b)
+      capacity_gib: 4096
+      total_throughput_mibps: 128
+      total_iops: 2048
+
+- group: netapp-volumes
+  modules:
+  - id: zonal_homefs
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_zonal]
+    settings:
+      volume_name: zonal_homefs
+      capacity_gib: 1024
+      local_mount: /zonal-home
+      protocols: ["NFSV3"]
+
+  - id: regional_homefs
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_regional]
+    settings:
+      volume_name: regional_homefs
+      capacity_gib: 1024
+      local_mount: /regional-home
+      protocols: ["NFSV3"]
+```
+
+#### Zone switch and Terraform state
+
+If a regional pool fails over outside Terraform, update `zone` and `replica_zone` in your blueprint to match the current active and replica zones before the next apply. Otherwise Terraform can initiate an unwanted zone switch.
+
+### ONTAP mode
+
+These modules provision and manage NetApp Volumes through Google Cloud APIs in Default mode only. They do not support Flex Unified pools in ONTAP mode.
+
+If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and integrate them with the [pre-existing-network-storage][pre-existing] module. In ONTAP mode, the pool is created through Google Cloud APIs, but volumes, snapshots, and policies inside the pool are managed with ONTAP tools. See [Manage ONTAP mode](https://cloud.google.com/netapp/volumes/docs/ontap/manage-ontap).
+
+### Outputs for netapp-volume
+
+When a volume module uses `use: [netapp_pool]`, Cluster Toolkit wires these pool outputs automatically:
+
+1. `netapp_storage_pool_id`
+2. `service_level`
+3. `type`
+4. `allow_auto_tiering`
+5. `scale_type`
+
+The volume module parses volume location from `netapp_storage_pool_id`. It does not inherit `region` or `zone`.
 
 ### On-boarding NetApp Volumes
 NetApp Volumes uses [Private Service Access](https://cloud.google.com/vpc/docs/private-services-access) (PSA) to connect volumes to your network. Before you create a storage pool, make sure to [connect NetApp Volumes to your network](https://cloud.google.com/netapp/volumes/docs/get-started/configure-access/networking).
@@ -85,9 +261,9 @@ deployment_groups:
       region: $(vars.region)
 ```
 
-### Storage pool example
+### Storage pool examples
 
-The following example shows all available parameters in use:
+#### Standard, Premium, or Extreme
 
 ```yaml
   - id: netapp_pool
@@ -98,11 +274,53 @@ The following example shows all available parameters in use:
       region: "us-west4"
       capacity_gib: 2048
       service_level: "EXTREME"
-      active_directory_policy: "projects/myproject/locations/us-east4/activeDirectories/my-ad"
-      cmek_policy: "projects/myproject/locations/us-east4/kmsConfigs/my-cmek-policy"
+      allow_auto_tiering: true
+      active_directory_policy: "projects/myproject/locations/us-west4/activeDirectories/my-ad"
+      cmek_policy: "projects/myproject/locations/us-west4/kmsConfigs/my-cmek-policy"
       ldap_enabled: false
-      allow_auto_tiering: false
       description: "Demo storage pool"
+      labels:
+        owner: bob
+```
+
+#### Flex Unified zonal with auto-tiering
+
+```yaml
+  - id: flex_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      capacity_gib: 4096
+      total_throughput_mibps: 256
+      total_iops: 4096
+      allow_auto_tiering: true
+      hot_tier_size_gib: 1024
+      enable_hot_tier_auto_resize: true
+      labels:
+        owner: bob
+```
+
+#### Flex Unified large capacity (SCALEOUT)
+
+```yaml
+  - id: flex_pool_large
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool-large"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      scale_type: SCALE_TYPE_SCALEOUT
+      capacity_gib: 12288
+      total_throughput_mibps: 1024
+      total_iops: 16384
+      allow_auto_tiering: true
+      hot_tier_size_gib: 2048
       labels:
         owner: bob
 ```
@@ -111,7 +329,7 @@ The following example shows all available parameters in use:
 
 Your project must have unused quota for NetApp Volumes in the region you will
 provision the storage pool. This can be found by browsing to the [Quota tab within IAM & Admin](https://console.cloud.google.com/iam-admin/quotas) in the Cloud Console.
-Please note that there are separate quota limits for Standard and Premium/Extreme service levels.
+Please note that there are separate quota limits for Standard, Premium/Extreme, and Flex Unified service levels.
 
 See also NetApp Volumes [default quotas](https://cloud.google.com/netapp/volumes/docs/quotas#netapp-volumes-default-quotas).
 
@@ -168,12 +386,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_active_directory_policy"></a> [active\_directory\_policy](#input\_active\_directory\_policy) | The ID of the Active Directory policy to apply to the storage pool in the format:<br/>`projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>` | `string` | `null` | no |
+| <a name="input_active_directory_policy"></a> [active\_directory\_policy](#input\_active\_directory\_policy) | The ID of the Active Directory policy to apply to the storage pool in the format:<br/>`projects/<project_id>/locations/<location>/activeDirectories/<name>` | `string` | `null` | no |
 | <a name="input_allow_auto_tiering"></a> [allow\_auto\_tiering](#input\_allow\_auto\_tiering) | Whether to allow automatic tiering for the storage pool. | `bool` | `false` | no |
-| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the storage pool in GiB. | `number` | `2048` | no |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the storage pool in GiB. Minimum is 2048 GiB for STANDARD, PREMIUM, and EXTREME; 1024 GiB for Flex Unified; 6144 GiB for large capacity (SCALE\_TYPE\_SCALEOUT) pools. | `number` | `2048` | no |
 | <a name="input_cmek_policy"></a> [cmek\_policy](#input\_cmek\_policy) | The ID of the Customer Managed Encryption Key (CMEK) policy to apply to the storage pool in the format:<br/>`projects/<project>/locations/<location>/kmsConfigs/<name>` | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment, used as name of the NetApp storage pool if no name is specified. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | A description of the NetApp storage pool. | `string` | `""` | no |
+| <a name="input_enable_hot_tier_auto_resize"></a> [enable\_hot\_tier\_auto\_resize](#input\_enable\_hot\_tier\_auto\_resize) | Whether hot-tier threshold will auto-increase when it reaches 100%. Flex-only. Requires allow\_auto\_tiering to be true. | `bool` | `null` | no |
+| <a name="input_hot_tier_size_gib"></a> [hot\_tier\_size\_gib](#input\_hot\_tier\_size\_gib) | Total hot tier capacity for the storage pool in GiB. Flex-only. Requires allow\_auto\_tiering to be true. | `number` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp storage pool. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_ldap_enabled"></a> [ldap\_enabled](#input\_ldap\_enabled) | Whether to enable LDAP for the storage pool. | `bool` | `false` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the NetApp storage pool is connected given in the format:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
@@ -181,13 +401,23 @@ No modules.
 | <a name="input_pool_name"></a> [pool\_name](#input\_pool\_name) | The name of the storage pool. Leave empty to generate name based on deployment name. | `string` | `null` | no |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the private VPC connection peering. | `string` | `"sn-netapp-prod"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region for the storage pool. Required for all service levels. | `string` | n/a | yes |
+| <a name="input_replica_zone"></a> [replica\_zone](#input\_replica\_zone) | Replica zone for regional Flex Unified pools. Must be within region when service\_level is FLEX. Omit for zonal Flex Unified pools. Ignored for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_scale_type"></a> [scale\_type](#input\_scale\_type) | Scale type of the storage pool. Flex-only. Use SCALE\_TYPE\_SCALEOUT for large capacity pools. | `string` | `null` | no |
 | <a name="input_service_level"></a> [service\_level](#input\_service\_level) | The service level of the storage pool. | `string` | `"PREMIUM"` | no |
+| <a name="input_total_iops"></a> [total\_iops](#input\_total\_iops) | Total pool IOPS for Flex Unified custom performance. Omit to let Google Cloud calculate IOPS from total\_throughput\_mibps. | `number` | `null` | no |
+| <a name="input_total_throughput_mibps"></a> [total\_throughput\_mibps](#input\_total\_throughput\_mibps) | Total pool throughput in MiB/s for Flex Unified custom performance. Omit to use the default 64 MiB/s. | `number` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone for zonal Flex Unified pools, or active zone for regional Flex Unified pools. Must be within region when service\_level is FLEX. Ignored for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_allow_auto_tiering"></a> [allow\_auto\_tiering](#output\_allow\_auto\_tiering) | Whether the storage pool supports auto-tiering enabled volumes. |
 | <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | Storage pool capacity in GiB. |
+| <a name="output_mode"></a> [mode](#output\_mode) | Storage pool mode. Flex-only. |
 | <a name="output_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#output\_netapp\_storage\_pool\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}` |
+| <a name="output_scale_type"></a> [scale\_type](#output\_scale\_type) | Scale type of the storage pool. Flex-only. |
+| <a name="output_service_level"></a> [service\_level](#output\_service\_level) | Storage pool service level. |
+| <a name="output_type"></a> [type](#output\_type) | Storage pool type. Flex Unified pools use UNIFIED. Omitted for STANDARD, PREMIUM, and EXTREME pools. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/netapp-storage-pool/main.tf
+++ b/modules/file-system/netapp-storage-pool/main.tf
@@ -19,6 +19,15 @@ locals {
   labels = merge(var.labels, { ghpc_module = "netapp-storage-pool", ghpc_role = "file-system" })
 }
 
+locals {
+  is_flex_zonal    = var.service_level == "FLEX" && var.zone != null && var.replica_zone == null
+  is_flex_regional = var.service_level == "FLEX" && var.zone != null && var.replica_zone != null
+  pool_location    = local.is_flex_zonal ? var.zone : var.region
+  min_capacity_gib = var.scale_type == "SCALE_TYPE_SCALEOUT" ? 6144 : (
+    var.service_level == "FLEX" ? 1024 : 2048
+  )
+}
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -32,7 +41,7 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   project = var.project_id
 
   name          = var.pool_name != null ? var.pool_name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
-  location      = var.region
+  location      = local.pool_location
   network       = var.network_id
   service_level = var.service_level
   capacity_gib  = var.capacity_gib
@@ -41,6 +50,16 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   kms_config         = var.cmek_policy
   ldap_enabled       = var.ldap_enabled
   allow_auto_tiering = var.allow_auto_tiering
+  mode               = var.service_level == "FLEX" ? "DEFAULT" : null
+  type               = var.service_level == "FLEX" ? "UNIFIED" : null
+  # zone and replica_zone are Flex regional-only API fields. Omit for all other pool types.
+  zone                        = local.is_flex_regional ? var.zone : null
+  replica_zone                = local.is_flex_regional ? var.replica_zone : null
+  hot_tier_size_gib           = var.service_level == "FLEX" ? var.hot_tier_size_gib : null
+  enable_hot_tier_auto_resize = var.service_level == "FLEX" ? var.enable_hot_tier_auto_resize : null
+  scale_type                  = var.service_level == "FLEX" ? var.scale_type : null
+  total_throughput_mibps      = var.service_level == "FLEX" ? var.total_throughput_mibps : null
+  total_iops                  = var.service_level == "FLEX" ? var.total_iops : null
 
   description = var.description
   labels      = local.labels
@@ -48,9 +67,42 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   depends_on = [data.google_compute_network_peering.private_peering]
 
   lifecycle {
+    # API defaults for mode, type, and scale_type differ from omitted (null) config on
+    # STANDARD, PREMIUM, and EXTREME pools. Ignore drift so Terraform does not send them.
+    ignore_changes = [
+      mode,
+      type,
+      scale_type,
+    ]
     precondition {
       condition     = data.google_compute_network_peering.private_peering.state == "ACTIVE"
       error_message = "The network for the storage pool must have private service access."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || var.zone != null
+      error_message = "FLEX pools require zone. For zonal pools set zone only. For regional pools set zone and replica_zone."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || var.replica_zone == null || var.zone != var.replica_zone
+      error_message = "zone and replica_zone must be different for regional FLEX pools."
+    }
+    precondition {
+      condition     = var.scale_type != "SCALE_TYPE_SCALEOUT" || (var.service_level == "FLEX" && var.replica_zone == null)
+      error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) must be zonal Flex Unified pools. Set zone and omit replica_zone."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || var.scale_type == null
+      error_message = "scale_type is supported only for FLEX storage pools."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || (var.total_throughput_mibps == null && var.total_iops == null)
+      error_message = "total_throughput_mibps and total_iops are supported only for FLEX storage pools."
+    }
+    precondition {
+      condition = var.capacity_gib >= local.min_capacity_gib
+      error_message = var.scale_type == "SCALE_TYPE_SCALEOUT" ? "Large capacity pools (SCALE_TYPE_SCALEOUT) require at least 6144 GiB." : (
+        var.service_level == "FLEX" ? "Flex Unified pools require at least 1024 GiB." : "STANDARD, PREMIUM, and EXTREME pools require at least 2048 GiB."
+      )
     }
   }
 }

--- a/modules/file-system/netapp-storage-pool/outputs.tf
+++ b/modules/file-system/netapp-storage-pool/outputs.tf
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+output "allow_auto_tiering" {
+  description = "Whether the storage pool supports auto-tiering enabled volumes."
+  value       = google_netapp_storage_pool.netapp_storage_pool.allow_auto_tiering
+}
+
+output "scale_type" {
+  description = "Scale type of the storage pool. Flex-only."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.scale_type : null
+}
+
 output "netapp_storage_pool_id" {
   description = "An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}`"
   value       = google_netapp_storage_pool.netapp_storage_pool.id
@@ -20,4 +30,19 @@ output "netapp_storage_pool_id" {
 output "capacity_gb" {
   description = "Storage pool capacity in GiB."
   value       = google_netapp_storage_pool.netapp_storage_pool.capacity_gib
+}
+
+output "service_level" {
+  description = "Storage pool service level."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level
+}
+
+output "mode" {
+  description = "Storage pool mode. Flex-only."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.mode : null
+}
+
+output "type" {
+  description = "Storage pool type. Flex Unified pools use UNIFIED. Omitted for STANDARD, PREMIUM, and EXTREME pools."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.type : null
 }

--- a/modules/file-system/netapp-storage-pool/variables.tf
+++ b/modules/file-system/netapp-storage-pool/variables.tf
@@ -25,7 +25,7 @@ variable "deployment_name" {
 }
 
 variable "region" {
-  description = "Location for NetApp storage pool."
+  description = "Region for the storage pool. Required for all service levels."
   type        = string
 }
 
@@ -64,31 +64,49 @@ variable "service_level" {
   type        = string
   default     = "PREMIUM"
   validation {
-    condition     = contains(["STANDARD", "PREMIUM", "EXTREME"], var.service_level)
-    error_message = "Allowed values for service_level are 'STANDARD', 'PREMIUM', or 'EXTREME'."
+    condition     = contains(["STANDARD", "PREMIUM", "EXTREME", "FLEX"], var.service_level)
+    error_message = "Allowed values for service_level are 'STANDARD', 'PREMIUM', 'EXTREME', or 'FLEX'."
+  }
+}
+
+variable "zone" {
+  description = "Zone for zonal Flex Unified pools, or active zone for regional Flex Unified pools. Must be within region when service_level is FLEX. Ignored for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.service_level != "FLEX" || var.zone == null || startswith(var.zone, "${var.region}-")
+    error_message = "zone must be within the specified region."
+  }
+}
+
+variable "replica_zone" {
+  description = "Replica zone for regional Flex Unified pools. Must be within region when service_level is FLEX. Omit for zonal Flex Unified pools. Ignored for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.service_level != "FLEX" || var.replica_zone == null || startswith(var.replica_zone, "${var.region}-")
+    error_message = "replica_zone must be within the specified region."
   }
 }
 
 variable "capacity_gib" {
-  description = "The capacity of the storage pool in GiB."
+  description = "The capacity of the storage pool in GiB. Minimum is 2048 GiB for STANDARD, PREMIUM, and EXTREME; 1024 GiB for Flex Unified; 6144 GiB for large capacity (SCALE_TYPE_SCALEOUT) pools."
   type        = number
   default     = 2048
-  validation {
-    condition     = var.capacity_gib >= 2048
-    error_message = "The minimum capacity for the storage pool is 2048 GiB."
-  }
 }
 
 variable "active_directory_policy" {
   description = <<-EOT
     The ID of the Active Directory policy to apply to the storage pool in the format:
-    `projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>`
+    `projects/<project_id>/locations/<location>/activeDirectories/<name>`
     EOT
   type        = string
   default     = null
   validation {
-    condition     = var.active_directory_policy == null ? true : length(split("/", var.active_directory_policy)) == 6
-    error_message = "The active directory policy must be provided in the following format: projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>."
+    condition = var.active_directory_policy == null ? true : can(
+      regex("^projects/[^/]+/locations/[^/]+/activeDirectories/[^/]+$", var.active_directory_policy)
+    )
+    error_message = "The Active Directory policy must use the format projects/<project_id>/locations/<location>/activeDirectories/<name>."
   }
 }
 
@@ -115,6 +133,76 @@ variable "allow_auto_tiering" {
   description = "Whether to allow automatic tiering for the storage pool."
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.service_level != "FLEX" || !var.allow_auto_tiering || var.hot_tier_size_gib != null
+    error_message = "hot_tier_size_gib is required when allow_auto_tiering is true for FLEX pools."
+  }
+
+  validation {
+    condition     = var.allow_auto_tiering || (var.hot_tier_size_gib == null && var.enable_hot_tier_auto_resize == null)
+    error_message = "hot_tier_size_gib and enable_hot_tier_auto_resize require allow_auto_tiering to be true."
+  }
+}
+
+variable "hot_tier_size_gib" {
+  description = "Total hot tier capacity for the storage pool in GiB. Flex-only. Requires allow_auto_tiering to be true."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.service_level == "FLEX" || var.hot_tier_size_gib == null
+    error_message = "hot_tier_size_gib is supported only for FLEX storage pools."
+  }
+}
+
+variable "enable_hot_tier_auto_resize" {
+  description = "Whether hot-tier threshold will auto-increase when it reaches 100%. Flex-only. Requires allow_auto_tiering to be true."
+  type        = bool
+  default     = null
+
+  validation {
+    condition     = var.service_level == "FLEX" || var.enable_hot_tier_auto_resize == null
+    error_message = "enable_hot_tier_auto_resize is supported only for FLEX storage pools."
+  }
+}
+
+variable "scale_type" {
+  description = "Scale type of the storage pool. Flex-only. Use SCALE_TYPE_SCALEOUT for large capacity pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.scale_type == null ? true : contains(["SCALE_TYPE_DEFAULT", "SCALE_TYPE_SCALEOUT"], var.scale_type)
+    error_message = "Allowed values for scale_type are SCALE_TYPE_DEFAULT or SCALE_TYPE_SCALEOUT."
+  }
+  validation {
+    condition     = var.scale_type != "SCALE_TYPE_SCALEOUT" || var.replica_zone == null
+    error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) must be zonal Flex Unified pools. Set zone and omit replica_zone."
+  }
+}
+
+variable "total_throughput_mibps" {
+  description = <<-EOT
+    Total pool throughput in MiB/s for Flex Unified custom performance. Omit to use the default 64 MiB/s.
+  EOT
+  type        = number
+  default     = null
+  validation {
+    condition     = var.total_throughput_mibps == null || var.total_throughput_mibps > 0
+    error_message = "total_throughput_mibps must be greater than 0."
+  }
+}
+
+variable "total_iops" {
+  description = <<-EOT
+    Total pool IOPS for Flex Unified custom performance. Omit to let Google Cloud calculate IOPS from total_throughput_mibps.
+  EOT
+  type        = number
+  default     = null
+  validation {
+    condition     = var.total_iops == null || var.total_iops > 0
+    error_message = "total_iops must be greater than 0."
+  }
 }
 
 variable "description" {

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -1,39 +1,81 @@
 ## Description
 
-This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
-volume.
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview) volume.
 
-NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volumes is a first-party Google service that provides NFS shared file systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
 NetApp Volume provides:
 
-- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
-- a [rich feature set][service-levels]
+- support for NFSv3 and NFSv4.1
+- a [rich feature set](https://cloud.google.com/netapp/volumes/docs/discover/service-levels)
 - scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
-- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
-- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+- [FlexCache](https://docs.cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview): Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimize cost
 
 Support for NetApp Volumes is split into two modules.
 
-- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
-- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level](https://cloud.google.com/netapp/volumes/docs/discover/service-levels), CMEK encryption, Active Directory and LDAP settings.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume is a file system container shared using NFSv3 or NFSv4.1.
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
 
-## Deletion protection
-The netapp-volume module currently doesn't implement volume deletion protection. If you create a volume with Cluster Toolkit by using this module, Cluster Toolkit will also delete it when you run `gcluster destroy`. All the data in the volume will be gone. If you want to retain the volume instead, it is advised to [use existing volumes not created by Cluster Toolkit](#using-existing-volumes-not-created-by-cluster-toolkit).
+## Deletion policy
+
+By default, `gcluster destroy` deletes volumes created by this module and all data is lost. Set `deletion_policy` in your blueprint to control destroy behavior:
+
+1. **Omit or `null`** — Provider default. Terraform deletes the volume in Google Cloud.
+2. **`DEFAULT` or `DELETE`** — Delete the volume in Google Cloud.
+3. **`FORCE`** — Delete the volume even when nested snapshot resources exist.
+4. **`PREVENT`** — Block Terraform from deleting the volume. Use this to protect production data from accidental `gcluster destroy`.
+5. **`ABANDON`** — Remove the volume from Terraform state without deleting it in Google Cloud. The volume remains available for manual management or mounting through [pre-existing-network-storage](../pre-existing-network-storage/README.md).
+
+Example:
+
+```yaml
+  - id: homefs
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]
+    settings:
+      volume_name: "homefs"
+      capacity_gib: 1024
+      local_mount: "/home"
+      protocols: ["NFSV3"]
+      deletion_policy: "PREVENT"
+```
+
+Storage pools can only be deleted when empty. This module does not expose `deletion_policy` for pools.
 
 ## Volumes overview
-Volumes are filesystem containers which can be shared using NFS or SMB filesharing protocols. Volumes *live* inside of [storage pools](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview), which can be provisioned using the [netapp-storage-pool] module. Volumes inherit fundamental settings from the pool. They *consume* capacity provided by the pool. You can create one or multiple volumes *inside* a pool.
 
-[netapp-storage-pool]: ../netapp-storage-pool/README.md
-[service-levels]: https://cloud.google.com/netapp/volumes/docs/discover/service-levels
-[auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
-[pre-existing]: ../pre-existing-network-storage/README.md
-[matrix]: ../../../docs/network_storage.md#compatibility-matrix
+Volumes are file system containers shared using NFSv3 or NFSv4.1. Volumes live inside [storage pools](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview), which can be provisioned using the [netapp-storage-pool](../netapp-storage-pool/README.md) module. Volumes inherit settings from the pool and consume capacity from the pool.
+
+### Inherited settings
+
+When you use `use: [netapp_pool]`, the volume module inherits:
+
+1. `netapp_storage_pool_id`
+2. `service_level`
+3. `type`
+4. `allow_auto_tiering`
+5. `scale_type`
+
+### Volume location
+
+The module sets volume location from the `locations/<location>` segment of `netapp_storage_pool_id`. When you use `use: [netapp_pool]`, Cluster Toolkit wires `netapp_storage_pool_id` from the pool automatically. Do not set location, region, or zone in the volume blueprint.
+
+1. Zonal pool — location is the zone (for example, `us-east1-b`).
+2. Regional pool — location is the region (for example, `us-east1`).
+
+### Volume naming
+
+Volume name rules depend on the storage pool service level. The module validates names at plan time.
+
+1. **FLEX pools** — Use lowercase letters, numbers, and underscores only. The name must start with a lowercase letter and cannot end with an underscore. Hyphens are not allowed.
+2. **STANDARD, PREMIUM, and EXTREME pools** — Hyphens are allowed. Underscores are not allowed.
 
 ## Volume examples
-The following examples show the use of netapp-volume. They builds on top of an storage pool which can be provisioned using the [netapp-storage-pool][netapp-storage-pool] module.
+
+The following examples show the use of netapp-volume. They build on top of a storage pool which can be provisioned using the [netapp-storage-pool](../netapp-storage-pool/README.md) module.
 
 ### Example with minimal parameters
 
@@ -46,8 +88,8 @@ The following examples show the use of netapp-volume. They builds on top of an s
       capacity_gib: 1024               # Size up to available capacity in the pool
       local_mount: "/eda-home"         # Mount point at client when client uses USE directive
       protocols: ["NFSV3"]
-      region: $(vars.region)
     # Default export policy exports to "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" and no_root_squash
+    # netapp_storage_pool_id and service_level are inherited from netapp_pool
 ```
 
 ### Example with all parameters
@@ -58,18 +100,17 @@ The following examples show the use of netapp-volume. They builds on top of an s
     use: [netapp_pool]              # Create this pool using the netapp-storage-pool module
     settings:
       volume_name: "eda-shared"
-      capacity_gib: 25000           # Size up to available capacity in the pool
+      capacity_gib: 25000           # At least 15360 GiB (15 TiB) when large_capacity is true
       large_capacity: true
       local_mount: "/shared"        # Mount point at client when client uses USE directive
       mount_options: "rw"           # Allows customizing mount options for special workloads
-      protocols: ["NFSV3","NFSV4"]  # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
-      region: $(vars.region)
-      unix_permissions: "0777"      # Specify default permissions for roo inode owned by root:root
+      protocols: ["NFSV3","NFSV4"]  # List of protocols. ["NFSV3"], ["NFSV4"], or ["NFSV3", "NFSV4"]
+      unix_permissions: "0770"      # Default permissions for root inode; supported on Flex Unified volumes
       # If no export policy is specified, a permissive default policy will be applied, which is:
       #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
       #  has_root_access = true      # no_root_squash enabled
       #  access_type = "READ_WRITE"
-      export_policy:
+      export_policy_rules:
       - allowed_clients: "10.10.20.8,10.10.20.9"
         has_root_access: true       # no_root_squash enabled
         access_type: "READ_WRITE"
@@ -83,25 +124,104 @@ The following examples show the use of netapp-volume. They builds on top of an s
       tiering_policy:               # Enable auto-tiering. Requires auto-tiering enabled storage pool
         tier_action: "ENABLED"
         cooling_threshold_days: 31  # tier data blocks which have not been touched for 31 days
+      deletion_policy: "DEFAULT"
 
       description: "Shared volume for EDA job"
       labels:
         owner: bob
 ```
 
+### Example: Flex Unified large capacity volume
+
+Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`. Do not set `large_capacity` on Flex Unified volumes.
+
+```yaml
+  - id: flex_large_volume
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_large]
+    settings:
+      volume_name: "flex_large_home"
+      capacity_gib: 12288          # Minimum 4800 GiB for Flex large capacity
+      local_mount: "/home"
+      protocols: ["NFSV3"]
+      large_capacity_config:
+        constituent_count: 48      # Typical value for SCALE_TYPE_SCALEOUT pools
+      tiering_policy:              # Requires allow_auto_tiering on the pool
+        tier_action: "ENABLED"
+        cooling_threshold_days: 31
+        hot_tier_bypass_mode_enabled: false  # Set true only during data migration; disable after
+```
+
 ## Protocol support
-Since Cluster Toolkit is currently built to provision Linux-based compute clusters, this module supports NFSv3 and NFSv4.1 only. SMB is blocked.
+
+This module supports NFSv3 and NFSv4.1 only. SMB and iSCSI are not supported.
+
+## ONTAP mode
+
+This module provisions and manages volumes through Google Cloud APIs in Default mode only. It does not support volumes in ONTAP-mode pools.
+
+If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and integrate them with the [pre-existing-network-storage](../pre-existing-network-storage/README.md) module. In ONTAP mode, volumes, snapshots, and policies are managed with ONTAP tools after the pool is created. See [Manage ONTAP mode](https://cloud.google.com/netapp/volumes/docs/ontap/manage-ontap).
 
 ## Large volumes
-Volumes larger than 15 TiB can be created as [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes). Such volumes can grow up to 3 PiB and can scale read performance up to 29 GiBps. They provide six IP addresses to the volume. They are exported via the `server_ips` output. When connecting a large volume to a client using the USE directive, cluster toolkit currently uses the first IP only. This will be improved in the future.
 
-This feature is allow-listed GA. To request allow-listing, see [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes).
+Standard, Premium, and Extreme service levels support [large capacity volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes) of 15 TiB or larger. Flex Unified large capacity volumes use a separate configuration model.
+
+### Minimum volume capacity
+
+The module enforces these minimum `capacity_gib` values at plan time:
+
+1. **STANDARD, PREMIUM, and EXTREME (regular volumes)** — 100 GiB
+2. **STANDARD, PREMIUM, and EXTREME (large capacity volumes)** — 15 TiB (15360 GiB)
+3. **Flex Unified** — 1 GiB
+4. **Flex Unified large capacity (**`large_capacity_config`**)** — 4800 GiB
+
+To create a large capacity volume:
+
+1. **Standard, Premium, and Extreme** — Set `large_capacity: true` and `capacity_gib` to at least 15360.
+2. **Flex Unified** — Use the `large_capacity_config` block with `constituent_count` in the blueprint. Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`. Large capacity pools cannot be regional. The typical value is 48. Do not set `large_capacity` on Flex Unified volumes.
+
+### Large capacity rules by service level
+
+1. **Standard, Premium, and Extreme** — Set `large_capacity: true`. Set `capacity_gib` to at least 15360 (15 TiB). The module configures multiple NFS endpoints internally. Do not set `large_capacity_config`.
+2. **Flex Unified** — Set `large_capacity_config` with `constituent_count`. Set `capacity_gib` to at least 4800. Do not set `large_capacity`. Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`.
+3. `large_capacity` **and** `large_capacity_config` **cannot be used together.**
+
+### Mounting large capacity volumes
+
+Large capacity volumes expose the same NFS export through multiple IP addresses . For best performance, spread clients evenly across all available IPs so load is distributed and aggregated throughput is higher. See [Connect large capacity volumes with multiple storage endpoints](https://cloud.google.com/netapp/volumes/docs/connect-clients/connect-large-capacity-volumes).
+
+When you attach a volume with the `use:` directive, the module mount runner passes all `server_ips` to the mount script. Each client selects one endpoint from that list at mount time, which spreads clients across the available IPs.
+
+Slurm integrations do not distribute clients across endpoints today. Slurm mounts use the first IP address only, so large capacity volumes do not get the full multi-endpoint performance benefit in Slurm clusters.
+
+For volumes mounted through [pre-existing-network-storage](../pre-existing-network-storage/README.md), you must configure endpoints yourself (for example, round-robin DNS or manual client grouping per the Google Cloud documentation).
+
+### Plan-time validation
+
+The module enforces these rules at plan time:
+
+1. Flex File pools (`service_level: FLEX` with `type: FILE`) are rejected.
+2. `large_capacity` is rejected on Flex Unified pools; use `large_capacity_config` instead.
+3. `large_capacity_config` requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`.
+4. `tiering_policy` requires a pool with `allow_auto_tiering: true`.
+5. `hot_tier_bypass_mode_enabled` is supported only when `service_level` is `FLEX`.
 
 ## Auto-tiering support
-For auto-tiering enabled storage pools you can enable auto-tiering on the volume. For more information, see [manage auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering).
+
+For storage pools with `allow_auto_tiering` enabled, you can enable auto-tiering on the volume using `tiering_policy`. For more information, see [Manage auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering).
+
+### Hot tier bypass mode
+
+Set `hot_tier_bypass_mode_enabled` only for FLEX service levels. Use it when you are migrating data into a new volume.
+
+When hot tier bypass mode is enabled, writes go directly to the cold tier instead of filling the hot tier. Frequently accessed data is promoted back to the hot tier based on client read activity.
+
+1. Enable `hot_tier_bypass_mode_enabled` before you migrate data into the volume.
+2. Disable `hot_tier_bypass_mode_enabled` after migration completes so normal tiering behavior resumes for ongoing workloads.
 
 ## Using existing volumes not created by Cluster Toolkit
-NetApp Volumes volumes are regular NFS exports. You can use the [pre-existing-network-storage] module to integrate them into Cluster Toolkit.
+
+NetApp Volumes volumes are regular NFS exports. Use the [pre-existing-network-storage](../pre-existing-network-storage/README.md) module to integrate volumes that Cluster Toolkit does not provision. This includes ONTAP-mode pools and volumes, FlexCache volumes, and any other NetApp export created outside these modules.
 
 Example code:
 
@@ -111,18 +231,16 @@ Example code:
   settings:
     server_ip: ## Set server IP here ##
     remote_mount: nfsshare
-    local_mount: /home
+    local_mount: /shared
     fs_type: nfs
 ```
 
-This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/home` by clients which mount if via USE directive.
+This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/shared` by clients which mount if via USE directive.
 
-Note that the `server_ip` must be known before deployment and this module does not allow
-to specify a list of IPs for large volumes.
-
-[pre-existing-network-storage]: ../pre-existing-network-storage/README.md
+Note that the `server_ip` must be known before deployment and this module does not allow to specify a list of IPs for large volumes. For large volumes it is recommended to use a DNS FQDN which hands out the volume IPs in round-robin fashion.
 
 ## FlexCache support
+
 NetApp FlexCache technology accelerates data access, reduces WAN latency and lowers WAN bandwidth costs for read-intensive workloads, especially where clients need to access the same data repeatedly. When you create a FlexCache volume, you create a remote cache of an already existing (origin) volume that contains only the actively accessed data (hot data) of the origin volume.
 
 The FlexCache support in Google Cloud NetApp Volumes allows you to provision a cache volume in your Google network to improve performance for hybrid cloud environments. A FlexCache volume can help you transition workloads to the hybrid cloud by caching data from an on-premises data center to cloud.
@@ -130,6 +248,7 @@ The FlexCache support in Google Cloud NetApp Volumes allows you to provision a c
 Deploying FlexCache volumes requires manual steps on the ONTAP origin side, which are not automated. Therefore this module has no support to deploy FlexCache volumes today. Deploy them manually and use the [pre-existing-network-storage](#using-existing-volumes-not-created-by-cluster-toolkit) instead.
 
 ## License
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC
 
@@ -150,13 +269,13 @@ limitations under the License.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.34.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 6.45.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 7.34.0 |
 
 ## Modules
 
@@ -172,20 +291,25 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. | `number` | `1024` | no |
+| <a name="input_allow_auto_tiering"></a> [allow\_auto\_tiering](#input\_allow\_auto\_tiering) | Whether the storage pool supports auto-tiering. Inherited from the pool when using use: [netapp\_pool]. | `bool` | `null` | no |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. Minimum is 100 GiB for STANDARD, PREMIUM, and EXTREME; 15 TiB (15360 GiB) for STANDARD, PREMIUM, and EXTREME large capacity volumes; 1 GiB for Flex Unified; 4800 GiB for Flex Unified large capacity volumes. | `number` | `1024` | no |
+| <a name="input_deletion_policy"></a> [deletion\_policy](#input\_deletion\_policy) | Controls Terraform destroy behavior. Omit to use the provider default (delete the volume in Google Cloud).<br/>DEFAULT or DELETE: delete the volume in Google Cloud.<br/>FORCE: delete the volume even when nested snapshot resources exist.<br/>PREVENT: block Terraform from deleting the volume.<br/>ABANDON: remove the volume from Terraform state without deleting it in Google Cloud. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the NetApp volume. | `string` | `""` | no |
 | <a name="input_export_policy_rules"></a> [export\_policy\_rules](#input\_export\_policy\_rules) | Define NFS export policy. | <pre>list(object({<br/>    allowed_clients = optional(string)<br/>    has_root_access = optional(bool, false)<br/>    access_type     = optional(string, "READ_WRITE")<br/>    nfsv3           = optional(bool)<br/>    nfsv4           = optional(bool)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "access_type": "READ_WRITE",<br/>    "allowed_clients": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",<br/>    "has_root_access": true<br/>  }<br/>]</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp volume. Key-value pairs. | `map(string)` | n/a | yes |
-| <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity.<br/>Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB. | `bool` | `false` | no |
+| <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity for STANDARD/PREMIUM/EXTREME service levels.<br/>For FLEX service level, use large\_capacity\_config instead. | `bool` | `false` | no |
+| <a name="input_large_capacity_config"></a> [large\_capacity\_config](#input\_large\_capacity\_config) | Configuration for a Flex Unified large capacity volume. Supported only for Flex Unified pools.<br/>Set constituent\_count in the blueprint. The typical value for current SCALE\_TYPE\_SCALEOUT pools is 48. | <pre>object({<br/>    constituent_count = number<br/>  })</pre> | `null` | no |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this volume. | `string` | `"/shared"` | no |
-| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"rw,hard,rsize=65536,wsize=65536,tcp"` | no |
-| <a name="input_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#input\_netapp\_storage\_pool\_id) | The ID of the NetApp storage pool to use for the volume. | `string` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
-| <a name="input_protocols"></a> [protocols](#input\_protocols) | The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported. | `list(string)` | <pre>[<br/>  "NFSV3"<br/>]</pre> | no |
-| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
-| <a name="input_tiering_policy"></a> [tiering\_policy](#input\_tiering\_policy) | Define the tiering policy for the NetApp volume. | <pre>object({<br/>    tier_action            = optional(string)<br/>    cooling_threshold_days = optional(number)<br/>  })</pre> | `null` | no |
-| <a name="input_unix_permissions"></a> [unix\_permissions](#input\_unix\_permissions) | UNIX permissions for root inode in the volume. | `string` | `"0777"` | no |
-| <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | The name of the volume. Needs to be unique within the storage pool. | `string` | `null` | no |
+| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"rw,hard,rsize=262144,wsize=262144,tcp"` | no |
+| <a name="input_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#input\_netapp\_storage\_pool\_id) | The ID of the NetApp storage pool to use for the volume. Volume location (region or zone) is parsed from this value.<br/>Inherited from the pool when using use: [netapp\_pool]. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp volume will be created. | `string` | n/a | yes |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | Access protocols for the volume. Only NFSv3 and NFSv4.1 (NFSV4) are supported. | `list(string)` | <pre>[<br/>  "NFSV3"<br/>]</pre> | no |
+| <a name="input_scale_type"></a> [scale\_type](#input\_scale\_type) | Scale type of the storage pool. Inherited from the pool when using use: [netapp\_pool]. Flex-only; null for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_service_level"></a> [service\_level](#input\_service\_level) | Service level of the storage pool used by this volume. Inherited from the pool when using use: [netapp\_pool]. | `string` | `null` | no |
+| <a name="input_tiering_policy"></a> [tiering\_policy](#input\_tiering\_policy) | Define the tiering policy for the NetApp volume. Requires a pool with allow\_auto\_tiering enabled.<br/>hot\_tier\_bypass\_mode\_enabled (FLEX only): use during data migration so writes go to the cold tier instead of filling the hot tier; disable after migration completes. | <pre>object({<br/>    tier_action                  = optional(string)<br/>    cooling_threshold_days       = optional(number)<br/>    hot_tier_bypass_mode_enabled = optional(bool)<br/>  })</pre> | `null` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of the storage pool used by this volume. Inherited from the pool when using use: [netapp\_pool]. Flex Unified pools use UNIFIED. Null for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_unix_permissions"></a> [unix\_permissions](#input\_unix\_permissions) | UNIX permissions for root inode in the volume. | `string` | `"0770"` | no |
+| <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | The name of the volume. Needs to be unique within the storage pool.<br/>FLEX pools: lowercase letters, numbers, and underscores only; must start with a lowercase letter and cannot end with an underscore.<br/>STANDARD, PREMIUM, and EXTREME pools: hyphens are allowed; underscores are not allowed. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/file-system/netapp-volume/main.tf
+++ b/modules/file-system/netapp-volume/main.tf
@@ -19,11 +19,24 @@ locals {
   labels = merge(var.labels, { ghpc_module = "netapp-volume", ghpc_role = "file-system" })
 }
 
-# resource "random_id" "resource_name_suffix" {
-#   byte_length = 4
-# }
-
 locals {
+  split_pool_id = split("/", var.netapp_storage_pool_id)
+  pool_name     = local.split_pool_id[5]
+  pool_location = local.split_pool_id[3]
+
+  # Inherited pool attributes are Flex-only; ignore API defaults on STANDARD/PREMIUM/EXTREME pools.
+  pool_type       = var.service_level == "FLEX" ? var.type : null
+  pool_scale_type = var.service_level == "FLEX" ? var.scale_type : null
+
+  # Flex Unified when service level is FLEX and pool type is UNIFIED or unset (inherited from pool).
+  is_flex_unified                 = var.service_level == "FLEX" && (local.pool_type == null || local.pool_type == "UNIFIED")
+  non_flex_large_min_capacity_gib = 15360 # 15 TiB
+  min_capacity_gib = var.large_capacity_config != null ? 4800 : (
+    local.is_flex_unified ? 1 : (
+      var.large_capacity ? local.non_flex_large_min_capacity_gib : 100
+    )
+  )
+
   full_path    = split(":", google_netapp_volume.netapp_volume.mount_options[0].export_full)
   server_ip    = local.full_path[0]
   remote_mount = local.full_path[1]
@@ -43,9 +56,6 @@ locals {
     "args"        = "\"${join(",", local.server_ips)}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
     "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
   }
-
-  split_pool_id = split("/", var.netapp_storage_pool_id)
-  pool_name     = local.split_pool_id[5]
 }
 
 resource "google_netapp_volume" "netapp_volume" {
@@ -53,19 +63,29 @@ resource "google_netapp_volume" "netapp_volume" {
 
   name               = var.volume_name
   share_name         = var.volume_name
-  location           = var.region
+  location           = local.pool_location
   protocols          = var.protocols
   capacity_gib       = var.capacity_gib
-  large_capacity     = var.large_capacity
-  multiple_endpoints = var.large_capacity == true ? true : null
+  large_capacity     = local.is_flex_unified ? null : var.large_capacity
+  multiple_endpoints = local.is_flex_unified ? null : (var.large_capacity ? true : null)
   storage_pool       = local.pool_name
   unix_permissions   = var.unix_permissions
+  security_style     = "UNIX"
+  deletion_policy    = var.deletion_policy
+
+  dynamic "large_capacity_config" {
+    for_each = var.large_capacity_config != null ? [1] : []
+    content {
+      constituent_count = var.large_capacity_config.constituent_count
+    }
+  }
 
   dynamic "tiering_policy" {
     for_each = var.tiering_policy == null ? [] : [0]
     content {
-      cooling_threshold_days = lookup(var.tiering_policy, "cooling_threshold_days", null)
-      tier_action            = lookup(var.tiering_policy, "tier_action", null)
+      cooling_threshold_days       = try(var.tiering_policy.cooling_threshold_days, null)
+      tier_action                  = try(var.tiering_policy.tier_action, null)
+      hot_tier_bypass_mode_enabled = try(var.tiering_policy.hot_tier_bypass_mode_enabled, null)
     }
   }
 
@@ -89,4 +109,55 @@ resource "google_netapp_volume" "netapp_volume" {
   }
 
   depends_on = [var.netapp_storage_pool_id]
+
+  lifecycle {
+    precondition {
+      condition     = local.pool_scale_type != "SCALE_TYPE_SCALEOUT" || var.large_capacity_config != null
+      error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) require large_capacity_config on the volume."
+    }
+    precondition {
+      condition     = var.large_capacity_config == null || local.is_flex_unified
+      error_message = "large_capacity_config is supported only with Flex Unified pools."
+    }
+    precondition {
+      condition     = !local.is_flex_unified || !var.large_capacity
+      error_message = "For Flex Unified pools, use large_capacity_config instead of large_capacity."
+    }
+    precondition {
+      condition     = !(var.large_capacity && var.large_capacity_config != null)
+      error_message = "large_capacity and large_capacity_config cannot be used together."
+    }
+    precondition {
+      condition     = local.pool_scale_type == null || var.large_capacity_config == null || local.pool_scale_type == "SCALE_TYPE_SCALEOUT"
+      error_message = "Flex Unified large capacity volumes require a storage pool with scale_type SCALE_TYPE_SCALEOUT."
+    }
+    precondition {
+      condition = var.capacity_gib >= local.min_capacity_gib
+      error_message = var.large_capacity_config != null ? "Flex Unified large capacity volumes require at least 4800 GiB." : (
+        local.is_flex_unified ? "Flex Unified volumes require at least 1 GiB." : (
+          var.large_capacity ? "STANDARD, PREMIUM, and EXTREME large capacity volumes require at least 15 TiB (15360 GiB)." : "STANDARD, PREMIUM, and EXTREME volumes require at least 100 GiB."
+        )
+      )
+    }
+    precondition {
+      condition     = var.tiering_policy == null || try(var.tiering_policy.hot_tier_bypass_mode_enabled, null) != true || var.service_level == "FLEX"
+      error_message = "hot_tier_bypass_mode_enabled is supported only for FLEX service level."
+    }
+    precondition {
+      condition     = var.tiering_policy == null || var.allow_auto_tiering == null || var.allow_auto_tiering
+      error_message = "tiering_policy requires a storage pool with allow_auto_tiering enabled."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || can(regex("^[a-z]([a-z0-9_]*[a-z0-9])?$", var.volume_name))
+      error_message = "Flex volume names must start with a lowercase letter, contain only lowercase letters, numbers, and underscores, and cannot end with an underscore."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || var.service_level == null || can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.volume_name))
+      error_message = "STANDARD, PREMIUM, and EXTREME volume names must start with a lowercase letter, contain only lowercase letters, numbers, and hyphens, and cannot end with a hyphen."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || local.pool_type != "FILE"
+      error_message = "Flex File pools (FLEX service level with type FILE) are not supported by this module."
+    }
+  }
 }

--- a/modules/file-system/netapp-volume/variables.tf
+++ b/modules/file-system/netapp-volume/variables.tf
@@ -15,12 +15,15 @@
  */
 
 variable "project_id" {
-  description = "ID of project in which the NetApp storage pool will be created."
+  description = "ID of project in which the NetApp volume will be created."
   type        = string
 }
 
 variable "netapp_storage_pool_id" {
-  description = "The ID of the NetApp storage pool to use for the volume."
+  description = <<-EOT
+    The ID of the NetApp storage pool to use for the volume. Volume location (region or zone) is parsed from this value.
+    Inherited from the pool when using use: [netapp_pool].
+    EOT
   type        = string
   validation {
     condition     = length(split("/", var.netapp_storage_pool_id)) == 6
@@ -28,29 +31,47 @@ variable "netapp_storage_pool_id" {
   }
 }
 
-variable "region" {
-  description = "Location for NetApp storage pool."
-  type        = string
-}
-
-variable "volume_name" {
-  description = "The name of the volume. Needs to be unique within the storage pool."
+variable "service_level" {
+  description = "Service level of the storage pool used by this volume. Inherited from the pool when using use: [netapp_pool]."
   type        = string
   default     = null
 }
 
+variable "type" {
+  description = "Type of the storage pool used by this volume. Inherited from the pool when using use: [netapp_pool]. Flex Unified pools use UNIFIED. Null for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+}
+
+variable "allow_auto_tiering" {
+  description = "Whether the storage pool supports auto-tiering. Inherited from the pool when using use: [netapp_pool]."
+  type        = bool
+  default     = null
+}
+
+variable "scale_type" {
+  description = "Scale type of the storage pool. Inherited from the pool when using use: [netapp_pool]. Flex-only; null for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+}
+
+variable "volume_name" {
+  description = <<-EOT
+    The name of the volume. Needs to be unique within the storage pool.
+    FLEX pools: lowercase letters, numbers, and underscores only; must start with a lowercase letter and cannot end with an underscore.
+    STANDARD, PREMIUM, and EXTREME pools: hyphens are allowed; underscores are not allowed.
+    EOT
+  type        = string
+}
+
 variable "capacity_gib" {
-  description = "The capacity of the volume in GiB."
+  description = "The capacity of the volume in GiB. Minimum is 100 GiB for STANDARD, PREMIUM, and EXTREME; 15 TiB (15360 GiB) for STANDARD, PREMIUM, and EXTREME large capacity volumes; 1 GiB for Flex Unified; 4800 GiB for Flex Unified large capacity volumes."
   type        = number
   default     = 1024
-  validation {
-    condition     = var.capacity_gib >= 100
-    error_message = "The minimum capacity for the volume is 100 GiB."
-  }
 }
 
 variable "protocols" {
-  description = "The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported."
+  description = "Access protocols for the volume. Only NFSv3 and NFSv4.1 (NFSV4) are supported."
   type        = list(string)
   default     = ["NFSV3"]
   validation {
@@ -83,35 +104,84 @@ variable "local_mount" {
 variable "mount_options" {
   description = "NFS mount options to mount file system."
   type        = string
-  default     = "rw,hard,rsize=65536,wsize=65536,tcp"
+  default     = "rw,hard,rsize=262144,wsize=262144,tcp"
 }
 
 variable "large_capacity" {
   description = <<-EOT
-    If true, the volume will be created with large capacity.
-    Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB.
+    If true, the volume will be created with large capacity for STANDARD/PREMIUM/EXTREME service levels.
+    For FLEX service level, use large_capacity_config instead.
     EOT
   type        = bool
   default     = false
 }
 
+variable "large_capacity_config" {
+  description = <<-EOT
+    Configuration for a Flex Unified large capacity volume. Supported only for Flex Unified pools.
+    Set constituent_count in the blueprint. The typical value for current SCALE_TYPE_SCALEOUT pools is 48.
+    EOT
+  type = object({
+    constituent_count = number
+  })
+  default = null
+  validation {
+    condition     = var.large_capacity_config == null || var.large_capacity_config.constituent_count >= 2
+    error_message = "constituent_count must be at least 2 for Flex Unified large capacity volumes."
+  }
+}
+
 variable "unix_permissions" {
   description = "UNIX permissions for root inode in the volume."
   type        = string
-  default     = "0777"
+  default     = "0770"
   validation {
-    condition     = length(var.unix_permissions) <= 4
-    error_message = "UNIX permissions must be a 4-digit octal number."
+    condition     = can(regex("^[0-7]{3,4}$", var.unix_permissions))
+    error_message = "UNIX permissions must be a 3 or 4-digit octal number (digits 0-7)."
   }
 }
 
 variable "tiering_policy" {
-  description = "Define the tiering policy for the NetApp volume."
+  description = <<-EOT
+    Define the tiering policy for the NetApp volume. Requires a pool with allow_auto_tiering enabled.
+    hot_tier_bypass_mode_enabled (FLEX only): use during data migration so writes go to the cold tier instead of filling the hot tier; disable after migration completes.
+    EOT
   type = object({
-    tier_action            = optional(string)
-    cooling_threshold_days = optional(number)
+    tier_action                  = optional(string)
+    cooling_threshold_days       = optional(number)
+    hot_tier_bypass_mode_enabled = optional(bool)
   })
   default = null
+  validation {
+    condition = var.tiering_policy == null || contains(
+      ["ENABLED", "PAUSED"],
+      coalesce(var.tiering_policy.tier_action, "PAUSED")
+    )
+    error_message = "tier_action must be ENABLED or PAUSED."
+  }
+  validation {
+    condition = var.tiering_policy == null || var.tiering_policy.cooling_threshold_days == null || (
+      coalesce(var.tiering_policy.cooling_threshold_days, 0) >= 2 &&
+      coalesce(var.tiering_policy.cooling_threshold_days, 0) <= 183
+    )
+    error_message = "cooling_threshold_days must be between 2 and 183."
+  }
+}
+
+variable "deletion_policy" {
+  description = <<-EOT
+    Controls Terraform destroy behavior. Omit to use the provider default (delete the volume in Google Cloud).
+    DEFAULT or DELETE: delete the volume in Google Cloud.
+    FORCE: delete the volume even when nested snapshot resources exist.
+    PREVENT: block Terraform from deleting the volume.
+    ABANDON: remove the volume from Terraform state without deleting it in Google Cloud.
+    EOT
+  type        = string
+  default     = null
+  validation {
+    condition     = var.deletion_policy == null ? true : contains(["DEFAULT", "FORCE", "PREVENT", "ABANDON", "DELETE"], var.deletion_policy)
+    error_message = "Allowed values for deletion_policy are DEFAULT, FORCE, PREVENT, ABANDON, or DELETE."
+  }
 }
 
 variable "export_policy_rules" {
@@ -130,4 +200,10 @@ variable "export_policy_rules" {
     access_type     = "READ_WRITE",
   }]
   nullable = true
+  validation {
+    condition = var.export_policy_rules == null ? true : alltrue([
+      for rule in var.export_policy_rules : contains(["READ_ONLY", "READ_WRITE", "READ_NONE"], rule.access_type)
+    ])
+    error_message = "access_type must be READ_ONLY, READ_WRITE, or READ_NONE."
+  }
 }

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.45.0"
+      version = ">= 7.34.0"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
Extend netapp-storage-pool and netapp-volume for Google Cloud NetApp
Volumes Flex Unified (Default mode, NFSv3/NFSv4.1). Pools support zonal
and regional Flex layouts, SCALE_TYPE_SCALEOUT large-capacity pools, and
Flex auto-tiering settings. Volumes inherit pool properties via use:
[netapp_pool], derive location from netapp_storage_pool_id, and support
Flex large_capacity_config with constituent_count.

Also enforce service-level capacity minimums at plan time, handle non-Flex
large volumes (15 TiB minimum, internal multiple_endpoints), expose
deletion_policy on volumes, and document NetApp Volumes in
docs/network_storage.md and module READMEs.

