### PR TITLE
Pin DCGM packages to 1:4.6.0-1 for a3mega

### DIFF
--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -187,9 +187,10 @@ deployment_groups:
               nvidia_packages:
                 - cuda-toolkit-13-0
                 - nvidia-container-toolkit
-                - datacenter-gpu-manager-4-cuda13
-                - datacenter-gpu-manager-4-dev
-                - datacenter-gpu-manager-4-core
+                - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
+                - datacenter-gpu-manager-4-dev=1:4.6.0-1
+                - datacenter-gpu-manager-4-core=1:4.6.0-1
+
             tasks:
               - name: Install NVIDIA repository keyring
                 ansible.builtin.apt:


### PR DESCRIPTION
This PR pins the datacenter-gpu-manager (DCGM) packages to version 1:4.6.0-1 in the A3 Mega Slurm blueprint. 

Testing:

Verified the correct pinned versions are installed and ran NCCL tests across the cluster: 
Avg Bus BW: 146.112 GB/s

Verified the DCGM systemd service starts successfully without crashing: showed "active (running)" status
DCGM command-line tool to ensure it discovers all 8 GPUs on the node: All 8 GPUs showed "active" status

Ran the DCGM built-in diagnostic tool to confirm there are no software or hardware issues reported: All GPUs showed "PASS"

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
