### PR TITLE
Fix(Telemetry): remove extra double quotes from machine type in node count metric

### DIFF
--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -150,12 +150,12 @@ func getMachineTypeFromModule(m config.Module, bp config.Blueprint) string {
 	// 1. Try explicit settings first
 	for _, key := range machineTypeSettings {
 		if t := extractExplicitStringSetting(key, m, bp); t != "" {
-return strings.Trim(t, "\"")
+            return strings.Trim(t, "\"")
 		}
 	}
 	// 2. If no explicit setting, try defaults
 	if t, found := extractDefaultSetting[string](machineTypeSettings, m); found && t != "" {
-return strings.Trim(t, "\"")
+        return strings.Trim(t, "\"")
 	}
 
 	return ""
@@ -337,7 +337,7 @@ func extractStringFromCtyMap(val cty.Value, targetKeys []string) string {
 		if v, exists := valMap[key]; exists {
 			v, _ = v.Unmark()
 			if v.IsKnown() && !v.IsNull() && v.Type() == cty.String {
-return strings.Trim(v.AsString(), "\"")
+                return strings.Trim(v.AsString(), "\"")
 			}
 		}
 	}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -150,7 +150,7 @@ func getMachineTypeFromModule(m config.Module, bp config.Blueprint) string {
 	// 1. Try explicit settings first
 	for _, key := range machineTypeSettings {
 		if t := extractExplicitStringSetting(key, m, bp); t != "" {
-			return strings.ReplaceAll(t, "\"", "")
+return strings.Trim(t, "\"")
 		}
 	}
 	// 2. If no explicit setting, try defaults

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -155,7 +155,7 @@ return strings.Trim(t, "\"")
 	}
 	// 2. If no explicit setting, try defaults
 	if t, found := extractDefaultSetting[string](machineTypeSettings, m); found && t != "" {
-		return strings.ReplaceAll(t, "\"", "")
+return strings.Trim(t, "\"")
 	}
 
 	return ""

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -337,7 +337,7 @@ func extractStringFromCtyMap(val cty.Value, targetKeys []string) string {
 		if v, exists := valMap[key]; exists {
 			v, _ = v.Unmark()
 			if v.IsKnown() && !v.IsNull() && v.Type() == cty.String {
-				return strings.ReplaceAll(v.AsString(), "\"", "")
+return strings.Trim(v.AsString(), "\"")
 			}
 		}
 	}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -150,12 +150,12 @@ func getMachineTypeFromModule(m config.Module, bp config.Blueprint) string {
 	// 1. Try explicit settings first
 	for _, key := range machineTypeSettings {
 		if t := extractExplicitStringSetting(key, m, bp); t != "" {
-			return t
+			return strings.ReplaceAll(t, "\"", "")
 		}
 	}
 	// 2. If no explicit setting, try defaults
 	if t, found := extractDefaultSetting[string](machineTypeSettings, m); found && t != "" {
-		return t
+		return strings.ReplaceAll(t, "\"", "")
 	}
 
 	return ""
@@ -337,7 +337,7 @@ func extractStringFromCtyMap(val cty.Value, targetKeys []string) string {
 		if v, exists := valMap[key]; exists {
 			v, _ = v.Unmark()
 			if v.IsKnown() && !v.IsNull() && v.Type() == cty.String {
-				return v.AsString()
+				return strings.ReplaceAll(v.AsString(), "\"", "")
 			}
 		}
 	}

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -150,12 +150,12 @@ func getMachineTypeFromModule(m config.Module, bp config.Blueprint) string {
 	// 1. Try explicit settings first
 	for _, key := range machineTypeSettings {
 		if t := extractExplicitStringSetting(key, m, bp); t != "" {
-            return strings.Trim(t, "\"")
+			return strings.Trim(t, "\"")
 		}
 	}
 	// 2. If no explicit setting, try defaults
 	if t, found := extractDefaultSetting[string](machineTypeSettings, m); found && t != "" {
-        return strings.Trim(t, "\"")
+		return strings.Trim(t, "\"")
 	}
 
 	return ""
@@ -337,7 +337,7 @@ func extractStringFromCtyMap(val cty.Value, targetKeys []string) string {
 		if v, exists := valMap[key]; exists {
 			v, _ = v.Unmark()
 			if v.IsKnown() && !v.IsNull() && v.Type() == cty.String {
-                return strings.Trim(v.AsString(), "\"")
+				return strings.Trim(v.AsString(), "\"")
 			}
 		}
 	}


### PR DESCRIPTION
This pull request addresses an issue where machine type identifiers in telemetry data were being captured with extra double quotes. By applying a string replacement utility to the extracted values, the telemetry output is now properly sanitized to ensure consistent and accurate reporting.

Changes:

* **Data Sanitization**: Implemented string cleaning to remove extraneous double quotes from machine type telemetry data.