### PR TITLE
Update A4high blueprints to use pre-built ACI image

### DIFF
--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -36,7 +36,7 @@ vars:
   instance_image:
     project: advanced-compute-images
     family: aci-gpu-u2404-slurm-2511-cuda-130-nvidia-580-amd64
-  disk_size_gb: 100
+  disk_size_gb: 300
   benchmark_dir: $(ghpc_stage("system_benchmarks"))
   base_network_name: $(vars.deployment_name)
 
@@ -282,20 +282,23 @@ deployment_groups:
           - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
+            vars:
+              cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run"
+              cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux.run"
             tasks:
               - name: Download CUDA runfile
                 ansible.builtin.get_url:
-                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
-                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  url: "{{ cuda_installer_url }}"
+                  dest: "{{ cuda_installer_file }}"
                   mode: '0755'
 
               - name: Install CUDA toolkit via runfile
                 ansible.builtin.command:
-                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
+                  cmd: "{{ cuda_installer_file }} --silent --toolkit"
 
               - name: Remove CUDA runfile
                 ansible.builtin.file:
-                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  path: "{{ cuda_installer_file }}"
                   state: absent
 
               - name: Install NVIDIA repository keyring
@@ -437,7 +440,7 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [a4high-slurm-net-0]
     settings:
-      disk_size_gb: 300
+      disk_size_gb: $(vars.disk_size_gb)
       enable_login_public_ips: true
       machine_type: e2-standard-16
       metadata:
@@ -501,7 +504,7 @@ deployment_groups:
     settings:
       enable_controller_public_ips: true
       disk_type: pd-extreme
-      disk_size_gb: 300
+      disk_size_gb: $(vars.disk_size_gb)
       machine_type: e2-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -25,11 +25,6 @@ vars:
   zone: # supply zone
   a4h_cluster_size: # supply cluster size
   # Image settings
-  base_image:
-    project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
-  image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -39,11 +34,9 @@ vars:
   # Cluster Settings
   local_ssd_mountpoint: /mnt/localssd
   instance_image:
-    project: $(vars.project_id)
-    family: $(vars.deployment_name)-u24
+    project: advanced-compute-images
+    family: aci-gpu-u2404-slurm-2511-cuda-130-nvidia-580-amd64
   disk_size_gb: 100
-  nccl_gib_version: 1.1.0
-  libnccl_version: 2.27.5-1+cuda12.9
   benchmark_dir: $(ghpc_stage("system_benchmarks"))
   base_network_name: $(vars.deployment_name)
 
@@ -69,214 +62,6 @@ vars:
   # per_unit_storage_throughput: 500
 
 deployment_groups:
-- group: image-env
-  modules:
-  - id: slurm-image-network
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.base_network_name)-net
-
-  - id: slurm-build-script
-    source: modules/scripts/startup-script
-    settings:
-      install_ansible: true
-      enable_gpu_network_wait_online: true
-      docker:
-        enabled: true
-        world_writable: true
-      runners:
-      - type: data
-        destination: /etc/apt/preferences.d/block-broken-nvidia-container
-        content: |
-          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
-          Pin: version 1.17.7-1
-          Pin-Priority: 100
-
-      # The following holds NVIDIA software that was already installed on the
-      # accelerator base image to be the same driver version. This reduces the
-      # risk of a driver version mismatch.
-      # Additional packages are held by:
-      # https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/ansible/group_vars/os_ubuntu.yml
-      - type: ansible-local
-        destination: hold-nvidia-packages.yml
-        content: |
-          ---
-          - name: Hold nvidia packages
-            hosts: all
-            become: true
-            vars:
-              nvidia_packages_to_hold:
-              - libnvidia-cfg1-*-server
-              - libnvidia-compute-*-server
-              - libnvidia-nscq-*
-              - nvidia-compute-utils-*-server
-              - nvidia-fabricmanager-*
-              - nvidia-utils-*-server
-              - nvidia-imex-*
-            tasks:
-            - name: Hold nvidia packages
-              ansible.builtin.command:
-                argv:
-                - apt-mark
-                - hold
-                - "{{ item }}"
-              loop: "{{ nvidia_packages_to_hold }}"
-
-      - type: data
-        destination: /var/tmp/slurm_vars.json
-        content: |
-          {
-            "reboot": false,
-            "install_cuda": false,
-            "install_gcsfuse": true,
-            "install_lustre": false,
-            "install_managed_lustre": false,
-            "install_ompi": true,
-            "allow_kernel_upgrades": false,
-            "monitoring_agent": "cloud-ops",
-          }
-      - type: shell
-        destination: install_slurm.sh
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C $(vars.build_slurm_from_git_ref) \
-              -i localhost, --limit localhost --connection=local \
-              -e @/var/tmp/slurm_vars.json \
-              ansible/playbook.yml
-      # this duplicates the ulimits configuration of the HPC VM Image
-      - type: data
-        destination: /etc/security/limits.d/99-unlimited.conf
-        content: |
-          * - memlock unlimited
-          * - nproc unlimited
-          * - stack unlimited
-          * - nofile 1048576
-          * - cpu unlimited
-          * - rtprio unlimited
-      - type: ansible-local
-        destination: install_cuda_and_dcgm.yml
-        content: |
-          ---
-          - name: Install and Configure CUDA 13 / DCGM
-            hosts: all
-            become: true
-            vars:
-              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
-              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
-              nvidia_packages:
-                - cuda-toolkit-13-0
-                - datacenter-gpu-manager-4-cuda13
-                - datacenter-gpu-manager-4-dev
-                - datacenter-gpu-manager-4-core
-            tasks:
-              - name: Install NVIDIA repository keyring
-                ansible.builtin.apt:
-                  deb: "{{ cuda_repo_url }}"
-                  state: present
-
-              - name: Update apt cache
-                ansible.builtin.apt:
-                  update_cache: yes
-
-              - name: Install NVIDIA packages
-                ansible.builtin.apt:
-                  name: "{{ item }}"
-                  state: present
-                  allow_downgrade: yes
-                loop: "{{ nvidia_packages }}"
-
-              - name: Freeze NVIDIA packages
-                ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
-                  selection: hold
-                loop: "{{ nvidia_packages }}"
-
-              - name: Create nvidia-persistenced override directory
-                ansible.builtin.file:
-                  path: /etc/systemd/system/nvidia-persistenced.service.d
-                  state: directory
-                  mode: 0o755
-
-              - name: Configure nvidia-persistenced override
-                ansible.builtin.copy:
-                  dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                  mode: 0o644
-                  content: |
-                    [Service]
-                    ExecStart=
-                    ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-                notify: Reload SystemD
-
-            handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
-
-            post_tasks:
-              - name: Disable NVIDIA services by default (Slurm starts them on boot)
-                ansible.builtin.service:
-                  name: "{{ item }}"
-                  state: stopped
-                  enabled: false
-                loop:
-                  - nvidia-dcgm.service
-                  - nvidia-persistenced.service
-
-      - type: ansible-local
-        destination: install_ibverbs_utils.yml
-        content: |
-          ---
-          - name: Install ibverbs-utils
-            hosts: all
-            become: true
-            tasks:
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - ibverbs-utils
-                state: present
-      - type: data
-        destination: /etc/enroot/enroot.conf
-        content: |
-          ENROOT_CONFIG_PATH     ${HOME}/.enroot
-
-- group: image
-  modules:
-  - id: slurm-a4high-image
-    source: modules/packer/custom-image
-    kind: packer
-    settings:
-      disk_size: $(vars.disk_size_gb)
-      machine_type: $(vars.image_build_machine_type)
-      source_image: $(vars.base_image.image)
-      source_image_project_id: [$(vars.base_image.project)]
-      image_family: $(vars.instance_image.family)
-      omit_external_ip: false
-      # Unattended upgrades are disabled in this blueprint so that software does not
-      # get updated daily and lead to potential instability in the cluster environment.
-      #
-      # Unattended Upgrades installs available security updates from the Ubuntu
-      # security pocket for installed packages daily by default. Administrators who
-      # disable this feature assume all responsibility for manually reviewing and
-      # patching their systems against vulnerabilities.
-      #
-      # To enable unattended upgrades, please remove this section.
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
-          write_files:
-          - path: /etc/apt/apt.conf.d/20auto-upgrades
-            permissions: '0644'
-            owner: root
-            content: |
-              APT::Periodic::Update-Package-Lists "0";
-              APT::Periodic::Unattended-Upgrade "0";
-    use:
-    - slurm-image-network
-    - slurm-build-script
 
 - group: cluster-env
   modules:
@@ -451,6 +236,7 @@ deployment_groups:
   - id: a4high_startup
     source: modules/scripts/startup-script
     settings:
+      install_ansible: true
       local_ssd_filesystem:
         mountpoint: $(vars.local_ssd_mountpoint)
         permissions: "1777" # must quote numeric filesystem permissions!
@@ -490,89 +276,53 @@ deployment_groups:
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       # Install NCCL
       - type: ansible-local
-        destination: install_nccl.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: Install nccl
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
             tasks:
-            - name: Update apt cache
-              ansible.builtin.apt:
-                update_cache: yes
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - "libnccl2=$(vars.libnccl_version)"
-                - "libnccl-dev=$(vars.libnccl_version)"
-                state: present
-      # Install NCCL-GIB Plugin
-      - type: ansible-local
-        destination: install_nccl_gib.yml
-        content: |
-          ---
-          - name: Install Google NCCL-GIB Plugin
-            hosts: all
-            become: true
-            tasks:
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://us-apt.pkg.dev/doc/repo-signing-key.gpg
-                state: present
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-                state: present
-            - name: Install Apt Transport AR Apt Repo
-              apt_repository:
-                repo: 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main'
-                state: present
-            - name: Install AR transport
-              ansible.builtin.apt:
-                name: "apt-transport-artifact-registry"
-                update_cache: true
-            - name: Install Google NCCL-GIB Plugin
-              apt_repository:
-                repo: "deb ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-gib-apt main"
-                state: present
-            - name: Install NCCL-GIB Plugin
-              ansible.builtin.apt:
-                name: "nccl-gib=$(vars.nccl_gib_version)"
-                update_cache: true
-            - name: Freeze NCCL GIB Plugin
-              ansible.builtin.dpkg_selections:
-                name: "nccl-gib"
-                selection: hold
-      # --------------------------------------------------------------------------
-      # Environment Configuration
-      # --------------------------------------------------------------------------
-      - type: ansible-local
-        destination: configure_nccl_env.yml
-        name: Ensure NCCL/gIB environment script is sourced for all users
-        content: |
-          ---
-          - name: Configure NCCL/gIB environment
-            hosts: all
-            become: true
-            tasks:
-              - name: Deploy /etc/profile.d/nccl-gib.sh
-                ansible.builtin.copy:
-                  dest: /etc/profile.d/nccl-gib.sh
-                  content: |
-                    # Load NCCL/gIB environment
-                    if [ -f "/usr/local/gib/scripts/set_nccl_env.sh" ]; then
-                      source /usr/local/gib/scripts/set_nccl_env.sh
-                    fi
+              - name: Download CUDA runfile
+                ansible.builtin.get_url:
+                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
+                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  mode: '0755'
 
-                    # Ensure /usr/local/gib/lib64 is in LD_LIBRARY_PATH
-                    if [ -d "/usr/local/gib/lib64" ]; then
-                      export LD_LIBRARY_PATH="/usr/local/gib/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-                    fi
-                  mode: '0644'
-            handlers:
-              - name: Reload SystemD
-                ansible.builtin.systemd:
-                  daemon_reload: true
+              - name: Install CUDA toolkit via runfile
+                ansible.builtin.command:
+                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
+
+              - name: Remove CUDA runfile
+                ansible.builtin.file:
+                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  state: absent
+
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install DCGM packages
+                ansible.builtin.apt:
+                  name:
+                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
+                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
+                    - datacenter-gpu-manager-4-core=1:4.6.0-1
+                  state: present
+
+              - name: Freeze DCGM packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -636,6 +386,10 @@ deployment_groups:
       enable_placement: false
       disk_type: hyperdisk-balanced
       on_host_maintenance: TERMINATE
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
       #Provisioning models
       reservation_name: $(vars.a4h_reservation_name)
@@ -685,12 +439,30 @@ deployment_groups:
     settings:
       disk_size_gb: 300
       enable_login_public_ips: true
-      machine_type: n2-standard-8
+      machine_type: e2-standard-16
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
   - id: controller_startup
     source: modules/scripts/startup-script
     settings:
       runners:
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
+          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
+          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       - type: shell
         destination: stage_scripts.sh
         content: |
@@ -730,6 +502,11 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: 300
-      machine_type: n2-standard-80
+      machine_type: e2-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
+      compute_startup_scripts_timeout: 1800
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true

--- a/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml
@@ -28,8 +28,9 @@ vars:
   instance_image_family: # supply instance image family
   # Image settings
   # Cluster env settings
-  # net0 ranges must not overlap
+  # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
+  filestore_ip_range: 192.168.32.0/24
   net1_range: 192.168.64.0/18
   rdma_net_range: 192.168.128.0/18
   # Cluster Settings
@@ -46,7 +47,24 @@ vars:
   a4h_dws_flex_enabled: false
   a4h_enable_spot_vm: false
 
+  # To enable Managed-Lustre please uncomment this section and fill out the settings.
+  # Additionally, please uncomment the private_service_access and managed-lustre modules.
+  # Managed Lustre is only supported in specific regions and zones
+  # Please refer https://cloud.google.com/managed-lustre/docs/locations
+
+  # Managed-Lustre instance name. This should be unique for each deployment.
+  # lustre_instance_id: lustre-instance
+
+  # The values of size_gib and per_unit_storage_throughput are co-related
+  # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
+  # Storage capacity of the lustre instance in GiB
+  # lustre_size_gib: 36000
+
+  # Maximum throughput of the lustre instance in MBps per TiB
+  # per_unit_storage_throughput: 500
+
 deployment_groups:
+
 - group: cluster-env
   modules:
   - id: a4high-slurm-net-0
@@ -97,6 +115,43 @@ deployment_groups:
         ip_range: $(vars.rdma_net_range)
         region: $(vars.region)
 
+  - id: homefs
+    source: modules/file-system/filestore
+    use:
+    - a4high-slurm-net-0
+    settings:
+      filestore_tier: HIGH_SCALE_SSD
+      size_gb: 10240
+      local_mount: /home
+      reserved_ip_range: $(vars.filestore_ip_range)
+      deletion_protection:
+        enabled: true
+        reason: Avoid data loss
+    outputs:
+    - network_storage
+
+  # To use Managed Lustre as for the shared /home directory:
+  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
+  # 2. Uncomment the managed-lustre and private-service-access blocks
+  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
+  # - id: private_service_access
+  #   source: modules/network/private-service-access
+  #   use: [a4high-slurm-net-0]
+
+  # - id: homefs
+  #   source: modules/file-system/managed-lustre
+  #   use:
+  #   - a4high-slurm-net-0
+  #   - private_service_access
+  #   settings:
+  #     size_gib: $(vars.lustre_size_gib)
+  #     name: $(vars.lustre_instance_id)
+  #     local_mount: /home
+  #     remote_mount: lustrefs
+  #     per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
+  #   outputs:
+  #   - network_storage
+
   # The following four modules create and mount a Cloud Storage Bucket with
   # gcsfuse.  They are optional but recommended for many use cases.
   # (Optional) The following creates a GCS bucket that will be mounted
@@ -110,14 +165,13 @@ deployment_groups:
       enable_hierarchical_namespace: true
       local_mount: /gcs
       random_suffix: true
-      mount_options: "implicit-dirs,\
-                      metadata-cache-negative-ttl-secs=0,\
-                      metadata-cache-ttl-secs=-1,\
-                      stat-cache-max-size-mb=-1,\
-                      type-cache-max-size-mb=-1,\
-                      enable-streaming-writes=true,\
-                      dir-mode=777,\
-                      file-mode=777,\
+      mount_options: "implicit_dirs,\
+                      metadata_cache_negative_ttl_secs=0,\
+                      metadata_cache_ttl_secs=-1,\
+                      stat_cache_max_size_mb=-1,\
+                      type_cache_max_size_mb=-1,\
+                      dir_mode=777,\
+                      file_mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for checkpoint writing/reading Uses
@@ -132,18 +186,10 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-checkpoints
       fs_type: gcsfuse
-      mount_options: "implicit-dirs,\
-                      metadata-cache-negative-ttl-secs=0,\
-                      metadata-cache-ttl-secs=-1,\
-                      stat-cache-max-size-mb=-1,\
-                      type-cache-max-size-mb=-1,\
-                      file-cache-max-size-mb=-1,\
-                      file-cache-cache-file-for-range-read=true,\
-                      file-cache-enable-parallel-downloads=true,\
-                      cache-dir=/mnt/localssd,\
-                      enable-streaming-writes=true,\
-                      dir-mode=777,\
-                      file-mode=777,\
+      mount_options: "profile=aiml-checkpointing,\
+                      cache_dir=/mnt/localssd,\
+                      dir_mode=777,\
+                      file_mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for reading training data.
@@ -165,14 +211,9 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-training-data
       fs_type: gcsfuse
-      mount_options: "implicit-dirs,\
-                      metadata-cache-negative-ttl-secs=0,\
-                      metadata-cache-ttl-secs=-1,\
-                      stat-cache-max-size-mb=-1,\
-                      type-cache-max-size-mb=-1,\
-                      enable-streaming-writes=true,\
-                      dir-mode=777,\
-                      file-mode=777,\
+      mount_options: "profile=aiml-training,\
+                      dir_mode=777,\
+                      file_mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for model serving.
@@ -186,17 +227,10 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-model-serving
       fs_type: gcsfuse
-      mount_options: "implicit-dirs,\
-                      cache-dir=/mnt/localssd,\
-                      metadata-cache-negative-ttl-secs=0,\
-                      metadata-cache-ttl-secs=-1,\
-                      stat-cache-max-size-mb=-1,\
-                      type-cache-max-size-mb=-1,\
-                      file-cache-max-size-mb=-1,\
-                      file-cache-cache-file-for-range-read=true,\
-                      file-cache-enable-parallel-downloads=true,\
-                      dir-mode=777,\
-                      file-mode=777,\
+      mount_options: "profile=aiml-serving,\
+                      cache_dir=/mnt/localssd,\
+                      dir_mode=777,\
+                      file_mode=777,\
                       allow_other"
 
 - group: cluster
@@ -222,6 +256,18 @@ deployment_groups:
       - $(gcs_training_data.mount_runner)
       - $(gcs_model_serving.client_install_runner)
       - $(gcs_model_serving.mount_runner)
+      - type: shell
+        destination: fix_enroot_env.sh
+        content: |
+          #!/bin/bash
+          # 1. Fix Ubuntu 24.04 AppArmor restriction on unprivileged user namespaces
+          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
+            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
+          fi
+          # 2. Ensure /etc/hostname exists (required by enroot-mount)
+          if [ ! -f /etc/hostname ]; then
+            hostname > /etc/hostname
+          fi
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
@@ -230,58 +276,55 @@ deployment_groups:
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
-      # --- DYNAMICALLY GENERATE HOST /etc/hostname ON BOOT TO ALLOW ENROOT BIND-MOUNTS ---
-      - type: shell
-        destination: write_hostname.sh
+      # Install NCCL
+      - type: ansible-local
+        destination: install_cuda_and_dcgm.yml
         content: |
-          #!/bin/bash
-          echo "Checking host /etc/hostname status..."
-          if [ ! -f /etc/hostname ]; then
-            echo "Host /etc/hostname not found! Generating dynamically..."
-            hostname -s | tee /etc/hostname
-            echo "Host /etc/hostname written successfully."
-          else
-            echo "Host /etc/hostname already exists."
-          fi
-      - type: shell
-        destination: install-cuda-toolkit.sh
-        content: |
-          #!/bin/bash
-          set -ex -o pipefail
+          ---
+          - name: Install and Configure CUDA 13 / DCGM
+            hosts: all
+            become: true
+            tasks:
+              - name: Download CUDA runfile
+                ansible.builtin.get_url:
+                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
+                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  mode: '0755'
 
-          CUDA_VERSION="13.0.0"
-          FM_VERSION="580.65.06"
-          FILE_NAME="cuda_${CUDA_VERSION}_${FM_VERSION}_linux.run"
-          URL="https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers/${FILE_NAME}"
+              - name: Install CUDA toolkit via runfile
+                ansible.builtin.command:
+                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
 
-          curl -s -L -o /tmp/$FILE_NAME "$URL"
-          sh /tmp/$FILE_NAME --silent --toolkit
-          rm -f /tmp/$FILE_NAME
-      - type: shell
-        destination: install-dcgm.sh
-        content: |
-          #!/bin/bash
-          set -ex -o pipefail
+              - name: Remove CUDA runfile
+                ansible.builtin.file:
+                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  state: absent
 
-          source /etc/os-release
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+                  state: present
 
-          UBUNTU_VERSION=`echo $VERSION_ID | tr -d '.'`
-          URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/cuda-keyring_1.1-1_all.deb"
-          echo "Downloading keyring from $URL"
-          curl -s -o /tmp/cuda-keyring_1.1-1_all.deb "$URL"
-          dpkg -i /tmp/cuda-keyring_1.1-1_all.deb
-          rm /tmp/cuda-keyring_1.1-1_all.deb
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
 
-          apt-get update -y
-          apt-get install -y \
-              datacenter-gpu-manager-4-cuda13 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
+              - name: Install DCGM packages
+                ansible.builtin.apt:
+                  name:
+                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
+                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
+                    - datacenter-gpu-manager-4-core=1:4.6.0-1
+                  state: present
 
-          apt-mark hold \
-              datacenter-gpu-manager-4-cuda13 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
+              - name: Freeze DCGM packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -345,6 +388,10 @@ deployment_groups:
       enable_placement: false
       disk_type: hyperdisk-balanced
       on_host_maintenance: TERMINATE
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
       #Provisioning models
       reservation_name: $(vars.a4h_reservation_name)
@@ -394,12 +441,22 @@ deployment_groups:
     settings:
       disk_size_gb: 300
       enable_login_public_ips: true
-      machine_type: n2-standard-8
+      machine_type: e2-standard-16
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
   - id: controller_startup
     source: modules/scripts/startup-script
     settings:
       runners:
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
@@ -417,6 +474,7 @@ deployment_groups:
           mkdir -m 0755 -p "${SLURM_ROOT}/scripts"
           # enable a GPU health check that runs at the completion of all jobs on A4 nodes
           mkdir -p "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d"
+          ln -s "/slurm/scripts/tools/gpu-test" "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d/gpu-test.epilog_slurmd"
           # enable the use of password-free sudo within Slurm jobs on all compute nodes
           # feature is restricted to users with OS Admin Login IAM role
           # https://cloud.google.com/iam/docs/understanding-roles#compute.osAdminLogin
@@ -440,11 +498,17 @@ deployment_groups:
     - a4high-slurm-net-0
     - a4high_partition
     - slurm_login
+    - homefs
     - gcs_bucket
     settings:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: 300
-      machine_type: n2-standard-80
+      machine_type: e2-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
+      compute_startup_scripts_timeout: 1800
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true

--- a/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a4high-custom-image-blueprint.yaml
@@ -28,9 +28,8 @@ vars:
   instance_image_family: # supply instance image family
   # Image settings
   # Cluster env settings
-  # net0 and filestore ranges must not overlap
+  # net0 ranges must not overlap
   net0_range: 192.168.0.0/19
-  filestore_ip_range: 192.168.32.0/24
   net1_range: 192.168.64.0/18
   rdma_net_range: 192.168.128.0/18
   # Cluster Settings
@@ -47,24 +46,7 @@ vars:
   a4h_dws_flex_enabled: false
   a4h_enable_spot_vm: false
 
-  # To enable Managed-Lustre please uncomment this section and fill out the settings.
-  # Additionally, please uncomment the private_service_access and managed-lustre modules.
-  # Managed Lustre is only supported in specific regions and zones
-  # Please refer https://cloud.google.com/managed-lustre/docs/locations
-
-  # Managed-Lustre instance name. This should be unique for each deployment.
-  # lustre_instance_id: lustre-instance
-
-  # The values of size_gib and per_unit_storage_throughput are co-related
-  # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
-  # Storage capacity of the lustre instance in GiB
-  # lustre_size_gib: 36000
-
-  # Maximum throughput of the lustre instance in MBps per TiB
-  # per_unit_storage_throughput: 500
-
 deployment_groups:
-
 - group: cluster-env
   modules:
   - id: a4high-slurm-net-0
@@ -115,43 +97,6 @@ deployment_groups:
         ip_range: $(vars.rdma_net_range)
         region: $(vars.region)
 
-  - id: homefs
-    source: modules/file-system/filestore
-    use:
-    - a4high-slurm-net-0
-    settings:
-      filestore_tier: HIGH_SCALE_SSD
-      size_gb: 10240
-      local_mount: /home
-      reserved_ip_range: $(vars.filestore_ip_range)
-      deletion_protection:
-        enabled: true
-        reason: Avoid data loss
-    outputs:
-    - network_storage
-
-  # To use Managed Lustre as for the shared /home directory:
-  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
-  # 2. Uncomment the managed-lustre and private-service-access blocks
-  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
-  # - id: private_service_access
-  #   source: modules/network/private-service-access
-  #   use: [a4high-slurm-net-0]
-
-  # - id: homefs
-  #   source: modules/file-system/managed-lustre
-  #   use:
-  #   - a4high-slurm-net-0
-  #   - private_service_access
-  #   settings:
-  #     size_gib: $(vars.lustre_size_gib)
-  #     name: $(vars.lustre_instance_id)
-  #     local_mount: /home
-  #     remote_mount: lustrefs
-  #     per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
-  #   outputs:
-  #   - network_storage
-
   # The following four modules create and mount a Cloud Storage Bucket with
   # gcsfuse.  They are optional but recommended for many use cases.
   # (Optional) The following creates a GCS bucket that will be mounted
@@ -165,13 +110,14 @@ deployment_groups:
       enable_hierarchical_namespace: true
       local_mount: /gcs
       random_suffix: true
-      mount_options: "implicit_dirs,\
-                      metadata_cache_negative_ttl_secs=0,\
-                      metadata_cache_ttl_secs=-1,\
-                      stat_cache_max_size_mb=-1,\
-                      type_cache_max_size_mb=-1,\
-                      dir_mode=777,\
-                      file_mode=777,\
+      mount_options: "implicit-dirs,\
+                      metadata-cache-negative-ttl-secs=0,\
+                      metadata-cache-ttl-secs=-1,\
+                      stat-cache-max-size-mb=-1,\
+                      type-cache-max-size-mb=-1,\
+                      enable-streaming-writes=true,\
+                      dir-mode=777,\
+                      file-mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for checkpoint writing/reading Uses
@@ -186,10 +132,18 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-checkpoints
       fs_type: gcsfuse
-      mount_options: "profile=aiml-checkpointing,\
-                      cache_dir=/mnt/localssd,\
-                      dir_mode=777,\
-                      file_mode=777,\
+      mount_options: "implicit-dirs,\
+                      metadata-cache-negative-ttl-secs=0,\
+                      metadata-cache-ttl-secs=-1,\
+                      stat-cache-max-size-mb=-1,\
+                      type-cache-max-size-mb=-1,\
+                      file-cache-max-size-mb=-1,\
+                      file-cache-cache-file-for-range-read=true,\
+                      file-cache-enable-parallel-downloads=true,\
+                      cache-dir=/mnt/localssd,\
+                      enable-streaming-writes=true,\
+                      dir-mode=777,\
+                      file-mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for reading training data.
@@ -211,9 +165,14 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-training-data
       fs_type: gcsfuse
-      mount_options: "profile=aiml-training,\
-                      dir_mode=777,\
-                      file_mode=777,\
+      mount_options: "implicit-dirs,\
+                      metadata-cache-negative-ttl-secs=0,\
+                      metadata-cache-ttl-secs=-1,\
+                      stat-cache-max-size-mb=-1,\
+                      type-cache-max-size-mb=-1,\
+                      enable-streaming-writes=true,\
+                      dir-mode=777,\
+                      file-mode=777,\
                       allow_other"
 
   # (Optional) Create a mount-point optimized for model serving.
@@ -227,10 +186,17 @@ deployment_groups:
       remote_mount: $(gcs_bucket.gcs_bucket_name)
       local_mount: /gcs-model-serving
       fs_type: gcsfuse
-      mount_options: "profile=aiml-serving,\
-                      cache_dir=/mnt/localssd,\
-                      dir_mode=777,\
-                      file_mode=777,\
+      mount_options: "implicit-dirs,\
+                      cache-dir=/mnt/localssd,\
+                      metadata-cache-negative-ttl-secs=0,\
+                      metadata-cache-ttl-secs=-1,\
+                      stat-cache-max-size-mb=-1,\
+                      type-cache-max-size-mb=-1,\
+                      file-cache-max-size-mb=-1,\
+                      file-cache-cache-file-for-range-read=true,\
+                      file-cache-enable-parallel-downloads=true,\
+                      dir-mode=777,\
+                      file-mode=777,\
                       allow_other"
 
 - group: cluster
@@ -256,18 +222,6 @@ deployment_groups:
       - $(gcs_training_data.mount_runner)
       - $(gcs_model_serving.client_install_runner)
       - $(gcs_model_serving.mount_runner)
-      - type: shell
-        destination: fix_enroot_env.sh
-        content: |
-          #!/bin/bash
-          # 1. Fix Ubuntu 24.04 AppArmor restriction on unprivileged user namespaces
-          if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
-            echo 0 > /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-          fi
-          # 2. Ensure /etc/hostname exists (required by enroot-mount)
-          if [ ! -f /etc/hostname ]; then
-            hostname > /etc/hostname
-          fi
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
@@ -276,55 +230,58 @@ deployment_groups:
           ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
-      # Install NCCL
-      - type: ansible-local
-        destination: install_cuda_and_dcgm.yml
+      # --- DYNAMICALLY GENERATE HOST /etc/hostname ON BOOT TO ALLOW ENROOT BIND-MOUNTS ---
+      - type: shell
+        destination: write_hostname.sh
         content: |
-          ---
-          - name: Install and Configure CUDA 13 / DCGM
-            hosts: all
-            become: true
-            tasks:
-              - name: Download CUDA runfile
-                ansible.builtin.get_url:
-                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
-                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
-                  mode: '0755'
+          #!/bin/bash
+          echo "Checking host /etc/hostname status..."
+          if [ ! -f /etc/hostname ]; then
+            echo "Host /etc/hostname not found! Generating dynamically..."
+            hostname -s | tee /etc/hostname
+            echo "Host /etc/hostname written successfully."
+          else
+            echo "Host /etc/hostname already exists."
+          fi
+      - type: shell
+        destination: install-cuda-toolkit.sh
+        content: |
+          #!/bin/bash
+          set -ex -o pipefail
 
-              - name: Install CUDA toolkit via runfile
-                ansible.builtin.command:
-                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
+          CUDA_VERSION="13.0.0"
+          FM_VERSION="580.65.06"
+          FILE_NAME="cuda_${CUDA_VERSION}_${FM_VERSION}_linux.run"
+          URL="https://developer.download.nvidia.com/compute/cuda/${CUDA_VERSION}/local_installers/${FILE_NAME}"
 
-              - name: Remove CUDA runfile
-                ansible.builtin.file:
-                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
-                  state: absent
+          curl -s -L -o /tmp/$FILE_NAME "$URL"
+          sh /tmp/$FILE_NAME --silent --toolkit
+          rm -f /tmp/$FILE_NAME
+      - type: shell
+        destination: install-dcgm.sh
+        content: |
+          #!/bin/bash
+          set -ex -o pipefail
 
-              - name: Install NVIDIA repository keyring
-                ansible.builtin.apt:
-                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
-                  state: present
+          source /etc/os-release
 
-              - name: Update apt cache
-                ansible.builtin.apt:
-                  update_cache: yes
+          UBUNTU_VERSION=`echo $VERSION_ID | tr -d '.'`
+          URL="https://developer.download.nvidia.com/compute/cuda/repos/ubuntu${UBUNTU_VERSION}/x86_64/cuda-keyring_1.1-1_all.deb"
+          echo "Downloading keyring from $URL"
+          curl -s -o /tmp/cuda-keyring_1.1-1_all.deb "$URL"
+          dpkg -i /tmp/cuda-keyring_1.1-1_all.deb
+          rm /tmp/cuda-keyring_1.1-1_all.deb
 
-              - name: Install DCGM packages
-                ansible.builtin.apt:
-                  name:
-                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
-                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
-                    - datacenter-gpu-manager-4-core=1:4.6.0-1
-                  state: present
+          apt-get update -y
+          apt-get install -y \
+              datacenter-gpu-manager-4-cuda13 \
+              datacenter-gpu-manager-4-dev \
+              datacenter-gpu-manager-4-core
 
-              - name: Freeze DCGM packages
-                ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
-                  selection: hold
-                loop:
-                  - datacenter-gpu-manager-4-cuda13
-                  - datacenter-gpu-manager-4-dev
-                  - datacenter-gpu-manager-4-core
+          apt-mark hold \
+              datacenter-gpu-manager-4-cuda13 \
+              datacenter-gpu-manager-4-dev \
+              datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -388,10 +345,6 @@ deployment_groups:
       enable_placement: false
       disk_type: hyperdisk-balanced
       on_host_maintenance: TERMINATE
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
 
       #Provisioning models
       reservation_name: $(vars.a4h_reservation_name)
@@ -441,22 +394,12 @@ deployment_groups:
     settings:
       disk_size_gb: 300
       enable_login_public_ips: true
-      machine_type: e2-standard-16
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
+      machine_type: n2-standard-8
 
   - id: controller_startup
     source: modules/scripts/startup-script
     settings:
       runners:
-      - type: shell
-        destination: ensure_mnt_localssd_permissions.sh
-        content: |
-          #!/bin/bash
-          mkdir -p /mnt/localssd
-          chmod 1777 /mnt/localssd
       - type: data
         destination: /etc/enroot/enroot.conf
         content: |
@@ -474,7 +417,6 @@ deployment_groups:
           mkdir -m 0755 -p "${SLURM_ROOT}/scripts"
           # enable a GPU health check that runs at the completion of all jobs on A4 nodes
           mkdir -p "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d"
-          ln -s "/slurm/scripts/tools/gpu-test" "${SLURM_ROOT}/partition-${PARTITION_NAME}-epilog_slurmd.d/gpu-test.epilog_slurmd"
           # enable the use of password-free sudo within Slurm jobs on all compute nodes
           # feature is restricted to users with OS Admin Login IAM role
           # https://cloud.google.com/iam/docs/understanding-roles#compute.osAdminLogin
@@ -498,17 +440,11 @@ deployment_groups:
     - a4high-slurm-net-0
     - a4high_partition
     - slurm_login
-    - homefs
     - gcs_bucket
     settings:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: 300
-      machine_type: e2-standard-16
+      machine_type: n2-standard-80
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
-      compute_startup_scripts_timeout: 1800
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -14,7 +14,6 @@
 
 ---
 tags:
-- m.custom-image
 - m.cloud-storage-bucket
 - m.pre-existing-network-storage
 - m.filestore


### PR DESCRIPTION
Replacing the Ubuntu accelerator image with ACI image in A4high blueprint.

Integration tests and NCCL tests passed successfully.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
