### PR TITLE
add nvlink checks to cluster health check daemon

### DIFF
--- a/community/cluster-health-check/README.md
+++ b/community/cluster-health-check/README.md
@@ -116,7 +116,7 @@ bash build-and-push-cluster-health-check.sh \
     -v "0.0.3"
 ```
 
-## Active Tests and Logs
+## Tests and Logs
 
 The healthcheck daemon actively monitors the following items by running specific commands on the node:
 
@@ -126,4 +126,4 @@ The healthcheck daemon actively monitors the following items by running specific
 - **PCIe link health**: Monitors PCIe link width consistency via `nvidia-smi --query-gpu=pcie.link.width.current,pcie.link.width.max --format=csv,noheader,nounits`.
 - **InfiniBand links**: Verifies InfiniBand port state and link layer status via `ibstat`.
 - **GPU temperature**: Monitors GPU temperatures against predefined thermal limits via `nvidia-smi --query-gpu=temperature.gpu,temperature.gpu.tlimit --format=csv,noheader,nounits`.
-- **NVLink health**: Checks for fatal NVLink errors and alignment issues via `nvidia-smi nvlink -s` and `nvidia-smi nvlink -e` (A4x nodes only).
+- **NVLink health**: Checks for fatal NVLink errors and alignment issues via `nvidia-smi nvlink -s` and `nvidia-smi nvlink -e` (A4x family nodes only).

--- a/community/cluster-health-check/README.md
+++ b/community/cluster-health-check/README.md
@@ -115,3 +115,15 @@ bash build-and-push-cluster-health-check.sh \
     -l "us-east1" \
     -v "0.0.3"
 ```
+
+## Active Tests and Logs
+
+The healthcheck daemon actively monitors the following items by running specific commands on the node:
+
+- **dcgmi health**: Detects hardware issues via DCGM using `dcgmi health -c -j`.
+- **XID/SXID monitoring**: Scans kernel logs for NVIDIA XID and NVSwitch SXID errors via `dmesg --since <daemon-start-time>`.
+- **ECC errors**: Checks for uncorrectable ECC memory errors via `nvidia-smi --query-gpu=ecc.errors.corrected.volatile.total,ecc.errors.uncorrected.volatile.total --format=csv,noheader,nounits`.
+- **PCIe link health**: Monitors PCIe link width consistency via `nvidia-smi --query-gpu=pcie.link.width.current,pcie.link.width.max --format=csv,noheader,nounits`.
+- **InfiniBand links**: Verifies InfiniBand port state and link layer status via `ibstat`.
+- **GPU temperature**: Monitors GPU temperatures against predefined thermal limits via `nvidia-smi --query-gpu=temperature.gpu,temperature.gpu.tlimit --format=csv,noheader,nounits`.
+- **NVLink health**: Checks for fatal NVLink errors and alignment issues via `nvidia-smi nvlink -s` and `nvidia-smi nvlink -e` (A4x nodes only).

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
@@ -222,9 +222,16 @@ func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, no
 		{"GPU temperature", checkTemperature},
 		// {"HCA Firmware", checkHCAFW},
 		// {"GPU Power draw", checkPower},
-		{"NVLink health", func(ctx context.Context) (string, error) {
+		{"NVLink bandwidth", func(ctx context.Context) (string, error) {
 			if isA4x(node) {
-				return checkNVLinkSmi(ctx)
+				return checkNVLinkBandwidth(ctx)
+			} else {
+				return "", nil
+			}
+		}},
+		{"NVLink errors", func(ctx context.Context) (string, error) {
+			if isA4x(node) {
+				return checkNVLinkErrors(ctx)
 			} else {
 				return "", nil
 			}
@@ -337,7 +344,8 @@ func runDcgmiHealth(ctx context.Context) (string, error) {
 
 	if overallHealthVal != "Healthy" {
 		severity := SeverityWarning
-		if strings.ToLower(overallHealthVal) == SeverityFailure {
+		normalizedSev := strings.ToLower(strings.TrimSpace(overallHealthVal))
+		if normalizedSev == SeverityFailure {
 			severity = SeverityFailure
 		}
 
@@ -762,12 +770,6 @@ func isA4x(node *corev1.Node) bool {
 	return strings.Contains(accel, "gb300") || strings.Contains(accel, "gb200") || strings.Contains(machine, "a4x")
 }
 
-func checkNVLinkSmi(ctx context.Context) (string, error) {
-	if sev, err := checkNVLinkBandwidth(ctx); err != nil {
-		return sev, err
-	}
-	return checkNVLinkErrors(ctx)
-}
 
 var nvlinkStatusRegex = regexp.MustCompile(`^\s*Link\s+\d+:\s+([0-9.]+)\s+GB/s`)
 var gpuLineRegex = regexp.MustCompile(`^(GPU\s+\d+).*?\b(UUID:\s*[^)]+)`)

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
@@ -770,7 +770,6 @@ func isA4x(node *corev1.Node) bool {
 	return strings.Contains(accel, "gb300") || strings.Contains(accel, "gb200") || strings.Contains(machine, "a4x")
 }
 
-
 var nvlinkStatusRegex = regexp.MustCompile(`^\s*Link\s+\d+:\s+([0-9.]+)\s+GB/s`)
 var gpuLineRegex = regexp.MustCompile(`^(GPU\s+\d+).*?\b(UUID:\s*[^)]+)`)
 

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
@@ -58,7 +58,7 @@ const (
 	SeverityFatal   = "fatal"
 	SeverityInfo    = "info"
 
-	A4xExpectedNvlinkSpeed = 53.125
+	A4xExpectedNvlinkSpeed = 50.0
 )
 
 func main() {
@@ -239,19 +239,7 @@ func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, no
 		errorMessages = append(errorMessages, fmt.Sprintf("%s: %v", chk.name, err))
 	}
 
-	hasIssue := false
-	conditionExists := false
-	var currentReason string
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == corev1.NodeConditionType(ConditionTypeGPUUnhealthy) {
-			conditionExists = true
-			if condition.Status == corev1.ConditionTrue {
-				hasIssue = true
-			}
-			currentReason = string(condition.Reason)
-			break
-		}
-	}
+	hasIssue, conditionExists, currentReason := getConditionStatus(node)
 
 	_, hasStatus := node.Labels[LabelHealthStatus]
 
@@ -275,6 +263,20 @@ func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, no
 	}
 
 	updateNodeHealth(ctx, clientset, node, reason, highestSeverity, desiredMessage)
+}
+
+func getConditionStatus(node *corev1.Node) (hasIssue bool, conditionExists bool, currentReason string) {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == corev1.NodeConditionType(ConditionTypeGPUUnhealthy) {
+			conditionExists = true
+			if condition.Status == corev1.ConditionTrue {
+				hasIssue = true
+			}
+			currentReason = string(condition.Reason)
+			break
+		}
+	}
+	return hasIssue, conditionExists, currentReason
 }
 
 func extractOverflowMessages(v interface{}) []string {
@@ -768,6 +770,15 @@ func checkNVLinkSmi(ctx context.Context) (string, error) {
 }
 
 var nvlinkStatusRegex = regexp.MustCompile(`^\s*Link\s+\d+:\s+([0-9.]+)\s+GB/s`)
+var gpuLineRegex = regexp.MustCompile(`^(GPU\s+\d+).*?\b(UUID:\s*[^)]+)`)
+
+func formatGPUName(line string) string {
+	matches := gpuLineRegex.FindStringSubmatch(line)
+	if len(matches) == 3 {
+		return fmt.Sprintf("%s (%s)", matches[1], matches[2])
+	}
+	return strings.TrimSpace(line)
+}
 
 func checkNVLinkBandwidth(ctx context.Context) (string, error) {
 	outS, err := exec.CommandContext(ctx, nvidiaSmiPath(), "nvlink", "-s").CombinedOutput()
@@ -775,12 +786,17 @@ func checkNVLinkBandwidth(ctx context.Context) (string, error) {
 		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -s failed: %v", err)
 	}
 
+	currentGPU := "Unknown GPU"
 	for _, line := range strings.Split(string(outS), "\n") {
+		if strings.HasPrefix(line, "GPU ") {
+			currentGPU = formatGPUName(line)
+			continue
+		}
 		matches := nvlinkStatusRegex.FindStringSubmatch(line)
 		if len(matches) > 1 {
 			if speed, err := strconv.ParseFloat(matches[1], 64); err == nil {
 				if speed < A4xExpectedNvlinkSpeed {
-					return SeverityWarning, fmt.Errorf("unexpected nvlink bandwidth: got %v GB/s, expected %v GB/s", speed, A4xExpectedNvlinkSpeed)
+					return SeverityWarning, fmt.Errorf("unexpected nvlink bandwidth on %s: got %v GB/s, expected %v GB/s", currentGPU, speed, A4xExpectedNvlinkSpeed)
 				}
 			}
 		}
@@ -795,8 +811,13 @@ func checkNVLinkErrors(ctx context.Context) (string, error) {
 		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -e failed: %v", err)
 	}
 
+	currentGPU := "Unknown GPU"
 	for _, line := range strings.Split(string(outE), "\n") {
-		if err := parseNVLinkErrorLine(line); err != nil {
+		if strings.HasPrefix(line, "GPU ") {
+			currentGPU = formatGPUName(line)
+			continue
+		}
+		if err := parseNVLinkErrorLine(currentGPU, line); err != nil {
 			return SeverityWarning, err
 		}
 	}
@@ -804,7 +825,7 @@ func checkNVLinkErrors(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-func parseNVLinkErrorLine(line string) error {
+func parseNVLinkErrorLine(gpu, line string) error {
 	line = strings.TrimSpace(line)
 	if !strings.HasPrefix(line, "Link ") {
 		return nil
@@ -823,28 +844,32 @@ func parseNVLinkErrorLine(line string) error {
 	}
 
 	if metricName == "Effective BER" || metricName == "Symbol BER" {
-		return checkBERThreshold(metricName, valStr, line)
+		return checkBERThreshold(gpu, metricName, valStr, line)
+	}
+
+	if metricName == "PLR Xmit Blocks" {
+		return nil
 	}
 
 	if !strings.Contains(metricName, "packets") && !strings.Contains(metricName, "bytes") {
 		if val, err := strconv.ParseInt(valStr, 10, 64); err == nil && val > 0 {
-			return fmt.Errorf("nvlink error detected: %s", line)
+			return fmt.Errorf("nvlink error detected on %s: %s", gpu, line)
 		}
 	}
 
 	return nil
 }
 
-func checkBERThreshold(metricName, valStr, line string) error {
+func checkBERThreshold(gpu, metricName, valStr, line string) error {
 	val, err := strconv.ParseFloat(valStr, 64)
 	if err != nil {
 		return nil
 	}
 	if metricName == "Effective BER" && val > 1e-9 {
-		return fmt.Errorf("nvlink effective BER degraded: %s", line)
+		return fmt.Errorf("nvlink effective BER degraded on %s: %s", gpu, line)
 	}
 	if metricName == "Symbol BER" && val > 1e-25 {
-		return fmt.Errorf("nvlink symbol BER active breakdown: %s", line)
+		return fmt.Errorf("nvlink symbol BER active breakdown on %s: %s", gpu, line)
 	}
 	return nil
 }

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
@@ -775,7 +775,7 @@ func checkNVLinkBandwidth(ctx context.Context) (string, error) {
 		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -s failed: %v", err)
 	}
 
-	for line := range strings.SplitSeq(string(outS), "\n") {
+	for _, line := range strings.Split(string(outS), "\n") {
 		matches := nvlinkStatusRegex.FindStringSubmatch(line)
 		if len(matches) > 1 {
 			if speed, err := strconv.ParseFloat(matches[1], 64); err == nil {
@@ -795,7 +795,7 @@ func checkNVLinkErrors(ctx context.Context) (string, error) {
 		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -e failed: %v", err)
 	}
 
-	for line := range strings.SplitSeq(string(outE), "\n") {
+	for _, line := range strings.Split(string(outE), "\n") {
 		if err := parseNVLinkErrorLine(line); err != nil {
 			return SeverityWarning, err
 		}

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main.go
@@ -57,6 +57,8 @@ const (
 	SeverityFailure = "failure"
 	SeverityFatal   = "fatal"
 	SeverityInfo    = "info"
+
+	A4xExpectedNvlinkSpeed = 53.125
 )
 
 func main() {
@@ -189,6 +191,12 @@ func parseFatalXids(data []byte) map[int]struct{} {
 }
 
 func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, nodeLister corev1listers.NodeLister, nodeName string, startTime time.Time) {
+	node, err := nodeLister.Get(nodeName)
+	if err != nil {
+		log.Printf("Failed to get node %s from cache: %v", nodeName, err)
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(mainCtx, 5*time.Minute)
 	defer cancel()
 
@@ -207,13 +215,20 @@ func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, no
 	}{
 		{"dcgmi health", runDcgmiHealth},
 		// {"NIC heartbeat", checkNICHeartbeat},
-		{"XID/SXID monitoring", func(c context.Context) (string, error) { return checkKernelLogsForXidSxid(c, fatalXids, startTime) }},
+		{"XID/SXID monitoring", func(ctx context.Context) (string, error) { return checkKernelLogsForXidSxid(ctx, fatalXids, startTime) }},
 		{"ECC errors", checkECCErrors},
 		{"PCIe link health", checkPCIe},
 		{"InfiniBand links", checkIB},
 		{"GPU temperature", checkTemperature},
 		// {"HCA Firmware", checkHCAFW},
 		// {"GPU Power draw", checkPower},
+		{"NVLink health", func(ctx context.Context) (string, error) {
+			if isA4x(node) {
+				return checkNVLinkSmi(ctx)
+			} else {
+				return "", nil
+			}
+		}},
 	}
 	for _, chk := range passiveChecks {
 		sev, err := chk.fn(ctx)
@@ -222,12 +237,6 @@ func runHealthCheck(mainCtx context.Context, clientset *kubernetes.Clientset, no
 		}
 		highestSeverity = mergeStatus(highestSeverity, sev)
 		errorMessages = append(errorMessages, fmt.Sprintf("%s: %v", chk.name, err))
-	}
-
-	node, err := nodeLister.Get(nodeName)
-	if err != nil {
-		log.Printf("Failed to get node %s from cache: %v", nodeName, err)
-		return
 	}
 
 	hasIssue := false
@@ -740,4 +749,102 @@ func clearNodeHealth(ctx context.Context, clientset *kubernetes.Clientset, nodeN
 			log.Printf("Info: Attempted to clear health labels on node %s: %v", nodeName, err)
 		}
 	}
+}
+
+func isA4x(node *corev1.Node) bool {
+	if node == nil || node.Labels == nil {
+		return false
+	}
+	accel := strings.ToLower(node.Labels["cloud.google.com/gke-accelerator"])
+	machine := strings.ToLower(node.Labels["cloud.google.com/machine-family"])
+	return strings.Contains(accel, "gb300") || strings.Contains(accel, "gb200") || strings.Contains(machine, "a4x")
+}
+
+func checkNVLinkSmi(ctx context.Context) (string, error) {
+	if sev, err := checkNVLinkBandwidth(ctx); err != nil {
+		return sev, err
+	}
+	return checkNVLinkErrors(ctx)
+}
+
+var nvlinkStatusRegex = regexp.MustCompile(`^\s*Link\s+\d+:\s+([0-9.]+)\s+GB/s`)
+
+func checkNVLinkBandwidth(ctx context.Context) (string, error) {
+	outS, err := exec.CommandContext(ctx, nvidiaSmiPath(), "nvlink", "-s").CombinedOutput()
+	if err != nil {
+		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -s failed: %v", err)
+	}
+
+	for line := range strings.SplitSeq(string(outS), "\n") {
+		matches := nvlinkStatusRegex.FindStringSubmatch(line)
+		if len(matches) > 1 {
+			if speed, err := strconv.ParseFloat(matches[1], 64); err == nil {
+				if speed < A4xExpectedNvlinkSpeed {
+					return SeverityWarning, fmt.Errorf("unexpected nvlink bandwidth: got %v GB/s, expected %v GB/s", speed, A4xExpectedNvlinkSpeed)
+				}
+			}
+		}
+	}
+
+	return "", nil
+}
+
+func checkNVLinkErrors(ctx context.Context) (string, error) {
+	outE, err := exec.CommandContext(ctx, nvidiaSmiPath(), "nvlink", "-e").CombinedOutput()
+	if err != nil {
+		return SeverityWarning, fmt.Errorf("nvidia-smi nvlink -e failed: %v", err)
+	}
+
+	for line := range strings.SplitSeq(string(outE), "\n") {
+		if err := parseNVLinkErrorLine(line); err != nil {
+			return SeverityWarning, err
+		}
+	}
+
+	return "", nil
+}
+
+func parseNVLinkErrorLine(line string) error {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "Link ") {
+		return nil
+	}
+
+	parts := strings.SplitN(line, ":", 3)
+	if len(parts) != 3 {
+		return nil
+	}
+
+	metricName := strings.TrimSpace(parts[1])
+	valStr := strings.TrimSpace(parts[2])
+
+	if strings.HasPrefix(metricName, "FEC Errors") {
+		return nil
+	}
+
+	if metricName == "Effective BER" || metricName == "Symbol BER" {
+		return checkBERThreshold(metricName, valStr, line)
+	}
+
+	if !strings.Contains(metricName, "packets") && !strings.Contains(metricName, "bytes") {
+		if val, err := strconv.ParseInt(valStr, 10, 64); err == nil && val > 0 {
+			return fmt.Errorf("nvlink error detected: %s", line)
+		}
+	}
+
+	return nil
+}
+
+func checkBERThreshold(metricName, valStr, line string) error {
+	val, err := strconv.ParseFloat(valStr, 64)
+	if err != nil {
+		return nil
+	}
+	if metricName == "Effective BER" && val > 1e-9 {
+		return fmt.Errorf("nvlink effective BER degraded: %s", line)
+	}
+	if metricName == "Symbol BER" && val > 1e-25 {
+		return fmt.Errorf("nvlink symbol BER active breakdown: %s", line)
+	}
+	return nil
 }

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
@@ -237,11 +237,12 @@ func TestParseNVLinkErrorLine(t *testing.T) {
 		{"Link 2: Link recovery failed events: 1", true}, // Error condition!
 		{"Link 3: Effective Errors: 0", false},           // Count is 0, safe
 		{"Link 0: Symbol Errors: 2", true},               // Error condition!
+		{"Link 0: PLR Xmit Blocks: 1234567890", false},   // Safe ignore
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.line, func(t *testing.T) {
-			err := parseNVLinkErrorLine(tc.line)
+			err := parseNVLinkErrorLine("GPU X", tc.line)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("parseNVLinkErrorLine(%q) error = %v, wantErr %v", tc.line, err, tc.wantErr)
 			}
@@ -271,9 +272,115 @@ func TestCheckBERThreshold(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := checkBERThreshold(tc.tag, tc.val, "dummy line")
+			err := checkBERThreshold("GPU X", tc.tag, tc.val, "dummy line")
 			if (err != nil) != tc.wantErr {
 				t.Errorf("checkBERThreshold(%q, %q) error = %v, wantErr %v", tc.tag, tc.val, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestFormatGPUName(t *testing.T) {
+	tests := []struct {
+		desc     string
+		line     string
+		expected string
+	}{
+		{
+			desc:     "Valid GPU and UUID",
+			line:     "GPU 0: NVIDIA GB200 (UUID: GPU-4fa1a8a8-f788-6a1a-41be-dcb11f40a232)",
+			expected: "GPU 0 (UUID: GPU-4fa1a8a8-f788-6a1a-41be-dcb11f40a232)",
+		},
+		{
+			desc:     "Another valid GPU with different wording",
+			line:     "GPU 1: NVIDIA H100 (UUID: GPU-12345678)",
+			expected: "GPU 1 (UUID: GPU-12345678)",
+		},
+		{
+			desc:     "Invalid line format without UUID",
+			line:     "GPU 0: NVIDIA GB200",
+			expected: "GPU 0: NVIDIA GB200", // Fallback to TrimSpace
+		},
+		{
+			desc:     "Empty line",
+			line:     "   ",
+			expected: "", // Fallback to TrimSpace
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := formatGPUName(tc.line)
+			if got != tc.expected {
+				t.Errorf("formatGPUName(%q) = %q, expected %q", tc.line, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetConditionStatus(t *testing.T) {
+	unhealthyType := corev1.NodeConditionType(ConditionTypeGPUUnhealthy)
+
+	tests := []struct {
+		desc               string
+		conditions         []corev1.NodeCondition
+		wantHasIssue       bool
+		wantConditionExist bool
+		wantReason         string
+	}{
+		{
+			desc:               "No conditions",
+			conditions:         []corev1.NodeCondition{},
+			wantHasIssue:       false,
+			wantConditionExist: false,
+			wantReason:         "",
+		},
+		{
+			desc: "Irrelevant condition",
+			conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+			wantHasIssue:       false,
+			wantConditionExist: false,
+			wantReason:         "",
+		},
+		{
+			desc: "GPU unhealthy condition present but false",
+			conditions: []corev1.NodeCondition{
+				{Type: unhealthyType, Status: corev1.ConditionFalse, Reason: "Resolved"},
+			},
+			wantHasIssue:       false,
+			wantConditionExist: true,
+			wantReason:         "Resolved",
+		},
+		{
+			desc: "GPU unhealthy condition present and true",
+			conditions: []corev1.NodeCondition{
+				{Type: unhealthyType, Status: corev1.ConditionTrue, Reason: string(ReasonActiveTestFailed)},
+			},
+			wantHasIssue:       true,
+			wantConditionExist: true,
+			wantReason:         string(ReasonActiveTestFailed),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			node := &corev1.Node{
+				Status: corev1.NodeStatus{
+					Conditions: tc.conditions,
+				},
+			}
+			gotHasIssue, gotConditionExist, gotReason := getConditionStatus(node)
+
+			if gotHasIssue != tc.wantHasIssue {
+				t.Errorf("hasIssue = %v, want %v", gotHasIssue, tc.wantHasIssue)
+			}
+			if gotConditionExist != tc.wantConditionExist {
+				t.Errorf("conditionExists = %v, want %v", gotConditionExist, tc.wantConditionExist)
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("currentReason = %v, want %v", gotReason, tc.wantReason)
 			}
 		})
 	}

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
@@ -17,6 +17,9 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestGetSeverity(t *testing.T) {
@@ -153,5 +156,125 @@ func TestParseFatalXids(t *testing.T) {
 		if got := parseFatalXids(test.input); !reflect.DeepEqual(got, test.expected) {
 			t.Errorf("parseFatalXids(%s) = %v, expected %v", test.desc, got, test.expected)
 		}
+	}
+}
+
+func TestIsA4x(t *testing.T) {
+	tests := []struct {
+		desc     string
+		labels   map[string]string
+		expected bool
+	}{
+		{
+			desc:     "A4X Accelerator label",
+			labels:   map[string]string{"cloud.google.com/gke-accelerator": "nvidia-gb200"},
+			expected: true,
+		},
+		{
+			desc:     "A4X Max Accelerator label",
+			labels:   map[string]string{"cloud.google.com/gke-accelerator": "nvidia-gb300"},
+			expected: true,
+		},
+		{
+			desc:     "A4X Machine Family",
+			labels:   map[string]string{"cloud.google.com/machine-family": "a4x"},
+			expected: true,
+		},
+		{
+			desc:     "A4X Max Machine Type",
+			labels:   map[string]string{"cloud.google.com/machine-family": "a4x", "cloud.google.com/gke-accelerator": "nvidia-gb300"},
+			expected: true,
+		},
+		{
+			desc:     "B200 / A4 Machine Family",
+			labels:   map[string]string{"cloud.google.com/machine-family": "a4", "cloud.google.com/gke-accelerator": "nvidia-b200"},
+			expected: false,
+		},
+		{
+			desc:     "No matching labels",
+			labels:   map[string]string{"cloud.google.com/machine-family": "a3-megagpu-8g"},
+			expected: false,
+		},
+		{
+			desc:     "Empty Map",
+			labels:   map[string]string{},
+			expected: false,
+		},
+		{
+			desc:     "Nil Node",
+			labels:   nil,
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			var node *corev1.Node
+			if tc.desc != "Nil Node" {
+				node = &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: tc.labels,
+					},
+				}
+			}
+			if got := isA4x(node); got != tc.expected {
+				t.Errorf("isA4x() = %v, expected %v", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseNVLinkErrorLine(t *testing.T) {
+	tests := []struct {
+		line    string
+		wantErr bool
+	}{
+		{"Link 0: FEC Errors - 0: 17941761", false},      // Safe ignore
+		{"Link 0: Tx packets: 12345", false},             // Ignore non-error metric
+		{"GPU 0: unhandled format", false},               // Unhandled syntax
+		{"Link 0: Buffer overrun Errors: 1", true},       // Error condition!
+		{"Link 1: Rx Errors: 50", true},                  // Error condition!
+		{"Link 2: Link recovery failed events: 1", true}, // Error condition!
+		{"Link 3: Effective Errors: 0", false},           // Count is 0, safe
+		{"Link 0: Symbol Errors: 2", true},               // Error condition!
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.line, func(t *testing.T) {
+			err := parseNVLinkErrorLine(tc.line)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("parseNVLinkErrorLine(%q) error = %v, wantErr %v", tc.line, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckBERThreshold(t *testing.T) {
+	tests := []struct {
+		desc    string
+		tag     string
+		val     string
+		wantErr bool
+	}{
+		{"Effective BER safely under edge", "Effective BER", "1e-10", false},
+		{"Effective BER exactly at edge", "Effective BER", "1e-9", false},
+		{"Effective BER slightly over edge", "Effective BER", "1.1e-9", true},
+		{"Effective BER significantly over", "Effective BER", "5e-6", true},
+
+		{"Symbol BER safely under edge", "Symbol BER", "1e-26", false},
+		{"Symbol BER exactly at edge", "Symbol BER", "1e-25", false},
+		{"Symbol BER slightly over edge", "Symbol BER", "2e-25", true},
+
+		{"Invalid float parsing", "Effective BER", "NaN", false}, // Fails parse, should ignore cleanly
+		{"Unknown tag bypass", "Unknown BER", "1e-5", false},     // Ignored threshold type
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			err := checkBERThreshold(tc.tag, tc.val, "dummy line")
+			if (err != nil) != tc.wantErr {
+				t.Errorf("checkBERThreshold(%q, %q) error = %v, wantErr %v", tc.tag, tc.val, err, tc.wantErr)
+			}
+		})
 	}
 }

--- a/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
+++ b/community/cluster-health-check/cmd/dcgm-healthcheck/main_test.go
@@ -385,3 +385,61 @@ func TestGetConditionStatus(t *testing.T) {
 		})
 	}
 }
+
+func TestNvlinkStatusRegex(t *testing.T) {
+	tests := []struct {
+		desc  string
+		line  string
+		want  string
+		match bool
+	}{
+		{
+			desc:  "Exact match",
+			line:  "Link 0: 50.0 GB/s",
+			want:  "50.0",
+			match: true,
+		},
+		{
+			desc:  "Extra trailing whitespace",
+			line:  "Link 2: 45.5 GB/s    ",
+			want:  "45.5",
+			match: true,
+		},
+		{
+			desc:  "Trailing text",
+			line:  "Link 3: 50.0 GB/s (active)",
+			want:  "50.0",
+			match: true,
+		},
+		{
+			desc:  "Leading whitespace and trailing text",
+			line:  "    Link 1: 50.0 GB/s with more words",
+			want:  "50.0",
+			match: true,
+		},
+		{
+			desc:  "No match - incorrect format",
+			line:  "Link 0: 50.0 MB/s",
+			match: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			matches := nvlinkStatusRegex.FindStringSubmatch(tc.line)
+			if tc.match {
+				if len(matches) < 2 {
+					t.Fatalf("expected match, got none for line: %q", tc.line)
+				}
+				got := matches[1]
+				if got != tc.want {
+					t.Errorf("got bandwidth %q, want %q", got, tc.want)
+				}
+			} else {
+				if len(matches) > 0 {
+					t.Errorf("expected no match, but got %v", matches)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces NVLink health monitoring specifically targeted at A4x and GB2xx node families (GB200/GB300).

**Key Changes:**
* Adds `isA4x` helper to detect nodes based on `gke-accelerator` (`gb200`, `gb300`) or `machine-family` (`a4x`) labels.
* Implements `checkNVLinkSmi` which monitors both NVLink bandwidth and error rates.
  * **Bandwidth Checks**: Parses output from `nvidia-smi nvlink -s` to ensure per-link bandwidth meets the expected `A4xExpectedNvlinkSpeed`.
  * **Error Rate Checks**: Parses output from `nvidia-smi nvlink -e` to flag hardware errors. It safely ignores benign `FEC Errors` while alerting on elevated `Effective BER` (>1e-9), `Symbol BER` (>1e-25), and other non-packet/byte error counters.