### PR TITLE
Pinning Rocky linux 9 version for managed lustre compatibility

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -31,7 +31,8 @@ vars:
     # for a list of valid family options with Slurm
     # Rocky 8: slurm-gcp-6-12-hpc-rocky-linux-8
     # Rocky 9: slurm-gcp-6-12-hpc-rocky-linux-9
-    family: slurm-gcp-6-12-hpc-rocky-linux-9
+    # Pinned to working version prior to July 10, 2026 due to Lustre client incompatibility on Rocky 9.8
+    name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519
     project: schedmd-slurm-public
   # If image above is changed to use custom image, then setting below must be set to true
   instance_image_custom: false

--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -35,6 +35,10 @@ vars:
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
   kms_key: ""
+  slurm_image:
+    # Pinned to working version prior to July 10, 2026 due to Lustre client incompatibility on Rocky 9.8
+    name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519
+    project: schedmd-slurm-public
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -70,6 +74,7 @@ deployment_groups:
       node_count_dynamic_max: 2
       machine_type: $(vars.compute_node_machine_type)
       allow_automatic_updates: false
+      instance_image: $(vars.slurm_image)
 
   - id: lustre_partition
     source: community/modules/compute/schedmd-slurm-gcp-v6-partition
@@ -85,6 +90,7 @@ deployment_groups:
     settings:
       machine_type: n2-standard-4
       enable_login_public_ips: true
+      instance_image: $(vars.slurm_image)
 
   - id: slurm_controller
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
@@ -96,3 +102,4 @@ deployment_groups:
     settings:
       machine_type: n2-standard-4
       enable_controller_public_ips: true
+      instance_image: $(vars.slurm_image)


### PR DESCRIPTION

### Description:
This PR temporarily pins the Rocky 9 Slurm image in our blueprints to `slurm-gcp-6-12-hpc-rocky-linux-9-20260519` to work around a Lustre client compilation failure on Rocky 9.8.

### Problem:
The latest public SchedMD Rocky 9 image (`slurm-gcp-6-12-hpc-rocky-linux-9-20260630`) is built on Rocky 9.8 (kernel `5.14.0-687`). This kernel is incompatible with the default Lustre client (`2.14.0_ddn255a`) pre-configured in the image. During provisioning, DKMS fails to compile the Lustre module, causing the mount step to fail and breaking the deployment.

### Solution:
We temporarily pin the image to the last working release, `slurm-gcp-6-12-hpc-rocky-linux-9-20260519` (May 19, 2026), which uses `Rocky 9.7` and works correctly with the `ddn255a` client.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
