### PR TITLE
[Telemetry] Add standalone storage module detection for file-systems

### DIFF
--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -609,6 +609,97 @@ func TestGetStorageType(t *testing.T) {
 			want: "pd-ssd",
 		},
 		{
+			name: "Extracts standalone Managed Lustre source",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("fast-lustre"),
+								Source: "modules/file-system/managed-lustre",
+							},
+						},
+					},
+				},
+			},
+			want: "managed-lustre",
+		},
+		{
+			name: "Extracts standalone Parallelstore source",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("fast-ps"),
+								Source: "modules/file-system/parallelstore",
+							},
+						},
+					},
+				},
+			},
+			want: "parallelstore",
+		},
+		{
+			name: "Extracts Netapp service_level explicitly",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("netapp-pool"),
+								Source: "modules/file-system/netapp-storage-pool",
+								Settings: config.NewDict(map[string]cty.Value{
+									"service_level": cty.StringVal("EXTREME"),
+								}),
+							},
+						},
+					},
+				},
+			},
+			want: "netapp-extreme",
+		},
+		{
+			name: "Extracts Netapp service_level default",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("netapp-pool-def"),
+								Source: "../../modules/file-system/netapp-storage-pool",
+							},
+						},
+					},
+				},
+			},
+			want: "netapp-premium", // standard default from variables.tf
+		},
+		{
+			name: "Extracts storage_type from gke-storage explicitly",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("gke-stor"),
+								Source: "../../modules/file-system/gke-storage",
+								Settings: config.NewDict(map[string]cty.Value{
+									"storage_type": cty.StringVal("hyperdisk-extreme"),
+								}),
+							},
+						},
+					},
+				},
+			},
+			want: "hyperdisk-extreme",
+		},
+		{
 			name: "Extracts storage_class from GCS bucket",
 			bp: config.Blueprint{
 				Groups: []config.Group{

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -609,6 +609,27 @@ func TestGetStorageType(t *testing.T) {
 			want: "pd-ssd",
 		},
 		{
+			name: "Extracts multiple standalone file-system modules sorted",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("ps"),
+								Source: "modules/file-system/parallelstore",
+							},
+							{
+								ID:     config.ModuleID("lustre"),
+								Source: "modules/file-system/managed-lustre",
+							},
+						},
+					},
+				},
+			},
+			want: "managed-lustre,parallelstore",
+		},
+		{
 			name: "Extracts standalone Managed Lustre source",
 			bp: config.Blueprint{
 				Groups: []config.Group{

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -609,6 +609,23 @@ func TestGetStorageType(t *testing.T) {
 			want: "pd-ssd",
 		},
 		{
+			name: "Extracts standalone Netapp Volume source",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("netapp-vol"),
+								Source: "modules/file-system/netapp-volume",
+							},
+						},
+					},
+				},
+			},
+			want: "netapp",
+		},
+		{
 			name: "Extracts multiple standalone file-system modules sorted",
 			bp: config.Blueprint{
 				Groups: []config.Group{

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -786,6 +786,47 @@ func TestGetStorageType(t *testing.T) {
 			want: "redis-basic,spanner-enterprise",
 		},
 		{
+			name: "Extracts database tier/edition defaults for Redis and Spanner",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("redis-def"),
+								Source: "../../modules/database/redis",
+							},
+							{
+								ID:     config.ModuleID("spanner-def"),
+								Source: "../../modules/database/spanner",
+							},
+						},
+					},
+				},
+			},
+			want: "redis-basic,spanner-standard",
+		},
+		{
+			name: "Extracts Netapp service_level explicitly with trimmed whitespace",
+			bp: config.Blueprint{
+				Groups: []config.Group{
+					{
+						Name: config.GroupName("primary"),
+						Modules: []config.Module{
+							{
+								ID:     config.ModuleID("netapp-pool"),
+								Source: "modules/file-system/netapp-storage-pool",
+								Settings: config.NewDict(map[string]cty.Value{
+									"service_level": cty.StringVal("  extreme  "),
+								}),
+							},
+						},
+					},
+				},
+			},
+			want: "netapp-extreme",
+		},
+		{
 			name: "Extracts fs_type from network_storage",
 			bp: config.Blueprint{
 				Groups: []config.Group{

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -49,14 +49,20 @@ type result struct {
 
 // Storage constants
 const (
-	StoragePrefixGCS       = "gcs"       // Prefix for Google Cloud Storage metrics
-	StoragePrefixFilestore = "filestore" // Prefix for Filestore tiers
-	StoragePrefixRedis     = "redis"     // Prefix for Redis database usage
-	StoragePrefixSpanner   = "spanner"   // Prefix for Spanner database usage
-	StorageTypeLocalSSD    = "local-ssd" // Standalone metric base for Local SSDs
+	StoragePrefixGCS         = "gcs"            // Prefix for Google Cloud Storage metrics
+	StoragePrefixFilestore   = "filestore"      // Prefix for Filestore tiers
+	StoragePrefixRedis       = "redis"          // Prefix for Redis database usage
+	StoragePrefixSpanner     = "spanner"        // Prefix for Spanner database usage
+	StoragePrefixNetapp      = "netapp"         // Prefix for Netapp tiers
+	StorageTypeLocalSSD      = "local-ssd"      // Standalone metric base for Local SSDs
+	StorageTypeLustre        = "managed-lustre" // Standalone metric base for Managed Lustre
+	StorageTypeParallelstore = "parallelstore"  // Standalone metric base for Parallelstore
 
-	ModuleSourceRedis   = "database/redis"   // Module origin to detect Redis
-	ModuleSourceSpanner = "database/spanner" // Module origin to detect Spanner
+	ModuleSourceRedis         = "database/redis"                  // Module origin to detect Redis
+	ModuleSourceSpanner       = "database/spanner"                // Module origin to detect Spanner
+	ModuleSourceLustre        = "file-system/managed-lustre"      // Module origin to detect Lustre
+	ModuleSourceParallelstore = "file-system/parallelstore"       // Module origin to detect Parallelstore
+	ModuleSourceNetappPool    = "file-system/netapp-storage-pool" // Module origin to detect Netapp
 )
 
 var (
@@ -222,6 +228,7 @@ func getStorageTypesFromModule(m config.Module, bp config.Blueprint) []string {
 	extractAdditionalDisks(m, bp, addStorageType)
 	extractInlineNodesets(m, bp, addStorageType)
 	extractDatabaseStorageTypes(m, bp, addStorageType)
+	extractFileSystemStorageTypes(m, bp, addStorageType)
 
 	return storageTypes
 }
@@ -272,6 +279,24 @@ func extractDatabaseStorageTypes(m config.Module, bp config.Blueprint, addStorag
 		extractAndAdd(StoragePrefixRedis, "tier")
 	} else if strings.Contains(src, ModuleSourceSpanner) {
 		extractAndAdd(StoragePrefixSpanner, "edition")
+	}
+}
+
+func extractFileSystemStorageTypes(m config.Module, bp config.Blueprint, addStorageType func(string)) {
+	src := string(m.Source)
+
+	if strings.Contains(src, ModuleSourceLustre) {
+		addStorageType(StorageTypeLustre)
+	} else if strings.Contains(src, ModuleSourceParallelstore) {
+		addStorageType(StorageTypeParallelstore)
+	} else if strings.Contains(src, ModuleSourceNetappPool) {
+		if val := extractExplicitStringSetting("service_level", m, bp); val != "" {
+			addStorageType(StoragePrefixNetapp + "-" + val)
+		} else if val, _, found := extractDefaultSetting[string]([]string{"service_level"}, m); found {
+			if trimmed := strings.TrimSpace(val); trimmed != "" {
+				addStorageType(StoragePrefixNetapp + "-" + trimmed)
+			}
+		}
 	}
 }
 

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -62,7 +62,8 @@ const (
 	ModuleSourceSpanner       = "database/spanner"                // Module origin to detect Spanner
 	ModuleSourceLustre        = "file-system/managed-lustre"      // Module origin to detect Lustre
 	ModuleSourceParallelstore = "file-system/parallelstore"       // Module origin to detect Parallelstore
-	ModuleSourceNetappPool    = "file-system/netapp-storage-pool" // Module origin to detect Netapp
+	ModuleSourceNetappPool    = "file-system/netapp-storage-pool" // Module origin to detect Netapp Pool
+	ModuleSourceNetappVolume  = "file-system/netapp-volume"       // Module origin to detect Netapp Volume
 )
 
 var (
@@ -294,6 +295,8 @@ func extractFileSystemStorageTypes(m config.Module, bp config.Blueprint, addStor
 		addStorageType(StorageTypeParallelstore)
 	} else if strings.Contains(src, ModuleSourceNetappPool) {
 		extractPrefixedSetting(StoragePrefixNetapp, "service_level", m, bp, addStorageType)
+	} else if strings.Contains(src, ModuleSourceNetappVolume) {
+		addStorageType(StoragePrefixNetapp)
 	}
 }
 

--- a/pkg/telemetry/collector_util.go
+++ b/pkg/telemetry/collector_util.go
@@ -264,21 +264,24 @@ func extractExplicitAndDefaultStorageTypes(m config.Module, bp config.Blueprint,
 	}
 }
 
+// extractPrefixedSetting is a helper function that extracts explicit or default settings and prepends a prefix.
+func extractPrefixedSetting(prefix, key string, m config.Module, bp config.Blueprint, addStorageType func(string)) {
+	if val := extractExplicitStringSetting(key, m, bp); val != "" {
+		addStorageType(prefix + "-" + val)
+	} else if val, _, found := extractDefaultSetting[string]([]string{key}, m); found {
+		if trimmed := strings.TrimSpace(val); trimmed != "" {
+			addStorageType(prefix + "-" + trimmed)
+		}
+	}
+}
+
 func extractDatabaseStorageTypes(m config.Module, bp config.Blueprint, addStorageType func(string)) {
 	src := string(m.Source)
 
-	extractAndAdd := func(moduleType, key string) {
-		if val := extractExplicitStringSetting(key, m, bp); val != "" {
-			addStorageType(moduleType + "-" + val)
-		} else if val, _, found := extractDefaultSetting[string]([]string{key}, m); found && val != "" {
-			addStorageType(moduleType + "-" + strings.TrimSpace(val))
-		}
-	}
-
 	if strings.Contains(src, ModuleSourceRedis) {
-		extractAndAdd(StoragePrefixRedis, "tier")
+		extractPrefixedSetting(StoragePrefixRedis, "tier", m, bp, addStorageType)
 	} else if strings.Contains(src, ModuleSourceSpanner) {
-		extractAndAdd(StoragePrefixSpanner, "edition")
+		extractPrefixedSetting(StoragePrefixSpanner, "edition", m, bp, addStorageType)
 	}
 }
 
@@ -290,13 +293,7 @@ func extractFileSystemStorageTypes(m config.Module, bp config.Blueprint, addStor
 	} else if strings.Contains(src, ModuleSourceParallelstore) {
 		addStorageType(StorageTypeParallelstore)
 	} else if strings.Contains(src, ModuleSourceNetappPool) {
-		if val := extractExplicitStringSetting("service_level", m, bp); val != "" {
-			addStorageType(StoragePrefixNetapp + "-" + val)
-		} else if val, _, found := extractDefaultSetting[string]([]string{"service_level"}, m); found {
-			if trimmed := strings.TrimSpace(val); trimmed != "" {
-				addStorageType(StoragePrefixNetapp + "-" + trimmed)
-			}
-		}
+		extractPrefixedSetting(StoragePrefixNetapp, "service_level", m, bp, addStorageType)
 	}
 }
 


### PR DESCRIPTION
#### Overview
This PR adds support to detect standalone file-system modules like Parallelstore, Managed Lustre, and Netapp instances even when no specific variable settings track them.

The change enhances the underlying telemetry collector mechanics to meticulously trace storage tier metrics for isolated file-systems intrinsically deployed standalone, notably without natively depending on the variable mappings usually consumed when mounting configurations into virtual machine configurations natively like `storage_class` or `.network_storage`.

#### Changes Made:
- Augments `pkg/telemetry/collector_util.go` logic to track `Module.Source` values directly across explicitly decoupled subsystems:
  - `modules/file-system/managed-lustre` intelligently extracts standalone default definitions.
  - `modules/file-system/parallelstore` properly triggers reporting hooks.
  - `modules/file-system/netapp-storage-pool` actively processes internal parameter `service_level`, systematically parsing default array-settings cleanly.
  - `modules/file-system/netapp-volume` correctly tracks generic `netapp` telemetry when deployed fully standalone with a pre-existing storage pool ID.
- Introduces `extractPrefixedSetting` utility to keep telemetry parsing extremely DRY across Database and File System sources (`redis`, `spanner`, and `netapp-storage-pool`), ensuring all explicit strings and default configurations are rigorously evaluated and whitespace is safely trimmed.
- Restructures constants cleanly defining `StoragePrefixNetapp`, `StorageTypeLustre`, and `StorageTypeParallelstore`.
- Upgrades unit tests within `TestGetStorageType` encompassing diverse conditions:
  - Extracting multi-module deployments gracefully sorted.
  - Evaluating and validating fallback behaviors precisely for `Spanner` and `Redis`.
  - Proving whitespace resilience cleanly across prefixed variables like `Netapp service_level`.