### PR TITLE
feat(config): support ai_assisted telemetry marker in blueprint config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -295,6 +295,7 @@ func (m Module) InfoOrDie() modulereader.ModuleInfo {
 type Blueprint struct {
 	BlueprintName            string      `yaml:"blueprint_name"`
 	GhpcVersion              string      `yaml:"ghpc_version,omitempty"`
+	AiAssisted               bool        `yaml:"ai_assisted,omitempty"`
 	Validators               []Validator `yaml:"validators,omitempty"`
 	ValidationLevel          int         `yaml:"validation_level,omitempty"`
 	Vars                     Dict

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -529,6 +529,37 @@ dragon: "Lews Therin Telamon"`))
 	c.Check(err, NotNil)
 }
 
+func (s *zeroSuite) TestParseBlueprint_AiAssisted(c *C) {
+	// Case 1: ai_assisted is true
+	{
+		bp, _, err := parseYaml[Blueprint]([]byte(`
+blueprint_name: test-bp
+ai_assisted: true
+`))
+		c.Assert(err, IsNil)
+		c.Check(bp.AiAssisted, Equals, true)
+	}
+
+	// Case 2: ai_assisted is false
+	{
+		bp, _, err := parseYaml[Blueprint]([]byte(`
+blueprint_name: test-bp
+ai_assisted: false
+`))
+		c.Assert(err, IsNil)
+		c.Check(bp.AiAssisted, Equals, false)
+	}
+
+	// Case 3: ai_assisted is missing (should default to false, no error)
+	{
+		bp, _, err := parseYaml[Blueprint]([]byte(`
+blueprint_name: test-bp
+`))
+		c.Assert(err, IsNil)
+		c.Check(bp.AiAssisted, Equals, false)
+	}
+}
+
 func (s *zeroSuite) TestExportBlueprint(c *C) {
 	bp := Blueprint{BlueprintName: "goo"}
 	outFilename := c.TestName() + ".yaml"

--- a/pkg/config/path.go
+++ b/pkg/config/path.go
@@ -130,6 +130,7 @@ type rootPath struct {
 	basePath
 	BlueprintName         basePath                    `path:"blueprint_name"`
 	GhpcVersion           basePath                    `path:"ghpc_version"`
+	AiAssisted            basePath                    `path:"ai_assisted"`
 	Validators            arrayPath[validatorCfgPath] `path:"validators"`
 	ValidationLevel       basePath                    `path:"validation_level"`
 	Vars                  dictPath                    `path:"vars"`

--- a/pkg/config/path_test.go
+++ b/pkg/config/path_test.go
@@ -31,6 +31,7 @@ func TestPath(t *testing.T) {
 		{r, ""},
 		{r.BlueprintName, "blueprint_name"},
 		{r.GhpcVersion, "ghpc_version"},
+		{r.AiAssisted, "ai_assisted"},
 		{r.Validators, "validators"},
 		{r.ValidationLevel, "validation_level"},
 		{r.Vars, "vars"},


### PR DESCRIPTION
Add support for the `ai_assisted` boolean field at the root level of the blueprint YAML configuration.

This field serves as a telemetry/provenance marker to indicate that a blueprint was generated or modified by an AI agent. Internal AI agents will be programmed to automatically add this field, setting the value to `true`. 

Changes:

- Add `AiAssisted` field to the Blueprint struct in `pkg/config/config.go` with `yaml:"ai_assisted,omitempty"` tag.
- Add `AiAssisted` field to the rootPath struct in `pkg/config/path.go` with `path:"ai_assisted"` tag to support path-based configuration resolution.
- Add unit tests in `pkg/config/config_test.go` (TestParseBlueprint_AiAssisted) to verify parsing of the `ai_assisted` field (covering true, false, and missing/default cases).
- Update unit tests in `pkg/config/path_test.go` (TestPath) to verify path resolution for the `ai_assisted` field.
