### PR TITLE
update and automate release notes

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -1,0 +1,68 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Draft CTK Release
+
+on:
+  pull_request:
+    types:
+    - ready_for_review
+    branches:
+    - main
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'release-candidate-') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix-')
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get Release Information
+      id: release
+      shell: bash
+      run: |
+        BRANCH="${{ github.event.pull_request.head.ref }}"
+
+        if [[ "$BRANCH" == release-candidate-* ]]; then
+          VERSION="${BRANCH#release-candidate-}"
+        elif [[ "$BRANCH" == hotfix-* ]]; then
+          VERSION="${BRANCH#hotfix-}"
+        else
+          echo "Unsupported branch: $BRANCH"
+          exit 1
+        fi
+
+        echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Create Draft Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.release.outputs.version }}
+        target_commitish: ${{ steps.release.outputs.rc_branch }}
+        name: ${{ steps.release.outputs.version }}
+        draft: true
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -30,7 +30,8 @@ on:
     branches:
     - main
     - develop
-    - release-candidate
+    - release-candidate-*
+    - hotfix-*
 
 jobs:
   pr-label-validation:

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -25,7 +25,7 @@ on:
     branches:
     - main
     - develop
-    - release-candidate
+    - release-candidate-*
     - hotfix-*
 
 permissions:

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,0 +1,85 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish CTK Release
+
+on:
+  pull_request:
+    types:
+    - closed
+    branches:
+    - main
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  publish-release:
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        startsWith(github.event.pull_request.head.ref, 'release-candidate-') ||
+        startsWith(github.event.pull_request.head.ref, 'hotfix-')
+      )
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Get Release Version
+      id: release
+      shell: bash
+      run: |
+        RC_BRANCH="${{ github.event.pull_request.head.ref }}"
+
+        if [[ "$RC_BRANCH" == release-candidate-* ]]; then
+          VERSION="${RC_BRANCH#release-candidate-}"
+        elif [[ "$RC_BRANCH" == hotfix-* ]]; then
+          VERSION="${RC_BRANCH#hotfix-}"
+        else
+          echo "Unsupported branch: $RC_BRANCH"
+          exit 1
+        fi
+
+        echo "rc_branch=$RC_BRANCH" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Create Tag
+      run: |
+        git config user.name "github-actions"
+        git config user.email "github-actions@github.com"
+
+        if git rev-parse "${{ steps.release.outputs.version }}" >/dev/null 2>&1; then
+          echo "Tag already exists"
+        else
+          git tag "${{ steps.release.outputs.version }}"
+          git push origin "${{ steps.release.outputs.version }}"
+        fi
+
+    - name: Publish GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.release.outputs.version }}
+        target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+        name: ${{ steps.release.outputs.version }}
+        generate_release_notes: true
+        make_latest: true
+        discussion_category_name: Announcements
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/create-release-candidate.sh
+++ b/tools/create-release-candidate.sh
@@ -86,7 +86,7 @@ esac
 NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
 NEW_TAG="v${NEW_VERSION}"
 
-RC_BRANCH=release-candidate
+RC_BRANCH="release-candidate-${NEW_TAG}"
 V_BRANCH="version/${NEW_TAG}"
 REMOTE_NAME=origin
 


### PR DESCRIPTION
### Draft Release Notes
Automatically creates a draft GitHub Release with generated release notes when the RC → main or hotfix → main pull request is ready for review.

### Publish Release Notes
Automatically creates the release tag and publishes the GitHub Release with generated release notes when the release-candidate-* or hotfix-* PR is merged into the main.

### Updated release-candidate branch naming: 
Changed the release-candidate branch from a fixed name (release-candidate) to a versioned format (release-candidate-vX.Y.Z). This allows each release to have its own dedicated release branch and enables the draft and publish release workflows to identify the release version directly from the branch name.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
