### PR TITLE
Support Managed Lustre for A3 HighGPU Slurm clusters. The Lustre client is compiled and installed using DKMS because a pre-compiled client module package for the TCPX kernel does not currently exist in the Artifact Registry.

### DIFF
--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
@@ -19,7 +19,16 @@ vars:
   # Default fallback remains false (MUNGE) to guarantee zero regression risk on upgrades.
   enable_slurm_auth: false
   sys_net_range: 172.16.0.0/16
-  filestore_ip_range: 192.168.0.0/29
+  # Managed-Lustre instance name. This should be unique for each deployment.
+  lustre_instance_id: $(vars.deployment_name)-lustre
+
+  # The values of size_gib and per_unit_storage_throughput are co-related
+  # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
+  # Storage capacity of the lustre instance in GiB
+  lustre_size_gib: 36000
+
+  # Maximum throughput of the lustre instance in MBps per TiB
+  per_unit_storage_throughput: 500
   source_image_project_id: ubuntu-os-cloud
   source_image_family: ubuntu-2204-lts
   local_mount_homefs: /home
@@ -61,15 +70,22 @@ deployment_groups:
       network_count: 4
       subnetwork_cidr_suffix: 20
 
-  - id: homefs
-    source: modules/file-system/filestore
+  - id: private_service_access
+    source: modules/network/private-service-access
     use:
     - sysnet
+
+  - id: homefs
+    source: modules/file-system/managed-lustre
+    use:
+    - sysnet
+    - private_service_access
     settings:
-      filestore_tier: BASIC_SSD
-      size_gb: 2560
-      reserved_ip_range: $(vars.filestore_ip_range)
+      name: $(vars.lustre_instance_id)
+      size_gib: $(vars.lustre_size_gib)
       local_mount: $(vars.local_mount_homefs)
+      remote_mount: lustrefs
+      per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
 
 - group: build-script
   modules:
@@ -301,8 +317,7 @@ deployment_groups:
             "monitoring_agent": "cloud-ops",
             "nvidia_version": "latest",
             "allow_kernel_upgrades": true, # tcpx kernel is held and gcp kernel is removed as the last task
-            "install_nvidia_repo": false,
-            "monitoring_agent": "cloud-ops",
+            "install_nvidia_repo": false
           }
 
       - type: shell
@@ -316,6 +331,40 @@ deployment_groups:
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml
+
+      - type: shell
+        destination: install_tcpx_lustre.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --yes --dearmor -o /usr/share/keyrings/google-cloud.gpg
+          curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --yes --dearmor -o /usr/share/keyrings/lustre-client.gpg
+          echo 'deb [signed-by=/usr/share/keyrings/google-cloud.gpg] http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main' > /etc/apt/sources.list.d/google-cloud.list
+          apt-get update
+          apt-get install -y apt-transport-artifact-registry
+          echo "deb [signed-by=/usr/share/keyrings/lustre-client.gpg] ar+https://us-apt.pkg.dev/projects/lustre-client-binaries lustre-client-ubuntu-jammy main" > /etc/apt/sources.list.d/artifact-registry.list
+          apt-get update
+          TCPX_KERNEL_VERSION=""
+          for d in /lib/modules/*tcpx*; do
+            if [ -d "$d" ]; then
+              TCPX_KERNEL_VERSION=`basename "$d"`
+              break
+            fi
+          done
+          if [ -n "${TCPX_KERNEL_VERSION}" ]; then
+            echo "Installing Lustre client modules for kernel ${TCPX_KERNEL_VERSION}..."
+            set +e
+            apt-get install -y lustre-client-modules-${TCPX_KERNEL_VERSION}
+            if [ $? -ne 0 ]; then
+              echo "Pre-compiled package lustre-client-modules-${TCPX_KERNEL_VERSION} not found. Installing via DKMS for ${TCPX_KERNEL_VERSION}..."
+              apt-get install -y dkms lustre-client-modules-dkms lustre-client-utils
+              echo "Building DKMS modules specifically for ${TCPX_KERNEL_VERSION}..."
+              dkms autoinstall -k "${TCPX_KERNEL_VERSION}"
+            fi
+            set -e
+          else
+            echo "No tcpx kernel modules directory found."
+          fi
 
       - type: data
         destination: /etc/security/limits.d/99-unlimited.conf

--- a/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/managed-lustre/scripts/install-managed-lustre-client.sh
@@ -61,7 +61,10 @@ if [[ ${DIST} == "Ubuntu" ]]; then
 
 	# Install modules
 	apt update
-	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
+	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || {
+		echo "Pre-compiled package lustre-client-modules-$(uname -r) not found. Attempting install via lustre-client-modules-dkms..."
+		apt install -y dkms lustre-client-modules-dkms lustre-client-utils
+	} || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
 elif [[ ${DIST} == "Rocky" ]]; then
 	# Set up yum repo
 	touch /etc/yum.repos.d/artifact-registry.repo

--- a/modules/file-system/pre-existing-network-storage/scripts/install-managed-lustre-client.sh
+++ b/modules/file-system/pre-existing-network-storage/scripts/install-managed-lustre-client.sh
@@ -61,7 +61,10 @@ if [[ ${DIST} == "Ubuntu" ]]; then
 
 	# Install modules
 	apt update
-	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
+	apt install -y "lustre-client-modules-$(uname -r)" lustre-client-utils || {
+		echo "Pre-compiled package lustre-client-modules-$(uname -r) not found. Attempting install via lustre-client-modules-dkms..."
+		apt install -y dkms lustre-client-modules-dkms lustre-client-utils
+	} || (echo "Error finding Lustre module packages, Lustre package may not exist for this kernel version" && exit 1)
 elif [[ ${DIST} == "Rocky" ]]; then
 	# Set up yum repo
 	touch /etc/yum.repos.d/artifact-registry.repo

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -15,7 +15,8 @@
 ---
 tags:
 - slurm6
-- m.filestore
+- m.managed-lustre
+- m.private-service-access
 - m.multivpc
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-slurm.yaml
@@ -15,7 +15,8 @@
 ---
 tags:
 - slurm6
-- m.filestore
+- m.managed-lustre
+- m.private-service-access
 - m.multivpc
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login


### PR DESCRIPTION
## Description
This PR transitions the A3 HighGPU (a3-highgpu-8g) Slurm blueprint from using Filestore to using Managed Lustre as the primary network storage.

Because the A3 HighGPU nodes utilize a specialized linux-gcp-tcpx kernel that currently lacks pre-compiled Lustre client packages in the Artifact Registry, this PR introduces DKMS fallback logic to compile the client from source

## Testing
Used the on demand capacity to launch the cluster and executed the NCCL tests against it.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
