### PR TITLE
 gke-a2-highgpu-kueue-onspot updated from zonal change from us-central1-b to us-central1-a

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -41,7 +41,7 @@ steps:
   - "PROJECT_ID=$PROJECT_ID"
   - "NUM_NODES=12"
   - "MIN_NODES=6"
-  - "ZONE=us-central1-b"
+  - "ZONE=us-central1-a"
   - "PROVISIONING_MODEL=SPOT"
   - "MACHINE_TYPE=a2-highgpu-2g"
   - "INSTANCE_PREFIX=a2hspgke"


### PR DESCRIPTION
 The gke-a2-highgpu-kueue-onspot is updated from us-central1-b to us-central1-a to resolve persistent GCE_STOCKOUT issues


