### PR TITLE
fix(validation): Resolve PSA collisions in base integration tests

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml
@@ -57,8 +57,18 @@
     ansible.builtin.include_tasks:
       file: tasks/create_deployment_directory.yml
 
+  - name: Set actual_network variable
+    ansible.builtin.set_fact:
+      actual_network: "{% if use_fixed_vpc | default(false) | bool %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}"
+
   - name: Create Infrastructure and test
     block:
+    - name: Clean up any existing PSA resources from previous runs
+      ansible.builtin.include_tasks:
+        file: tasks/cleanup_existing_psa.yml
+      vars:
+        psa_network: "{{ actual_network }}"
+
     - name: Create Cluster with gcluster
       register: deployment
       changed_when: deployment.changed
@@ -120,7 +130,7 @@
         - "{{ deployment_name }}"
         - --direction=INGRESS
         - --priority=1000
-        - --network={% if use_fixed_vpc | default(false) %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}
+        - --network={{ actual_network }}
         - --action=ALLOW
         - --rules=tcp:22
         - --source-ranges={{ build_ip.stdout }}
@@ -143,6 +153,7 @@
       ansible.builtin.add_host:
         hostname: "{{ remote_ip }}"
         groups: [remote_host]
+        actual_network: "{{ actual_network }}"
       when: (remote_ip | default('')) | ansible.utils.ipaddr != false
 
     - name: Wait for host tasks

--- a/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml
@@ -54,7 +54,7 @@
 
   - name: Set actual network name
     ansible.builtin.set_fact:
-      actual_network: "{% if use_fixed_vpc | default(false) %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}"
+      actual_network: "{% if use_fixed_vpc | default(false) | bool %}{{ test_prefix | default('') }}{{ test_name }}-0{% else %}{{ network }}{% endif %}"
 
   - name: Run Pre Deploy Tasks
     ansible.builtin.include_tasks: "{{ pre_deploy_task }}"


### PR DESCRIPTION
Apply the PSA cleanup and variable scope fixes to the base integration test playbook (`base-integration-test.yml`). This ensures GKE and other non-Slurm tests can also resolve static VPC names, clean up stale PSA connections pre-deployment, and correctly target them during failure recovery/rescue.