### PR TITLE
Fix NCCL test cloud doc link in README of GKE A3 Mega

### DIFF
--- a/examples/gke-a3-megagpu/README.md
+++ b/examples/gke-a3-megagpu/README.md
@@ -166,7 +166,7 @@ To avoid incurring charges for the resources created, destroy the deployment:
 
 Refer to [Deploy an A3 Mega GKE cluster for ML training](https://cloud.google.com/cluster-toolkit/docs/deploy/deploy-a3-mega-gke-cluster) for more instructions on creating the GKE-A3M cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for more instructions on running a NCCL test on the GKE-A3M cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-mega) for more instructions on running a NCCL test on the GKE-A3M cluster.
 
 ### Additional Consumption Options
 The Cluster Toolkit supports alternative consumption options such as Spot VMs or Dynamic Workload Scheduler (DWS) Flex-start.


### PR DESCRIPTION
Initially the README of GKE A3 Mega pointed to wrong NCCL test cloud doc. Updated the doc link in this PR.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
