### PR TITLE
feat: Support DNS endpoints for GKE clusters

### DIFF
--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -52,6 +52,9 @@ func TestCancelCmd_Success(t *testing.T) {
 type mockCancelExecutor struct{}
 
 func (m *mockCancelExecutor) ExecuteCommand(name string, args ...string) shell.CommandResult {
+	if name == "gcloud" && len(args) >= 3 && args[0] == "container" && args[1] == "clusters" && args[2] == "describe" {
+		return shell.CommandResult{ExitCode: 0, Stdout: "{}"}
+	}
 	return shell.CommandResult{ExitCode: 0}
 }
 

--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCancelCmd_Success(t *testing.T) {
-	resetSubmitCmdFlags() // Reset shared flags
+	setupSubmitTestEnv(t) // Reset shared flags
 
 	// Mock the orchestrator factory
 	oldFactory := gkeOrchestratorFactory
@@ -91,7 +91,7 @@ func (m *mockKubeClient) GetCurrentNamespace() (string, error) {
 }
 
 func TestCancelCmd_MissingArgs(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd, "cancel")
 	if err == nil {
@@ -104,7 +104,7 @@ func TestCancelCmd_MissingArgs(t *testing.T) {
 }
 
 func TestCancelCmd_JobNotFound(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldFactory := gkeOrchestratorFactory
 	defer func() { gkeOrchestratorFactory = oldFactory }()

--- a/cmd/job/inspect_test.go
+++ b/cmd/job/inspect_test.go
@@ -25,8 +25,8 @@ type mockJobOrchestrator struct {
 	inspectCalled bool
 }
 
-func (m *mockJobOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
-	return projectID, location, nil
+func (m *mockJobOrchestrator) Initialize(clusterName, location, projectID string) (string, error) {
+	return location, nil
 }
 
 func (m *mockJobOrchestrator) SubmitJob(job orchestrator.JobDefinition) error { return nil }

--- a/cmd/job/inspect_test.go
+++ b/cmd/job/inspect_test.go
@@ -25,6 +25,10 @@ type mockJobOrchestrator struct {
 	inspectCalled bool
 }
 
+func (m *mockJobOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
+	return projectID, location, nil
+}
+
 func (m *mockJobOrchestrator) SubmitJob(job orchestrator.JobDefinition) error { return nil }
 func (m *mockJobOrchestrator) ListJobs(opts orchestrator.ListOptions) ([]orchestrator.JobStatus, error) {
 	return nil, nil

--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -60,14 +60,15 @@ var JobCmd = &cobra.Command{
 			return fmt.Errorf("location is required; please specify it using the --location flag or set a default value using 'gcluster job config set location <value>'")
 		}
 
-		resolvedProj, resolvedLoc, err := orc.Initialize(clusterName, location, projectID)
+		if projectID == "" {
+			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
+		}
+
+		resolvedLoc, err := orc.Initialize(clusterName, location, projectID)
 		if err != nil {
 			return err
 		}
-		if resolvedProj == "" {
-			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
-		}
-		projectID = resolvedProj
+		location = resolvedLoc
 		location = resolvedLoc
 
 		return nil

--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -69,7 +69,6 @@ var JobCmd = &cobra.Command{
 			return err
 		}
 		location = resolvedLoc
-		location = resolvedLoc
 
 		return nil
 	},

--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -59,9 +59,16 @@ var JobCmd = &cobra.Command{
 		if location == "" {
 			return fmt.Errorf("location is required; please specify it using the --location flag or set a default value using 'gcluster job config set location <value>'")
 		}
-		if projectID == "" {
+
+		resolvedProj, resolvedLoc, err := orc.Initialize(clusterName, location, projectID)
+		if err != nil {
+			return err
+		}
+		if resolvedProj == "" {
 			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
 		}
+		projectID = resolvedProj
+		location = resolvedLoc
 
 		return nil
 	},

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -50,6 +50,16 @@ func TestListWorkloadsCmd_Success(t *testing.T) {
 func TestListWorkloadsCmd_InvalidStatus(t *testing.T) {
 	resetSubmitCmdFlags()
 
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		g := gke.NewGKEOrchestrator()
+		g.SetExecutor(&mockCancelExecutor{}) // Use the mock from cancel_test.go if available
+		g.SetKubeClient(&mockKubeClient{namespace: "default"})
+		return g
+	}
+
 	_, err := executeCommand(JobCmd, "list", "--status", "InvalidStatus", "--cluster", "test-cluster", "--location", "us-central1-a", "--project", "test-project")
 	if err == nil {
 		t.Fatalf("expected error for invalid status, got nil")

--- a/cmd/job/list_test.go
+++ b/cmd/job/list_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestListWorkloadsCmd_Success(t *testing.T) {
-	resetSubmitCmdFlags() // Reset shared flags
+	setupSubmitTestEnv(t) // Reset shared flags
 
 	// Mock the orchestrator factory
 	oldFactory := gkeOrchestratorFactory
@@ -48,7 +48,7 @@ func TestListWorkloadsCmd_Success(t *testing.T) {
 }
 
 func TestListWorkloadsCmd_InvalidStatus(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldFactory := gkeOrchestratorFactory
 	defer func() { gkeOrchestratorFactory = oldFactory }()

--- a/cmd/job/logs_test.go
+++ b/cmd/job/logs_test.go
@@ -25,6 +25,9 @@ import (
 type mockLogsExecutor struct{}
 
 func (m *mockLogsExecutor) ExecuteCommand(name string, args ...string) shell.CommandResult {
+	if name == "gcloud" && len(args) >= 3 && args[0] == "container" && args[1] == "clusters" && args[2] == "describe" {
+		return shell.CommandResult{ExitCode: 0, Stdout: "{}"}
+	}
 	if name == "kubectl" && len(args) > 0 && args[0] == "logs" {
 		return shell.CommandResult{ExitCode: 0, Stdout: "mock logs output"}
 	}

--- a/cmd/job/logs_test.go
+++ b/cmd/job/logs_test.go
@@ -39,7 +39,7 @@ func (m *mockLogsExecutor) ExecuteCommandStream(name string, args ...string) err
 }
 
 func TestLogsCmd_Success(t *testing.T) {
-	resetSubmitCmdFlags() // Reset shared flags
+	setupSubmitTestEnv(t) // Reset shared flags
 
 	// Mock the orchestrator factory
 	oldFactory := gkeOrchestratorFactory

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -300,10 +300,14 @@ func setupSubmitTestEnv(t *testing.T) {
 
 type mockOrchestrator struct {
 	orchestrator.JobOrchestrator
+	initializeFunc func(string, string, string) (string, error)
 }
 
-func (m *mockOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
-	return projectID, location, nil
+func (m *mockOrchestrator) Initialize(clusterName, location, projectID string) (string, error) {
+	if m.initializeFunc != nil {
+		return m.initializeFunc(clusterName, location, projectID)
+	}
+	return location, nil
 }
 
 func (m *mockOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -68,7 +68,7 @@ func TestSubmitCmd_PathwaysDryRun(t *testing.T) {
 	}
 
 	// Reset flags before each test
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	output, err := executeCommand(JobCmd,
 		"submit",
@@ -143,7 +143,7 @@ func TestSubmitCmd_RegularDryRun(t *testing.T) {
 	}
 
 	// Reset flags before each test
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	output, err := executeCommand(JobCmd,
 		"submit",
@@ -181,7 +181,7 @@ func TestSubmitCmd_RegularDryRun(t *testing.T) {
 }
 
 func TestSubmitCmd_TPUWithNumNodes_Fails(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -221,7 +221,7 @@ func TestSubmitCmd_TPUWithNumNodes_Fails(t *testing.T) {
 }
 
 func TestSubmitCmd_LongWorkloadName_Fails(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -252,7 +252,7 @@ func TestSubmitCmd_LongWorkloadName_Fails(t *testing.T) {
 	}
 }
 
-func resetSubmitCmdFlags() {
+func setupSubmitTestEnv(t *testing.T) {
 	imageName = ""
 	baseImage = ""
 	buildContext = ""
@@ -288,6 +288,11 @@ func resetSubmitCmdFlags() {
 	pathwaysProxyEnv = nil
 	pathwaysServerEnv = nil
 	pathwaysWorkerEnv = nil
+
+	oldFactory := gkeOrchestratorFactory
+	defer t.Cleanup(func() {
+		gkeOrchestratorFactory = oldFactory
+	})
 	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
 		return &mockOrchestrator{}
 	}
@@ -355,7 +360,7 @@ func TestParseDurationToSeconds(t *testing.T) {
 }
 
 func TestSubmitCmd_MissingRepoEnvVar(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	origRepo := os.Getenv("GCLUSTER_IMAGE_REPO")
 	os.Setenv("GCLUSTER_IMAGE_REPO", "")
@@ -393,7 +398,7 @@ func TestSubmitCmd_MissingRepoEnvVar(t *testing.T) {
 }
 
 func TestSubmitCmd_MissingUserEnvVar(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	origUser := os.Getenv("USER")
 	origUsername := os.Getenv("USERNAME")
@@ -438,7 +443,7 @@ func TestSubmitCmd_MissingUserEnvVar(t *testing.T) {
 }
 
 func TestSubmitCmd_InvalidGKENAPProvisioning(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -478,7 +483,7 @@ func TestSubmitCmd_InvalidGKENAPProvisioning(t *testing.T) {
 }
 
 func TestSubmitCmd_ReservationModelWithoutName_Fails(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -518,7 +523,7 @@ func TestSubmitCmd_ReservationModelWithoutName_Fails(t *testing.T) {
 }
 
 func TestSubmitCmd_NonReservationModelWithName_Fails(t *testing.T) {
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -581,7 +586,7 @@ func TestSubmitCmd_DryRunMissingDir_Approved(t *testing.T) {
 	defer func() { shell.PromptYesNo = oldPrompt }()
 	shell.PromptYesNo = func(prompt string) bool { return true }
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err = executeCommand(JobCmd,
 		"submit",
@@ -631,7 +636,7 @@ func TestSubmitCmd_DryRunMissingDir_Rejected(t *testing.T) {
 	defer func() { shell.PromptYesNo = oldPrompt }()
 	shell.PromptYesNo = func(prompt string) bool { return false }
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	output, err := executeCommand(JobCmd,
 		"submit",
@@ -670,7 +675,7 @@ func TestSubmitCmd_DryRunIsDir_Existing(t *testing.T) {
 	defer func() { store = oldStore }()
 	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err = executeCommand(JobCmd,
 		"submit",
@@ -699,7 +704,7 @@ func TestSubmitCmd_DryRunIsDir_TrailingSlash(t *testing.T) {
 	defer func() { store = oldStore }()
 	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -743,7 +748,7 @@ func TestSubmitCmd_ValidEnvVars(t *testing.T) {
 		return &mockOrchestrator{}
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -777,7 +782,7 @@ func TestSubmitCmd_InvalidEnvFormat_Fails(t *testing.T) {
 		},
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -822,7 +827,7 @@ func TestSubmitCmd_PathwaysEnv_Success(t *testing.T) {
 		return &mockOrchestrator{}
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -866,7 +871,7 @@ func TestSubmitCmd_PathwaysEnv_InvalidFormat_Fails(t *testing.T) {
 		return &mockOrchestrator{}
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -930,7 +935,7 @@ func TestSubmitCmd_InvalidEnvKey_Fails(t *testing.T) {
 				},
 			}
 
-			resetSubmitCmdFlags()
+			setupSubmitTestEnv(t)
 
 			_, err := executeCommand(JobCmd,
 				"submit",
@@ -978,7 +983,7 @@ func TestSubmitCmd_PathwaysMTCFlags(t *testing.T) {
 		return &mockOrchestrator{}
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",
@@ -1032,7 +1037,7 @@ func TestSubmitCmd_PathwaysHeadless(t *testing.T) {
 		return &mockOrchestrator{}
 	}
 
-	resetSubmitCmdFlags()
+	setupSubmitTestEnv(t)
 
 	_, err := executeCommand(JobCmd,
 		"submit",

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -288,10 +288,17 @@ func resetSubmitCmdFlags() {
 	pathwaysProxyEnv = nil
 	pathwaysServerEnv = nil
 	pathwaysWorkerEnv = nil
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
 }
 
 type mockOrchestrator struct {
 	orchestrator.JobOrchestrator
+}
+
+func (m *mockOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
+	return projectID, location, nil
 }
 
 func (m *mockOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -428,6 +428,8 @@ func (g *GKEOrchestrator) ApplyManifest(manifestContent, outputManifestPath, wor
 	return nil
 }
 
+// Initialize fetches GKE cluster metadata and resolves the cluster location,
+// handling regional fallback if necessary.
 func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (string, error) {
 	g.projectID = projectID
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -428,12 +428,8 @@ func (g *GKEOrchestrator) ApplyManifest(manifestContent, outputManifestPath, wor
 	return nil
 }
 
-func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
-	proj, err := g.getProjectID(projectID)
-	if err != nil {
-		return "", "", err
-	}
-	g.projectID = proj
+func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (string, error) {
+	g.projectID = projectID
 
 	logging.Info("Fetching GKE cluster metadata for '%s'...", clusterName)
 	res := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", clusterName,
@@ -442,7 +438,7 @@ func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (s
 		"--format=json")
 	if res.ExitCode != 0 {
 		if strings.Contains(res.Stderr, "403") || strings.Contains(strings.ToLower(res.Stderr), "permission denied") {
-			return "", "", fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", clusterName, g.projectID)
+			return "", fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", clusterName, g.projectID)
 		}
 		// If the user specified a zone (location with 3 components, e.g. us-central1-a), try to fallback to the region
 		if len(strings.Split(location, "-")) == 3 {
@@ -460,16 +456,16 @@ func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (s
 				location = region
 				res = fallbackRes
 			} else {
-				return "", "", fmt.Errorf("failed to describe GKE cluster %s in zone %s and fallback region %s: %s", clusterName, location, region, res.Stderr)
+				return "", fmt.Errorf("failed to describe GKE cluster %s in zone %s and fallback region %s: %s", clusterName, location, region, res.Stderr)
 			}
 		} else {
-			return "", "", fmt.Errorf("failed to describe GKE cluster %s: %s", clusterName, res.Stderr)
+			return "", fmt.Errorf("failed to describe GKE cluster %s: %s", clusterName, res.Stderr)
 		}
 	}
 
 	var clusterDesc gkeCluster
 	if err := json.Unmarshal([]byte(res.Stdout), &clusterDesc); err != nil {
-		return "", "", fmt.Errorf("failed to parse GKE cluster description: %w", err)
+		return "", fmt.Errorf("failed to parse GKE cluster description: %w", err)
 	}
 
 	g.clusterZones = clusterDesc.Locations
@@ -478,7 +474,7 @@ func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (s
 	g.napEnabled = clusterDesc.Autoscaling.EnableNodeAutoprovisioning
 	g.napLimits = parseNAPLimits(clusterDesc.Autoscaling)
 
-	return g.projectID, location, nil
+	return location, nil
 }
 
 func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinition) error {
@@ -918,23 +914,6 @@ func (g *GKEOrchestrator) hasRequiredResources(rgList []interface{}) bool {
 	}
 
 	return hasCPU && hasMem
-}
-
-func (g *GKEOrchestrator) getProjectID(initialProjectID string) (string, error) {
-	if initialProjectID != "" {
-		return initialProjectID, nil
-	}
-
-	res := g.executor.ExecuteCommand("gcloud", "config", "get-value", "project")
-	if res.ExitCode != 0 {
-		return "", fmt.Errorf("failed to get GCP project ID from gcloud config: %s", res.Stderr)
-	}
-	projectID := strings.TrimSpace(res.Stdout)
-	if projectID == "" {
-		return "", fmt.Errorf("GCP project ID is empty. Please provide it via --project flag or configure gcloud CLI.")
-	}
-	logging.Info("Using GCP Project ID inferred from gcloud config: %s", projectID)
-	return projectID, nil
 }
 
 func (g *GKEOrchestrator) resolveKueueQueue(requestedQueueName string) (string, error) {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1248,7 +1248,15 @@ func (g *GKEOrchestrator) BuildContainerImage(job orchestrator.JobDefinition) (s
 }
 
 func (g *GKEOrchestrator) configureKubectl(clusterName, clusterLocation, projectID string) error {
-	credsRes := g.executor.ExecuteCommand("gcloud", "container", "clusters", "get-credentials", clusterName, "--location", clusterLocation, "--project", projectID)
+	args := []string{"container", "clusters", "get-credentials", clusterName, "--location", clusterLocation, "--project", projectID}
+
+	if g.clusterDesc.ControlPlaneEndpointsConfig != nil &&
+		g.clusterDesc.ControlPlaneEndpointsConfig.DnsEndpointConfig != nil &&
+		g.clusterDesc.ControlPlaneEndpointsConfig.DnsEndpointConfig.AllowExternalTraffic {
+		args = append(args, "--dns-endpoint")
+	}
+
+	credsRes := g.executor.ExecuteCommand("gcloud", args...)
 	if credsRes.ExitCode != 0 {
 		if strings.Contains(strings.ToLower(credsRes.Stderr), "multiple") || strings.Contains(strings.ToLower(credsRes.Stderr), "ambiguous") {
 			return fmt.Errorf("found multiple GKE clusters named %s. Please specify the exact Zone using --location to disambiguate.", clusterName)

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -428,49 +428,48 @@ func (g *GKEOrchestrator) ApplyManifest(manifestContent, outputManifestPath, wor
 	return nil
 }
 
-func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinition) error {
-	projectID, err := g.getProjectID(job.ProjectID)
+func (g *GKEOrchestrator) Initialize(clusterName, location, projectID string) (string, string, error) {
+	proj, err := g.getProjectID(projectID)
 	if err != nil {
-		return err
+		return "", "", err
 	}
-	job.ProjectID = projectID
-	g.projectID = projectID
+	g.projectID = proj
 
-	logging.Info("Fetching GKE cluster metadata for '%s'...", job.ClusterName)
-	res := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", job.ClusterName,
-		"--location", job.ClusterLocation,
-		"--project", job.ProjectID,
+	logging.Info("Fetching GKE cluster metadata for '%s'...", clusterName)
+	res := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", clusterName,
+		"--location", location,
+		"--project", g.projectID,
 		"--format=json")
 	if res.ExitCode != 0 {
 		if strings.Contains(res.Stderr, "403") || strings.Contains(strings.ToLower(res.Stderr), "permission denied") {
-			return fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", job.ClusterName, job.ProjectID)
+			return "", "", fmt.Errorf("your account lacks the required permission to access cluster '%s' in project '%s'. Please ask your project administrator to grant you the Kubernetes Engine Viewer role (roles/container.viewer)", clusterName, g.projectID)
 		}
 		// If the user specified a zone (location with 3 components, e.g. us-central1-a), try to fallback to the region
-		if len(strings.Split(job.ClusterLocation, "-")) == 3 {
-			region := shell.ExtractRegion(job.ClusterLocation)
-			logging.Info("Failed to find cluster in zone %s. Trying fallback to region %s...", job.ClusterLocation, region)
-			fallbackRes := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", job.ClusterName,
+		if len(strings.Split(location, "-")) == 3 {
+			region := shell.ExtractRegion(location)
+			logging.Info("Failed to find cluster in zone %s. Trying fallback to region %s...", location, region)
+			fallbackRes := g.executor.ExecuteCommand("gcloud", "container", "clusters", "describe", clusterName,
 				"--location", region,
-				"--project", job.ProjectID,
+				"--project", g.projectID,
 				"--format=json")
 			if fallbackRes.ExitCode == 0 {
 				logging.Warn("Cluster '%s' is a regional cluster in '%s'. Found it by falling back from zone '%s'. "+
 					"Note: This does NOT restrict your job to '%s'. To run specifically in '%s', "+
 					"please use the '--node-constraint topology.kubernetes.io/zone=%s' flag.",
-					job.ClusterName, region, job.ClusterLocation, job.ClusterLocation, job.ClusterLocation, job.ClusterLocation)
-				job.ClusterLocation = region
+					clusterName, region, location, location, location, location)
+				location = region
 				res = fallbackRes
 			} else {
-				return fmt.Errorf("failed to describe GKE cluster %s in zone %s and fallback region %s: %s", job.ClusterName, job.ClusterLocation, region, res.Stderr)
+				return "", "", fmt.Errorf("failed to describe GKE cluster %s in zone %s and fallback region %s: %s", clusterName, location, region, res.Stderr)
 			}
 		} else {
-			return fmt.Errorf("failed to describe GKE cluster %s: %s", job.ClusterName, res.Stderr)
+			return "", "", fmt.Errorf("failed to describe GKE cluster %s: %s", clusterName, res.Stderr)
 		}
 	}
 
 	var clusterDesc gkeCluster
 	if err := json.Unmarshal([]byte(res.Stdout), &clusterDesc); err != nil {
-		return fmt.Errorf("failed to parse GKE cluster description: %w", err)
+		return "", "", fmt.Errorf("failed to parse GKE cluster description: %w", err)
 	}
 
 	g.clusterZones = clusterDesc.Locations
@@ -478,6 +477,11 @@ func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinitio
 
 	g.napEnabled = clusterDesc.Autoscaling.EnableNodeAutoprovisioning
 	g.napLimits = parseNAPLimits(clusterDesc.Autoscaling)
+
+	return g.projectID, location, nil
+}
+
+func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinition) error {
 
 	if job.IsPathwaysJob {
 		if job.Pathways.HeadNodePool != "" {
@@ -491,7 +495,7 @@ func (g *GKEOrchestrator) populateClusterMetadata(job *orchestrator.JobDefinitio
 		job.Pathways.HeadNodePool = g.resolvedHeadNodePool
 	}
 
-	capacity, nodePoolSAs, err := g.calculateClusterCapacity(clusterDesc, job.ClusterLocation)
+	capacity, nodePoolSAs, err := g.calculateClusterCapacity(g.clusterDesc, job.ClusterLocation)
 	if err != nil {
 		return err
 	}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2272,7 +2272,7 @@ func TestPopulateClusterMetadata_NAPLimitsLoopOrder(t *testing.T) {
 		ClusterLocation: "us-central1-a",
 	}
 
-	_, _, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
+	_, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
 	if err != nil {
 		t.Fatalf("Initialize failed: %v", err)
 	}
@@ -2320,7 +2320,7 @@ func TestPopulateClusterMetadata_LocationFallback(t *testing.T) {
 		ClusterLocation: "us-central1-a",
 	}
 
-	_, loc, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
+	loc, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
 	if err != nil {
 		t.Fatalf("Initialize failed: %v", err)
 	}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2272,7 +2272,12 @@ func TestPopulateClusterMetadata_NAPLimitsLoopOrder(t *testing.T) {
 		ClusterLocation: "us-central1-a",
 	}
 
-	err := orc.populateClusterMetadata(job)
+	_, _, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+
+	err = orc.populateClusterMetadata(job)
 	if err != nil {
 		t.Fatalf("populateClusterMetadata failed: %v", err)
 	}
@@ -2315,7 +2320,13 @@ func TestPopulateClusterMetadata_LocationFallback(t *testing.T) {
 		ClusterLocation: "us-central1-a",
 	}
 
-	err := orc.populateClusterMetadata(job)
+	_, loc, err := orc.Initialize(job.ClusterName, job.ClusterLocation, job.ProjectID)
+	if err != nil {
+		t.Fatalf("Initialize failed: %v", err)
+	}
+	job.ClusterLocation = loc
+
+	err = orc.populateClusterMetadata(job)
 	if err != nil {
 		t.Fatalf("populateClusterMetadata failed: %v", err)
 	}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -276,9 +276,18 @@ type gkeClusterAutoscaling struct {
 }
 
 type gkeCluster struct {
-	Locations   []string              `json:"locations"`
-	NodePools   []gkeJobNodePool      `json:"nodePools"`
-	Autoscaling gkeClusterAutoscaling `json:"autoscaling"`
+	Locations                   []string                     `json:"locations"`
+	NodePools                   []gkeJobNodePool             `json:"nodePools"`
+	Autoscaling                 gkeClusterAutoscaling        `json:"autoscaling"`
+	ControlPlaneEndpointsConfig *controlPlaneEndpointsConfig `json:"controlPlaneEndpointsConfig,omitempty"`
+}
+
+type controlPlaneEndpointsConfig struct {
+	DnsEndpointConfig *dnsEndpointConfig `json:"dnsEndpointConfig,omitempty"`
+}
+
+type dnsEndpointConfig struct {
+	AllowExternalTraffic bool `json:"allowExternalTraffic,omitempty"`
 }
 
 // Types for JobSet status unmarshaling

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -146,6 +146,7 @@ type InspectOptions struct {
 
 // JobOrchestrator defines the interface to interact with job orchestrators like GKE.
 type JobOrchestrator interface {
+	Initialize(clusterName, location, projectID string) (resolvedProjectID string, resolvedLocation string, err error)
 	SubmitJob(job JobDefinition) error
 	ListJobs(opts ListOptions) ([]JobStatus, error)
 	CancelJob(name string, opts CancelOptions) error

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -146,6 +146,7 @@ type InspectOptions struct {
 
 // JobOrchestrator defines the interface to interact with job orchestrators like GKE.
 type JobOrchestrator interface {
+	// Initialize fetches cluster metadata and resolves the cluster location.
 	Initialize(clusterName, location, projectID string) (resolvedLocation string, err error)
 	SubmitJob(job JobDefinition) error
 	ListJobs(opts ListOptions) ([]JobStatus, error)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -146,7 +146,7 @@ type InspectOptions struct {
 
 // JobOrchestrator defines the interface to interact with job orchestrators like GKE.
 type JobOrchestrator interface {
-	Initialize(clusterName, location, projectID string) (resolvedProjectID string, resolvedLocation string, err error)
+	Initialize(clusterName, location, projectID string) (resolvedLocation string, err error)
 	SubmitJob(job JobDefinition) error
 	ListJobs(opts ListOptions) ([]JobStatus, error)
 	CancelJob(name string, opts CancelOptions) error


### PR DESCRIPTION
This PR updates the GKE authentication flow to support configuring kubectl via DNS endpoints when interacting with a GKE cluster. It also fixes the now incorrect behavior where job subcommands (list, cancel, logs, inspect) would bypass the cluster endpoint configuration logic, causing them to fail when targeting clusters that require specific control plane endpoints (like `--dns-endpoint`)

Previously, CT always fell back to using the default control plane IP behavior for cluster authentication. Now, it queries the cluster's control plane endpoint configuration and dynamically appends the `--dns-endpoint` flag to the `gcloud container clusters get-credentials` command if the cluster has `allowExternalTraffic` enabled for DNS endpoints.

### Architecture Refactor
Previously, populateClusterMetadata (which shell outs to gcloud to describe the cluster) was initialized lazily only in SubmitJob. To fix this without introducing redundant network calls, we've refactored the initialization architecture:

 * Introduced a new Initialize(clusterName, location, projectID string) method on the JobOrchestrator interface.
Hooked this Initialize method into the Cobra PersistentPreRunE of the base job command.
 * This ensures the orchestrator reliably fetches the cluster topology exactly once per CLI invocation, resolving missing location/projectID configs and appropriately populating the endpoint configuration for all subcommands.

### Changes:

* pkg/orchestrator/gke/types.go: Added ControlPlaneEndpointsConfig struct bindings to the gkeCluster model to deserialize DNS configurations from `gcloud container clusters describe --format=json`.

* pkg/orchestrator/gke/gke_job_orchestrator.go: Updated configureKubectl to check the cluster metadata for DNS endpoint support and conditionally pass the `--dns-endpoint` flag during authentication.

* Fixed test files to handle the new initialize logic
