### PR TITLE
Update gib version to 1.1.2 across gke and slurm blueprints

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -264,7 +264,7 @@ deployment_groups:
         install: true  # NCCL gIB plugin via DaemonSet initContainer
         path: $(vars.gib_installer_path)
         template_vars:
-          version: v1.1.0
+          version: v1.1.2
           accelerator_count: 8
 
   - id: job-template

--- a/examples/gke-a3-ultragpu/nccl-jobset-example.yaml
+++ b/examples/gke-a3-ultragpu/nccl-jobset-example.yaml
@@ -125,7 +125,7 @@ spec:
             - name: nccl
               stdin: true
               tty: true
-              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
               securityContext:
                 privileged: true
               env:

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
@@ -126,7 +126,7 @@ data:
           | sed 's/ / -x /g')
 
         container_name: nccl-tests
-        container_uri: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+        container_uri: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
         gke_container_name: nccl
         gke_namespace: ramble
         gpus_per_node: 8

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -296,7 +296,7 @@ deployment_groups:
         install: true  # NCCL gIB plugin via DaemonSet initContainer
         path: $(vars.gib_installer_path)
         template_vars:
-          version: v1.1.0
+          version: v1.1.2
           accelerator_count: 8
 
   - id: job-template

--- a/examples/gke-a4/nccl-jobset-example.yaml
+++ b/examples/gke-a4/nccl-jobset-example.yaml
@@ -125,7 +125,7 @@ spec:
             - name: nccl
               stdin: true
               tty: true
-              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
               securityContext:
                 privileged: true
               env:

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -274,7 +274,7 @@ deployment_groups:
         path: $(vars.gib_installer_path)
         template_vars:
           image: "us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64"
-          version: v1.1.0
+          version: v1.1.2
           accelerator_count: 4
           node_affinity:
             requiredDuringSchedulingIgnoredDuringExecution:

--- a/examples/gke-a4x/nccl-jobset-example.yaml
+++ b/examples/gke-a4x/nccl-jobset-example.yaml
@@ -82,7 +82,7 @@ spec:
             - name: nccl-test
               stdin: true
               tty: true
-              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.0.6
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.1.2
               env:
               - name: MY_NODE_NAME
                 valueFrom:

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-installer.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-installer.yaml
@@ -70,7 +70,7 @@ spec:
           sysctl -w net.ipv4.conf.gpu5rdma0.log_martians=0
           sysctl -w net.ipv4.conf.gpu6rdma0.log_martians=0
           sysctl -w net.ipv4.conf.gpu7rdma0.log_martians=0
-      - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.1.0
+      - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.1.2
         name: nccl-rdma-installer
         resources:
           requests:

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-jobset-example.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/nccl-jobset-example.yaml
@@ -128,7 +128,7 @@ spec:
             - name: nccl
               stdin: true
               tty: true
-              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
               securityContext:
                 privileged: true
               env:

--- a/examples/gke-consumption-options/dws-flex-start/nccl-installer.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/nccl-installer.yaml
@@ -70,7 +70,7 @@ spec:
           sysctl -w net.ipv4.conf.gpu5rdma0.log_martians=0
           sysctl -w net.ipv4.conf.gpu6rdma0.log_martians=0
           sysctl -w net.ipv4.conf.gpu7rdma0.log_martians=0
-      - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.1.0
+      - image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:v1.1.2
         name: nccl-rdma-installer
         resources:
           requests:

--- a/examples/gke-consumption-options/dws-flex-start/nccl-jobset-example.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/nccl-jobset-example.yaml
@@ -125,7 +125,7 @@ spec:
             - name: nccl
               stdin: true
               tty: true
-              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
               securityContext:
                 privileged: true
               env:

--- a/examples/machine-learning/a3-ultragpu-8g/nemo-framework/Dockerfile
+++ b/examples/machine-learning/a3-ultragpu-8g/nemo-framework/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 ARG NEMOFW_VERSION=24.12
-ARG NCCL_GIB_VERSION=v1.1.0
+ARG NCCL_GIB_VERSION=v1.1.2
 
 # Stage 1: Use the nccl-plugin-gib container as an installer
 FROM us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib:${NCCL_GIB_VERSION} AS nccl-gib

--- a/examples/machine-learning/a3-ultragpu-8g/nemo-framework/README.md
+++ b/examples/machine-learning/a3-ultragpu-8g/nemo-framework/README.md
@@ -53,7 +53,7 @@ README
        stages=[training] \
        training=gpt3/5b \
        env_vars.TRANSFORMERS_OFFLINE=0 \
-       container=../nemo-24.12-v1.1.0.sqsh \
+       container=../nemo-24.12-v1.1.2.sqsh \
        container_mounts=[${HOME}/.cache] \
        cluster.srun_args=["--container-writable"] \
        training.model.data.data_impl=mock \

--- a/examples/machine-learning/a3-ultragpu-8g/nemo-framework/setup_nemo.sh
+++ b/examples/machine-learning/a3-ultragpu-8g/nemo-framework/setup_nemo.sh
@@ -19,7 +19,7 @@
 #SBATCH --exclusive
 
 : "${NEMOFW_VERSION:=24.12}"
-: "${NCCL_GIB_VERSION:=v1.1.0}"
+: "${NCCL_GIB_VERSION:=v1.1.2}"
 
 # This ensures that the docker process on the compute node can access us-docker.pkg.dev
 srun gcloud auth configure-docker us-docker.pkg.dev --quiet

--- a/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -119,8 +119,8 @@ ramble:
     hostlist: \${SLURM_JOB_NODELIST}
 
     container_dir: "${SOFTWARE_INSTALL}/ramble/sqsh"
-    container_name: nccl-plugin-gib-diagnostic-v1.1.0
-    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.0
+    container_name: nccl-plugin-gib-diagnostic-v1.1.2
+    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
     processes_per_node: 8
     processes_per_node: '{gpus_per_node}'
     gpus_per_node: '8'

--- a/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -119,8 +119,8 @@ ramble:
     hostlist: \${SLURM_JOB_NODELIST}
 
     container_dir: "${SOFTWARE_INSTALL}/ramble/sqsh"
-    container_name: nccl-plugin-gib-diagnostic-arm64:v1.0.6
-    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.0.6
+    container_name: nccl-plugin-gib-diagnostic-arm64:v1.1.2
+    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.1.2
     processes_per_node: 4
     processes_per_node: '{gpus_per_node}'
     gpus_per_node: '4'

--- a/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -119,7 +119,7 @@ ramble:
     hostlist: \${SLURM_JOB_NODELIST}
 
     container_dir: "${SOFTWARE_INSTALL}/ramble/sqsh"
-    container_name: nccl-plugin-gib-diagnostic-arm64:v1.1.2
+    container_name: nccl-plugin-gib-diagnostic-arm64-v1.1.2
     container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.1.2
     processes_per_node: 4
     processes_per_node: '{gpus_per_node}'

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -116,7 +116,7 @@ ramble:
     hostlist: \${SLURM_JOB_NODELIST}
 
     container_dir: "${SOFTWARE_INSTALL}/ramble/sqsh"
-    container_name: nccl-plugin-gib-diagnostic-arm64:v1.1.2
+    container_name: nccl-plugin-gib-diagnostic-arm64-v1.1.2
     container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.1.2
     # processes_per_node: 4
     processes_per_node: '{gpus_per_node}'

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -116,8 +116,8 @@ ramble:
     hostlist: \${SLURM_JOB_NODELIST}
 
     container_dir: "${SOFTWARE_INSTALL}/ramble/sqsh"
-    container_name: nccl-plugin-gib-diagnostic-arm64:v1.0.6
-    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.0.6
+    container_name: nccl-plugin-gib-diagnostic-arm64:v1.1.2
+    container_uri: docker://us-docker.pkg.dev#gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic-arm64:v1.1.2
     # processes_per_node: 4
     processes_per_node: '{gpus_per_node}'
     gpus_per_node: '4'

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -26,7 +26,7 @@ locals {
   # Officially supported latest helm chart versions of Jobset.
   # For details refer the official change log https://github.com/kubernetes-sigs/jobset/releases
   jobset_supported_versions    = ["0.10.1", "0.10.0", "0.9.1", "0.9.0"]
-  gib_supported_versions_x86   = ["v1.0.2", "v1.0.3", "v1.0.5", "v1.0.6", "v1.1.0"]
+  gib_supported_versions_x86   = ["v1.0.2", "v1.0.3", "v1.0.5", "v1.0.6", "v1.1.0", "v1.1.2"]
   gib_supported_versions_arm64 = ["v1.1.2", "v1.1.0", "v1.0.7"]
   gib_supported_versions = var.target_architecture == "arm64" ? (
     local.gib_supported_versions_arm64

--- a/modules/management/kubectl-apply/variables.tf
+++ b/modules/management/kubectl-apply/variables.tf
@@ -26,7 +26,7 @@ locals {
   # Officially supported latest helm chart versions of Jobset.
   # For details refer the official change log https://github.com/kubernetes-sigs/jobset/releases
   jobset_supported_versions    = ["0.10.1", "0.10.0", "0.9.1", "0.9.0"]
-  gib_supported_versions_x86   = ["v1.0.2", "v1.0.3", "v1.0.5", "v1.0.6", "v1.1.0", "v1.1.2"]
+  gib_supported_versions_x86   = ["v1.1.2", "v1.1.0", "v1.0.6", "v1.0.5", "v1.0.3", "v1.0.2"]
   gib_supported_versions_arm64 = ["v1.1.2", "v1.1.0", "v1.0.7"]
   gib_supported_versions = var.target_architecture == "arm64" ? (
     local.gib_supported_versions_arm64


### PR DESCRIPTION
This PR updates the GIB version across GKE and Slurm blueprints for both x86 and arm64 architectures.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
