### PR TITLE
Update reservation name validation to support reservation block

### DIFF
--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -477,7 +477,8 @@ func getProjectIfReservationMatches(resVal cty.Value, reservationName string) st
 		return ""
 	}
 	resAttrs := resVal.AsValueMap()
-	if getSafeString(resAttrs, "name") != reservationName {
+	nameVal := strings.Split(getSafeString(resAttrs, "name"), "/reservationBlocks/")[0]
+	if nameVal != reservationName {
 		return ""
 	}
 	return getSafeString(resAttrs, "project")


### PR DESCRIPTION
Updated reservation name validation to strip `/reservationBlocks/` suffixes when matching reservation names. This ensures validation succeeds regardless of whether the user supplies only the reservation name or the full resource path containing a reservation block.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
