### PR TITLE
[Telemetry] Promote Telemetry to production and filter internal test data from dashboard

### DIFF
--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -36,6 +36,7 @@ var (
 	isGkeModulePatterns        = []string{"gke-node-pool", "gke-cluster"}
 	isSlurmModulePatterns      = []string{"schedmd-slurm-gcp-"}
 	isVmInstanceModulePatterns = []string{"vm-instance"}
+	testProjects               = []string{"hpc-toolkit-dev"}
 )
 
 // NewCollector creates and initializes a new Telemetry Collector.
@@ -56,6 +57,7 @@ func (c *Collector) CollectMetrics(errorCode int, err error) {
 	defer c.mu.Unlock()
 
 	bpModulesList := getBpModulesList(c.blueprint)
+	project_id := config.GetKeyFromBlueprint("project_id", c.blueprint)
 
 	c.metadata[COMMAND_FLAGS] = getCmdFlags(c.eventCmd)
 	c.metadata[BLUEPRINT] = getBlueprintName(c.blueprint)
@@ -76,7 +78,7 @@ func (c *Collector) CollectMetrics(errorCode int, err error) {
 	c.metadata[TERRAFORM_VERSION] = getTerraformVersion()
 	c.metadata[INSTALLATION_MODE] = c.installationMode
 	c.metadata[IS_AI_ASSISTED] = strconv.FormatBool(c.blueprint.AIAssisted)
-	c.metadata[IS_TEST_DATA] = getIsTestData()
+	c.metadata[IS_TEST_DATA] = getIsTestData(project_id)
 	c.metadata[EXIT_CODE] = strconv.Itoa(errorCode)
 	c.metadata[ERROR_TYPE] = getErrorType(err)
 }
@@ -420,9 +422,12 @@ func getErrorType(err error) string {
 	return ErrTypeUnknown
 }
 
-// This method intentionally returns "true", as all telemetry is in testing phase currently.
-func getIsTestData() string {
-	return "true" // do not modify
+// This method returns "true" for test projects, and "false" otherwise.
+func getIsTestData(projectID string) string {
+	if slices.Contains(testProjects, projectID) {
+		return "true"
+	}
+	return "false"
 }
 
 func getLatencyMs(eventStartTime time.Time) int64 {

--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -57,7 +57,7 @@ func (c *Collector) CollectMetrics(errorCode int, err error) {
 	defer c.mu.Unlock()
 
 	bpModulesList := getBpModulesList(c.blueprint)
-	project_id := config.GetKeyFromBlueprint("project_id", c.blueprint)
+	projectID := config.GetKeyFromBlueprint("project_id", c.blueprint)
 
 	c.metadata[COMMAND_FLAGS] = getCmdFlags(c.eventCmd)
 	c.metadata[BLUEPRINT] = getBlueprintName(c.blueprint)
@@ -78,7 +78,7 @@ func (c *Collector) CollectMetrics(errorCode int, err error) {
 	c.metadata[TERRAFORM_VERSION] = getTerraformVersion()
 	c.metadata[INSTALLATION_MODE] = c.installationMode
 	c.metadata[IS_AI_ASSISTED] = strconv.FormatBool(c.blueprint.AIAssisted)
-	c.metadata[IS_TEST_DATA] = getIsTestData(project_id)
+	c.metadata[IS_TEST_DATA] = getIsTestData(projectID)
 	c.metadata[EXIT_CODE] = strconv.Itoa(errorCode)
 	c.metadata[ERROR_TYPE] = getErrorType(err)
 }
@@ -88,16 +88,16 @@ func (c *Collector) BuildConcordEvent() ConcordEvent {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	project_id := config.GetKeyFromBlueprint("project_id", c.blueprint)
+	projectID := config.GetKeyFromBlueprint("project_id", c.blueprint)
 
 	return ConcordEvent{
 		ConsoleType:      CLUSTER_TOOLKIT,
 		EventType:        "gclusterCLI",
 		EventName:        getCommandName(c.eventCmd),
 		EventMetadata:    getEventMetadataKVPairs(c.metadata),
-		ProjectNumber:    getProjectNumber(project_id),
+		ProjectNumber:    getProjectNumber(projectID),
 		ClientInstallId:  getClientInstallId(),
-		BillingAccountId: getBillingAccountId(project_id),
+		BillingAccountId: getBillingAccountId(projectID),
 		ReleaseVersion:   getReleaseVersion(),
 		IsGoogler:        getIsGoogler(),
 		LatencyMs:        getLatencyMs(c.eventStartTime),

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -118,7 +118,7 @@ func TestCollectMetrics_Extensible(t *testing.T) {
 				}
 			},
 			expectedValues: map[string]string{
-				IS_TEST_DATA:       "true",
+				IS_TEST_DATA:       "false",
 				EXIT_CODE:          "0",
 				COMMAND_FLAGS:      "force,project",
 				REGION:             "us-central1",
@@ -147,7 +147,7 @@ func TestCollectMetrics_Extensible(t *testing.T) {
 				}
 			},
 			expectedValues: map[string]string{
-				IS_TEST_DATA:       "true",
+				IS_TEST_DATA:       "false",
 				EXIT_CODE:          "1",
 				COMMAND_FLAGS:      "",
 				REGION:             "",
@@ -442,8 +442,34 @@ func TestGetReleaseVersion(t *testing.T) {
 }
 
 func TestGetIsTestData(t *testing.T) {
-	if got := getIsTestData(); got != "true" {
-		t.Errorf("getIsTestData() = %v, want true", got)
+	tests := []struct {
+		name      string
+		projectID string
+		want      string
+	}{
+		{
+			name:      "dev project",
+			projectID: "hpc-toolkit-dev",
+			want:      "true",
+		},
+		{
+			name:      "prod project",
+			projectID: "some-other-project",
+			want:      "false",
+		},
+		{
+			name:      "empty project",
+			projectID: "",
+			want:      "false",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getIsTestData(tt.projectID); got != tt.want {
+				t.Errorf("getIsTestData() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**Background**
The telemetry project has heavily been in the testing phase, resulting in 35+ metrics successfully implemented, tested, and integrated into the primary telemetry dashboards. With the implementation safely completed, it's time to graduate telemetry from the test phase to the production phase.

**Changes**
*   **Flipped the `IS_TEST_DATA` Flag**: The `getIsTestData` flag logic has been flipped to evaluate to `false` by default indicating that execution metrics are now treated as production payload rather than test data.
*   **Filtered out the `hpc-toolkit-dev` Project**: To maintain dashboard hygiene, we explicitly mark runs executing in the `hpc-toolkit-dev` project as test runs (setting `IS_TEST_DATA` to `true`). We moved this out of a hardcoded conditional into a dedicated `testProjects` string slice that we check against.

**Impact on Telemetry & Dashboard Visualizations**
Up until now, the dashboard has visualized metrics collected while the broader `IS_TEST_DATA = true` metric has been emitting to Clearcut. Moving forward:
1.  **Production Readiness**: Live user workflows will begin transmitting to the dashboards with the property `is_test_data: false`. The dashboard visualizations should now reliably reflect authentic user traffic and real-world metrics, as the prod dashboards filter specifically for records where `is_test_data` evaluates to `false`.
2.  **Noise Reduction**: Because our daily end-to-end tests and PR validation tests execute exclusively within the `hpc-toolkit-dev` GCP project, these automated executions will continue emitting `is_test_data: true`. Ultimately, this preserves the health of the production metrics by deliberately excluding automated noise, edge-case testing, and pipeline traffic from our analytics visualization.