### PR TITLE
docs: Fix broken NCCL test anchor links for GKE blueprints

### DIFF
--- a/examples/gke-a3-ultragpu/README.md
+++ b/examples/gke-a3-ultragpu/README.md
@@ -1,3 +1,3 @@
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A3U cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE-A3U cluster.

--- a/examples/gke-a3-ultragpu/README.md
+++ b/examples/gke-a3-ultragpu/README.md
@@ -1,3 +1,3 @@
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE-A3U cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE-A3U cluster.

--- a/examples/gke-a4/README.md
+++ b/examples/gke-a4/README.md
@@ -1,3 +1,3 @@
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A4 cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4) for instructions on running a NCCL test on the GKE-A4 cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4) for instructions on running a NCCL test on the GKE-A4 cluster.

--- a/examples/gke-a4/README.md
+++ b/examples/gke-a4/README.md
@@ -1,3 +1,3 @@
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A4 cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A4 cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4) for instructions on running a NCCL test on the GKE-A4 cluster.

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -4,7 +4,7 @@ This example provides the configuration to deploy a GKE cluster with A4X machine
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A4X cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE-A4X cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4x) for instructions on running a NCCL test on the GKE-A4X cluster.
 
 ## Install and Run MPI Operator on GKE Cluster
 

--- a/examples/gke-a4x/README.md
+++ b/examples/gke-a4x/README.md
@@ -4,7 +4,7 @@ This example provides the configuration to deploy a GKE cluster with A4X machine
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A4X cluster.
 
-Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4x) for instructions on running a NCCL test on the GKE-A4X cluster.
+Refer to [Deploy and run NCCL test with Topology Aware Scheduling (TAS)](https://cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a4x) for instructions on running a NCCL test on the GKE-A4X cluster.
 
 ## Install and Run MPI Operator on GKE Cluster
 

--- a/examples/gke-consumption-options/dws-calendar.md
+++ b/examples/gke-consumption-options/dws-calendar.md
@@ -10,4 +10,4 @@ The [gke-a3-ultragpu](../gke-a3-ultragpu/README.md) example can be used to creat
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 
-Refer to [Deploy and run NCCL test](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE A3 Ultragpu cluster.
+Refer to [Deploy and run NCCL test](https://cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE A3 Ultragpu cluster.

--- a/examples/gke-consumption-options/dws-calendar.md
+++ b/examples/gke-consumption-options/dws-calendar.md
@@ -10,4 +10,4 @@ The [gke-a3-ultragpu](../gke-a3-ultragpu/README.md) example can be used to creat
 
 Refer to [Create an AI-optimized GKE cluster with default configuration](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#use-cluster-toolkit) for instructions on creating the GKE-A3U cluster.
 
-Refer to [Deploy and run NCCL test](https://cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test) for instructions on running a NCCL test on the GKE A3 Ultragpu cluster.
+Refer to [Deploy and run NCCL test](https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke#a3-ultra) for instructions on running a NCCL test on the GKE A3 Ultragpu cluster.


### PR DESCRIPTION
## Description
The NCCL test documentation link in `cloud.google.com/ai-hypercomputer/docs/create/gke-ai-hypercompute#deploy-run-nccl-tas-test` is obsolete and leads to a broken or missing anchor tag on the generic page. The underlying Cloud Docs have been split into hardware-specific anchors on `https://docs.cloud.google.com/ai-hypercomputer/docs/nccl/test-gke`.

While the `develop` branch has already successfully updated this endpoint for the A3 Mega blueprint, the remaining blueprints were missed and were still routing to the dead `/create/` link. 

This PR aligns the remainder of the GKE blueprints to point sequentially to their new hardware-specific anchors in the `nccl/test-gke` docs (e.g., `#a3-ultra`, `#a4`, `#a4x`).

### Affected Files
* `examples/gke-a3-ultragpu/README.md`
* `examples/gke-a4/README.md`
* `examples/gke-a4x/README.md`
* `examples/gke-consumption-options/dws-calendar.md`
