### PR TITLE
test(g4): add nvbandwidth validation for G4 confidential VMs

### DIFF
--- a/examples/gke-g4-confidential/g4-verification-nvbandwidth.yaml
+++ b/examples/gke-g4-confidential/g4-verification-nvbandwidth.yaml
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: g4-verification-nvbandwidth
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        name: g4-verification-nvbandwidth
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/machine-family: g4
+        cloud.google.com/gke-confidential-nodes: "true"
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: nvbandwidth
+        image: nvidia/cuda:13.0.0-devel-ubuntu24.04
+        resources:
+          limits:
+            nvidia.com/gpu: 1
+          requests:
+            nvidia.com/gpu: 1
+        command: ["/bin/bash", "-c"]
+        args:
+        - |
+          set -ex
+          echo "=== INSTALLING SYSTEM DEPENDENCIES ==="
+          apt-get update && apt-get install -y \
+            git build-essential cmake libboost-program-options-dev libopenmpi-dev openmpi-bin
+          echo "=== COMPILING AND RUNNING NVBANDWIDTH ==="
+          git clone -b v0.10.0 --depth 1 https://github.com/NVIDIA/nvbandwidth.git
+          cd nvbandwidth
+          cmake -DCMAKE_CUDA_ARCHITECTURES="89;90;100" .
+          make
+          echo "=== EXECUTING PCIE BANDWIDTH TESTS ==="
+          ./nvbandwidth -t 0 1 2 3 -s

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-g4-confidential.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-g4-confidential.yml
@@ -88,6 +88,35 @@
       - "'SUCCESS: G4 GPU computation completed successfully!' in storage_logs.stdout"
       fail_msg: "The Storage Verification Test did not verify both successful confidential volume read/write and GPU computation."
 
+  - name: Run the G4 NVBandwidth test
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl create -f {{ workspace }}/examples/gke-g4-confidential/g4-verification-nvbandwidth.yaml -v=9
+    args:
+      executable: /bin/bash
+
+  - name: Wait for NVBandwidth test to hit completion
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl wait --for=condition=complete job/g4-verification-nvbandwidth --timeout=1200s
+    register: wait_result
+    until: wait_result.rc == 0
+    retries: 3
+    delay: 10
+
+  - name: Fetch logs from the nvbandwidth pod
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      kubectl logs job/g4-verification-nvbandwidth
+    register: nvbandwidth_logs
+
+  - name: Ensure nvbandwidth output confirms confidential encrypted bounce buffers
+    ansible.builtin.assert:
+      that:
+      - "'Detected platform using encrypted bounce buffers for CPU<->GPU traffic.' in nvbandwidth_logs.stdout"
+      - "'Waived host_to_device_bidirectional_memcpy_ce: bounce-buffer confidential computing enabled' in nvbandwidth_logs.stdout"
+      fail_msg: "NVBandwidth test failed or did not run under bounce-buffer CC mode."
+
   rescue:
   - name: Capture K8s events for jobs, pods, and PVCs on failure
     delegate_to: localhost
@@ -130,7 +159,21 @@
       msg: "G4 Confidential Verification tests failed."
 
   always:
+  - name: Fetch logs and describe nvbandwidth pod on failure
+    delegate_to: localhost
+    ansible.builtin.shell: |
+      echo "=== NVBANDWIDTH JOB & POD DESCRIPTION ==="
+      kubectl describe job g4-verification-nvbandwidth || true
+      kubectl describe pods -l name=g4-verification-nvbandwidth || true
+      echo "=== NVBANDWIDTH LOGS ==="
+      kubectl logs job/g4-verification-nvbandwidth || true
+    register: failed_nvbandwidth_logs
+
+  - name: Print nvbandwidth logs on failure
+    ansible.builtin.debug:
+      var: failed_nvbandwidth_logs.stdout_lines
+
   - name: Clean up
     delegate_to: localhost
     ansible.builtin.shell: |
-      kubectl delete job g4-verification-test g4-verification-storage-test --ignore-not-found -v=9
+      kubectl delete job g4-verification-test g4-verification-storage-test g4-verification-nvbandwidth --ignore-not-found -v=9


### PR DESCRIPTION
## Description
Adds integration testing for G4 Confidential VMs leveraging the NVBandwidth benchmark instead of NCCL.

NCCL is unsupported on G4 confidential instances due to architectural constraints with encrypted memory enclaves. To correctly validate that the hardware utilizes confidential computing bounce-buffers for CPU<->GPU communication, this PR:
1. Introduces a kubernetes job manifest (`g4-verification-nvbandwidth.yaml`) that downloads, compiles, and runs the `NVIDIA/nvbandwidth` tests with the `-s` flag (skip-verification, required to prevent security interrupts that brick the VM).
2. Modifies the G4 daily test ansible playbook to execute the bandwidth test.
3. Adds ansible assertions parsing the benchmark logs to explicitly confirm that the confidential encrypted bounce buffers were properly enabled and validated by the hardware.

## How Has This Been Tested?
The test was manually deployed and validated on a live G4 cluster. 

### Output Log Snippet:
```text
=== EXECUTING PCIE BANDWIDTH TESTS ===
nvbandwidth Version: v0.10.0
Built from Git version: v0.10.0

CUDA Runtime Version: 12.6 (12060)
CUDA Driver Version (API): 13.0 (13000)
Driver Version: 580.159.04

Detected platform using encrypted bounce buffers for CPU<->GPU traffic.
...
Waived host_to_device_bidirectional_memcpy_ce: bounce-buffer confidential computing enabled
Waived device_to_host_bidirectional_memcpy_ce: bounce-buffer confidential computing enabled
NOTE: The reported results may not reflect the full capabilities of the platform.
Performance can vary with software drivers, hardware clocks, and system topology.
```
