### PR TITLE
Revert PR 6026 to restore ACI integration

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -24,24 +24,17 @@ vars:
   region: # supply region
   zone: # supply zone
   a3u_cluster_size: # supply cluster size
+  instance_image:
+    project: advanced-compute-images
+    family: aci-gpu-u2404-slurm-2511-cuda-130-nvidia-580-amd64
   # Image settings
-  base_image:
-    project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
-  image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
   net0_range: 192.168.0.0/19
   net1_range: 192.168.64.0/18
   rdma_net_range: 192.168.128.0/18
   # Cluster Settings
   local_ssd_mountpoint: /mnt/localssd
-  instance_image:
-    project: $(vars.project_id)
-    family: $(vars.deployment_name)-u24
-  disk_size_gb: 100
-  nccl_gib_version: 1.1.0
-  libnccl_version: 2.27.5-1+cuda12.9
+  disk_size_gb: 300
   base_network_name: $(vars.deployment_name)
 
   #Provisioning models (set to true or fill in reservation name, pick only one)
@@ -64,220 +57,6 @@ vars:
   per_unit_storage_throughput: 500
 
 deployment_groups:
-- group: image-env
-  modules:
-  - id: slurm-image-network
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.base_network_name)-net
-
-  - id: slurm-build-script
-    source: modules/scripts/startup-script
-    settings:
-      install_ansible: true
-      enable_gpu_network_wait_online: true
-      docker:
-        enabled: true
-        world_writable: true
-      runners:
-      - type: data
-        destination: /etc/apt/preferences.d/block-broken-nvidia-container
-        content: |
-          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
-          Pin: version 1.17.7-1
-          Pin-Priority: 100
-
-      # The following holds NVIDIA software that was already installed on the
-      # accelerator base image to be the same driver version. This reduces the
-      # risk of a driver version mismatch.
-      # Additional packages are held by:
-      # https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/ansible/group_vars/os_ubuntu.yml
-      - type: ansible-local
-        destination: hold-nvidia-packages.yml
-        content: |
-          ---
-          - name: Hold nvidia packages
-            hosts: all
-            become: true
-            vars:
-              nvidia_packages_to_hold:
-              - libnvidia-cfg1-*-server
-              - libnvidia-compute-*-server
-              - libnvidia-nscq-*
-              - nvidia-compute-utils-*-server
-              - nvidia-fabricmanager-*
-              - nvidia-utils-*-server
-              - nvidia-imex-*
-            tasks:
-            - name: Hold nvidia packages
-              ansible.builtin.command:
-                argv:
-                - apt-mark
-                - hold
-                - "{{ item }}"
-              loop: "{{ nvidia_packages_to_hold }}"
-
-      - type: data
-        destination: /var/tmp/slurm_vars.json
-        content: |
-          {
-            "reboot": false,
-            "install_cuda": false,
-            "install_gcsfuse": true,
-            "install_lustre": false,
-            "install_managed_lustre": true,
-            "install_ompi": true,
-            "allow_kernel_upgrades": false,
-            "monitoring_agent": "cloud-ops",
-          }
-      - type: shell
-        destination: install_slurm.sh
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C $(vars.build_slurm_from_git_ref) \
-              -i localhost, --limit localhost --connection=local \
-              -e @/var/tmp/slurm_vars.json \
-              ansible/playbook.yml
-      # this duplicates the ulimits configuration of the HPC VM Image
-      - type: data
-        destination: /etc/security/limits.d/99-unlimited.conf
-        content: |
-          * - memlock unlimited
-          * - nproc unlimited
-          * - stack unlimited
-          * - nofile 1048576
-          * - cpu unlimited
-          * - rtprio unlimited
-
-      - type: ansible-local
-        destination: install_cuda_and_dcgm.yml
-        content: |
-          ---
-          - name: Install and Configure CUDA 13 / DCGM
-            hosts: all
-            become: true
-            vars:
-              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
-              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
-              nvidia_packages:
-                - cuda-toolkit-13-0
-                - datacenter-gpu-manager-4-cuda13
-                - datacenter-gpu-manager-4-dev
-                - datacenter-gpu-manager-4-core
-            tasks:
-              - name: Install NVIDIA repository keyring
-                ansible.builtin.apt:
-                  deb: "{{ cuda_repo_url }}"
-                  state: present
-
-              - name: Update apt cache
-                ansible.builtin.apt:
-                  update_cache: yes
-
-              - name: Install NVIDIA packages
-                ansible.builtin.apt:
-                  name: "{{ item }}"
-                  state: present
-                  allow_downgrade: yes
-                loop: "{{ nvidia_packages }}"
-
-              - name: Freeze NVIDIA packages
-                ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
-                  selection: hold
-                loop: "{{ nvidia_packages }}"
-
-              - name: Create nvidia-persistenced override directory
-                ansible.builtin.file:
-                  path: /etc/systemd/system/nvidia-persistenced.service.d
-                  state: directory
-                  owner: root
-                  group: root
-                  mode: 0o755
-
-              - name: Configure nvidia-persistenced override
-                ansible.builtin.copy:
-                  dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                  owner: root
-                  group: root
-                  mode: 0o644
-                  content: |
-                    [Service]
-                    ExecStart=
-                    ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-                notify: Reload SystemD
-
-            handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
-
-            post_tasks:
-              - name: Disable NVIDIA services by default (Slurm starts them on boot)
-                ansible.builtin.service:
-                  name: "{{ item }}"
-                  state: stopped
-                  enabled: false
-                loop:
-                  - nvidia-dcgm.service
-                  - nvidia-persistenced.service
-
-      - type: ansible-local
-        destination: install_ibverbs_utils.yml
-        content: |
-          ---
-          - name: Install ibverbs-utils
-            hosts: all
-            become: true
-            tasks:
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - ibverbs-utils
-                state: present
-      - type: data
-        destination: /etc/enroot/enroot.conf
-        content: |
-          ENROOT_CONFIG_PATH ${HOME}/.enroot
-
-- group: image
-  modules:
-  - id: slurm-a3ultra-image
-    source: modules/packer/custom-image
-    kind: packer
-    settings:
-      disk_size: $(vars.disk_size_gb)
-      machine_type: $(vars.image_build_machine_type)
-      source_image: $(vars.base_image.image)
-      source_image_project_id: [$(vars.base_image.project)]
-      image_family: $(vars.instance_image.family)
-      omit_external_ip: false
-
-      # Unattended upgrades are disabled in this blueprint so that software does not
-      # get updated daily and lead to potential instability in the cluster environment.
-      #
-      # Unattended Upgrades installs available security updates from the Ubuntu
-      # security pocket for installed packages daily by default. Administrators who
-      # disable this feature assume all responsibility for manually reviewing and
-      # patching their systems against vulnerabilities.
-      #
-      # To enable unattended upgrades, please remove this section.
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
-          write_files:
-          - path: /etc/apt/apt.conf.d/20auto-upgrades
-            permissions: '0644'
-            owner: root
-            content: |
-              APT::Periodic::Update-Package-Lists "0";
-              APT::Periodic::Unattended-Upgrade "0";
-    use:
-    - slurm-image-network
-    - slurm-build-script
 
 - group: cluster-env
   modules:
@@ -433,6 +212,7 @@ deployment_groups:
   - id: a3ultra_startup
     source: modules/scripts/startup-script
     settings:
+      install_ansible: true
       local_ssd_filesystem:
         mountpoint: $(vars.local_ssd_mountpoint)
         permissions: "1777" # must quote numeric filesystem permissions!
@@ -473,92 +253,54 @@ deployment_groups:
           if [ ! -f /etc/hostname ]; then
             hostname > /etc/hostname
           fi
-      # Install NCCL
       - type: ansible-local
-        destination: install_nccl.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: Install nccl
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
             tasks:
-            - name: Update apt cache
-              ansible.builtin.apt:
-                update_cache: yes
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - "libnccl2=$(vars.libnccl_version)"
-                - "libnccl-dev=$(vars.libnccl_version)"
-                state: present
-      # Install NCCL-GIB Plugin
-      - type: ansible-local
-        destination: install_nccl_gib.yml
-        content: |
-          ---
-          - name: Install Google NCCL-GIB Plugin
-            hosts: all
-            become: true
-            tasks:
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://us-apt.pkg.dev/doc/repo-signing-key.gpg
-                state: present
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-                state: present
-            - name: Install Apt Transport AR Apt Repo
-              apt_repository:
-                repo: 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main'
-                state: present
-            - name: Install AR transport
-              ansible.builtin.apt:
-                name: "apt-transport-artifact-registry"
-                update_cache: true
-            - name: Install Google NCCL-GIB Plugin
-              apt_repository:
-                repo: "deb ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-gib-apt main"
-                state: present
-            - name: Install NCCL-GIB Plugin
-              ansible.builtin.apt:
-                name: "nccl-gib=$(vars.nccl_gib_version)"
-                update_cache: true
-            - name: Freeze NCCL GIB Plugin
-              ansible.builtin.dpkg_selections:
-                name: "nccl-gib"
-                selection: hold
-      # --------------------------------------------------------------------------
-      # Environment Configuration
-      # --------------------------------------------------------------------------
-      - type: ansible-local
-        destination: configure_nccl_env.yml
-        name: Ensure NCCL/gIB environment script is sourced for all users
-        content: |
-          ---
-          - name: Configure NCCL/gIB environment
-            hosts: all
-            become: true
-            tasks:
-            - name: Deploy /etc/profile.d/nccl-gib.sh
-              ansible.builtin.copy:
-                dest: /etc/profile.d/nccl-gib.sh
-                content: |
-                  # Load NCCL/gIB environment
-                  if [ -f "/usr/local/gib/scripts/set_nccl_env.sh" ]; then
-                    source /usr/local/gib/scripts/set_nccl_env.sh
-                  fi
+              - name: Download CUDA runfile
+                ansible.builtin.get_url:
+                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
+                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  mode: '0755'
 
-                  # Ensure /usr/local/gib/lib64 is in LD_LIBRARY_PATH
-                  if [ -d "/usr/local/gib/lib64" ]; then
-                    export LD_LIBRARY_PATH="/usr/local/gib/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-                  fi
-                mode: '0644'
-            handlers:
-              - name: Reload SystemD
-                ansible.builtin.systemd:
-                  daemon_reload: true
+              - name: Install CUDA toolkit via runfile
+                ansible.builtin.command:
+                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
 
+              - name: Remove CUDA runfile
+                ansible.builtin.file:
+                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  state: absent
+
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install DCGM packages
+                ansible.builtin.apt:
+                  name:
+                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
+                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
+                    - datacenter-gpu-manager-4-core=1:4.6.0-1
+                  state: present
+
+              - name: Freeze DCGM packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -672,12 +414,32 @@ deployment_groups:
     settings:
       disk_size_gb: 300
       enable_login_public_ips: true
-      machine_type: n2-standard-8
+      machine_type: e2-standard-16
 
   - id: controller_startup
     source: modules/scripts/startup-script
     settings:
       runners:
+      - type: shell
+        destination: restart_nfs.sh
+        content: |
+          #!/bin/bash
+          # Restart NFS server after mounting Lustre to /home to ensure the export correctly reflects the new mount point.
+          systemctl restart nfs-server || systemctl restart nfs-kernel-server
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
+          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
+          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       - type: shell
         destination: stage_scripts.sh
         content: |
@@ -711,6 +473,7 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: 300
-      machine_type: n2-standard-80
+      machine_type: e2-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
+      compute_startup_scripts_timeout: 1800

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -25,11 +25,6 @@ vars:
   zone: # supply zone
   a4h_cluster_size: # supply cluster size
   # Image settings
-  base_image:
-    project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-amd64-with-nvidia-580-v20260522
-  image_build_machine_type: n2-standard-16
-  build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -39,11 +34,9 @@ vars:
   # Cluster Settings
   local_ssd_mountpoint: /mnt/localssd
   instance_image:
-    project: $(vars.project_id)
-    family: $(vars.deployment_name)-u24
-  disk_size_gb: 100
-  nccl_gib_version: 1.1.0
-  libnccl_version: 2.27.5-1+cuda12.9
+    project: advanced-compute-images
+    family: aci-gpu-u2404-slurm-2511-cuda-130-nvidia-580-amd64
+  disk_size_gb: 300
   benchmark_dir: $(ghpc_stage("system_benchmarks"))
   base_network_name: $(vars.deployment_name)
 
@@ -69,214 +62,6 @@ vars:
   # per_unit_storage_throughput: 500
 
 deployment_groups:
-- group: image-env
-  modules:
-  - id: slurm-image-network
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.base_network_name)-net
-
-  - id: slurm-build-script
-    source: modules/scripts/startup-script
-    settings:
-      install_ansible: true
-      enable_gpu_network_wait_online: true
-      docker:
-        enabled: true
-        world_writable: true
-      runners:
-      - type: data
-        destination: /etc/apt/preferences.d/block-broken-nvidia-container
-        content: |
-          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
-          Pin: version 1.17.7-1
-          Pin-Priority: 100
-
-      # The following holds NVIDIA software that was already installed on the
-      # accelerator base image to be the same driver version. This reduces the
-      # risk of a driver version mismatch.
-      # Additional packages are held by:
-      # https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/ansible/group_vars/os_ubuntu.yml
-      - type: ansible-local
-        destination: hold-nvidia-packages.yml
-        content: |
-          ---
-          - name: Hold nvidia packages
-            hosts: all
-            become: true
-            vars:
-              nvidia_packages_to_hold:
-              - libnvidia-cfg1-*-server
-              - libnvidia-compute-*-server
-              - libnvidia-nscq-*
-              - nvidia-compute-utils-*-server
-              - nvidia-fabricmanager-*
-              - nvidia-utils-*-server
-              - nvidia-imex-*
-            tasks:
-            - name: Hold nvidia packages
-              ansible.builtin.command:
-                argv:
-                - apt-mark
-                - hold
-                - "{{ item }}"
-              loop: "{{ nvidia_packages_to_hold }}"
-
-      - type: data
-        destination: /var/tmp/slurm_vars.json
-        content: |
-          {
-            "reboot": false,
-            "install_cuda": false,
-            "install_gcsfuse": true,
-            "install_lustre": false,
-            "install_managed_lustre": false,
-            "install_ompi": true,
-            "allow_kernel_upgrades": false,
-            "monitoring_agent": "cloud-ops",
-          }
-      - type: shell
-        destination: install_slurm.sh
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C $(vars.build_slurm_from_git_ref) \
-              -i localhost, --limit localhost --connection=local \
-              -e @/var/tmp/slurm_vars.json \
-              ansible/playbook.yml
-      # this duplicates the ulimits configuration of the HPC VM Image
-      - type: data
-        destination: /etc/security/limits.d/99-unlimited.conf
-        content: |
-          * - memlock unlimited
-          * - nproc unlimited
-          * - stack unlimited
-          * - nofile 1048576
-          * - cpu unlimited
-          * - rtprio unlimited
-      - type: ansible-local
-        destination: install_cuda_and_dcgm.yml
-        content: |
-          ---
-          - name: Install and Configure CUDA 13 / DCGM
-            hosts: all
-            become: true
-            vars:
-              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
-              cuda_repo_url: "https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/x86_64/cuda-keyring_1.1-1_all.deb"
-              nvidia_packages:
-                - cuda-toolkit-13-0
-                - datacenter-gpu-manager-4-cuda13
-                - datacenter-gpu-manager-4-dev
-                - datacenter-gpu-manager-4-core
-            tasks:
-              - name: Install NVIDIA repository keyring
-                ansible.builtin.apt:
-                  deb: "{{ cuda_repo_url }}"
-                  state: present
-
-              - name: Update apt cache
-                ansible.builtin.apt:
-                  update_cache: yes
-
-              - name: Install NVIDIA packages
-                ansible.builtin.apt:
-                  name: "{{ item }}"
-                  state: present
-                  allow_downgrade: yes
-                loop: "{{ nvidia_packages }}"
-
-              - name: Freeze NVIDIA packages
-                ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
-                  selection: hold
-                loop: "{{ nvidia_packages }}"
-
-              - name: Create nvidia-persistenced override directory
-                ansible.builtin.file:
-                  path: /etc/systemd/system/nvidia-persistenced.service.d
-                  state: directory
-                  mode: 0o755
-
-              - name: Configure nvidia-persistenced override
-                ansible.builtin.copy:
-                  dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                  mode: 0o644
-                  content: |
-                    [Service]
-                    ExecStart=
-                    ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-                notify: Reload SystemD
-
-            handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
-
-            post_tasks:
-              - name: Disable NVIDIA services by default (Slurm starts them on boot)
-                ansible.builtin.service:
-                  name: "{{ item }}"
-                  state: stopped
-                  enabled: false
-                loop:
-                  - nvidia-dcgm.service
-                  - nvidia-persistenced.service
-
-      - type: ansible-local
-        destination: install_ibverbs_utils.yml
-        content: |
-          ---
-          - name: Install ibverbs-utils
-            hosts: all
-            become: true
-            tasks:
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - ibverbs-utils
-                state: present
-      - type: data
-        destination: /etc/enroot/enroot.conf
-        content: |
-          ENROOT_CONFIG_PATH     ${HOME}/.enroot
-
-- group: image
-  modules:
-  - id: slurm-a4high-image
-    source: modules/packer/custom-image
-    kind: packer
-    settings:
-      disk_size: $(vars.disk_size_gb)
-      machine_type: $(vars.image_build_machine_type)
-      source_image: $(vars.base_image.image)
-      source_image_project_id: [$(vars.base_image.project)]
-      image_family: $(vars.instance_image.family)
-      omit_external_ip: false
-      # Unattended upgrades are disabled in this blueprint so that software does not
-      # get updated daily and lead to potential instability in the cluster environment.
-      #
-      # Unattended Upgrades installs available security updates from the Ubuntu
-      # security pocket for installed packages daily by default. Administrators who
-      # disable this feature assume all responsibility for manually reviewing and
-      # patching their systems against vulnerabilities.
-      #
-      # To enable unattended upgrades, please remove this section.
-      metadata:
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
-          write_files:
-          - path: /etc/apt/apt.conf.d/20auto-upgrades
-            permissions: '0644'
-            owner: root
-            content: |
-              APT::Periodic::Update-Package-Lists "0";
-              APT::Periodic::Unattended-Upgrade "0";
-    use:
-    - slurm-image-network
-    - slurm-build-script
 
 - group: cluster-env
   modules:
@@ -451,6 +236,7 @@ deployment_groups:
   - id: a4high_startup
     source: modules/scripts/startup-script
     settings:
+      install_ansible: true
       local_ssd_filesystem:
         mountpoint: $(vars.local_ssd_mountpoint)
         permissions: "1777" # must quote numeric filesystem permissions!
@@ -490,89 +276,56 @@ deployment_groups:
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       # Install NCCL
       - type: ansible-local
-        destination: install_nccl.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: Install nccl
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
+            vars:
+              cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run"
+              cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux.run"
             tasks:
-            - name: Update apt cache
-              ansible.builtin.apt:
-                update_cache: yes
-            - name: Install Linux Modules Extra
-              ansible.builtin.package:
-                name:
-                - "libnccl2=$(vars.libnccl_version)"
-                - "libnccl-dev=$(vars.libnccl_version)"
-                state: present
-      # Install NCCL-GIB Plugin
-      - type: ansible-local
-        destination: install_nccl_gib.yml
-        content: |
-          ---
-          - name: Install Google NCCL-GIB Plugin
-            hosts: all
-            become: true
-            tasks:
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://us-apt.pkg.dev/doc/repo-signing-key.gpg
-                state: present
-            - name: Add artifact registry gpg key
-              ansible.builtin.apt_key:
-                url: https://packages.cloud.google.com/apt/doc/apt-key.gpg
-                state: present
-            - name: Install Apt Transport AR Apt Repo
-              apt_repository:
-                repo: 'deb http://packages.cloud.google.com/apt apt-transport-artifact-registry-stable main'
-                state: present
-            - name: Install AR transport
-              ansible.builtin.apt:
-                name: "apt-transport-artifact-registry"
-                update_cache: true
-            - name: Install Google NCCL-GIB Plugin
-              apt_repository:
-                repo: "deb ar+https://us-apt.pkg.dev/projects/gce-ai-infra gpudirect-gib-apt main"
-                state: present
-            - name: Install NCCL-GIB Plugin
-              ansible.builtin.apt:
-                name: "nccl-gib=$(vars.nccl_gib_version)"
-                update_cache: true
-            - name: Freeze NCCL GIB Plugin
-              ansible.builtin.dpkg_selections:
-                name: "nccl-gib"
-                selection: hold
-      # --------------------------------------------------------------------------
-      # Environment Configuration
-      # --------------------------------------------------------------------------
-      - type: ansible-local
-        destination: configure_nccl_env.yml
-        name: Ensure NCCL/gIB environment script is sourced for all users
-        content: |
-          ---
-          - name: Configure NCCL/gIB environment
-            hosts: all
-            become: true
-            tasks:
-              - name: Deploy /etc/profile.d/nccl-gib.sh
-                ansible.builtin.copy:
-                  dest: /etc/profile.d/nccl-gib.sh
-                  content: |
-                    # Load NCCL/gIB environment
-                    if [ -f "/usr/local/gib/scripts/set_nccl_env.sh" ]; then
-                      source /usr/local/gib/scripts/set_nccl_env.sh
-                    fi
+              - name: Download CUDA runfile
+                ansible.builtin.get_url:
+                  url: "{{ cuda_installer_url }}"
+                  dest: "{{ cuda_installer_file }}"
+                  mode: '0755'
 
-                    # Ensure /usr/local/gib/lib64 is in LD_LIBRARY_PATH
-                    if [ -d "/usr/local/gib/lib64" ]; then
-                      export LD_LIBRARY_PATH="/usr/local/gib/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
-                    fi
-                  mode: '0644'
-            handlers:
-              - name: Reload SystemD
-                ansible.builtin.systemd:
-                  daemon_reload: true
+              - name: Install CUDA toolkit via runfile
+                ansible.builtin.command:
+                  cmd: "{{ cuda_installer_file }} --silent --toolkit"
+
+              - name: Remove CUDA runfile
+                ansible.builtin.file:
+                  path: "{{ cuda_installer_file }}"
+                  state: absent
+
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install DCGM packages
+                ansible.builtin.apt:
+                  name:
+                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
+                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
+                    - datacenter-gpu-manager-4-core=1:4.6.0-1
+                  state: present
+
+              - name: Freeze DCGM packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -636,6 +389,10 @@ deployment_groups:
       enable_placement: false
       disk_type: hyperdisk-balanced
       on_host_maintenance: TERMINATE
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
       #Provisioning models
       reservation_name: $(vars.a4h_reservation_name)
@@ -683,14 +440,32 @@ deployment_groups:
     source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
     use: [a4high-slurm-net-0]
     settings:
-      disk_size_gb: 300
+      disk_size_gb: $(vars.disk_size_gb)
       enable_login_public_ips: true
-      machine_type: n2-standard-8
+      machine_type: e2-standard-16
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true
 
   - id: controller_startup
     source: modules/scripts/startup-script
     settings:
       runners:
+      - type: shell
+        destination: ensure_mnt_localssd_permissions.sh
+        content: |
+          #!/bin/bash
+          mkdir -p /mnt/localssd
+          chmod 1777 /mnt/localssd
+      - type: data
+        destination: /etc/enroot/enroot.conf
+        content: |
+          ENROOT_CONFIG_PATH     ${HOME}/.enroot
+          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
+          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
+          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
+          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       - type: shell
         destination: stage_scripts.sh
         content: |
@@ -729,7 +504,12 @@ deployment_groups:
     settings:
       enable_controller_public_ips: true
       disk_type: pd-extreme
-      disk_size_gb: 300
-      machine_type: n2-standard-80
+      disk_size_gb: $(vars.disk_size_gb)
+      machine_type: e2-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
+      compute_startup_scripts_timeout: 1800
+      metadata:
+        user-data: |
+          #cloud-config
+          create_hostname_file: true

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -25,15 +25,6 @@ vars:
   region: ## A4X Reservation Region ##
   zone: ## A4X Reservation Zone ##
   a4x_cluster_size: # supply cluster size
-  # Image settings
-  base_image:
-    project: ubuntu-os-accelerator-images
-    image: ubuntu-accelerator-2404-arm64-with-nvidia-580-v20260522
-  image_build_machine_type: c4a-highcpu-16
-  image_build_disk_type: hyperdisk-balanced
-  image_disk_size_gb: 100
-  built_image_family: slurm-ubuntu2404-accelerator-arm64-64k
-  build_slurm_from_git_ref: 6.12.1
   # Cluster env settings
   # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
@@ -43,10 +34,9 @@ vars:
   # Cluster Settings
   disk_size_gb: 100 # It is recommended to have at least 100 GB per node.
   local_ssd_mountpoint: /mnt/localssd
-  nccl_plugin_version: v1.0.6
   instance_image:
-    project: $(vars.project_id)
-    family: slurm-ubuntu2404-accelerator-arm64-64k
+    project: advanced-compute-images
+    family: aci-gpu-u2404-slurm-2511-cuda-130-nvidia-580-arm64
   a4x_reservation_name: "" # supply reservation name
   benchmark_dir: $(ghpc_stage("system_benchmarks"))
 
@@ -67,219 +57,6 @@ vars:
   per_unit_storage_throughput: 500
 
 deployment_groups:
-- group: image-env
-  modules:
-  - id: a4x-slurm-image-net
-    source: modules/network/vpc
-
-  - id: slurm-build-script
-    source: modules/scripts/startup-script
-    settings:
-      enable_gpu_network_wait_online: true
-      runners:
-      - type: data
-        destination: /etc/apt/preferences.d/block-broken-nvidia-container
-        content: |
-          Package: nvidia-container-toolkit nvidia-container-toolkit-base libnvidia-container-tools libnvidia-container1
-          Pin: version 1.17.7-1
-          Pin-Priority: 100
-
-      # The following holds NVIDIA software that was already installed on the
-      # accelerator base image to be the same driver version. This reduces the
-      # risk of a driver version mismatch.
-      # Additional packages are held by:
-      # https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/ansible/group_vars/os_ubuntu.yml
-      - type: ansible-local
-        destination: hold-nvidia-packages.yml
-        content: |
-          ---
-          - name: Hold nvidia packages
-            hosts: all
-            become: true
-            vars:
-              nvidia_packages_to_hold:
-              - libnvidia-cfg1-*-server
-              - libnvidia-compute-*-server
-              - libnvidia-nscq-*
-              - nvidia-compute-utils-*-server
-              - nvidia-fabricmanager-*
-              - nvidia-utils-*-server
-              - nvidia-imex-*
-            tasks:
-            - name: Hold nvidia packages
-              ansible.builtin.command:
-                argv:
-                - apt-mark
-                - hold
-                - "{{ item }}"
-              loop: "{{ nvidia_packages_to_hold }}"
-
-      - type: data
-        destination: /etc/enroot/enroot.conf
-        content: |
-          ENROOT_CONFIG_PATH     ${HOME}/.enroot
-          ENROOT_RUNTIME_PATH    $(vars.local_ssd_mountpoint)/${UID}/enroot/runtime
-          ENROOT_CACHE_PATH      $(vars.local_ssd_mountpoint)/${UID}/enroot/cache
-          ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
-          ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
-      - type: data
-        destination: /etc/security/limits.d/99-unlimited.conf
-        content: |
-          * - memlock unlimited
-          * - nproc unlimited
-          * - stack 8192
-          * - nofile 1048576
-          * - cpu unlimited
-          * - rtprio unlimited
-      - type: ansible-local
-        destination: update_settings.yml
-        content: |
-          ---
-          - name: Update OS settings prior to Slurm install
-            hosts: all
-            become: true
-            tasks:
-            - name: Turn off username space restriction in Apparmor
-              ansible.builtin.lineinfile:
-                path: /etc/sysctl.d/20-apparmor-donotrestrict.conf
-                regexp: '^kernel.apparmor_restrict_unprivileged_userns'
-                line: kernel.apparmor_restrict_unprivileged_userns = 0
-                create: yes
-              when: ansible_distribution == "Ubuntu" and  ansible_distribution_major_version is version('23', '>=')
-      - type: data
-        destination: /var/tmp/slurm_vars.json
-        # Note kernel_packages and kernel_header_packages should be fixed at soon
-        content: |
-          {
-            "reboot": false,
-            "install_ompi": true,
-            "install_lustre": false,
-            "install_gcsfuse": true,
-            "install_cuda": false,
-            "allow_kernel_upgrades": false,
-            "monitoring_agent": "cloud-ops",
-            install_managed_lustre: true,
-          }
-      - type: shell
-        destination: install_slurm.sh
-        # Note: changes to slurm-gcp `/scripts` folder in the built image will not reflect in the deployed cluster.
-        # Instead the scripts referenced in `schedmd-slurm-gcp-v6-controller/slurm_files` will be used.
-        content: |
-          #!/bin/bash
-          set -e -o pipefail
-          ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C $(vars.build_slurm_from_git_ref) \
-              -i localhost, --limit localhost --connection=local \
-              -e @/var/tmp/slurm_vars.json \
-              ansible/playbook.yml
-      - type: ansible-local
-        destination: install_a4x_drivers.yml
-        content: |
-          ---
-          - name: Install A4X Drivers and Utils
-            hosts: all
-            become: true
-            vars:
-              distribution: "{{ ansible_distribution | lower }}{{ ansible_distribution_version | replace('.','') }}"
-              cuda_repo_url: https://developer.download.nvidia.com/compute/cuda/repos/{{ distribution }}/sbsa/cuda-keyring_1.1-1_all.deb
-              cuda_repo_filename: /tmp/{{ cuda_repo_url | basename }}
-              nvidia_packages:
-              - cuda-toolkit-13-0
-              - datacenter-gpu-manager-4-cuda13
-              - datacenter-gpu-manager-4-dev
-            tasks:
-            - name: Download NVIDIA repository package
-              ansible.builtin.get_url:
-                url: "{{ cuda_repo_url }}"
-                dest: "{{ cuda_repo_filename }}"
-            - name: Install NVIDIA repository package
-              ansible.builtin.apt:
-                deb: "{{ cuda_repo_filename }}"
-                state: present
-            - name: Install NVIDIA fabric and CUDA
-              ansible.builtin.apt:
-                name: "{{ item }}"
-                update_cache: true
-                allow_downgrade: yes
-              loop: "{{ nvidia_packages }}"
-            - name: Freeze NVIDIA fabric and CUDA
-              ansible.builtin.command:
-                argv:
-                - apt-mark
-                - hold
-                - "{{ item }}"
-              loop: "{{ nvidia_packages }}"
-            - name: Create nvidia-persistenced override directory
-              ansible.builtin.file:
-                path: /etc/systemd/system/nvidia-persistenced.service.d
-                state: directory
-                owner: root
-                group: root
-                mode: 0o755
-            - name: Configure nvidia-persistenced override
-              ansible.builtin.copy:
-                dest: /etc/systemd/system/nvidia-persistenced.service.d/persistence_mode.conf
-                owner: root
-                group: root
-                mode: 0o644
-                content: |
-                  [Service]
-                  ExecStart=
-                  ExecStart=/usr/bin/nvidia-persistenced --user nvidia-persistenced --verbose
-              notify: Reload SystemD
-            handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
-            post_tasks:
-            - name: Disable NVIDIA DCGM by default (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-dcgm.service
-                state: stopped
-                enabled: false
-            - name: Disable nvidia-persistenced SystemD unit (enable during boot on GPU nodes)
-              ansible.builtin.service:
-                name: nvidia-persistenced.service
-                state: stopped
-                enabled: false
-
-- group: image
-  modules:
-  - id: slurm-a4xhigh-image
-    source: modules/packer/custom-image
-    kind: packer
-    settings:
-      disk_size: $(vars.image_disk_size_gb)
-      disk_type: $(vars.image_build_disk_type)
-      machine_type: $(vars.image_build_machine_type)
-      source_image: $(vars.base_image.image)
-      source_image_project_id: [$(vars.base_image.project)]
-      image_family: $(vars.built_image_family)
-      omit_external_ip: true
-      metadata:
-        # Needed in Ubuntu 24.04 for enroot, not required on VMs using this image
-        # Unattended upgrades are disabled in this blueprint so that software does not
-        # get updated daily and lead to potential instability in the cluster environment.
-        #
-        # Unattended Upgrades installs available security updates from the Ubuntu
-        # security pocket for installed packages daily by default. Administrators who
-        # disable this feature assume all responsibility for manually reviewing and
-        # patching their systems against vulnerabilities.
-        #
-        # To enable unattended upgrades, please remove this section.
-        user-data: |
-          #cloud-config
-          create_hostname_file: true
-          write_files:
-          - path: /etc/apt/apt.conf.d/20auto-upgrades
-            permissions: '0644'
-            owner: root
-            content: |
-              APT::Periodic::Update-Package-Lists "0";
-              APT::Periodic::Unattended-Upgrade "0";
-    use:
-    - a4x-slurm-image-net
-    - slurm-build-script
 
 - group: cluster-env
   modules:
@@ -346,10 +123,6 @@ deployment_groups:
   #   outputs:
   #   - network_storage
 
-  # To use Managed Lustre as for the shared /home directory:
-  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
-  # 2. Uncomment the managed-lustre and private-service-access blocks
-  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
   - id: private_service_access
     source: modules/network/private-service-access
     use: [a4x-slurm-net-0]
@@ -494,46 +267,57 @@ deployment_groups:
           ENROOT_DATA_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot/data
           ENROOT_TEMP_PATH       $(vars.local_ssd_mountpoint)/${UID}/enroot
       - type: ansible-local
-        destination: nccl_plugin.yml
+        destination: install_cuda_and_dcgm.yml
         content: |
           ---
-          - name: Install NCCL plugin for A4X series
+          - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
+            vars:
+              cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux_sbsa.run"
+              cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux_sbsa.run"
+              dcgm_version: "1:4.6.0-1"
             tasks:
-            - name: Add SystemD unit for NCCL plugin installation
-              ansible.builtin.copy:
-                dest: /etc/systemd/system/nccl-plugin@$(vars.nccl_plugin_version).service
-                mode: 0o0644
-                content: |
-                  [Unit]
-                  After=network-online.target docker.service
-                  Before=slurmd.service
-                  Requires=docker.service
+              - name: Download CUDA runfile
+                ansible.builtin.get_url:
+                  url: "{{ cuda_installer_url }}"
+                  dest: "{{ cuda_installer_file }}"
+                  mode: '0755'
 
-                  [Service]
-                  Type=oneshot
-                  ExecStartPre=/usr/bin/rm -rf /usr/local/gib
-                  ExecStartPre=/usr/bin/mkdir -p /usr/local/gib
-                  ExecStartPre=/snap/bin/gcloud auth configure-docker --quiet us-docker.pkg.dev
-                  ExecStart=/usr/bin/docker run --rm --name nccl-gib-installer --volume /usr/local/gib:/var/lib/gib \
-                      us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-arm64:latest install --install-nccl
-                  ExecStartPost=/usr/bin/chmod -R a+r /usr/local/gib
+              - name: Install CUDA toolkit via runfile
+                ansible.builtin.command:
+                  cmd: "{{ cuda_installer_file }} --silent --toolkit"
 
-                  [Install]
-                  WantedBy=slurmd.service
-              notify:
-              - Reload SystemD
-            handlers:
-            - name: Reload SystemD
-              ansible.builtin.systemd:
-                daemon_reload: true
-            post_tasks:
-            - name: Enable NCCL plugin SystemD unit
-              ansible.builtin.service:
-                name: nccl-plugin@$(vars.nccl_plugin_version).service
-                state: started
-                enabled: true
+              - name: Remove CUDA runfile
+                ansible.builtin.file:
+                  path: "{{ cuda_installer_file }}"
+                  state: absent
+
+              - name: Install NVIDIA repository keyring
+                ansible.builtin.apt:
+                  deb: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/cuda-keyring_1.1-1_all.deb
+                  state: present
+
+              - name: Update apt cache
+                ansible.builtin.apt:
+                  update_cache: yes
+
+              - name: Install DCGM packages
+                ansible.builtin.apt:
+                  name:
+                    - "datacenter-gpu-manager-4-cuda13={{ dcgm_version }}"
+                    - "datacenter-gpu-manager-4-dev={{ dcgm_version }}"
+                    - "datacenter-gpu-manager-4-core={{ dcgm_version }}"
+                  state: present
+
+              - name: Freeze DCGM packages
+                ansible.builtin.dpkg_selections:
+                  name: "{{ item }}"
+                  selection: hold
+                loop:
+                  - datacenter-gpu-manager-4-cuda13
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-core
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |
@@ -637,9 +421,9 @@ deployment_groups:
       zone: $(vars.zone)
       enable_login_public_ips: true
       instance_image_custom: true
-      disk_type: hyperdisk-balanced
+      disk_type: pd-balanced
       disk_size_gb: $(vars.disk_size_gb)
-      machine_type: c4a-standard-4
+      machine_type: t2a-standard-2
 
   - id: controller_startup
     source: modules/scripts/startup-script
@@ -705,14 +489,15 @@ deployment_groups:
     - slurm_login
     settings:
       enable_controller_public_ips: true
-      machine_type: c4a-highcpu-16
-      disk_type: hyperdisk-balanced
+      machine_type: t2a-standard-2
+      zone: $(vars.zone)
+      disk_type: pd-balanced
       disk_size_gb: $(vars.disk_size_gb)
       instance_image_custom: true
-      zone: $(vars.zone)
       cloud_parameters:
         prolog_flags: Alloc,DeferBatch,NoHold
         switch_type: switch/nvidia_imex
       controller_state_disk: null
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
+      compute_startup_scripts_timeout: 1800

--- a/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/a3ultra-custom-image-blueprint.yaml
@@ -256,9 +256,9 @@ deployment_groups:
 
           apt-get update -y
           apt-get install -y \
-              datacenter-gpu-manager-4-cuda13 \
-              datacenter-gpu-manager-4-dev \
-              datacenter-gpu-manager-4-core
+              datacenter-gpu-manager-4-cuda13=1:4.6.0-1 \
+              datacenter-gpu-manager-4-dev=1:4.6.0-1 \
+              datacenter-gpu-manager-4-core=1:4.6.0-1
 
           apt-mark hold \
               datacenter-gpu-manager-4-cuda13 \

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -14,7 +14,6 @@
 
 ---
 tags:
-- m.custom-image
 - m.cloud-storage-bucket
 - m.pre-existing-network-storage
 - m.managed-lustre

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-slurm.yaml
@@ -14,7 +14,6 @@
 
 ---
 tags:
-- m.custom-image
 - m.cloud-storage-bucket
 - m.pre-existing-network-storage
 - m.managed-lustre

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -14,7 +14,6 @@
 
 ---
 tags:
-- m.custom-image
 - m.cloud-storage-bucket
 - m.pre-existing-network-storage
 - m.filestore

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -21,7 +21,6 @@ tags:
 - m.schedmd-slurm-gcp-v6-partition
 - m.startup-script
 - m.vpc
-- m.custom-image
 - m.cloud-storage-bucket
 - m.gpu-rdma-vpc
 - m.pre-existing-network-storage


### PR DESCRIPTION
This reverts PR #6026 to bring back the ACI configurations and monitor the stability of the ACI image access via daily tests.

TAG=agy

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
