### PR TITLE
feat: automatic GKE namespace detection for job commands

### DIFF
--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -67,10 +67,6 @@ type mockKubeClient struct {
 	err       error
 }
 
-func (m *mockKubeClient) GetJobNamespace(workloadName string) (string, error) {
-	return m.namespace, m.err
-}
-
 func (m *mockKubeClient) ListWorkloads(namespace string, workloadName string) ([]string, error) {
 	return nil, nil
 }

--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -79,7 +79,7 @@ func (m *mockKubeClient) ListJobSets(namespace string, labelSelector string) ([]
 	return []orchestrator.JobStatus{}, m.err
 }
 
-func (m *mockKubeClient) GetCurrentNamespace() (string, error) {
+func (m *mockKubeClient) GetCurrentNamespace(clusterName, location, projectID string) (string, error) {
 	if m.namespace != "" {
 		return m.namespace, nil
 	}

--- a/cmd/job/cancel_test.go
+++ b/cmd/job/cancel_test.go
@@ -79,7 +79,7 @@ func (m *mockKubeClient) DeleteJobSet(namespace string, name string) error {
 	return m.err
 }
 
-func (m *mockKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+func (m *mockKubeClient) ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error) {
 	return []orchestrator.JobStatus{}, m.err
 }
 

--- a/cmd/job/list.go
+++ b/cmd/job/list.go
@@ -58,9 +58,9 @@ func init() {
 func runListWorkloads(cmd *cobra.Command, args []string) error {
 
 	opts := orchestrator.ListOptions{
+		ProjectID:       projectID,
 		ClusterName:     clusterName,
 		ClusterLocation: location,
-		ProjectID:       projectID,
 		Status:          filterStatus,
 		NameContains:    filterName,
 	}

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -338,12 +338,18 @@ func (g *GKEOrchestrator) printConsoleLinks(job orchestrator.JobDefinition) {
 	if job.IsPathwaysJob {
 		jobName = job.WorkloadName + "-pathways-head-0"
 	}
-	gkeLink := fmt.Sprintf("https://console.cloud.google.com/kubernetes/job/%s/%s/default/%s/details?project=%s",
-		job.ClusterLocation, job.ClusterName, jobName, job.ProjectID)
+
+	ns, err := g.getCurrentNamespace()
+	if err != nil {
+		ns = "default"
+	}
+
+	gkeLink := fmt.Sprintf("https://console.cloud.google.com/kubernetes/job/%s/%s/%s/%s/details?project=%s",
+		job.ClusterLocation, job.ClusterName, ns, jobName, job.ProjectID)
 
 	logging.Info("Follow your workload details here: %s", gkeLink)
 
-	logsLink := getCloudConsoleLogsURL(job.ProjectID, job.ClusterLocation, job.ClusterName, "default", jobName)
+	logsLink := getCloudConsoleLogsURL(job.ProjectID, job.ClusterLocation, job.ClusterName, ns, jobName)
 	logging.Info("View your workload logs in real-time here: %s or use gcluster job logs [job-name] to view logs using kubectl", logsLink)
 }
 
@@ -752,7 +758,12 @@ func (g *GKEOrchestrator) processAccelerators(accelerators []gkeAccelerator, nod
 }
 
 func (g *GKEOrchestrator) configureClusterEnvironment(job *orchestrator.JobDefinition) error {
-	localQueue, err := g.resolveKueueQueue(job.KueueQueueName)
+	ns, err := g.getCurrentNamespace()
+	if err != nil {
+		return fmt.Errorf("failed to get current namespace: %w", err)
+	}
+
+	localQueue, err := g.resolveKueueQueue(job.KueueQueueName, ns)
 	if err != nil {
 		logging.Info("Warning: Failed to auto-discover Kueue Queue Name: %v. Falling back to default-queue.", err)
 		localQueue = "default-queue"
@@ -764,23 +775,23 @@ func (g *GKEOrchestrator) configureClusterEnvironment(job *orchestrator.JobDefin
 			logging.Info("Warning: Failed to ensure ResourceFlavors: %v", err)
 		}
 
-		exists, err := g.checkLocalQueueExists(localQueue)
+		exists, err := g.checkLocalQueueExists(localQueue, ns)
 		if err != nil {
 			logging.Info("Warning: Failed to check if LocalQueue exists: %v", err)
 		}
 		if !exists {
-			promptMsg := fmt.Sprintf("LocalQueue '%s' does not exist. Do you want gcluster to create default Kueue resources (ClusterQueue and LocalQueue) with calculated cluster capacity?", localQueue)
+			promptMsg := fmt.Sprintf("LocalQueue '%s' does not exist in namespace '%s'. Do you want gcluster to create default Kueue resources (ClusterQueue and LocalQueue) with calculated cluster capacity?", localQueue, ns)
 			if shell.PromptYesNo(promptMsg) {
-				if err := g.createDefaultQueues(localQueue); err != nil {
+				if err := g.createDefaultQueues(localQueue, ns); err != nil {
 					logging.Info("Warning: Failed to create default queues: %v. Workload might remain suspended.", err)
 				}
 			} else {
-				return fmt.Errorf("LocalQueue '%s' does not exist and user declined to create default queues. Please create one manually or specify an existing queue using --queue flag", localQueue)
+				return fmt.Errorf("LocalQueue '%s' does not exist in namespace '%s' and user declined to create default queues. Please create one manually or specify an existing queue using --queue flag", localQueue, ns)
 			}
 		}
 
 		if job.IsPathwaysJob {
-			if err := g.ensureClusterQueueCoverage(localQueue); err != nil {
+			if err := g.ensureClusterQueueCoverage(localQueue, ns); err != nil {
 				logging.Info("Warning: Could not automatically update ClusterQueue: %v. Workload might remain suspended.", err)
 			}
 		}
@@ -789,8 +800,8 @@ func (g *GKEOrchestrator) configureClusterEnvironment(job *orchestrator.JobDefin
 	return nil
 }
 
-func (g *GKEOrchestrator) checkLocalQueueExists(name string) (bool, error) {
-	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", name, "-n", "default")
+func (g *GKEOrchestrator) checkLocalQueueExists(name, ns string) (bool, error) {
+	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", name, "-n", ns)
 	if res.ExitCode == 0 {
 		return true, nil
 	}
@@ -800,7 +811,7 @@ func (g *GKEOrchestrator) checkLocalQueueExists(name string) (bool, error) {
 	return false, fmt.Errorf("failed to check localqueue status: %s", res.Stderr)
 }
 
-func (g *GKEOrchestrator) createDefaultQueues(localQueueName string) error {
+func (g *GKEOrchestrator) createDefaultQueues(localQueueName, ns string) error {
 	logging.Info("Creating default ClusterQueue and LocalQueue...")
 
 	// Render and apply ClusterQueue
@@ -822,7 +833,7 @@ func (g *GKEOrchestrator) createDefaultQueues(localQueueName string) error {
 		Namespace        string
 		LocalQueueName   string
 		ClusterQueueName string
-	}{"default", localQueueName, defaultClusterQueue}); err != nil {
+	}{ns, localQueueName, defaultClusterQueue}); err != nil {
 		return fmt.Errorf("failed to execute local_queue.tmpl template: %w", err)
 	}
 
@@ -834,8 +845,8 @@ func (g *GKEOrchestrator) createDefaultQueues(localQueueName string) error {
 	return nil
 }
 
-func (g *GKEOrchestrator) ensureClusterQueueCoverage(localQueueName string) error {
-	cqName, err := g.getClusterQueueName(localQueueName)
+func (g *GKEOrchestrator) ensureClusterQueueCoverage(localQueueName, ns string) error {
+	cqName, err := g.getClusterQueueName(localQueueName, ns)
 	if err != nil {
 		return err
 	}
@@ -865,10 +876,10 @@ func (g *GKEOrchestrator) ensureClusterQueueCoverage(localQueueName string) erro
 	return fmt.Errorf("clusterQueue '%s' does not cover required resources (CPU and Memory). Please configure it manually to include quotas for 'cpu' and 'memory' resources.", cqName)
 }
 
-func (g *GKEOrchestrator) getClusterQueueName(localQueueName string) (string, error) {
-	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", localQueueName, "-n", "default", "-o", "jsonpath={.spec.clusterQueue}")
+func (g *GKEOrchestrator) getClusterQueueName(localQueueName, ns string) (string, error) {
+	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", localQueueName, "-n", ns, "-o", "jsonpath={.spec.clusterQueue}")
 	if res.ExitCode != 0 {
-		return "", fmt.Errorf("failed to find clusterqueue for %s: %s", localQueueName, res.Stderr)
+		return "", fmt.Errorf("failed to find clusterqueue for %s in namespace %s: %s", localQueueName, ns, res.Stderr)
 	}
 	cqName := strings.TrimSpace(res.Stdout)
 	if cqName == "" {
@@ -925,15 +936,15 @@ func (g *GKEOrchestrator) hasRequiredResources(rgList []interface{}) bool {
 	return hasCPU && hasMem
 }
 
-func (g *GKEOrchestrator) resolveKueueQueue(requestedQueueName string) (string, error) {
+func (g *GKEOrchestrator) resolveKueueQueue(requestedQueueName, ns string) (string, error) {
 	if requestedQueueName != "" {
 		logging.Info("Using provided Kueue LocalQueue: %s", requestedQueueName)
 		return requestedQueueName, nil
 	}
 
-	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", "-n", "default", "-o", "jsonpath={.items[*].metadata.name}")
+	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", "-n", ns, "-o", "jsonpath={.items[*].metadata.name}")
 	if res.ExitCode != 0 {
-		return "", fmt.Errorf("failed to query LocalQueues: %s", res.Stderr)
+		return "", fmt.Errorf("failed to query LocalQueues in namespace %s: %s", ns, res.Stderr)
 	}
 
 	output := strings.TrimSpace(res.Stdout)

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -145,9 +145,14 @@ func (g *GKEOrchestrator) ListJobs(opts orchestrator.ListOptions) ([]orchestrato
 		return nil, err
 	}
 
-	list, err := g.kubeClient.ListJobSets("gcluster.google.com/workload")
+	ns, err := g.getCurrentNamespace()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list jobsets across all namespaces: %w", err)
+		return nil, fmt.Errorf("failed to get current namespace: %w", err)
+	}
+
+	list, err := g.kubeClient.ListJobSets(ns, "gcluster.google.com/workload")
+	if err != nil {
+		return nil, fmt.Errorf("failed to list jobsets in namespace %s: %w", ns, err)
 	}
 
 	var filteredJobs []orchestrator.JobStatus
@@ -177,11 +182,11 @@ func (g *GKEOrchestrator) CancelJob(name string, opts orchestrator.CancelOptions
 		return fmt.Errorf("failed to initialize k8s client: %w", err)
 	}
 
-	// Find the job to get its namespace
-	foundNamespace, err := g.kubeClient.GetJobNamespace(name)
+	ns, err := g.getCurrentNamespace()
 	if err != nil {
 		return err
 	}
+	foundNamespace := ns
 
 	status, err := g.getJobSetStatus(name, foundNamespace)
 	actionVerb := "Cancel"
@@ -1251,6 +1256,26 @@ func (g *GKEOrchestrator) BuildContainerImage(job orchestrator.JobDefinition) (s
 }
 
 func (g *GKEOrchestrator) configureKubectl(clusterName, clusterLocation, projectID string) error {
+	// 1. Capture current namespace context before gcloud resets it
+	originalNamespace, err := g.getCurrentNamespace()
+	if err != nil {
+		logging.Warn("Could not read current namespace before gcloud (defaulting to 'default'): %v", err)
+		if originalNamespace == "" {
+			originalNamespace = "default"
+		}
+	}
+
+	// 2. Refresh credentials via gcloud (this resets namespace to 'default')
+	if err := g.refreshGKEAuth(clusterName, clusterLocation, projectID); err != nil {
+		return err
+	}
+
+	// 3. Restore the original namespace context
+	return g.restoreNamespaceContext(originalNamespace)
+}
+
+// refreshGKEAuth handles the gcloud container clusters get-credentials call.
+func (g *GKEOrchestrator) refreshGKEAuth(clusterName, clusterLocation, projectID string) error {
 	args := []string{"container", "clusters", "get-credentials", clusterName, "--location", clusterLocation, "--project", projectID}
 
 	if g.clusterDesc.ControlPlaneEndpointsConfig != nil &&
@@ -1265,6 +1290,21 @@ func (g *GKEOrchestrator) configureKubectl(clusterName, clusterLocation, project
 			return fmt.Errorf("found multiple GKE clusters named %s. Please specify the exact Zone using --location to disambiguate.", clusterName)
 		}
 		return fmt.Errorf("failed to get GKE cluster credentials: %s\n%s", credsRes.Stderr, credsRes.Stdout)
+	}
+	return nil
+}
+
+// restoreNamespaceContext sets the current namespace back to its original value if needed.
+func (g *GKEOrchestrator) restoreNamespaceContext(namespace string) error {
+	// If it was default, gcloud already set it to default, so we can skip.
+	if namespace == "" || namespace == "default" {
+		return nil
+	}
+
+	logging.Info("Restoring namespace context to '%s'...", namespace)
+	restoreRes := g.executor.ExecuteCommand("kubectl", "config", "set-context", "--current", "--namespace="+namespace)
+	if restoreRes.ExitCode != 0 {
+		return fmt.Errorf("failed to restore namespace context to %s: %s", namespace, restoreRes.Stderr)
 	}
 	return nil
 }
@@ -1490,7 +1530,8 @@ func parseConditions(conditions []interface{}, statusStr *string, completionTime
 
 func (g *GKEOrchestrator) getCurrentNamespace() (string, error) {
 	if g.kubeClient == nil {
-		return "default", nil
+		client := &DefaultKubeClient{}
+		return client.GetCurrentNamespace()
 	}
 	return g.kubeClient.GetCurrentNamespace()
 }
@@ -2013,11 +2054,12 @@ func (d *DefaultKubeClient) ListWorkloads(namespace string, workloadName string)
 	return matchedWorkloads, nil
 }
 
-func (d *DefaultKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+func (d *DefaultKubeClient) ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error) {
 	gvr := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
-	list, err := d.dynClient.Resource(gvr).Namespace("").List(context.Background(), metav1.ListOptions{
+	list, err := d.dynClient.Resource(gvr).Namespace(namespace).List(context.Background(), metav1.ListOptions{
 		LabelSelector: labelSelector,
 	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -145,7 +145,7 @@ func (g *GKEOrchestrator) ListJobs(opts orchestrator.ListOptions) ([]orchestrato
 		return nil, err
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(opts.ClusterName, opts.ClusterLocation, opts.ProjectID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get current namespace: %w", err)
 	}
@@ -182,7 +182,7 @@ func (g *GKEOrchestrator) CancelJob(name string, opts orchestrator.CancelOptions
 		return fmt.Errorf("failed to initialize k8s client: %w", err)
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(opts.ClusterName, opts.ClusterLocation, opts.ProjectID)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,7 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 		return "", err
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(opts.ClusterName, opts.ClusterLocation, opts.ProjectID)
 	if err != nil {
 		return "", err
 	}
@@ -345,8 +345,10 @@ func (g *GKEOrchestrator) printConsoleLinks(job orchestrator.JobDefinition) {
 		jobName = job.WorkloadName + "-pathways-head-0"
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(job.ClusterName, job.ClusterLocation, job.ProjectID)
 	if err != nil {
+		// Non-critical path (printing informational links).
+		// Fallback to 'default' to avoid failing the command output if namespace cannot be determined.
 		ns = "default"
 	}
 
@@ -764,7 +766,7 @@ func (g *GKEOrchestrator) processAccelerators(accelerators []gkeAccelerator, nod
 }
 
 func (g *GKEOrchestrator) configureClusterEnvironment(job *orchestrator.JobDefinition) error {
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(job.ClusterName, job.ClusterLocation, job.ProjectID)
 	if err != nil {
 		return fmt.Errorf("failed to get current namespace: %w", err)
 	}
@@ -1257,8 +1259,9 @@ func (g *GKEOrchestrator) BuildContainerImage(job orchestrator.JobDefinition) (s
 }
 
 func (g *GKEOrchestrator) configureKubectl(clusterName, clusterLocation, projectID string) error {
-	// 1. Capture current namespace context before gcloud resets it
-	originalNamespace, err := g.getCurrentNamespace()
+	// 1. Capture current namespace context before gcloud resets it on best effort to preserve current namespace.
+	// If we can't read it, using 'default' allows gcloud setup to proceed,
+	originalNamespace, err := g.getCurrentNamespace(clusterName, clusterLocation, projectID)
 	if err != nil {
 		logging.Warn("Could not read current namespace before gcloud (defaulting to 'default'): %v", err)
 		if originalNamespace == "" {
@@ -1529,12 +1532,24 @@ func parseConditions(conditions []interface{}, statusStr *string, completionTime
 	}
 }
 
-func (g *GKEOrchestrator) getCurrentNamespace() (string, error) {
+func (g *GKEOrchestrator) getCurrentNamespace(clusterName, location, projectID string) (string, error) {
+	if g.namespace != "" {
+		return g.namespace, nil
+	}
+
+	var ns string
+	var err error
 	if g.kubeClient == nil {
 		client := &DefaultKubeClient{}
-		return client.GetCurrentNamespace()
+		ns, err = client.GetCurrentNamespace(clusterName, location, projectID)
+	} else {
+		ns, err = g.kubeClient.GetCurrentNamespace(clusterName, location, projectID)
 	}
-	return g.kubeClient.GetCurrentNamespace()
+
+	if err == nil {
+		g.namespace = ns
+	}
+	return ns, err
 }
 
 func (g *GKEOrchestrator) getKueueWorkloadStatus(client dynamic.Interface, ns string, uid string) (string, error) {
@@ -1768,7 +1783,7 @@ func (g *GKEOrchestrator) awaitJobCompletion(workloadName, clusterName, clusterL
 		}
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(clusterName, clusterLocation, projectID)
 	if err != nil {
 		return fmt.Errorf("failed to get current namespace: %w", err)
 	}
@@ -2067,13 +2082,33 @@ func (d *DefaultExecutor) ExecuteCommandStream(name string, args ...string) erro
 	return cmd.Run()
 }
 
-func (d *DefaultKubeClient) GetCurrentNamespace() (string, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	configOverrides := &clientcmd.ConfigOverrides{}
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-	ns, _, err := kubeConfig.Namespace()
-	if err != nil || ns == "" {
+func (d *DefaultKubeClient) GetCurrentNamespace(clusterName, location, projectID string) (string, error) {
+	config, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	if err != nil {
+		return "", fmt.Errorf("failed to load kubeconfig: %w", err)
+	}
+
+	// Standard GKE context naming convention
+	expectedContext := fmt.Sprintf("gke_%s_%s_%s", projectID, location, clusterName)
+
+	if context, ok := config.Contexts[expectedContext]; ok {
+		if context.Namespace != "" {
+			return context.Namespace, nil
+		}
 		return "default", nil
 	}
-	return ns, nil
+
+	// Fallback/Legacy: Also check if there's a context with just the cluster name
+	// (sometimes users manually rename them)
+	for contextName, context := range config.Contexts {
+		if contextName == clusterName || context.Cluster == clusterName {
+			if context.Namespace != "" {
+				return context.Namespace, nil
+			}
+			return "default", nil
+		}
+	}
+
+	// Fallback to default if no matching context found
+	return "default", nil
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -212,10 +212,11 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 		return "", err
 	}
 
-	foundNamespace, err := g.getJobNamespace(name)
+	ns, err := g.getCurrentNamespace()
 	if err != nil {
 		return "", err
 	}
+	foundNamespace := ns
 
 	selector, mainOnly, podCountForNotice := g.resolveLogsSelector(name, foundNamespace, opts.MainOnly)
 
@@ -1736,16 +1737,6 @@ func (g *GKEOrchestrator) generateImagePullSecrets(secrets string) string {
 	return string(b)
 }
 
-func (g *GKEOrchestrator) getJobNamespace(name string) (string, error) {
-	if g.kubeClient == nil {
-		_, err := g.getDynamicClient()
-		if err != nil {
-			return "", fmt.Errorf("failed to get dynamic client: %w", err)
-		}
-	}
-	return g.kubeClient.GetJobNamespace(name)
-}
-
 func (g *GKEOrchestrator) getDynamicClient() (dynamic.Interface, error) {
 	if g.dynClient != nil {
 		return g.dynClient, nil
@@ -1777,9 +1768,9 @@ func (g *GKEOrchestrator) awaitJobCompletion(workloadName, clusterName, clusterL
 		}
 	}
 
-	ns, err := g.kubeClient.GetJobNamespace(workloadName)
+	ns, err := g.getCurrentNamespace()
 	if err != nil {
-		return fmt.Errorf("failed to get job namespace: %w", err)
+		return fmt.Errorf("failed to get current namespace: %w", err)
 	}
 
 	jobConsoleLink := fmt.Sprintf("https://console.cloud.google.com/kubernetes/workload/gke/%s/%s/details/%s?project=%s",
@@ -1999,24 +1990,6 @@ func (g *GKEOrchestrator) buildTopologyAnnotation(topology string, machineType s
 		}
 	}
 	return ""
-}
-
-func (d *DefaultKubeClient) GetJobNamespace(workloadName string) (string, error) {
-	gvr := schema.GroupVersionResource{Group: "jobset.x-k8s.io", Version: "v1alpha2", Resource: "jobsets"}
-	optsSelector := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("gcluster.google.com/workload=%s", workloadName),
-	}
-	list, err := d.dynClient.Resource(gvr).Namespace("").List(context.TODO(), optsSelector)
-	if err != nil {
-		return "", fmt.Errorf("failed to search for jobset %s across namespaces: %w", workloadName, err)
-	}
-
-	if len(list.Items) == 1 {
-		return list.Items[0].GetNamespace(), nil
-	} else if len(list.Items) > 1 {
-		return "", fmt.Errorf("found multiple jobsets named %s in different namespaces; this is not currently supported. Please ensure job names are unique across the cluster", workloadName)
-	}
-	return "", fmt.Errorf("jobset %s not found in any namespace", workloadName)
 }
 
 func (d *DefaultKubeClient) DeleteJobSet(namespace string, name string) error {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -128,7 +128,7 @@ func (m *MockKubeClient) ListJobSets(namespace string, labelSelector string) ([]
 	return []orchestrator.JobStatus{}, m.Err
 }
 
-func (m *MockKubeClient) GetCurrentNamespace() (string, error) {
+func (m *MockKubeClient) GetCurrentNamespace(clusterName, location, projectID string) (string, error) {
 	if m.Namespace != "" {
 		return m.Namespace, nil
 	}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -116,10 +116,6 @@ type MockKubeClient struct {
 	Err       error
 }
 
-func (m *MockKubeClient) GetJobNamespace(workloadName string) (string, error) {
-	return m.Namespace, m.Err
-}
-
 func (m *MockKubeClient) ListWorkloads(namespace string, workloadName string) ([]string, error) {
 	return m.Workloads, m.Err
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -1888,7 +1888,7 @@ func TestResolveKueueQueue(t *testing.T) {
 			mockExec := NewMockExecutor(responses)
 			orc := newTestGKEOrchestrator(mockExec)
 
-			got, err := orc.resolveKueueQueue(tt.requestedName)
+			got, err := orc.resolveKueueQueue(tt.requestedName, "default")
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("resolveKueueQueue() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -128,7 +128,7 @@ func (m *MockKubeClient) DeleteJobSet(namespace string, name string) error {
 	return m.Err
 }
 
-func (m *MockKubeClient) ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error) {
+func (m *MockKubeClient) ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error) {
 	return []orchestrator.JobStatus{}, m.Err
 }
 

--- a/pkg/orchestrator/gke/inspector.go
+++ b/pkg/orchestrator/gke/inspector.go
@@ -150,11 +150,11 @@ func (g *GKEOrchestrator) inspectWorkload(writer *inspectWriter, workloadName st
 		return workloadNamespace
 	}
 
-	ns, err := g.getJobNamespace(workloadName)
+	ns, err := g.getCurrentNamespace()
 	if err == nil {
 		workloadNamespace = ns
 	} else {
-		logging.Warn("Failed to auto-discover namespace for workload %s, defaulting to 'default': %v", workloadName, err)
+		logging.Warn("Failed to get current namespace, defaulting to 'default' for inspection: %v", err)
 	}
 
 	logWorkloadList(writer.writer, g.executor, "EVERYTHING", workloadName, workloadNamespace)

--- a/pkg/orchestrator/gke/inspector.go
+++ b/pkg/orchestrator/gke/inspector.go
@@ -74,7 +74,8 @@ func (g *GKEOrchestrator) InspectCluster(opts orchestrator.InspectOptions) error
 	}()
 
 	// Resolve namespace context
-	targetNamespace, err := g.getCurrentNamespace()
+	// Fallback to 'default' to capture as much info as possible instead of failing diagnostics.
+	targetNamespace, err := g.getCurrentNamespace(opts.ClusterName, opts.ClusterLocation, opts.ProjectID)
 	if err != nil {
 		logging.Warn("Failed to resolve current namespace: %v. Defaulting to 'default'", err)
 		targetNamespace = "default"
@@ -135,7 +136,7 @@ func (g *GKEOrchestrator) InspectCluster(opts orchestrator.InspectOptions) error
 	logWorkloadList(outputTarget, g.executor, "QUEUED", "", targetNamespace)
 	logWorkloadList(outputTarget, g.executor, "RUNNING", "", targetNamespace)
 
-	workloadNamespace := g.inspectWorkload(writer, opts.WorkloadName)
+	workloadNamespace := g.inspectWorkload(writer, opts.WorkloadName, opts.ClusterName, opts.ClusterLocation, opts.ProjectID)
 
 	// --- 7. Console Links ---
 	logConsoleLinks(outputTarget, opts, workloadNamespace)
@@ -144,16 +145,17 @@ func (g *GKEOrchestrator) InspectCluster(opts orchestrator.InspectOptions) error
 	return nil
 }
 
-func (g *GKEOrchestrator) inspectWorkload(writer *inspectWriter, workloadName string) string {
+func (g *GKEOrchestrator) inspectWorkload(writer *inspectWriter, workloadName, clusterName, clusterLocation, projectID string) string {
 	workloadNamespace := "default"
 	if workloadName == "" {
 		return workloadNamespace
 	}
 
-	ns, err := g.getCurrentNamespace()
+	ns, err := g.getCurrentNamespace(clusterName, clusterLocation, projectID)
 	if err == nil {
 		workloadNamespace = ns
 	} else {
+		// Non-critical diagnostic path.
 		logging.Warn("Failed to get current namespace, defaulting to 'default' for inspection: %v", err)
 	}
 

--- a/pkg/orchestrator/gke/inspector_test.go
+++ b/pkg/orchestrator/gke/inspector_test.go
@@ -49,6 +49,7 @@ func defaultMockResponses(clusterName, location, project string) map[string][]sh
 		"kubectl get workloads":                                           {workloadsResult, workloadsResult, workloadsResult, workloadsResult},
 		"kubectl describe jobsets":                                        {{ExitCode: 0, Stdout: "jobset-config"}},
 		"kubectl describe workloads":                                      {{ExitCode: 0, Stdout: "workload-config"}},
+		"kubectl config set-context":                                      {{ExitCode: 0}},
 	}
 }
 

--- a/pkg/orchestrator/gke/storage.go
+++ b/pkg/orchestrator/gke/storage.go
@@ -236,7 +236,7 @@ func (sm *StorageManager) handleFilestoreMount(src, dest string, readOnly bool, 
 	var ns string
 	if sm.orchestrator != nil {
 		var err error
-		ns, err = sm.orchestrator.getCurrentNamespace()
+		ns, err = sm.orchestrator.getCurrentNamespace(job.ClusterName, job.ClusterLocation, job.ProjectID)
 		if err != nil {
 			logging.Warn("failed to get current namespace: %v. Defaulting to 'default' for PV name.", err)
 		}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -42,7 +42,6 @@ type Executor interface {
 
 // KubeClient defines the interface for specific Kubernetes API operations needed by the orchestrator.
 type KubeClient interface {
-	GetJobNamespace(workloadName string) (string, error)
 	ListWorkloads(namespace string, workloadName string) ([]string, error)
 	DeleteJobSet(namespace string, name string) error
 	ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error)

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -45,7 +45,7 @@ type KubeClient interface {
 	ListWorkloads(namespace string, workloadName string) ([]string, error)
 	DeleteJobSet(namespace string, name string) error
 	ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error)
-	GetCurrentNamespace() (string, error)
+	GetCurrentNamespace(clusterName, location, projectID string) (string, error)
 }
 
 type MachineTypeClient interface {
@@ -74,6 +74,7 @@ type GKEOrchestrator struct {
 	clusterDesc                 gkeCluster
 	dynClient                   dynamic.Interface
 	kubeClient                  KubeClient
+	namespace                   string
 	machineTypeClient           MachineTypeClient
 	acceleratorToMachineType    map[string]string
 	machineCapCache             map[string]MachineTypeCap

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -45,7 +45,7 @@ type KubeClient interface {
 	GetJobNamespace(workloadName string) (string, error)
 	ListWorkloads(namespace string, workloadName string) ([]string, error)
 	DeleteJobSet(namespace string, name string) error
-	ListJobSets(labelSelector string) ([]orchestrator.JobStatus, error)
+	ListJobSets(namespace string, labelSelector string) ([]orchestrator.JobStatus, error)
 	GetCurrentNamespace() (string, error)
 }
 


### PR DESCRIPTION
This pull request refactors the GKE job orchestrator to scope Kubernetes operations (such as listing jobsets, resolving Kueue queues, and retrieving logs) to the current active namespace instead of querying across all namespaces or hardcoding the "default" namespace. 
* Removes the GetJobNamespace method and updates the `KubeClient` interface and its implementations accordingly. 
* Iintroduces logic in `configureKubectl` to preserve and restore the active namespace context across `gcloud credential `refreshes, which otherwise reset the context to "default".