### PR TITLE
Enhance Terraform version error message

### DIFF
--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -90,13 +90,13 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 
 	installedVersion, err := getInstalledTfVersion(path)
 	if err != nil {
-		fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s. See: %s\n", err, version, docLink)
+		fmt.Fprintf(os.Stderr, "Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s. See: %s\n", err, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 
 	cmp, err := compareVersions(installedVersion, version)
 	if err != nil {
-		fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s. See: %s\n", installedVersion, err, version, docLink)
+		fmt.Fprintf(os.Stderr, "Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s. See: %s\n", installedVersion, err, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 
@@ -105,11 +105,11 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 		return nil // exact match, use installed version
 	case cmp > 0:
 		// installed version is newer
-		fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features. See: %s\n", installedVersion, version, docLink)
+		fmt.Fprintf(os.Stderr, "WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features. See: %s\n", installedVersion, version, docLink)
 		return nil // proceed with newer version
 	default:
 		// installed version is older (cmp < 0)
-		fmt.Printf("Installed terraform version %s is older than required version %s. For version requirements and installation instructions, please see: %s\n", installedVersion, version, docLink)
+		fmt.Fprintf(os.Stderr, "Installed terraform version %s is older than required version %s. For version requirements and installation instructions, please see: %s\n", installedVersion, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 }
@@ -168,7 +168,7 @@ func confirmDownload(binaryName, version string, decision DownloadDecision) erro
 	}
 
 	if decision == DownloadDecisionAsk {
-		fmt.Printf("%s v%s is missing or incompatible. Do you want to download it? [y/N]: ", binaryName, version)
+		fmt.Fprintf(os.Stderr, "%s v%s is missing or incompatible. Do you want to download it? [y/N]: ", binaryName, version)
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -86,15 +86,17 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 		return nil // for packer, just check existence for now
 	}
 
+	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
+
 	installedVersion, err := getInstalledTfVersion(path)
 	if err != nil {
-		fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s.\n", err, version)
+		fmt.Printf("Warning: Could not determine installed terraform version: %v. Proceeding to download recommended version %s. See: %s\n", err, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 
 	cmp, err := compareVersions(installedVersion, version)
 	if err != nil {
-		fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s.\n", installedVersion, err, version)
+		fmt.Printf("Warning: Could not parse installed terraform version %q: %v. Proceeding to download recommended version %s. See: %s\n", installedVersion, err, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 
@@ -103,11 +105,11 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 		return nil // exact match, use installed version
 	case cmp > 0:
 		// installed version is newer
-		fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features.\n", installedVersion, version)
+		fmt.Printf("WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features. See: %s\n", installedVersion, version, docLink)
 		return nil // proceed with newer version
 	default:
 		// installed version is older (cmp < 0)
-		fmt.Printf("Installed terraform version %s is older than required version %s.\n", installedVersion, version)
+		fmt.Printf("Installed terraform version %s is older than required version %s. For version requirements and installation instructions, please see: %s\n", installedVersion, version, docLink)
 		return downloadFlow(binaryName, version, decision)
 	}
 }
@@ -161,17 +163,19 @@ func compareVersions(v1, v2 string) (int, error) {
 }
 
 func confirmDownload(binaryName, version string, decision DownloadDecision) error {
+	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
+
 	if decision == DownloadDecisionNo {
-		return fmt.Errorf("%s is missing. Download is explicitly disabled. Enable download by specifying --download-dependencies flag.", binaryName)
+		return fmt.Errorf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
 	}
 
 	if decision == DownloadDecisionAsk {
-		fmt.Printf("%s v%s is missing. Do you want to download it? [y/N]: ", binaryName, version)
+		fmt.Printf("%s v%s is missing or incompatible. Do you want to download it? [y/N]: ", binaryName, version)
 		reader := bufio.NewReader(os.Stdin)
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
-			return fmt.Errorf("user declined to download %s", binaryName)
+			return fmt.Errorf("user declined to download %s. See %s", binaryName, docLink)
 		}
 	}
 

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hashicorp/go-version"
 )
 
+const docLink = "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
+
 type DownloadDecision int
 
 const (
@@ -85,8 +87,6 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 	if binaryName != "terraform" {
 		return nil // for packer, just check existence for now
 	}
-
-	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
 
 	installedVersion, err := getInstalledTfVersion(path)
 	if err != nil {
@@ -163,8 +163,6 @@ func compareVersions(v1, v2 string) (int, error) {
 }
 
 func confirmDownload(binaryName, version string, decision DownloadDecision) error {
-	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
-
 	if decision == DownloadDecisionNo {
 		return fmt.Errorf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
 	}

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -173,7 +173,7 @@ func confirmDownload(binaryName, version string, decision DownloadDecision) erro
 		response, _ := reader.ReadString('\n')
 		response = strings.TrimSpace(strings.ToLower(response))
 		if response != "y" && response != "yes" {
-			return fmt.Errorf("user declined to download %s. See %s", binaryName, docLink)
+			return fmt.Errorf("user declined to download %s; see %s", binaryName, docLink)
 		}
 	}
 

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -105,7 +105,7 @@ func ensureBinary(binaryName, version string, decision DownloadDecision) error {
 		return nil // exact match, use installed version
 	case cmp > 0:
 		// installed version is newer
-		fmt.Fprintf(os.Stderr, "WARNING: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features. See: %s\n", installedVersion, version, docLink)
+		fmt.Fprintf(os.Stderr, "Warning: Terraform version %s is currently installed. We recommend using version %s for compatibility with all features. See: %s\n", installedVersion, version, docLink)
 		return nil // proceed with newer version
 	default:
 		// installed version is older (cmp < 0)

--- a/pkg/dependencies/resolver.go
+++ b/pkg/dependencies/resolver.go
@@ -164,7 +164,7 @@ func compareVersions(v1, v2 string) (int, error) {
 
 func confirmDownload(binaryName, version string, decision DownloadDecision) error {
 	if decision == DownloadDecisionNo {
-		return fmt.Errorf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
+		return fmt.Errorf("%s is missing or incompatible; download is explicitly disabled, enable download by specifying --download-dependencies flag (see %s)", binaryName, docLink)
 	}
 
 	if decision == DownloadDecisionAsk {

--- a/pkg/dependencies/resolver_test.go
+++ b/pkg/dependencies/resolver_test.go
@@ -61,7 +61,6 @@ func TestEnsureBinary_MissingAndDecisionNo(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error when binary is missing and decision is No")
 	}
-	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
 	expectedErrMsg := fmt.Sprintf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
 	if err.Error() != expectedErrMsg {
 		t.Errorf("Expected error %q, got %q", expectedErrMsg, err.Error())

--- a/pkg/dependencies/resolver_test.go
+++ b/pkg/dependencies/resolver_test.go
@@ -61,7 +61,7 @@ func TestEnsureBinary_MissingAndDecisionNo(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error when binary is missing and decision is No")
 	}
-	expectedErrMsg := fmt.Sprintf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
+	expectedErrMsg := fmt.Sprintf("%s is missing or incompatible; download is explicitly disabled, enable download by specifying --download-dependencies flag (see %s)", binaryName, docLink)
 	if err.Error() != expectedErrMsg {
 		t.Errorf("Expected error %q, got %q", expectedErrMsg, err.Error())
 	}

--- a/pkg/dependencies/resolver_test.go
+++ b/pkg/dependencies/resolver_test.go
@@ -61,7 +61,8 @@ func TestEnsureBinary_MissingAndDecisionNo(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Expected error when binary is missing and decision is No")
 	}
-	expectedErrMsg := fmt.Sprintf("%s is missing. Download is explicitly disabled. Enable download by specifying --download-dependencies flag.", binaryName)
+	docLink := "https://cloud.google.com/cluster-toolkit/docs/setup/install-dependencies"
+	expectedErrMsg := fmt.Sprintf("%s is missing or incompatible. Download is explicitly disabled. Enable download by specifying --download-dependencies flag. See %s", binaryName, docLink)
 	if err.Error() != expectedErrMsg {
 		t.Errorf("Expected error %q, got %q", expectedErrMsg, err.Error())
 	}


### PR DESCRIPTION
### Description
**Enhance Terraform version error message**

This PR updates `resolver.go` so that if a user runs the CLI with a missing or incompatible Terraform version, the error message clearly states the issue and provides a direct link to the `install-dependencies` documentation page to help them fix it.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)