### PR TITLE
Automate release notes and pin GitHub actions

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -1,0 +1,69 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Draft Release Notes
+
+on:
+  pull_request:
+    types:
+    - ready_for_review
+    branches:
+    - main
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'release-candidate-') ||
+      startsWith(github.event.pull_request.head.ref, 'hotfix-')
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        fetch-depth: 0
+
+    - name: Get Release Information
+      id: release
+      shell: bash
+      env:
+        BRANCH: ${{ github.event.pull_request.head.ref }}
+      run: |
+        if [[ "$BRANCH" == release-candidate-* ]]; then
+          VERSION="${BRANCH#release-candidate-}"
+        elif [[ "$BRANCH" == hotfix-* ]]; then
+          VERSION="${BRANCH#hotfix-}"
+        else
+          echo "Unsupported branch: $BRANCH"
+          exit 1
+        fi
+
+        echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Create Draft Release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.release.outputs.version }}
+        RC_BRANCH: ${{ steps.release.outputs.rc_branch }}
+      run: |
+        gh release create "$VERSION" \
+          --title "$VERSION" \
+          --target "$RC_BRANCH" \
+          --draft \
+          --generate-notes

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -30,7 +30,8 @@ on:
     branches:
     - main
     - develop
-    - release-candidate
+    - release-candidate-*
+    - hotfix-*
 
 jobs:
   pr-label-validation:
@@ -40,14 +41,14 @@ jobs:
       pull-requests: read
     steps:
     - id: check-labels
-      uses: mheap/github-action-required-labels@v5
+      uses: mheap/github-action-required-labels@23e10fde7e062233401931a0eece796cd9bf3177 #v5.6.0
       with:
         mode: minimum
         count: 1
         labels: "release-chore, release-key-new-features, release-new-modules, release-module-improvements, release-improvements, release-deprecations, release-version-updates, release-bugfix, release-breaking-changes"
         message: "This PR is being prevented from merging because it is not labeled.  Please add a label to this PR.  Accepted labels: release-chore, release-key-new-features, release-new-modules, release-module-improvements, release-improvements, release-deprecations, release-version-updates, release-bugfix, release-breaking-changes"
     - id: do-not-merge
-      uses: mheap/github-action-required-labels@v5
+      uses: mheap/github-action-required-labels@23e10fde7e062233401931a0eece796cd9bf3177 #v5.6.0
       with:
         mode: exactly
         count: 0

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -25,7 +25,7 @@ on:
     branches:
     - main
     - develop
-    - release-candidate
+    - release-candidate-*
     - hotfix-*
 
 permissions:
@@ -35,75 +35,75 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 #v6.1.0
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
       with:
         tool-cache: false
         android: true
         dotnet: true
         haskell: true
         large-packages: true
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6.3.0
       with:
         # internal Python tests require Python 3.12
         python-version: '3.12'
         check-latest: true
         cache: 'pip'
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version: '1.25'
         check-latest: true
-    - uses: hashicorp/setup-terraform@v4
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e #v4.0.1
       with:
         terraform_version: "1.12.2"
         terraform_wrapper: false
     - run: make install-dev-deps
-    - uses: terraform-linters/setup-tflint@v6
+    - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 #v6.2.2
       with:
         tflint_version: v0.49.0
     - run: tflint --init
       env:
         # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
         GITHUB_TOKEN: ${{ github.token }}
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
       with:
         extra_args: --show-diff-on-failure --all-files
   pre-commit-highest-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 #v6.1.0
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
       with:
         tool-cache: false
         android: true
         dotnet: true
         haskell: true
         large-packages: true
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 #v6.3.0
       with:
         # the slurm-files Python requirements.txt requires updating
         # to enable 3.12+ compatibility
         python-version: '3.11'
         check-latest: true
         cache: 'pip'
-    - uses: actions/setup-go@v6
+    - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version: '1.25'
         check-latest: true
-    - uses: hashicorp/setup-terraform@v4
+    - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e #v4.0.1
       with:
         terraform_version: "1.12.2"
         terraform_wrapper: false
     - run: make install-dev-deps
-    - uses: terraform-linters/setup-tflint@v6
+    - uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 #v6.2.2
       with:
         tflint_version: v0.49.0
     - run: tflint --init
       env:
         # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
         GITHUB_TOKEN: ${{ github.token }}
-    - uses: pre-commit/action@v3.0.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd #v3.0.1
       with:
         extra_args: --show-diff-on-failure --all-files

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -1,0 +1,73 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Publish Release Notes
+
+on:
+  pull_request:
+    types:
+    - closed
+    branches:
+    - main
+
+permissions:
+  contents: write
+  discussions: write
+
+jobs:
+  publish-release:
+    if: |
+      github.event.pull_request.merged == true &&
+      (
+        startsWith(github.event.pull_request.head.ref, 'release-candidate-') ||
+        startsWith(github.event.pull_request.head.ref, 'hotfix-')
+      )
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+    - name: Get Release Information
+      id: release
+      shell: bash
+      env:
+        BRANCH: ${{ github.event.pull_request.head.ref }}
+      run: |
+        if [[ "$BRANCH" == release-candidate-* ]]; then
+          VERSION="${BRANCH#release-candidate-}"
+        elif [[ "$BRANCH" == hotfix-* ]]; then
+          VERSION="${BRANCH#hotfix-}"
+        else
+          echo "Unsupported branch: $BRANCH"
+          exit 1
+        fi
+
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+    - name: Publish Existing Draft Release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        VERSION: ${{ steps.release.outputs.version }}
+      run: |
+        echo "Publishing draft release: $VERSION"
+
+        # Publish the draft, set as latest, and add to Announcements discussion
+        gh release edit "$VERSION" \
+          --draft=false \
+          --latest \
+          --discussion-category "Announcements"
+
+        echo "Release published successfully."

--- a/tools/create-release-candidate.sh
+++ b/tools/create-release-candidate.sh
@@ -86,7 +86,7 @@ esac
 NEW_VERSION="${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
 NEW_TAG="v${NEW_VERSION}"
 
-RC_BRANCH=release-candidate
+RC_BRANCH="release-candidate-${NEW_TAG}"
 V_BRANCH="version/${NEW_TAG}"
 REMOTE_NAME=origin
 


### PR DESCRIPTION
### Draft Release Notes
Automatically creates a draft GitHub Release with generated release notes when the RC → main or hotfix → main pull request is ready for review.

### Publish Release Notes
Automatically creates the release tag and publishes the GitHub Release with generated release notes when the release-candidate-* or hotfix-* PR is merged into the main.

### Updated release-candidate branch naming:
Changed the release-candidate branch from a fixed name (release-candidate) to a versioned format (release-candidate-vX.Y.Z). This allows each release to have its own dedicated release branch and enables the draft and publish release workflows to identify the release version directly from the branch name.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
