### PR TITLE
feat(gke-g4-confidential): add support for Local SSD block and epheme…

### DIFF
--- a/examples/gke-g4-confidential/README.md
+++ b/examples/gke-g4-confidential/README.md
@@ -75,6 +75,11 @@ Before deploying, fill out the `gke-g4-confidential-deployment.yaml` file with y
 | `reservation` | (Optional) The name of a zonal GCE reservation matching `g4-standard-48` to consume capacity from. |
 | `enable_confidential_storage` | (Optional) Set to `true` to enable Confidential Storage, encrypting both the Kubernetes dynamic PVs (using CMEK) and the VM boot disks of all GKE nodes (system and workload). Defaults to `false`. |
 | `disk_encryption_kms_key` | (Optional) The resource path to your Cloud KMS key used for CMEK storage encryption. Defaults to empty (`""`). |
+| `local_ssd_count_nvme_block` | (Optional) Number of Local SSDs to attach as raw block NVMe devices (supports `0` or `4` for `g4-standard-48`). Defaults to `0` (no SSDs attached). |
+| `local_ssd_count_ephemeral_storage` | (Optional) Number of Local SSDs to format as ephemeral emptyDir scratch storage (supports `0` or `4` for `g4-standard-48`). Defaults to `0` (no SSDs attached). |
+
+> [!IMPORTANT]
+> The `local_ssd_count_nvme_block` and `local_ssd_count_ephemeral_storage` settings are mutually exclusive in the underlying GKE node pool module. Specifying non-zero values for both at the same time will cause a Terraform planning error.
 
 ### (Optional) KMS CMEK Setup for Storage
 

--- a/examples/gke-g4-confidential/gke-g4-confidential-deployment.yaml
+++ b/examples/gke-g4-confidential/gke-g4-confidential-deployment.yaml
@@ -53,3 +53,13 @@ vars:
 
   # The Customer-Managed Encryption Key (CMEK) path (required if enable_confidential_storage is true)
   disk_encryption_kms_key: ""
+
+  # (Optional) Local SSD storage configuration (supports 0 or 4 for g4-standard-48).
+  # Defaults to 0 (no SSDs attached).
+  # Note: These settings are mutually exclusive. Uncommenting both will cause a Terraform planning error.
+  #
+  # Exposes Local SSDs as raw /dev/nvmeX block devices:
+  # local_ssd_count_nvme_block: 4
+  #
+  # Formats and mounts Local SSDs for GKE ephemeral scratch storage (emptyDir):
+  # local_ssd_count_ephemeral_storage: 4

--- a/examples/gke-g4-confidential/gke-g4-confidential.yaml
+++ b/examples/gke-g4-confidential/gke-g4-confidential.yaml
@@ -51,6 +51,16 @@ vars:
   # The Customer-Managed Encryption Key (CMEK) path (required if enable_confidential_storage is true)
   disk_encryption_kms_key: ""
 
+  # (Optional) Local SSD storage configuration (supports 0 or 4 for g4-standard-48).
+  # Defaults to 0 (no SSDs attached).
+  # Note: These settings are mutually exclusive. Uncommenting both will cause a Terraform planning error.
+  #
+  # Exposes Local SSDs as raw /dev/nvmeX block devices:
+  # local_ssd_count_nvme_block: 4
+  #
+  # Formats and mounts Local SSDs for GKE ephemeral scratch storage (emptyDir):
+  # local_ssd_count_ephemeral_storage: 4
+
   # VPC and Subnet Name overrides for primary (net-0) and secondary (net-1) networks
   network_name_0: $(vars.deployment_name)-net-0
   subnetwork_name_0: $(vars.deployment_name)-sub-0
@@ -163,6 +173,9 @@ deployment_groups:
       zones: [$(vars.zone)]
       static_node_count: $(vars.static_node_count)
       disk_type: "hyperdisk-balanced"
+      # To enable Local SSDs, uncomment the corresponding line below:
+      # local_ssd_count_nvme_block: $(vars.local_ssd_count_nvme_block)
+      # local_ssd_count_ephemeral_storage: $(vars.local_ssd_count_ephemeral_storage)
       enable_numa_aware_scheduling: true
       guest_accelerator:
       - type: nvidia-rtx-pro-6000


### PR DESCRIPTION
This PR exposes configuration variables in the G4 Confidential example blueprint to allow users to provision Local SSD (LSSD) storage on GPU-enabled G4 node pools (g4-standard-48).

G4 virtual machines natively support up to 4 Local SSD disks (1,500 GiB total capacity). While the underlying GKE Node Pool module (modules/compute/gke-node-pool) already supports Local SSD resource allocation, these settings were not exposed in the G4 Confidential blueprint. This PR maps these settings to the example blueprint, overrides, and user documentation.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
