### PR TITLE
BYOSA policy requirement for Cloud Build triggers

### DIFF
--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -69,6 +69,7 @@ When prompted for project, use integration test project.
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_daily_tests_project_id"></a> [daily\_tests\_project\_id](#input\_daily\_tests\_project\_id) | The GCP project for daily tests | `string` | `"hpc-toolkit-dev-2"` | no |
+| <a name="input_daily_tests_service_account"></a> [daily\_tests\_service\_account](#input\_daily\_tests\_service\_account) | The service account to run daily tests under. If null, the default Cloud Build service account is used. For projects enforcing BYOSA (like hpc-toolkit-dev-2), you must set this via environment variable, e.g. export TF\_VAR\_daily\_tests\_service\_account="projects/..." | `string` | `null` | no |
 | <a name="input_kueue_migrated_tests"></a> [kueue\_migrated\_tests](#input\_kueue\_migrated\_tests) | List of tests migrated to Kueue | `list(string)` | <pre>[<br/>  "slurm-gcp-v6-rocky8"<br/>]</pre> | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |

--- a/tools/cloud-build/provision/daily-tests.tf
+++ b/tools/cloud-build/provision/daily-tests.tf
@@ -51,6 +51,9 @@ resource "google_cloudbuild_trigger" "daily_test_migrated" {
   name     = "DAILY-test-${each.key}"
   project  = var.daily_tests_project_id
   tags     = [local.notify_chat_tag]
+  # For projects with BYOSA enforced (e.g. hpc-toolkit-dev-2), export the service account environment variable before applying:
+  # export TF_VAR_daily_tests_service_account="projects/MY_PROJECT/serviceAccounts/my-service-account@MY_PROJECT.iam.gserviceaccount.com"
+  service_account = var.daily_tests_service_account
 
   git_file_source {
     path      = "tools/cloud-build/daily-tests/builds/${each.key}.yaml"

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -51,3 +51,9 @@ variable "kueue_migrated_tests" {
     "slurm-gcp-v6-rocky8"
   ]
 }
+
+variable "daily_tests_service_account" {
+  description = "The service account to run daily tests under. If null, the default Cloud Build service account is used. For projects enforcing BYOSA (like hpc-toolkit-dev-2), you must set this via environment variable, e.g. export TF_VAR_daily_tests_service_account=\"projects/...\""
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This PR updates the scheduled Cloud Build triggers to explicitly assign a custom service account for hpc-toolkit-dev-2

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
