### PR TITLE
Configure default logs bucket behavior for cleanup builds

### DIFF
--- a/tools/cloud-build/project-cleanup-filestore.yaml
+++ b/tools/cloud-build/project-cleanup-filestore.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 ---
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
 
 steps:
 - name: gcr.io/cloud-builders/gcloud

--- a/tools/cloud-build/project-cleanup-slurm.yaml
+++ b/tools/cloud-build/project-cleanup-slurm.yaml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 ---
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
 
 steps:
 - name: gcr.io/cloud-builders/gcloud

--- a/tools/cloud-build/project-cleanup.yaml
+++ b/tools/cloud-build/project-cleanup.yaml
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 ---
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+
 timeout: 28800s
 steps:
 - name: gcr.io/cloud-builders/gcloud


### PR DESCRIPTION
For projects enforcing a BYOSA (Bring Your Own Service Account) policy for Cloud Build. When a custom service account is attached to a trigger, Cloud Build loses access to the default Google-managed logs bucket and fails the build on startup.

Changes:
* Added defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET to the options block of project-cleanup.yaml, project-cleanup-filestore.yaml, and project-cleanup-slurm.yaml.
* This explicitly routes the build logs to a regional bucket owned by our custom service account, resolving the invalid argument failure.
* Backward Compatibility: This change is fully backward-compatible. In projects without BYOSA , the default Cloud Build service account will simply stream logs to an automatically generated regional project bucket.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
