### PR TITLE
Update kueue config paths for GKE TPU examples

### DIFF
--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -136,8 +136,8 @@ This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native
 By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
 
 1. **Custom Configurations:**
-* If you want to override the toolkit's default embedded configurations, or if you explicitly disable both Pathways and Dynamic Slicing, no default queues are created by the toolkit.
-* In such scenarios, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to apply your custom Queue/ResourceFlavor configurations.
+* If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+* If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to point to your custom configuration file.
 * For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).

--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -136,9 +136,9 @@ This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native
 By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
 
 1. **Custom Configurations:**
-* If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
-* If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
-* For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+   - If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+   - If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
+   - For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
 
@@ -150,7 +150,7 @@ By default, the toolkit dynamically applies an embedded kueue configuration base
     kubectl create -f ~/cluster-toolkit/examples/gke-tpu-7x/kueue-job-sample.yaml
     ```
 
-3. **Validation:** Check the status of your workload.
+4. **Validation:** Check the status of your workload.
 
     ```sh
     kubectl get workloads

--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -132,8 +132,17 @@ The process is nearly identical to the basic deployment.
 
 This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native system for managing quotas and job queuing. This is enabled by default in the advanced blueprint (`gke-tpu-7x-advanced.yaml`).
 
-1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
-2. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
+**NOTE**:
+By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
+
+1. **Custom Configurations:**
+* If you want to override the toolkit's default embedded configurations, or if you explicitly disable both Pathways and Dynamic Slicing, no default queues are created by the toolkit.
+* In such scenarios, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to apply your custom Queue/ResourceFlavor configurations.
+* For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+
+2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).
+
+3. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
 
     A sample job file is provided: `kueue-job-sample.yaml`.
 

--- a/examples/gke-tpu-7x/README.md
+++ b/examples/gke-tpu-7x/README.md
@@ -137,7 +137,7 @@ By default, the toolkit dynamically applies an embedded kueue configuration base
 
 1. **Custom Configurations:**
 * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
-* If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to point to your custom configuration file.
+* If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
 * For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue` matching the total static TPU capacity of your cluster (slices x nodes x chips).

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -55,9 +55,6 @@ vars:
   # Enable Dynamic Slicing for TPUs
   enable_dynamic_slicing_for_tpus: false
 
-  # Kueue configuration
-  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -278,7 +275,6 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
-        config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -58,9 +58,6 @@ vars:
   # The namespace to be configured for running workloads
   user_namespace: default
 
-  # # Path to a custom Kueue configuration template.
-  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -279,7 +276,7 @@ deployment_groups:
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
         ## Custom kueue config path
-        # config_path: $(vars.kueue_configuration_path)
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -58,6 +58,11 @@ vars:
   # The namespace to be configured for running workloads
   user_namespace: default
 
+  # # Path to a custom Kueue configuration template.
+  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
+  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
+  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -275,6 +280,8 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
+        ## Custom kueue config path (Uncomment to override defaults)
+        # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -59,8 +59,6 @@ vars:
   user_namespace: default
 
   # # Path to a custom Kueue configuration template.
-  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
-  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
   # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
@@ -280,7 +278,7 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
-        ## Custom kueue config path (Uncomment to override defaults)
+        ## Custom kueue config path
         # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -55,9 +55,6 @@ vars:
   # Enable Dynamic Slicing for TPUs
   enable_dynamic_slicing_for_tpus: false
 
-  # # Path to a custom Kueue configuration template.
-  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -176,7 +173,7 @@ deployment_groups:
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
         ## Custom kueue config path
-        # config_path: $(vars.kueue_configuration_path)
+        #config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -56,8 +56,6 @@ vars:
   enable_dynamic_slicing_for_tpus: false
 
   # # Path to a custom Kueue configuration template.
-  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
-  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
   # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # The namespace to be configured for running workloads
@@ -177,7 +175,7 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
-        ## Custom kueue config path (Uncomment to override defaults)
+        ## Custom kueue config path
         # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -55,9 +55,6 @@ vars:
   # Enable Dynamic Slicing for TPUs
   enable_dynamic_slicing_for_tpus: false
 
-  # Kueue configuration
-  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -175,7 +172,6 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
-        config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -55,6 +55,11 @@ vars:
   # Enable Dynamic Slicing for TPUs
   enable_dynamic_slicing_for_tpus: false
 
+  # # Path to a custom Kueue configuration template.
+  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
+  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
+  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -172,6 +177,8 @@ deployment_groups:
         enable_dynamic_slicing_for_tpus: $(vars.enable_dynamic_slicing_for_tpus)
         accelerator_topology_mode: $(gke-tpu-7x-pool.accelerator_topology_mode)
         machine_type: $(gke-tpu-7x-pool.machine_type)
+        ## Custom kueue config path (Uncomment to override defaults)
+        # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-7x-pool.node_count_static * gke-tpu-7x-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -128,9 +128,9 @@ This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native
 By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
 
 1. **Custom Configurations:**
-* If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
-* * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
-* For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+   * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+   * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
+   * For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
 3. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
@@ -141,7 +141,7 @@ By default, the toolkit dynamically applies an embedded kueue configuration base
     kubectl create -f ~/cluster-toolkit/examples/gke-tpu-v6e/kueue-job-sample.yaml
     ```
 
-3. **Validation:** Check the status of your workload.
+4. **Validation:** Check the status of your workload.
 
     ```sh
     kubectl get workloads

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -129,7 +129,7 @@ By default, the toolkit dynamically applies an embedded kueue configuration base
 
 1. **Custom Configurations:**
 * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
-* * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to point to your custom configuration file.
+* * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
 * For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -128,9 +128,9 @@ This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native
 By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
 
 1. **Custom Configurations:**
-* If you want to override the toolkit's default embedded configurations, or if you explicitly disable both Pathways and Dynamic Slicing, no default queues are created by the toolkit.
-* In such scenarios, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to apply your custom Queue/ResourceFlavor configurations.
-* For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+* If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+* * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to point to your custom configuration file.
+* For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
 
 2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
 3. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.

--- a/examples/gke-tpu-v6e/README.md
+++ b/examples/gke-tpu-v6e/README.md
@@ -124,8 +124,16 @@ The process is nearly identical to the basic deployment.
 
 This blueprint supports [Kueue](https://kueue.sigs.k8s.io/), a kubernetes-native system for managing quotas and job queuing. This is enabled by default in the advanced blueprint (`gke-tpu-v6e-advanced.yaml`).
 
-1. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
-2. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
+**NOTE**:
+By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
+
+1. **Custom Configurations:**
+* If you want to override the toolkit's default embedded configurations, or if you explicitly disable both Pathways and Dynamic Slicing, no default queues are created by the toolkit.
+* In such scenarios, you can uncomment and set the `kueue_configuration_path` variable in your blueprint to apply your custom Queue/ResourceFlavor configurations.
+* For more details on toolkit's default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+
+2. **Quota:** The blueprint automatically calculates and sets a `google.com/tpu` quota in the `ClusterQueue`. The node count is automatically derived from your `machine_type` and `tpu_topology`, and the quota is calculated as: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
+3. **Submit a Job:** To submit a job to the queue, add the label `kueue.x-k8s.io/queue-name: user-queue` to your Job or JobSet manifest.
 
     A sample job file is provided: `kueue-job-sample.yaml`.
 

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -59,9 +59,6 @@ vars:
   # The namespace to be configured for running workloads
   user_namespace: default
 
-  # # Path to a custom Kueue configuration template.
-  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -272,7 +269,7 @@ deployment_groups:
       kueue:
         install: true
         ## Custom kueue config path
-        # config_path: $(vars.kueue_configuration_path)
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -56,9 +56,6 @@ vars:
   # Accelerator type for Kueue configuration
   accelerator_type: tpu-v6e-slice
 
-  # Kueue configuration
-  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -271,7 +268,6 @@ deployment_groups:
     settings:
       kueue:
         install: true
-        config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -60,8 +60,6 @@ vars:
   user_namespace: default
 
   # # Path to a custom Kueue configuration template.
-  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
-  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
   # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
@@ -273,7 +271,7 @@ deployment_groups:
     settings:
       kueue:
         install: true
-        ## Custom kueue config path (Uncomment to override defaults)
+        ## Custom kueue config path
         # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -59,6 +59,11 @@ vars:
   # The namespace to be configured for running workloads
   user_namespace: default
 
+  # # Path to a custom Kueue configuration template.
+  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
+  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
+  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.
   # # Managed Lustre is only supported in specific regions and zones
@@ -268,6 +273,8 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        ## Custom kueue config path (Uncomment to override defaults)
+        # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -56,8 +56,6 @@ vars:
   accelerator_type: tpu-v6e-slice
 
   # # Path to a custom Kueue configuration template.
-  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
-  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
   # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
 
   # The namespace to be configured for running workloads
@@ -189,7 +187,7 @@ deployment_groups:
     settings:
       kueue:
         install: true
-        ## Custom kueue config path (Uncomment to override defaults)
+        ## Custom kueue config path
         # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -55,9 +55,6 @@ vars:
   # Accelerator type for Kueue configuration
   accelerator_type: tpu-v6e-slice
 
-  # # Path to a custom Kueue configuration template.
-  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -188,7 +185,7 @@ deployment_groups:
       kueue:
         install: true
         ## Custom kueue config path
-        # config_path: $(vars.kueue_configuration_path)
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -55,6 +55,11 @@ vars:
   # Accelerator type for Kueue configuration
   accelerator_type: tpu-v6e-slice
 
+  # # Path to a custom Kueue configuration template.
+  # # By default, the toolkit automatically applies an embedded configuration based on Pathways and Dynamic Slicing settings.
+  # # Set this path to apply custom or basic configurations.You can also use this to override the toolkit's default embedded configuration.
+  # kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
+
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -184,6 +189,8 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        ## Custom kueue config path (Uncomment to override defaults)
+        # config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -55,9 +55,6 @@ vars:
   # Accelerator type for Kueue configuration
   accelerator_type: tpu-v6e-slice
 
-  # Kueue configuration
-  kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
-
   # The namespace to be configured for running workloads
   user_namespace: default
 
@@ -187,7 +184,6 @@ deployment_groups:
     settings:
       kueue:
         install: true
-        config_path: $(vars.kueue_configuration_path)
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v6e-pool.node_count_static * gke-tpu-v6e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)


### PR DESCRIPTION
## Overview
Updates the TPU blueprints (v6e and 7x) to remove hardcoded Kueue configuration paths and instead dynamically apply pathway-specific Kueue configuration templates during cluster creation.

## What Changed
- Removed hardcoded kueue config path references from GKE TPU examples
- Implemented dynamic Kueue configuration using `kubectl apply` with `kueue-configuration-pathways.yaml.tftpl` template

## Why This Matters
This change improves flexibility and maintainability by:
- Decoupling Kueue configuration from hardcoded paths
- Enabling pathway-specific template customization
- Simplifying future updates to Kueue configurations without modifying blueprint code
- Making it easier to adapt configurations for different deployment scenarios

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
