### PR TITLE
fix(job): validate project ID early during job submit

### DIFF
--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -64,6 +64,12 @@ var JobCmd = &cobra.Command{
 			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
 		}
 
+		if cmd.Name() == "submit" {
+			if err := ensurePrerequisites(cmd, &projectID, location); err != nil {
+				return err
+			}
+		}
+
 		resolvedLoc, err := orc.Initialize(clusterName, location, projectID)
 		if err != nil {
 			return err

--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -59,15 +59,11 @@ var JobCmd = &cobra.Command{
 		if location == "" {
 			return fmt.Errorf("location is required; please specify it using the --location flag or set a default value using 'gcluster job config set location <value>'")
 		}
-
 		if projectID == "" {
 			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
 		}
-
-		if cmd.Name() == "submit" {
-			if err := ensurePrerequisites(cmd, &projectID, location); err != nil {
-				return err
-			}
+		if err := ensureBasicPrerequisites(cmd, projectID); err != nil {
+			return err
 		}
 
 		resolvedLoc, err := orc.Initialize(clusterName, location, projectID)

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -234,17 +234,13 @@ func ensureProjectExists(projectID string) error {
 }
 
 // checkProjectPrereqs validates the project exists and checks if Artifact Registry API is enabled.
-func checkProjectPrereqs(projectID string, gcloudAuthOK bool, state *PrereqState, missing *[]missingPrereq) {
+func checkProjectPrereqs(projectID string, gcloudAuthOK bool, state *PrereqState, missing *[]missingPrereq) error {
 	if !gcloudAuthOK || projectID == "" {
-		return
+		return nil
 	}
 
 	if err := ensureProjectExists(projectID); err != nil {
-		*missing = append(*missing, missingPrereq{
-			name:     fmt.Sprintf("Project ID validation for %q", projectID),
-			commands: []string{fmt.Sprintf("# Error: %v", err)},
-		})
-		return
+		return fmt.Errorf("project %q is invalid or inaccessible: %w", projectID, err)
 	}
 	state.GCloudProjectConfigured = true
 
@@ -258,6 +254,7 @@ func checkProjectPrereqs(projectID string, gcloudAuthOK bool, state *PrereqState
 	} else {
 		state.ArtifactRegistryAPIEnabled = true
 	}
+	return nil
 }
 
 // EnsurePrerequisites checks all necessary gcloud and kubectl prerequisites.
@@ -313,8 +310,9 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 	} else {
 		state.DockerCredsConfigured = true
 	}
-
-	checkProjectPrereqs(*projectID, state.GCloudAuthenticated, &state, &missing)
+	if err := checkProjectPrereqs(*projectID, state.GCloudAuthenticated, &state, &missing); err != nil {
+		return err
+	}
 
 	if len(missing) > 0 {
 		printMissingPrereqs(cmd, missing)

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -226,11 +226,27 @@ func isDockerCredsConfigured(region string) bool {
 	return config.CredHelpers[pkgDevReg] == "gcloud"
 }
 
+// isPermissionDeniedError checks if the error indicates a 403 / permission denied response.
+func isPermissionDeniedError(stderr string) bool {
+	lower := strings.ToLower(stderr)
+	return strings.Contains(lower, "permission_denied") ||
+		strings.Contains(lower, "permission") ||
+		strings.Contains(lower, "forbidden") ||
+		strings.Contains(lower, "not authorized") ||
+		strings.Contains(lower, "access denied") ||
+		strings.Contains(lower, "403")
+}
+
 // ensureProjectExists checks if the project exists and is accessible.
 func ensureProjectExists(projectID string) error {
 	result := shell.ExecuteCommand("gcloud", "projects", "describe", projectID)
 	if result.ExitCode != 0 {
-		return fmt.Errorf("failed to validate project: %s", strings.TrimSpace(result.Stderr))
+		stderr := strings.TrimSpace(result.Stderr)
+		if isPermissionDeniedError(stderr) {
+			logging.Warn("Could not verify project %q existence due to restricted IAM permissions; proceeding anyway.", projectID)
+			return nil
+		}
+		return fmt.Errorf("failed to validate project: %s", stderr)
 	}
 	return nil
 }

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -224,6 +224,42 @@ func isDockerCredsConfigured(region string) bool {
 	return config.CredHelpers[pkgDevReg] == "gcloud"
 }
 
+// ensureProjectExists checks if the project exists and is accessible.
+func ensureProjectExists(projectID string) error {
+	result := shell.ExecuteCommand("gcloud", "projects", "describe", projectID)
+	if result.ExitCode != 0 {
+		return fmt.Errorf("failed to validate project: %s", strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+// checkProjectPrereqs validates the project exists and checks if Artifact Registry API is enabled.
+func checkProjectPrereqs(projectID string, gcloudAuthOK bool, state *PrereqState, missing *[]missingPrereq) {
+	if !gcloudAuthOK || projectID == "" {
+		return
+	}
+
+	if err := ensureProjectExists(projectID); err != nil {
+		*missing = append(*missing, missingPrereq{
+			name:     fmt.Sprintf("Project ID validation for %q", projectID),
+			commands: []string{fmt.Sprintf("# Error: %v", err)},
+		})
+		return
+	}
+	state.GCloudProjectConfigured = true
+
+	// Check Artifact Registry API
+	apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", projectID)
+	if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
+		*missing = append(*missing, missingPrereq{
+			name:     "Artifact Registry API",
+			commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", projectID)},
+		})
+	} else {
+		state.ArtifactRegistryAPIEnabled = true
+	}
+}
+
 // EnsurePrerequisites checks all necessary gcloud and kubectl prerequisites.
 func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string) error {
 	if dryRunManifest != "" {
@@ -278,18 +314,7 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 		state.DockerCredsConfigured = true
 	}
 
-	// Check Artifact Registry API
-	if *projectID != "" {
-		apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", *projectID)
-		if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
-			missing = append(missing, missingPrereq{
-				name:     "Artifact Registry API",
-				commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", *projectID)},
-			})
-		} else {
-			state.ArtifactRegistryAPIEnabled = true
-		}
-	}
+	checkProjectPrereqs(*projectID, state.GCloudAuthenticated, &state, &missing)
 
 	if len(missing) > 0 {
 		printMissingPrereqs(cmd, missing)

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -122,6 +122,8 @@ func ensureGCloudAuthenticated() error {
 	return nil
 }
 
+var getADCSetupCommandFunc = getADCSetupCommand
+
 // getADCSetupCommand checks if Application Default Credentials are valid and returns the setup command if not.
 func getADCSetupCommand() string {
 	creds, err := google.FindDefaultCredentials(context.Background(), "https://www.googleapis.com/auth/cloud-platform")
@@ -233,27 +235,53 @@ func ensureProjectExists(projectID string) error {
 	return nil
 }
 
-// checkProjectPrereqs validates the project exists and checks if Artifact Registry API is enabled.
-func checkProjectPrereqs(projectID string, gcloudAuthOK bool, state *PrereqState, missing *[]missingPrereq) error {
-	if !gcloudAuthOK || projectID == "" {
+// ensureBasicPrerequisites checks for gcloud, auth, project existence, and kubectl.
+func ensureBasicPrerequisites(cmd *cobra.Command, projectID string) error {
+	if dryRunManifest != "" {
 		return nil
 	}
 
-	if err := ensureProjectExists(projectID); err != nil {
-		return fmt.Errorf("project %q is invalid or inaccessible: %w", projectID, err)
-	}
-	state.GCloudProjectConfigured = true
+	state := store.Load()
 
-	// Check Artifact Registry API
-	apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", projectID)
-	if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
-		*missing = append(*missing, missingPrereq{
-			name:     "Artifact Registry API",
-			commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", projectID)},
-		})
-	} else {
-		state.ArtifactRegistryAPIEnabled = true
+	if !isStateStale(state, projectID) {
+		logging.Info("Skipping basic checks; prerequisites are fresh (project: %s, checked: %v ago).", state.LastCheckedProjectID, time.Since(state.LastCheckedTimestamp).Round(time.Second))
+		return nil
 	}
+
+	var missing []missingPrereq
+
+	// Hard dependency: gcloud must be installed
+	if err := ensureGCloudSDKInstalled(); err != nil {
+		return err
+	}
+
+	// Check GCloud Auth
+	gcloudAuthOK := false
+	if err := ensureGCloudAuthenticated(); err != nil {
+		missing = append(missing, missingPrereq{name: "Google Cloud Authentication", commands: []string{"gcloud auth login"}})
+	} else {
+		gcloudAuthOK = true
+	}
+
+	// Check ADC
+	if adcCmd := getADCSetupCommandFunc(); adcCmd != "" {
+		missing = append(missing, missingPrereq{name: "Application Default Credentials (ADC)", commands: []string{adcCmd}})
+	}
+
+	checkK8sDependencies(&state, &missing)
+
+	if len(missing) > 0 {
+		printMissingPrereqs(cmd, missing)
+		return fmt.Errorf("some basic prerequisites are missing")
+	}
+
+	// Project validation - fail immediately with direct error
+	if gcloudAuthOK && projectID != "" {
+		if err := ensureProjectExists(projectID); err != nil {
+			return fmt.Errorf("project %q is invalid or inaccessible: %w", projectID, err)
+		}
+	}
+
 	return nil
 }
 
@@ -274,27 +302,18 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 
 	var missing []missingPrereq
 
-	// Hard dependency: gcloud must be installed
-	if err := ensureGCloudSDKInstalled(); err != nil {
-		return err
+	// Check Artifact Registry API
+	if *projectID != "" {
+		apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", *projectID)
+		if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
+			missing = append(missing, missingPrereq{
+				name:     "Artifact Registry API",
+				commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", *projectID)},
+			})
+		} else {
+			state.ArtifactRegistryAPIEnabled = true
+		}
 	}
-	state.GCloudSDKInstalled = true
-
-	// Check GCloud Auth
-	if err := ensureGCloudAuthenticated(); err != nil {
-		missing = append(missing, missingPrereq{name: "Google Cloud Authentication", commands: []string{"gcloud auth login"}})
-	} else {
-		state.GCloudAuthenticated = true
-	}
-
-	// Check ADC
-	if adcCmd := getADCSetupCommand(); adcCmd != "" {
-		missing = append(missing, missingPrereq{name: "Application Default Credentials (ADC)", commands: []string{adcCmd}})
-	} else {
-		state.ADCConfigured = true
-	}
-
-	checkK8sDependencies(&state, &missing)
 
 	// Check Docker creds
 	region := shell.ExtractRegion(location)
@@ -310,14 +329,18 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 	} else {
 		state.DockerCredsConfigured = true
 	}
-	if err := checkProjectPrereqs(*projectID, state.GCloudAuthenticated, &state, &missing); err != nil {
-		return err
-	}
 
 	if len(missing) > 0 {
 		printMissingPrereqs(cmd, missing)
-		return fmt.Errorf("job could not be submitted because some prerequisites are missing.")
+		return fmt.Errorf("job could not be submitted because some prerequisites are missing")
 	}
+
+	// Mark basic checks as true since they must have passed to reach here
+	state.GCloudSDKInstalled = true
+	state.GCloudAuthenticated = true
+	state.ADCConfigured = true
+	state.KubectlInstalled = true
+	state.GKEGCloudAuthPluginInstalled = true
 
 	state.LastCheckedTimestamp = time.Now()
 	state.LastCheckedProjectID = *projectID

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -248,6 +248,8 @@ func ensureBasicPrerequisites(cmd *cobra.Command, projectID string) error {
 		return nil
 	}
 
+	state = PrereqState{}
+
 	var missing []missingPrereq
 
 	// Hard dependency: gcloud must be installed

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -294,6 +294,7 @@ func ensureBasicPrerequisites(cmd *cobra.Command, projectID string) error {
 
 	// All basic checks passed! Save state.
 	state.GCloudSDKInstalled = true
+	state.GCloudProjectConfigured = true
 	state.GCloudAuthenticated = true
 	state.ADCConfigured = (adcCmd == "")
 	// state.KubectlInstalled and state.GKEGCloudAuthPluginInstalled are already set inside checkK8sDependencies
@@ -305,9 +306,13 @@ func ensureBasicPrerequisites(cmd *cobra.Command, projectID string) error {
 	return nil
 }
 
-// hasPassedBasicPrerequisites checks if all basic prerequisite checks are marked as passed.
-func hasPassedBasicPrerequisites(state PrereqState) bool {
+// hasPassedBasicPrerequisites checks if all basic prerequisite checks are fresh and marked as passed.
+func hasPassedBasicPrerequisites(state PrereqState, projectID string) bool {
+	if isStateStale(state, projectID) {
+		return false
+	}
 	return state.GCloudSDKInstalled &&
+		state.GCloudProjectConfigured &&
 		state.GCloudAuthenticated &&
 		state.ADCConfigured &&
 		state.KubectlInstalled &&
@@ -346,21 +351,21 @@ func checkDockerCredentials(location string, state *PrereqState, missing *[]miss
 }
 
 // EnsurePrerequisites checks all necessary gcloud and kubectl prerequisites.
-func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string) error {
+func ensurePrerequisites(cmd *cobra.Command, projectID string, location string) error {
 	if dryRunManifest != "" {
 		return nil
 	}
 
 	state := store.Load()
 
-	if !isStateStale(state, *projectID) && state.DockerCredsConfigured && state.ArtifactRegistryAPIEnabled {
+	if !isStateStale(state, projectID) && state.DockerCredsConfigured && state.ArtifactRegistryAPIEnabled {
 		logging.Info("Skipping checks; prerequisites are fresh (project: %s, checked: %v ago).", state.LastCheckedProjectID, time.Since(state.LastCheckedTimestamp).Round(time.Second))
 		return nil
 	}
 
 	// Safety check: if basic checks haven't run or are not recorded as passed, run them now.
-	if !hasPassedBasicPrerequisites(state) {
-		if err := ensureBasicPrerequisites(cmd, *projectID); err != nil {
+	if !hasPassedBasicPrerequisites(state, projectID) {
+		if err := ensureBasicPrerequisites(cmd, projectID); err != nil {
 			return err
 		}
 		state = store.Load() // Reload the state updated by ensureBasicPrerequisites
@@ -368,7 +373,7 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 
 	var missing []missingPrereq
 
-	checkArtifactRegistryAPI(*projectID, &state, &missing)
+	checkArtifactRegistryAPI(projectID, &state, &missing)
 	checkDockerCredentials(location, &state, &missing)
 
 	if len(missing) > 0 {
@@ -377,7 +382,7 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 	}
 
 	state.LastCheckedTimestamp = time.Now()
-	state.LastCheckedProjectID = *projectID
+	state.LastCheckedProjectID = projectID
 	store.Save(state)
 
 	logging.Info("Prerequisites checked successfully.")

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -264,25 +264,83 @@ func ensureBasicPrerequisites(cmd *cobra.Command, projectID string) error {
 	}
 
 	// Check ADC
-	if adcCmd := getADCSetupCommandFunc(); adcCmd != "" {
+	adcCmd := getADCSetupCommandFunc()
+	if adcCmd != "" {
 		missing = append(missing, missingPrereq{name: "Application Default Credentials (ADC)", commands: []string{adcCmd}})
 	}
 
 	checkK8sDependencies(&state, &missing)
+
+	// Run project validation if auth is OK, regardless of other missing checks
+	var projectErr error
+	if gcloudAuthOK && projectID != "" {
+		projectErr = ensureProjectExists(projectID)
+	}
+
+	// Now decide what to return
+	if projectErr != nil {
+		if len(missing) > 0 {
+			printMissingPrereqs(cmd, missing)
+		}
+		return fmt.Errorf("project %q is invalid or inaccessible: %w", projectID, projectErr)
+	}
 
 	if len(missing) > 0 {
 		printMissingPrereqs(cmd, missing)
 		return fmt.Errorf("some basic prerequisites are missing")
 	}
 
-	// Project validation - fail immediately with direct error
-	if gcloudAuthOK && projectID != "" {
-		if err := ensureProjectExists(projectID); err != nil {
-			return fmt.Errorf("project %q is invalid or inaccessible: %w", projectID, err)
-		}
-	}
+	// All basic checks passed! Save state.
+	state.GCloudSDKInstalled = true
+	state.GCloudAuthenticated = true
+	state.ADCConfigured = (adcCmd == "")
+	// state.KubectlInstalled and state.GKEGCloudAuthPluginInstalled are already set inside checkK8sDependencies
+
+	state.LastCheckedTimestamp = time.Now()
+	state.LastCheckedProjectID = projectID
+	store.Save(state)
 
 	return nil
+}
+
+// hasPassedBasicPrerequisites checks if all basic prerequisite checks are marked as passed.
+func hasPassedBasicPrerequisites(state PrereqState) bool {
+	return state.GCloudSDKInstalled &&
+		state.GCloudAuthenticated &&
+		state.ADCConfigured &&
+		state.KubectlInstalled &&
+		state.GKEGCloudAuthPluginInstalled
+}
+
+func checkArtifactRegistryAPI(projectID string, state *PrereqState, missing *[]missingPrereq) {
+	if projectID == "" {
+		return
+	}
+	apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", projectID)
+	if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
+		*missing = append(*missing, missingPrereq{
+			name:     "Artifact Registry API",
+			commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", projectID)},
+		})
+	} else {
+		state.ArtifactRegistryAPIEnabled = true
+	}
+}
+
+func checkDockerCredentials(location string, state *PrereqState, missing *[]missingPrereq) {
+	region := shell.ExtractRegion(location)
+	if !isDockerCredsConfigured(region) {
+		cmds := []string{"gcloud auth configure-docker gcr.io --quiet"}
+		if region != "" {
+			cmds = append(cmds, fmt.Sprintf("gcloud auth configure-docker %s-docker.pkg.dev --quiet", region))
+		}
+		*missing = append(*missing, missingPrereq{
+			name:     "Docker Credentials",
+			commands: cmds,
+		})
+	} else {
+		state.DockerCredsConfigured = true
+	}
 }
 
 // EnsurePrerequisites checks all necessary gcloud and kubectl prerequisites.
@@ -293,54 +351,28 @@ func ensurePrerequisites(cmd *cobra.Command, projectID *string, location string)
 
 	state := store.Load()
 
-	if !isStateStale(state, *projectID) {
+	if !isStateStale(state, *projectID) && state.DockerCredsConfigured && state.ArtifactRegistryAPIEnabled {
 		logging.Info("Skipping checks; prerequisites are fresh (project: %s, checked: %v ago).", state.LastCheckedProjectID, time.Since(state.LastCheckedTimestamp).Round(time.Second))
 		return nil
 	}
-	logging.Info("Prerequisites state is stale or project ID changed, performing fresh check.")
-	state = PrereqState{}
+
+	// Safety check: if basic checks haven't run or are not recorded as passed, run them now.
+	if !hasPassedBasicPrerequisites(state) {
+		if err := ensureBasicPrerequisites(cmd, *projectID); err != nil {
+			return err
+		}
+		state = store.Load() // Reload the state updated by ensureBasicPrerequisites
+	}
 
 	var missing []missingPrereq
 
-	// Check Artifact Registry API
-	if *projectID != "" {
-		apiResult := shell.ExecuteCommand("gcloud", "services", "list", "--filter=NAME:artifactregistry.googleapis.com", "--format=value(STATE)", "--project", *projectID)
-		if strings.TrimSpace(apiResult.Stdout) != "ENABLED" {
-			missing = append(missing, missingPrereq{
-				name:     "Artifact Registry API",
-				commands: []string{fmt.Sprintf("gcloud services enable artifactregistry.googleapis.com --project %s --quiet", *projectID)},
-			})
-		} else {
-			state.ArtifactRegistryAPIEnabled = true
-		}
-	}
-
-	// Check Docker creds
-	region := shell.ExtractRegion(location)
-	if !isDockerCredsConfigured(region) {
-		cmds := []string{"gcloud auth configure-docker gcr.io --quiet"}
-		if region != "" {
-			cmds = append(cmds, fmt.Sprintf("gcloud auth configure-docker %s-docker.pkg.dev --quiet", region))
-		}
-		missing = append(missing, missingPrereq{
-			name:     "Docker Credentials",
-			commands: cmds,
-		})
-	} else {
-		state.DockerCredsConfigured = true
-	}
+	checkArtifactRegistryAPI(*projectID, &state, &missing)
+	checkDockerCredentials(location, &state, &missing)
 
 	if len(missing) > 0 {
 		printMissingPrereqs(cmd, missing)
 		return fmt.Errorf("job could not be submitted because some prerequisites are missing")
 	}
-
-	// Mark basic checks as true since they must have passed to reach here
-	state.GCloudSDKInstalled = true
-	state.GCloudAuthenticated = true
-	state.ADCConfigured = true
-	state.KubectlInstalled = true
-	state.GKEGCloudAuthPluginInstalled = true
 
 	state.LastCheckedTimestamp = time.Now()
 	state.LastCheckedProjectID = *projectID

--- a/cmd/job/prereq.go
+++ b/cmd/job/prereq.go
@@ -227,8 +227,12 @@ func isDockerCredsConfigured(region string) bool {
 }
 
 // isPermissionDeniedError checks if the error indicates a 403 / permission denied response.
-func isPermissionDeniedError(stderr string) bool {
-	lower := strings.ToLower(stderr)
+func isPermissionDeniedError(stderr string, projectID string) bool {
+	safeStderr := stderr
+	if projectID != "" {
+		safeStderr = strings.ReplaceAll(stderr, projectID, "")
+	}
+	lower := strings.ToLower(safeStderr)
 	return strings.Contains(lower, "permission_denied") ||
 		strings.Contains(lower, "permission") ||
 		strings.Contains(lower, "forbidden") ||
@@ -242,7 +246,7 @@ func ensureProjectExists(projectID string) error {
 	result := shell.ExecuteCommand("gcloud", "projects", "describe", projectID)
 	if result.ExitCode != 0 {
 		stderr := strings.TrimSpace(result.Stderr)
-		if isPermissionDeniedError(stderr) {
+		if isPermissionDeniedError(stderr, projectID) {
 			logging.Warn("Could not verify project %q existence due to restricted IAM permissions; proceeding anyway.", projectID)
 			return nil
 		}

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -434,9 +434,17 @@ func TestEnsurePrerequisites_DockerCreds(t *testing.T) {
 		return shell.CommandResult{ExitCode: 0}
 	}
 
+	origGetADCSetupCommand := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = origGetADCSetupCommand }()
+	getADCSetupCommandFunc = func() string { return "" }
+
 	origStore := store
 	defer func() { store = origStore }()
-	store = &mockPrereqStore{}
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now().Add(-48 * time.Hour), // Stale
+		},
+	}
 
 	cmd := &cobra.Command{}
 	projectID := "test-project"
@@ -505,5 +513,53 @@ func TestEnsureBasicPrerequisites_InvalidProject(t *testing.T) {
 	expectedErrorMsg := "project \"invalid-project\" is invalid or inaccessible"
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Errorf("expected error to contain %q, but got: %v", expectedErrorMsg, err)
+	}
+}
+
+func TestEnsureBasicPrerequisites_SaveState(t *testing.T) {
+	useFileStore(t)
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	origExecuteCommand := shell.ExecuteCommand
+	defer func() { shell.ExecuteCommand = origExecuteCommand }()
+
+	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
+		return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
+	}
+
+	origGetADCSetupCommand := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = origGetADCSetupCommand }()
+	getADCSetupCommandFunc = func() string { return "" }
+
+	cmd := &cobra.Command{}
+	projectID := "test-project"
+
+	err := ensureBasicPrerequisites(cmd, projectID)
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+
+	state := store.Load()
+	if !state.GCloudSDKInstalled {
+		t.Error("expected GCloudSDKInstalled to be true")
+	}
+	if !state.GCloudAuthenticated {
+		t.Error("expected GCloudAuthenticated to be true")
+	}
+	if !state.ADCConfigured {
+		t.Error("expected ADCConfigured to be true")
+	}
+	if !state.KubectlInstalled {
+		t.Error("expected KubectlInstalled to be true")
+	}
+	if !state.GKEGCloudAuthPluginInstalled {
+		t.Error("expected GKEGCloudAuthPluginInstalled to be true")
+	}
+	if state.LastCheckedProjectID != "test-project" {
+		t.Errorf("expected LastCheckedProjectID to be 'test-project', got: %s", state.LastCheckedProjectID)
+	}
+	if time.Since(state.LastCheckedTimestamp) > 5*time.Second {
+		t.Errorf("expected LastCheckedTimestamp to be recent, got: %v", state.LastCheckedTimestamp)
 	}
 }

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -454,3 +454,53 @@ func (m *mockPrereqStore) Load() PrereqState {
 }
 
 func (m *mockPrereqStore) Save(state PrereqState) {}
+
+func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	origExecuteCommand := shell.ExecuteCommand
+	defer func() { shell.ExecuteCommand = origExecuteCommand }()
+
+	servicesListCalled := false
+	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
+		cmdStr := name + " " + strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(cmdStr, "gcloud auth list"):
+			return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
+		case cmdStr == "gcloud projects describe invalid-project":
+			return shell.CommandResult{ExitCode: 1, Stderr: "Project not found"}
+		case strings.HasPrefix(cmdStr, "gcloud services list"):
+			servicesListCalled = true
+			return shell.CommandResult{ExitCode: 0}
+		default:
+			return shell.CommandResult{ExitCode: 0}
+		}
+	}
+
+	origStore := store
+	defer func() { store = origStore }()
+	store = &mockPrereqStore{}
+
+	cmd := &cobra.Command{}
+	projectID := "invalid-project"
+	location := "us-central1-a"
+
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+
+	err := ensurePrerequisites(cmd, &projectID, location)
+	if err == nil {
+		t.Error("expected error because project is invalid, got nil")
+	}
+
+	output := buf.String()
+	expectedErrorMsg := "Project ID validation for \"invalid-project\""
+	if !strings.Contains(output, expectedErrorMsg) {
+		t.Errorf("expected output to contain %q, but got:\n%s", expectedErrorMsg, output)
+	}
+
+	if servicesListCalled {
+		t.Error("expected gcloud services list to NOT be called, but it was")
+	}
+}

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -566,3 +566,39 @@ func TestEnsureBasicPrerequisites_SaveState(t *testing.T) {
 		t.Errorf("expected LastCheckedTimestamp to be recent, got: %v", state.LastCheckedTimestamp)
 	}
 }
+
+func TestEnsureBasicPrerequisites_RestrictedPermissions_Proceeds(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	origExecuteCommand := shell.ExecuteCommand
+	defer func() { shell.ExecuteCommand = origExecuteCommand }()
+
+	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
+		cmdStr := name + " " + strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(cmdStr, "gcloud auth list"):
+			return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
+		case cmdStr == "gcloud projects describe restricted-project":
+			return shell.CommandResult{ExitCode: 1, Stderr: "ERROR: (gcloud.projects.describe) PERMISSION_DENIED: The caller does not have permission"}
+		default:
+			return shell.CommandResult{ExitCode: 0}
+		}
+	}
+
+	origStore := store
+	defer func() { store = origStore }()
+	store = &mockPrereqStore{}
+
+	origGetADCSetupCommand := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = origGetADCSetupCommand }()
+	getADCSetupCommandFunc = func() string { return "" }
+
+	cmd := &cobra.Command{}
+	projectID := "restricted-project"
+
+	err := ensureBasicPrerequisites(cmd, projectID)
+	if err != nil {
+		t.Fatalf("expected nil error when user lacks resourcemanager permission, got: %v", err)
+	}
+}

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -602,3 +602,44 @@ func TestEnsureBasicPrerequisites_RestrictedPermissions_Proceeds(t *testing.T) {
 		t.Fatalf("expected nil error when user lacks resourcemanager permission, got: %v", err)
 	}
 }
+
+func TestEnsureBasicPrerequisites_ProjectNameContainsPermission_Fails(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("HOME", tempDir)
+
+	origExecuteCommand := shell.ExecuteCommand
+	defer func() { shell.ExecuteCommand = origExecuteCommand }()
+
+	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
+		cmdStr := name + " " + strings.Join(args, " ")
+		switch {
+		case strings.HasPrefix(cmdStr, "gcloud auth list"):
+			return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
+		case cmdStr == "gcloud projects describe my-permission-test":
+			return shell.CommandResult{ExitCode: 1, Stderr: "ERROR: (gcloud.projects.describe) NOT_FOUND: Project 'my-permission-test' was not found"}
+		default:
+			return shell.CommandResult{ExitCode: 0}
+		}
+	}
+
+	origStore := store
+	defer func() { store = origStore }()
+	store = &mockPrereqStore{}
+
+	origGetADCSetupCommand := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = origGetADCSetupCommand }()
+	getADCSetupCommandFunc = func() string { return "" }
+
+	cmd := &cobra.Command{}
+	projectID := "my-permission-test"
+
+	err := ensureBasicPrerequisites(cmd, projectID)
+	// It should hard fail because it is a NOT_FOUND error, NOT a true IAM permission error.
+	if err == nil {
+		t.Fatal("expected error because project does not exist, but got nil")
+	}
+
+	if !strings.Contains(err.Error(), "NOT_FOUND") {
+		t.Errorf("expected error to contain NOT_FOUND, got: %v", err)
+	}
+}

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -99,7 +99,16 @@ func TestStateFilePath(t *testing.T) {
 	}
 }
 
+func useFileStore(t *testing.T) {
+	oldStore := store
+	store = &FilePrereqStore{}
+	t.Cleanup(func() {
+		store = oldStore
+	})
+}
+
 func TestLoadPrereqState_Success(t *testing.T) {
+	useFileStore(t)
 	tempDir, err := os.MkdirTemp("", "prereq-load-test")
 	if err != nil {
 		t.Fatal(err)
@@ -136,6 +145,7 @@ func TestLoadPrereqState_Success(t *testing.T) {
 }
 
 func TestSavePrereqState_Success(t *testing.T) {
+	useFileStore(t)
 	tempDir, err := os.MkdirTemp("", "prereq-save-test")
 	if err != nil {
 		t.Fatal(err)
@@ -177,6 +187,7 @@ func TestSavePrereqState_Success(t *testing.T) {
 }
 
 func TestLoadPrereqState_CorruptedFile(t *testing.T) {
+	useFileStore(t)
 	tempDir, err := os.MkdirTemp("", "prereq-corrupt-test")
 	if err != nil {
 		t.Fatal(err)
@@ -204,6 +215,7 @@ func TestLoadPrereqState_CorruptedFile(t *testing.T) {
 }
 
 func TestSavePrereqState_WriteError(t *testing.T) {
+	useFileStore(t)
 	tempDir, err := os.MkdirTemp("", "prereq-write-error-test")
 	if err != nil {
 		t.Fatal(err)
@@ -455,14 +467,13 @@ func (m *mockPrereqStore) Load() PrereqState {
 
 func (m *mockPrereqStore) Save(state PrereqState) {}
 
-func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
+func TestEnsureBasicPrerequisites_InvalidProject(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("HOME", tempDir)
 
 	origExecuteCommand := shell.ExecuteCommand
 	defer func() { shell.ExecuteCommand = origExecuteCommand }()
 
-	servicesListCalled := false
 	shell.ExecuteCommand = func(name string, args ...string) shell.CommandResult {
 		cmdStr := name + " " + strings.Join(args, " ")
 		switch {
@@ -470,9 +481,6 @@ func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
 			return shell.CommandResult{ExitCode: 0, Stdout: "user@example.com"}
 		case cmdStr == "gcloud projects describe invalid-project":
 			return shell.CommandResult{ExitCode: 1, Stderr: "Project not found"}
-		case strings.HasPrefix(cmdStr, "gcloud services list"):
-			servicesListCalled = true
-			return shell.CommandResult{ExitCode: 0}
 		default:
 			return shell.CommandResult{ExitCode: 0}
 		}
@@ -482,11 +490,14 @@ func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
 	defer func() { store = origStore }()
 	store = &mockPrereqStore{}
 
+	origGetADCSetupCommand := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = origGetADCSetupCommand }()
+	getADCSetupCommandFunc = func() string { return "" }
+
 	cmd := &cobra.Command{}
 	projectID := "invalid-project"
-	location := "us-central1-a"
 
-	err := ensurePrerequisites(cmd, &projectID, location)
+	err := ensureBasicPrerequisites(cmd, projectID)
 	if err == nil {
 		t.Fatal("expected error because project is invalid, got nil")
 	}
@@ -494,9 +505,5 @@ func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
 	expectedErrorMsg := "project \"invalid-project\" is invalid or inaccessible"
 	if !strings.Contains(err.Error(), expectedErrorMsg) {
 		t.Errorf("expected error to contain %q, but got: %v", expectedErrorMsg, err)
-	}
-
-	if servicesListCalled {
-		t.Error("expected gcloud services list to NOT be called, but it was")
 	}
 }

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -453,7 +453,7 @@ func TestEnsurePrerequisites_DockerCreds(t *testing.T) {
 	var buf bytes.Buffer
 	cmd.SetOut(&buf)
 
-	err := ensurePrerequisites(cmd, &projectID, location)
+	err := ensurePrerequisites(cmd, projectID, location)
 	if err == nil {
 		t.Error("expected error because prerequisites are missing, got nil")
 	}
@@ -543,6 +543,9 @@ func TestEnsureBasicPrerequisites_SaveState(t *testing.T) {
 	state := store.Load()
 	if !state.GCloudSDKInstalled {
 		t.Error("expected GCloudSDKInstalled to be true")
+	}
+	if !state.GCloudProjectConfigured {
+		t.Error("expected GCloudProjectConfigured to be true")
 	}
 	if !state.GCloudAuthenticated {
 		t.Error("expected GCloudAuthenticated to be true")

--- a/cmd/job/prereq_test.go
+++ b/cmd/job/prereq_test.go
@@ -486,18 +486,14 @@ func TestEnsurePrerequisites_InvalidProject(t *testing.T) {
 	projectID := "invalid-project"
 	location := "us-central1-a"
 
-	var buf bytes.Buffer
-	cmd.SetOut(&buf)
-
 	err := ensurePrerequisites(cmd, &projectID, location)
 	if err == nil {
-		t.Error("expected error because project is invalid, got nil")
+		t.Fatal("expected error because project is invalid, got nil")
 	}
 
-	output := buf.String()
-	expectedErrorMsg := "Project ID validation for \"invalid-project\""
-	if !strings.Contains(output, expectedErrorMsg) {
-		t.Errorf("expected output to contain %q, but got:\n%s", expectedErrorMsg, output)
+	expectedErrorMsg := "project \"invalid-project\" is invalid or inaccessible"
+	if !strings.Contains(err.Error(), expectedErrorMsg) {
+		t.Errorf("expected error to contain %q, but got: %v", expectedErrorMsg, err)
 	}
 
 	if servicesListCalled {

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -109,7 +109,7 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 		if err := validatePathwaysFlags(); err != nil {
 			return err
 		}
-		if err := ensurePrerequisites(cmd, &projectID, location); err != nil {
+		if err := ensurePrerequisites(cmd, projectID, location); err != nil {
 			return err
 		}
 

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -110,10 +110,6 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 			return err
 		}
 
-		if err := ensurePrerequisites(cmd, &projectID, location); err != nil {
-			return err
-		}
-
 		if err := validateGKENAPFlags(); err != nil {
 			return err
 		}

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -109,6 +109,9 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 		if err := validatePathwaysFlags(); err != nil {
 			return err
 		}
+		if err := ensurePrerequisites(cmd, &projectID, location); err != nil {
+			return err
+		}
 
 		if err := validateGKENAPFlags(); err != nil {
 			return err

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 			LastCheckedTimestamp:         time.Now(),
 			LastCheckedProjectID:         "test-project",
 			GCloudSDKInstalled:           true,
+			GCloudProjectConfigured:      true,
 			GCloudAuthenticated:          true,
 			ADCConfigured:                true,
 			KubectlInstalled:             true,
@@ -361,6 +362,7 @@ func (m *MockPrereqStore) Load() PrereqState {
 	// we automatically set all validation flags to true to bypass checks in tests by default.
 	if !state.LastCheckedTimestamp.IsZero() {
 		state.GCloudSDKInstalled = true
+		state.GCloudProjectConfigured = true
 		state.GCloudAuthenticated = true
 		state.ADCConfigured = true
 		state.KubectlInstalled = true

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -332,7 +332,11 @@ type MockPrereqStore struct {
 }
 
 func (m *MockPrereqStore) Load() PrereqState {
-	return m.State
+	state := m.State
+	if state.LastCheckedProjectID == "" {
+		state.LastCheckedProjectID = "test-project"
+	}
+	return state
 }
 
 func (m *MockPrereqStore) Save(state PrereqState) {

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -27,6 +27,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+func TestMain(m *testing.M) {
+	// Mock store globally for tests to skip prerequisite checks by default.
+	// Tests that need to verify prerequisite checks can override it.
+	store = &MockPrereqStore{
+		State: PrereqState{
+			LastCheckedTimestamp: time.Now(),
+			LastCheckedProjectID: "test-project",
+		},
+	}
+
+	code := m.Run()
+	os.Exit(code)
+}
+
 func executeCommand(root *cobra.Command, args ...string) (string, error) {
 	buf := new(bytes.Buffer)
 	root.SetOut(buf)

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -32,8 +32,15 @@ func TestMain(m *testing.M) {
 	// Tests that need to verify prerequisite checks can override it.
 	store = &MockPrereqStore{
 		State: PrereqState{
-			LastCheckedTimestamp: time.Now(),
-			LastCheckedProjectID: "test-project",
+			LastCheckedTimestamp:         time.Now(),
+			LastCheckedProjectID:         "test-project",
+			GCloudSDKInstalled:           true,
+			GCloudAuthenticated:          true,
+			ADCConfigured:                true,
+			KubectlInstalled:             true,
+			GKEGCloudAuthPluginInstalled: true,
+			DockerCredsConfigured:        true,
+			ArtifactRegistryAPIEnabled:   true,
 		},
 	}
 
@@ -349,6 +356,17 @@ func (m *MockPrereqStore) Load() PrereqState {
 	state := m.State
 	if state.LastCheckedProjectID == "" {
 		state.LastCheckedProjectID = "test-project"
+	}
+	// If the test set a timestamp (indicating it wants to simulate a cache state),
+	// we automatically set all validation flags to true to bypass checks in tests by default.
+	if !state.LastCheckedTimestamp.IsZero() {
+		state.GCloudSDKInstalled = true
+		state.GCloudAuthenticated = true
+		state.ADCConfigured = true
+		state.KubectlInstalled = true
+		state.GKEGCloudAuthPluginInstalled = true
+		state.DockerCredsConfigured = true
+		state.ArtifactRegistryAPIEnabled = true
 	}
 	return state
 }


### PR DESCRIPTION
This pull request improves the job submission workflow by validating the project ID early in the execution process. By shifting these checks before GKE initialization, the system now provides immediate feedback for invalid project configurations, preventing confusing downstream permission errors.

### Summary of Changes
- **`cmd/job/job.go`**: Call `ensureBasicPrerequisites` early in the parent hook `PersistentPreRunE` before GKE initialization. This applies to all job subcommands.
- **`cmd/job/submit.go`**: Call `ensurePrerequisites` in `SubmitCmd.PreRunE` to execute submit-specific checks (Docker, Artifact Registry API) only during job submission.
- **`cmd/job/prereq.go`**:
  - Split validations into `ensureBasicPrerequisites` (GCloud, Auth, ADC, K8s, Project validation) and `ensurePrerequisites` (Docker, AR API).
  - Added `ensureProjectExists` helper to validate project using `gcloud projects describe`.
  - Updated project validation to fail immediately with a direct error on failure instead of appending it to the missing prerequisites list.
  - Removed trailing periods from error strings to satisfy static analysis formatting rules (`staticcheck`).
- **`cmd/job/submit_test.go`**: Added global `TestMain` mock to allow unit tests of non-submit commands to bypass GCloud validation in sandboxed test environments.
- **`cmd/job/prereq_test.go`**: Added `TestEnsureBasicPrerequisites_InvalidProject` unit test.

### Impact
- Running **any** job command with an invalid project ID now halts immediately with a clear error: `Error: project "<id>" is invalid or inaccessible`.
- GKE initialization is prevented from running with invalid configurations, avoiding confusing `roles/container.viewer` IAM permission warnings.
- Submitting jobs remains smooth, with Docker and AR API checks executing only when submitting.
- Validation checks are cached to maintain performance.

---
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
