### PR TITLE
Refactor: Use Secret Manager for triage agent config and enforce mTLS URLs

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -46,9 +46,9 @@
       exit 0
     fi
 
-    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$TRIAGE_PROJECT_NUMBER" 2>/dev/null || echo "false")
+    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$TRIAGE_PROJECT_NUMBER" || echo "false")
     if [ "$ENABLE_AGENT" != "true" ]; then
-      echo "SKIPPED: Failure Triage Agent is currently disabled in Secret Manager." >&2
+      echo "SKIPPED: Failure Triage Agent is currently disabled in Secret Manager, or the secret could not be accessed." >&2
       exit 0
     fi
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -46,9 +46,9 @@
       exit 0
     fi
 
-    CONFIG_CONTENT=$(gcloud storage cat "gs://$TRIAGE_GCS_BUCKET/config_triage_agent.env" 2>/dev/null || echo "enable_agent=false")
-    if ! echo "$CONFIG_CONTENT" | grep -qi '^[[:space:]]*enable_agent[[:space:]]*=[[:space:]]*true'; then
-      echo "SKIPPED: Failure Triage Agent is currently disabled in config_triage_agent.env." >&2
+    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$TRIAGE_PROJECT_NUMBER" 2>/dev/null || echo "false")
+    if [ "$ENABLE_AGENT" != "true" ]; then
+      echo "SKIPPED: Failure Triage Agent is currently disabled in Secret Manager." >&2
       exit 0
     fi
 
@@ -140,8 +140,8 @@
         {{ (agent_state.stdout | default('{}', true) | from_json).executive_summary | default('No summary available.') | wordwrap(100) }}
 
         Full diagnostic report available at:
-        https://storage.cloud.google.com/{{ triage_gcs_bucket }}/{{ triage_build_id }}/report.txt
+        https://storage.mtls.cloud.google.com/{{ triage_gcs_bucket }}/{{ triage_build_id }}/report.txt
         {% endif %}
 
         For detailed intermediate state information, please review the diagnostic state file:
-        https://console.cloud.google.com/storage/browser/_details/{{ triage_gcs_bucket }}/{{ triage_build_id }}/state.json
+        https://storage.mtls.cloud.google.com/{{ triage_gcs_bucket }}/{{ triage_build_id }}/state.json


### PR DESCRIPTION
### Description
This PR updates the failure triage agent playbook to improve security and configuration management. 

Specifically, it includes the following changes in `tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml`:
- **Secret Manager Integration**: Migrates the configuration check from reading a file in GCS to using Google Secret Manager (`gcloud secrets versions access latest --secret="triage_agent_enabled"`).
- **mTLS Enforcement**: Updates the diagnostic report and state file URLs to use mTLS-enabled endpoints (`https://storage.mtls.cloud.google.com/`).

Tested the following daily test trigger with these changes:
1. [DAILY-test-chrome-remote-desktop](https://pantheon.corp.google.com/cloud-build/builds;region=global/38f935e8-17a4-4e46-940e-ff8640b26bef?e=-13802955&mods=monitoring_api_prod&project=hpc-toolkit-dev)
2. [DAILY-test-ml-h4d-onspot-slurm](https://pantheon.corp.google.com/cloud-build/builds;region=global/dcaa9499-3c99-48ed-ab3a-9a69cf5ee5fc?e=-13802955&mods=monitoring_api_prod&project=hpc-toolkit-dev)
3. [DAILY-test-chrome-remote-desktop-ubuntu](https://pantheon.corp.google.com/cloud-build/builds;region=global/1cb37611-9a54-407c-b758-90f00324151f?e=-13802955&mods=monitoring_api_prod&project=hpc-toolkit-dev)

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
