### PR TITLE
feat(packer): add network_ip and address options to custom-image module

### DIFF
--- a/modules/packer/custom-image/README.md
+++ b/modules/packer/custom-image/README.md
@@ -260,6 +260,7 @@ No resources.
 | ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_accelerator_count"></a> [accelerator\_count](#input\_accelerator\_count) | Number of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `number` | `null` | no |
 | <a name="input_accelerator_type"></a> [accelerator\_type](#input\_accelerator\_type) | Type of accelerator cards to attach to the VM; not necessary for families that always include GPUs (A2). | `string` | `null` | no |
+| <a name="input_address"></a> [address](#input\_address) | The name of a pre-allocated static external IP address. If specified, omit\_external\_ip must be set to false. | `string` | `null` | no |
 | <a name="input_ansible_playbooks"></a> [ansible\_playbooks](#input\_ansible\_playbooks) | A list of Ansible playbook configurations that will be uploaded to customize the VM image | <pre>list(object({<br/>    playbook_file   = string<br/>    galaxy_file     = string<br/>    extra_arguments = list(string)<br/>  }))</pre> | `[]` | no |
 | <a name="input_communicator"></a> [communicator](#input\_communicator) | Communicator to use for provisioners that require access to VM ("ssh" or "winrm") | `string` | `null` | no |
 | <a name="input_compute_endpoint_version"></a> [compute\_endpoint\_version](#input\_compute\_endpoint\_version) | Custom Google Compute API endpoint version. | `string` | `null` | no |
@@ -276,6 +277,7 @@ No resources.
 | <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | VM machine type on which to build new image | `string` | `"n2-standard-4"` | no |
 | <a name="input_manifest_file"></a> [manifest\_file](#input\_manifest\_file) | File to which to write Packer build manifest | `string` | `"packer-manifest.json"` | no |
 | <a name="input_metadata"></a> [metadata](#input\_metadata) | Instance metadata for the builder VM (use var.startup\_script or var.startup\_script\_file to set startup-script metadata) | `map(string)` | `{}` | no |
+| <a name="input_network_ip"></a> [network\_ip](#input\_network\_ip) | The network IP address reserved to use for the launched instance | `string` | `null` | no |
 | <a name="input_network_project_id"></a> [network\_project\_id](#input\_network\_project\_id) | Project ID of Shared VPC network | `string` | `null` | no |
 | <a name="input_omit_external_ip"></a> [omit\_external\_ip](#input\_omit\_external\_ip) | Provision the image building VM without a public IP address | `bool` | `true` | no |
 | <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. If left blank this will default to `MIGRATE` except the use of GPUs requires it to be `TERMINATE` | `string` | `null` | no |

--- a/modules/packer/custom-image/image.pkr.hcl
+++ b/modules/packer/custom-image/image.pkr.hcl
@@ -113,6 +113,8 @@ source "googlecompute" "toolkit_image" {
   use_internal_ip             = var.omit_external_ip
   subnetwork                  = var.subnetwork_name
   network_project_id          = var.network_project_id
+  network_ip                  = var.network_ip
+  address                     = var.address
   service_account_email       = var.service_account_email
   scopes                      = var.service_account_scopes
   source_image                = var.source_image

--- a/modules/packer/custom-image/variables.pkr.hcl
+++ b/modules/packer/custom-image/variables.pkr.hcl
@@ -68,6 +68,18 @@ variable "omit_external_ip" {
   default     = true
 }
 
+variable "network_ip" {
+  description = "The network IP address reserved to use for the launched instance"
+  type        = string
+  default     = null
+}
+
+variable "address" {
+  description = "The name of a pre-allocated static external IP address. If specified, omit_external_ip must be set to false."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Assign network tags to apply firewall rules to VM instance"
   type        = list(string)

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/image.pkr.hcl
@@ -113,6 +113,8 @@ source "googlecompute" "toolkit_image" {
   use_internal_ip             = var.omit_external_ip
   subnetwork                  = var.subnetwork_name
   network_project_id          = var.network_project_id
+  network_ip                  = var.network_ip
+  address                     = var.address
   service_account_email       = var.service_account_email
   scopes                      = var.service_account_scopes
   source_image                = var.source_image

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/one/image/variables.pkr.hcl
@@ -68,6 +68,18 @@ variable "omit_external_ip" {
   default     = true
 }
 
+variable "network_ip" {
+  description = "The network IP address reserved to use for the launched instance"
+  type        = string
+  default     = null
+}
+
+variable "address" {
+  description = "The name of a pre-allocated static external IP address. If specified, omit_external_ip must be set to false."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Assign network tags to apply firewall rules to VM instance"
   type        = list(string)

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/image.pkr.hcl
@@ -113,6 +113,8 @@ source "googlecompute" "toolkit_image" {
   use_internal_ip             = var.omit_external_ip
   subnetwork                  = var.subnetwork_name
   network_project_id          = var.network_project_id
+  network_ip                  = var.network_ip
+  address                     = var.address
   service_account_email       = var.service_account_email
   scopes                      = var.service_account_scopes
   source_image                = var.source_image

--- a/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
+++ b/tools/validate_configs/golden_copies/expectations/text_escape/zero/lime/variables.pkr.hcl
@@ -68,6 +68,18 @@ variable "omit_external_ip" {
   default     = true
 }
 
+variable "network_ip" {
+  description = "The network IP address reserved to use for the launched instance"
+  type        = string
+  default     = null
+}
+
+variable "address" {
+  description = "The name of a pre-allocated static external IP address. If specified, omit_external_ip must be set to false."
+  type        = string
+  default     = null
+}
+
 variable "tags" {
   description = "Assign network tags to apply firewall rules to VM instance"
   type        = list(string)


### PR DESCRIPTION
#### This PR adds support for configuring `network_ip` and `address` parameters in the custom-image Packer module (modules/packer/custom-image).

These options allow users to:

Specify a reserved internal IP address (network_ip) for the temporary builder VM.
Specify a pre-allocated static external IP address name (address) for the temporary builder VM.

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
