### PR TITLE
feat(job): Add custom templates path override

### DIFF
--- a/cmd/job/gke_template_extract.go
+++ b/cmd/job/gke_template_extract.go
@@ -1,0 +1,57 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"hpc-toolkit/pkg/orchestrator/gke"
+	"hpc-toolkit/pkg/shell"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	outputDir    string
+	overwriteDst bool
+)
+
+var gkeTemplateExtractCmd = &cobra.Command{
+	Use:   "gke-template-extract",
+	Short: "Extract all default GKE templates to a local directory",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		parentDir := filepath.Dir(outputDir)
+		if _, err := os.Stat(parentDir); err != nil {
+			if os.IsNotExist(err) {
+				prompt := fmt.Sprintf("Directory %q does not exist. Would you like to create it?", parentDir)
+				if !shell.PromptYesNo(prompt) {
+					return fmt.Errorf("directory %q does not exist. Please check your path for typos or create the directory manually", parentDir)
+				}
+			} else {
+				return fmt.Errorf("failed to check directory %s: %w", parentDir, err)
+			}
+		}
+		return gke.ExtractDefaultTemplates(outputDir, overwriteDst)
+	},
+}
+
+func init() {
+	JobCmd.AddCommand(gkeTemplateExtractCmd) // Register under gcluster job
+
+	gkeTemplateExtractCmd.Flags().StringVar(&outputDir, "output-dir", "./gke-templates", "The target directory to extract the templates to.")
+	gkeTemplateExtractCmd.Flags().BoolVar(&overwriteDst, "overwrite", false, "Overwrite existing templates in the target directory.")
+}

--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -43,6 +43,10 @@ var JobCmd = &cobra.Command{
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		orc = gkeOrchestratorFactory()
 
+		if cmd.Name() == "gke-template-extract" {
+			return nil
+		}
+
 		ctx := loadContext()
 		if clusterName == "" {
 			clusterName = ctx.ClusterName

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -53,13 +53,14 @@ var (
 	placementPolicy string
 	nodeConstraint  map[string]string
 
-	cpuAffinityStr     string
-	restartOnExitCodes []int
-	imagePullSecrets   string
-	serviceAccountName string
-	topology           string
-	gkeScheduler       string
-	platform           string
+	cpuAffinityStr         string
+	restartOnExitCodes     []int
+	imagePullSecrets       string
+	serviceAccountName     string
+	topology               string
+	gkeCustomTemplatesPath string
+	gkeScheduler           string
+	platform               string
 
 	awaitJobCompletion bool
 	timeout            string
@@ -185,7 +186,8 @@ func init() {
 	SubmitCmd.Flags().StringVar(&pathways.HeadNodePool, "pathways-head-np", "", "The node pool to use for the Pathways head job. If empty, it will be auto-detected (looking for 'cpu-np' or 'pathways-np').")
 
 	SubmitCmd.Flags().BoolVar(&gkeMtcEnabled, "gke-mtc-enabled", false, "Enable Multi-Tier Checkpointing (MTC).")
-	SubmitCmd.Flags().StringVar(&gkeMtcRamdiskDirectory, "gke-mtc-ramdisk-dir", "", "The ramdisk directory path for local checkpoints in MTC.")
+	SubmitCmd.Flags().StringVar(&gkeMtcRamdiskDirectory, "gke-mtc-ramdisk-dir", "", "Ramdisk directory for Multi-Tier Checkpointing (MTC).")
+	SubmitCmd.Flags().StringVar(&gkeCustomTemplatesPath, "gke-custom-templates-path", "", "Path to a local directory containing custom GKE templates overrides.")
 
 	_ = SubmitCmd.MarkFlagRequired("name")
 	_ = SubmitCmd.MarkFlagRequired("compute-type")
@@ -261,6 +263,7 @@ func runSubmitCmd(cmd *cobra.Command, args []string) error {
 		Verbose:                       verbose,
 		GKEMTCEnabled:                 gkeMtcEnabled,
 		GKEMTCRamdiskDirectory:        gkeMtcRamdiskDirectory,
+		GkeCustomTemplatesPath:        gkeCustomTemplatesPath,
 		GKENAPProvisioning:            gkeNapProvisioning,
 		GKENAPReservation:             gkeNapReservation,
 		IsPathwaysJob:                 isPathwaysJob,

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -1064,6 +1064,34 @@ When GKE NAP options are used, GCluster performs several operations to structure
   * Reservation: Injects reservation tolerations (`cloud.google.com/reservation-name=<reservation-name>:NoSchedule`) to allow scheduling on nodes spawned by GKE to consume the target reservation. If a block/sub-block path format is provided, the short reservation identifier is automatically extracted and used as the `<reservation-name>`.
 * **Pre-flight Limit Verification:** GCluster queries GKE Cluster Metadata to retrieve autoprovisioning limits. It validates that the requested machine type (e.g., `ct6e-standard-4t`, `a3-megagpu-8g`) is explicitly configured in GKE NAP limits. If the machine type is not covered by GKE NAP limits, GCluster **fails fast** during submission, preventing scheduling locks.
 
+### 8.4 Custom Kubernetes Manifest Templates
+
+GCluster uses embedded Go templates to generate the Kubernetes manifests (JobSets, Kueue configurations, etc.) deployed to your GKE cluster. If you need to deeply customize the generated manifests beyond what the CLI flags provide (e.g., adding custom sidecars, specific annotations, or modifying the core structure), you can override these embedded templates with your own local copies.
+
+#### 1. Extract the Default Templates
+First, use the `gke-template-extract` command to extract the embedded default templates into a local directory so you have a starting point:
+
+```bash
+./gcluster job gke-template-extract --output-dir=/path/to/my-templates
+```
+
+*(Use `--overwrite` if the directory already contains files you want to replace).*
+
+#### 2. Modify the Templates
+Open the extracted `.tmpl` files in your preferred editor. These are standard Go text templates (`text/template` and `yamltemplate`). You can inject any static Kubernetes YAML or modify the existing template variables.
+
+#### 3. Use Your Custom Templates
+When submitting your job, you can tell `gcluster` to use your custom templates instead of the embedded ones.
+
+Pass the `--gke-custom-templates-path` flag to the `submit` command:
+
+```bash
+./gcluster job submit ... --gke-custom-templates-path=/path/to/my-templates
+```
+
+> [!TIP]
+> If a template file (e.g., `jobset.tmpl`) is not found in your custom directory, `gcluster` will automatically fall back to using its embedded default version for that specific file.
+
 ## 9. `gcluster job` Command Reference
 
 ### 9.1 Common Flags
@@ -1173,6 +1201,7 @@ The `gcluster job submit` command deploys a container image as a job (Kubernetes
 | `--gke-disable-parallel-containers` | `bool` | Disable parallel containers for TPU v7/v7x on GKE. (Default: `false`) |
 | `--gke-nap-provisioning` | `string` | Compute provisioning model for GKE NAP. Allowed values: `on-demand`, `spot`, `reservation`. |
 | `--gke-nap-reservation` | `string` | Name of the Google Cloud Reservation for GKE NAP (required if `--gke-nap-provisioning=reservation`). |
+| `--gke-custom-templates-path` | `string` | Path to a local directory containing custom GKE manifest template overrides. |
 
 ### 9.4 `list` Flags
 *Use these flags to filter the list of jobs.*

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -86,6 +86,7 @@ func (g *GKEOrchestrator) SetKubeClient(c KubeClient) {
 func (g *GKEOrchestrator) SubmitJob(job orchestrator.JobDefinition) error {
 	g.namespace = job.GKENamespace
 	logging.Info("Starting gcluster job submit workflow...")
+	g.gkeCustomTemplatesPath = job.GkeCustomTemplatesPath
 
 	sm := &StorageManager{orchestrator: g}
 	if err := sm.ValidateMounts(job.RawMounts); err != nil {
@@ -389,7 +390,7 @@ func (g *GKEOrchestrator) GeneratePathwaysManifest(job orchestrator.JobDefinitio
 		job.Pathways.WorkerImage = job.Pathways.ServerImage
 	}
 
-	tmpl, err := yamltemplate.New("pathways_jobset.tmpl").ParseFS(templatesFS, "templates/pathways_jobset.tmpl")
+	tmpl, err := g.parseGKETemplate("pathways_jobset.tmpl")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse pathways jobset template: %w", err)
 	}

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -31,8 +31,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/safetext/yamltemplate"
-
 	"hpc-toolkit/pkg/orchestrator"
 
 	"gopkg.in/yaml.v2"
@@ -279,15 +277,22 @@ func (g *GKEOrchestrator) installKueue(version string) error {
 
 func (g *GKEOrchestrator) installPriorityClasses() error {
 	logging.Info("Installing Kueue PriorityClasses...")
-	priorityClassesTmpl, err := yamltemplate.New("priority_classes.tmpl").ParseFS(templatesFS, "templates/priority_classes.tmpl")
+	tmpl, err := g.parseGKETemplate("priority_classes.tmpl")
 	if err != nil {
-		return fmt.Errorf("failed to parse priority_classes.tmpl: %w", err)
+		return err
 	}
-	var priorityClassesBuf bytes.Buffer
-	if err := priorityClassesTmpl.Execute(&priorityClassesBuf, nil); err != nil {
-		return fmt.Errorf("failed to execute priority_classes.tmpl template: %w", err)
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, nil); err != nil {
+		return fmt.Errorf("failed to execute priority_classes template: %w", err)
 	}
-	return g.applyManifests(priorityClassesBuf.Bytes(), "priority-classes.yaml")
+
+	logging.Info("Applying Kueue priority classes...")
+	if err := g.applyManifests(buf.Bytes(), "kueue_priority_classes.yaml"); err != nil {
+		return fmt.Errorf("failed to apply Kueue priority classes: %w", err)
+	}
+
+	return nil
 }
 
 func (g *GKEOrchestrator) installKueueResources(cqName string, lqName string) error {
@@ -313,7 +318,7 @@ func (g *GKEOrchestrator) installKueueResources(cqName string, lqName string) er
 	}
 
 	// Install LocalQueue
-	localQueueTmpl, err := yamltemplate.New("local_queue.tmpl").ParseFS(templatesFS, "templates/local_queue.tmpl")
+	localQueueTmpl, err := g.parseGKETemplate("local_queue.tmpl")
 	if err != nil {
 		return fmt.Errorf("failed to parse local_queue.tmpl: %w", err)
 	}

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -344,7 +344,7 @@ func TestEnsurePriorityClassesInstalled_Missing(t *testing.T) {
 				// Return only system priority classes to simulate no user priority classes
 				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical system-node-critical"}
 			}
-			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "priority-classes.yaml") {
+			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "kueue_priority_classes.yaml") {
 				applyCalled = true
 				return shell.CommandResult{ExitCode: 0}
 			}
@@ -375,7 +375,7 @@ func TestEnsurePriorityClassesInstalled_Present(t *testing.T) {
 				// Return system classes and at least one user class (e.g. 'low') to simulate pre-existing classes
 				return shell.CommandResult{ExitCode: 0, Stdout: "system-cluster-critical system-node-critical low"}
 			}
-			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "priority-classes.yaml") {
+			if strings.Contains(fullCmd, "kubectl apply") && strings.Contains(fullCmd, "kueue_priority_classes.yaml") {
 				applyCalled = true
 				return shell.CommandResult{ExitCode: 0}
 			}

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -21,8 +21,6 @@ import (
 	"hpc-toolkit/pkg/orchestrator"
 	"strings"
 
-	"github.com/google/safetext/yamltemplate"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	k8syaml "sigs.k8s.io/yaml"
@@ -46,7 +44,7 @@ func (g *GKEOrchestrator) GenerateGKEManifest(opts ManifestOptions, profile JobP
 
 	cmdSlice := []string{"/bin/bash", "-c", opts.CommandToRun}
 
-	tmpl, err := yamltemplate.New("jobset.tmpl").ParseFS(templatesFS, "templates/jobset.tmpl")
+	tmpl, err := g.parseGKETemplate("jobset.tmpl")
 	if err != nil {
 		return "", fmt.Errorf("failed to parse jobset template: %w", err)
 	}

--- a/pkg/orchestrator/gke/storage.go
+++ b/pkg/orchestrator/gke/storage.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"strings"
-	"text/template"
 	"time"
 
 	"hpc-toolkit/pkg/logging"
@@ -32,9 +31,6 @@ import (
 
 	"gopkg.in/yaml.v2"
 )
-
-// filestoreTmpl is the pre-parsed template for Filestore configuration.
-var filestoreTmpl = template.Must(template.ParseFS(templatesFS, "templates/filestore.tmpl"))
 
 // ProcessMounts parses mount strings and generates necessary K8s resources.
 func (sm *StorageManager) ProcessMounts(mounts []string, job orchestrator.JobDefinition) ([]MountInfo, []string, error) {
@@ -229,6 +225,11 @@ func (sm *StorageManager) handleFilestoreMount(src, dest string, readOnly bool, 
 		ns = "default"
 	}
 	pvName := sanitizePVCName(fmt.Sprintf("%s-%s", pvcName, ns))
+
+	filestoreTmpl, err := sm.orchestrator.parseGKETextTemplate("filestore.tmpl")
+	if err != nil {
+		return MountInfo{}, "", fmt.Errorf("failed to parse filestore template: %w", err)
+	}
 
 	var buf bytes.Buffer
 	err = filestoreTmpl.Execute(&buf, map[string]string{

--- a/pkg/orchestrator/gke/templates.go
+++ b/pkg/orchestrator/gke/templates.go
@@ -1,0 +1,121 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gke
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"text/template"
+
+	"hpc-toolkit/pkg/logging"
+
+	"github.com/google/safetext/yamltemplate"
+)
+
+func (g *GKEOrchestrator) getTemplatePath() (string, error) {
+	if g != nil && g.gkeCustomTemplatesPath != "" {
+		stat, err := os.Stat(g.gkeCustomTemplatesPath)
+		if err != nil {
+			return "", fmt.Errorf("custom template directory specified in flag %q could not be accessed: %w", g.gkeCustomTemplatesPath, err)
+		}
+		if !stat.IsDir() {
+			return "", fmt.Errorf("custom template directory specified in flag %q is not a directory", g.gkeCustomTemplatesPath)
+		}
+		return g.gkeCustomTemplatesPath, nil
+	}
+	return "", nil
+}
+
+func (g *GKEOrchestrator) parseGKETemplate(name string) (*yamltemplate.Template, error) {
+	customPath, err := g.getTemplatePath()
+	if err != nil {
+		return nil, err
+	}
+	if customPath != "" {
+		localFile := filepath.Join(customPath, name)
+		if _, err := os.Stat(localFile); err == nil {
+			logging.Info("Loading GKE template %q from custom path %q", name, customPath)
+			dirFS := os.DirFS(customPath)
+			return yamltemplate.New(name).ParseFS(dirFS, name)
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to access custom template %q: %w", localFile, err)
+		}
+		logging.Info("Template %q not found in custom path %q. Falling back to embedded default.", name, customPath)
+	}
+	return yamltemplate.New(name).ParseFS(templatesFS, "templates/"+name)
+}
+
+func (g *GKEOrchestrator) parseGKETextTemplate(name string) (*template.Template, error) {
+	customPath, err := g.getTemplatePath()
+	if err != nil {
+		return nil, err
+	}
+	if customPath != "" {
+		localFile := filepath.Join(customPath, name)
+		if _, err := os.Stat(localFile); err == nil {
+			logging.Info("Loading GKE text template %q from custom path %q", name, customPath)
+			dirFS := os.DirFS(customPath)
+			return template.ParseFS(dirFS, name)
+		} else if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("failed to access custom text template %q: %w", localFile, err)
+		}
+		logging.Info("Text template %q not found in custom path %q. Falling back to embedded default.", name, customPath)
+	}
+	return template.ParseFS(templatesFS, "templates/"+name)
+}
+
+// ExtractDefaultTemplates writes all embedded templates to targetDir.
+func ExtractDefaultTemplates(targetDir string, overwrite bool) error {
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	entries, err := fs.ReadDir(templatesFS, "templates")
+	if err != nil {
+		return fmt.Errorf("failed to read embedded templates: %w", err)
+	}
+
+	// Pre-check to avoid partial extraction if overwrite is disabled
+	if !overwrite {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			destPath := filepath.Join(targetDir, entry.Name())
+			if _, err := os.Stat(destPath); err == nil {
+				return fmt.Errorf("file %q already exists. Use --overwrite to replace it", destPath)
+			}
+		}
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		destPath := filepath.Join(targetDir, entry.Name())
+		data, err := templatesFS.ReadFile("templates/" + entry.Name())
+		if err != nil {
+			return fmt.Errorf("failed to read embedded file %q: %w", entry.Name(), err)
+		}
+
+		if err := os.WriteFile(destPath, data, 0644); err != nil {
+			return fmt.Errorf("failed to write file %q: %w", destPath, err)
+		}
+		logging.Info("Extracted template: %s", destPath)
+	}
+	return nil
+}

--- a/pkg/orchestrator/gke/templates_test.go
+++ b/pkg/orchestrator/gke/templates_test.go
@@ -1,0 +1,111 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gke
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupTestCustomTemplate(t *testing.T) string {
+	dir := t.TempDir()
+	customPath := filepath.Join(dir, "custom-templates")
+	err := os.MkdirAll(customPath, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	customContent := `custom: {{.WorkloadName}}`
+	err = os.WriteFile(filepath.Join(customPath, "jobset.tmpl"), []byte(customContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return customPath
+}
+
+func TestCustomTemplateLoading_CLIFlag(t *testing.T) {
+	customPath := setupTestCustomTemplate(t)
+
+	g := &GKEOrchestrator{
+		gkeCustomTemplatesPath: customPath,
+	}
+	tmpl, err := g.parseGKETemplate("jobset.tmpl")
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, struct{ WorkloadName string }{"my-test-job"})
+	if err != nil {
+		t.Fatalf("Failed to execute: %v", err)
+	}
+
+	if buf.String() != "custom: my-test-job" {
+		t.Errorf("Expected custom content, got %q", buf.String())
+	}
+}
+
+func TestCustomTemplateLoading_RawManifest(t *testing.T) {
+	customPath := setupTestCustomTemplate(t)
+	g := &GKEOrchestrator{
+		gkeCustomTemplatesPath: customPath,
+	}
+
+	rawContent := `apiVersion: v1
+kind: Pod
+metadata:
+  name: static-pod`
+	err := os.WriteFile(filepath.Join(customPath, "raw.tmpl"), []byte(rawContent), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpl, err := g.parseGKETemplate("raw.tmpl")
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	if err != nil {
+		t.Fatalf("Failed to execute: %v", err)
+	}
+
+	if buf.String() != rawContent {
+		t.Errorf("Expected raw content, got %q", buf.String())
+	}
+}
+
+func TestExtractDefaultTemplates(t *testing.T) {
+	dir := t.TempDir()
+	err := ExtractDefaultTemplates(dir, false)
+	if err != nil {
+		t.Fatalf("ExtractDefaultTemplates failed: %v", err)
+	}
+
+	// Verify that we can't overwrite without the flag
+	err = ExtractDefaultTemplates(dir, false)
+	if err == nil {
+		t.Fatal("Expected error when overwriting without overwrite=true, got nil")
+	}
+
+	// Verify we can overwrite with the flag
+	err = ExtractDefaultTemplates(dir, true)
+	if err != nil {
+		t.Fatalf("Expected no error when overwriting with overwrite=true, got: %v", err)
+	}
+}

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -87,6 +87,7 @@ type GKEOrchestrator struct {
 	topologyCache               map[string]string
 	slicingTopologiesChecked    bool
 	slicingTopologiesDetected   bool
+	gkeCustomTemplatesPath      string
 }
 
 // Types for GetClusterInfo unmarshaling

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -99,6 +99,8 @@ type JobDefinition struct {
 	GKEMTCEnabled          bool
 	GKEMTCRamdiskDirectory string
 
+	GkeCustomTemplatesPath string
+
 	RawMounts []string
 	Env       map[string]string
 


### PR DESCRIPTION
This pull request introduces support for custom GKE manifest templates in `gcluster`. It adds a new `gke-template-extract` command to extract default templates, a `--gke-custom-templates-path` flag