### PR TITLE
Update TPU v5 and v4 blueprints with kueue config 

### DIFF
--- a/examples/gke-tpu-v4/README.md
+++ b/examples/gke-tpu-v4/README.md
@@ -80,6 +80,14 @@ This section guides you through the cluster creation process, ensuring that your
 
 This blueprint installs and configures [Kueue](https://kueue.sigs.k8s.io/) by default to manage TPU quotas and queue job submissions. The provided `tpu-kueue-jax-sample.yaml` file creates a Kubernetes JobSet that integrates both Kueue queue routing and JAX TPU device count validation.
 
+**NOTE**:
+By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
+
+* **Custom Configurations:**
+  * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+  * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
+  * For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+
 1. **Connect to your cluster:**
 
     ```sh

--- a/examples/gke-tpu-v4/gke-tpu-v4.yaml
+++ b/examples/gke-tpu-v4/gke-tpu-v4.yaml
@@ -165,6 +165,8 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        ## Custom kueue config path
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v4-pool.node_count_static * gke-tpu-v4-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v5e/README.md
+++ b/examples/gke-tpu-v5e/README.md
@@ -86,6 +86,14 @@ This section guides you through the cluster creation process, ensuring that your
 
 This blueprint installs and configures [Kueue](https://kueue.sigs.k8s.io/) by default to manage TPU quotas and queue job submissions. The provided `tpu-kueue-jax-sample.yaml` file creates a Kubernetes Job that integrates both Kueue queue routing and JAX TPU device count validation.
 
+**NOTE**:
+By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
+
+* **Custom Configurations:**
+  * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+  * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
+  * For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+
 * **Quota Allocation:** The blueprint automatically calculates and sets a `google.com/tpu` quota in Kueue's `ClusterQueue`. The node count is derived from your `machine_type` and `tpu_topology`, and the quota is calculated using the formula: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
 
 1. **Connect to your cluster:**

--- a/examples/gke-tpu-v5e/gke-tpu-v5e.yaml
+++ b/examples/gke-tpu-v5e/gke-tpu-v5e.yaml
@@ -164,6 +164,8 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        ## Custom kueue config path
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v5e-pool.node_count_static * gke-tpu-v5e-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)

--- a/examples/gke-tpu-v5p/README.md
+++ b/examples/gke-tpu-v5p/README.md
@@ -86,6 +86,14 @@ This section guides you through the cluster creation process, ensuring that your
 
 This blueprint installs and configures [Kueue](https://kueue.sigs.k8s.io/) by default to manage TPU quotas and queue job submissions. The provided `tpu-kueue-jax-sample.yaml` file creates a Kubernetes Job that integrates both Kueue queue routing and JAX TPU device count validation.
 
+**NOTE**:
+By default, the toolkit dynamically applies an embedded kueue configuration based on your **Pathways** and **Dynamic Slicing** settings.
+
+* **Custom Configurations:**
+  * If you explicitly disable both Pathways and Dynamic Slicing, the toolkit will still install the Kueue engine/controllers, but it leaves them unconfigured(no default queues or resource flavors are created).
+  * If you want to override the default embedded configurations, or apply configuration in the scenario above, you can uncomment and set `config_path` in the `kueue` section of the `workload-manager-install` module in the blueprint.
+  * For more details on default configurations and variables, see the [`kubectl-apply` documentation](https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/management/kubectl-apply#inputs).
+
 * **Quota Allocation:** The blueprint automatically calculates and sets a `google.com/tpu` quota in Kueue's `ClusterQueue`. The node count is derived from your `machine_type` and `tpu_topology`, and the quota is calculated using the formula: `num_slices` × `(total_chips_in_topology / chips_per_machine)` × `chips_per_machine`.
 
 1. **Connect to your cluster:**

--- a/examples/gke-tpu-v5p/gke-tpu-v5p.yaml
+++ b/examples/gke-tpu-v5p/gke-tpu-v5p.yaml
@@ -165,6 +165,8 @@ deployment_groups:
     settings:
       kueue:
         install: true
+        ## Custom kueue config path
+        # config_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
         config_template_vars:
           tpu_quota: $(vars.num_slices * gke-tpu-v5p-pool.node_count_static * gke-tpu-v5p-pool.tpu_chips_per_node)
           accelerator_type: $(vars.accelerator_type)


### PR DESCRIPTION
This pull request improves the usability of Kueue configurations within the GKE TPU blueprints. It provides clearer documentation on how the toolkit handles default Kueue settings and adds a convenient, commented-out placeholder in the blueprint configuration files for users who need to supply custom Kueue configuration templates.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
