### PR TITLE
feat(a4x-max):Configure GRUB PCIe ACS overrides in A4X-Max

### DIFF
--- a/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
@@ -105,9 +105,12 @@ deployment_groups:
         content: |
           #!/bin/bash
           set -e -x
+          # Apply PCIe ACS overrides to prevent kernel IOMMU isolation on PCIe root ports
+          # and switches, enabling GPUDirect RDMA peer-to-peer traffic between GPUs and CX-8 NICs.
           echo "Configuring GRUB kernel command line for A4X-Max PCIe ACS overrides"
           sudo mkdir -p /etc/default/grub.d
           cat << 'EOF' | sudo tee /etc/default/grub.d/99-a4xmax-acs-overrides.cfg
+          # A4X-Max PCIe ACS overrides for GPUDirect RDMA between GB300 GPUs and ConnectX-8 NICs.
           GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX pci=config_acs=\"xx111x0@0008:00:00.0;xx110x1@0008:02:00.0;xx101x1@0008:02:03.0;xx111x0@0009:00:00.0;xx110x1@0009:02:00.0;xx101x1@0009:02:01.0;xx111x0@0018:00:00.0;xx110x1@0018:02:00.0;xx101x1@0018:02:03.0;xx111x0@0019:00:00.0;xx110x1@0019:02:00.0;xx101x1@0019:02:01.0\" console=ttyS0,115200 panic=-1"
           EOF
           sudo update-grub

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
@@ -100,6 +100,17 @@ deployment_groups:
           ExecStart=/lib/systemd/systemd-networkd-wait-online --ipv4 --timeout=60 --any --operational-state=routable
           EOF
           sudo systemctl daemon-reload
+      - type: shell
+        destination: configure_grub_acs_overrides.sh
+        content: |
+          #!/bin/bash
+          set -e -x
+          echo "Configuring GRUB kernel command line for A4X-Max PCIe ACS overrides"
+          sudo mkdir -p /etc/default/grub.d
+          cat << 'EOF' | sudo tee /etc/default/grub.d/99-a4xmax-acs-overrides.cfg
+          GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX pci=config_acs=\"xx111x0@0008:00:00.0;xx110x1@0008:02:00.0;xx101x1@0008:02:03.0;xx111x0@0009:00:00.0;xx110x1@0009:02:00.0;xx101x1@0009:02:01.0;xx111x0@0018:00:00.0;xx110x1@0018:02:00.0;xx101x1@0018:02:03.0;xx111x0@0019:00:00.0;xx110x1@0019:02:00.0;xx101x1@0019:02:01.0\" console=ttyS0,115200 panic=-1"
+          EOF
+          sudo update-grub
       - type: data
         destination: /etc/apt/preferences.d/block-broken-nvidia-container
         content: |


### PR DESCRIPTION
Add PCIe Access Control Services (ACS) kernel parameter overrides to the A4X-Max bare-metal Slurm blueprint (`a4xmax-bm-slurm-blueprint.yaml`).

A4X-Max (GB300 NVL72) bare-metal instances require specific PCIe ACS mask overrides applied at the Linux kernel bootloader level. Without these overrides:
- PCIe root ports and internal bridge switches enforce default isolation rules.
- GPUs and ConnectX-8 NICs are partitioned into separate IOMMU groups, preventing GPUDirect RDMA operations from achieving full line-rate throughput.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
