### PR TITLE
[Telemetry] Add support to collect blueprint names from new paths

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1146,7 +1146,9 @@ func fetchExampleFilesFromGitHub(version string) []string {
 		for _, item := range treeResp.Tree {
 			// Check for YAML files in the examples directories.
 			if item.Type == "blob" &&
-				(strings.HasPrefix(item.Path, "examples/") || strings.HasPrefix(item.Path, "community/examples/")) &&
+				(strings.HasPrefix(item.Path, "examples/") ||
+					strings.HasPrefix(item.Path, "community/examples/") ||
+					strings.HasPrefix(item.Path, "tools/cloud-build/daily-tests/blueprints/")) &&
 				(strings.HasSuffix(item.Path, ".yaml") || strings.HasSuffix(item.Path, ".yml")) {
 
 				predefinedExamples = append(predefinedExamples, item.Path)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1144,7 +1144,7 @@ func fetchExampleFilesFromGitHub(version string) []string {
 	if err == nil {
 		// Parse the remote tree
 		for _, item := range treeResp.Tree {
-			// Check for YAML files in the examples directories.
+			// Check for YAML files in the examples and daily tests directories.
 			if item.Type == "blob" &&
 				(strings.HasPrefix(item.Path, "examples/") ||
 					strings.HasPrefix(item.Path, "community/examples/") ||

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1183,10 +1183,13 @@ func TestGetPredefinedExampleFiles(t *testing.T) {
 		"tree": [
 			{"path": "examples/hpc-slurm.yaml", "type": "blob"},
 			{"path": "community/examples/ml-cluster.yml", "type": "blob"},
-			{"path": "examples/README.md", "type": "blob"}
+			{"path": "examples/README.md", "type": "blob"},
+			{"path": "tools/cloud-build/daily-tests/blueprints/test-blueprint.yaml", "type": "blob"},
+			{"path": "examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml", "type": "blob"},
+			{"path": "tools/cloud-build/daily-tests/blueprints/not-yaml.txt", "type": "blob"}
 		]
 	}`
-	expectedExamples := []string{"community/examples/ml-cluster.yml", "examples/hpc-slurm.yaml"}
+	expectedExamples := []string{"community/examples/ml-cluster.yml", "examples/hpc-slurm.yaml", "examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml", "tools/cloud-build/daily-tests/blueprints/test-blueprint.yaml"}
 
 	tests := []struct {
 		name       string

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1824,7 +1824,9 @@ func TestGetDeploymentFile(t *testing.T) {
 	mockJSON := `{
 		"tree": [
 			{"path": "examples/hpc-slurm.yaml", "type": "blob"},
-			{"path": "community/examples/ml-cluster.yml", "type": "blob"}
+			{"path": "community/examples/ml-cluster.yml", "type": "blob"},
+			{"path": "examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml", "type": "blob"},
+			{"path": "tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml", "type": "blob"}
 		]
 	}`
 
@@ -1835,6 +1837,26 @@ func TestGetDeploymentFile(t *testing.T) {
 		mockResp   *http.Response
 		expected   string
 	}{
+		{
+			name:       "success: match machine learning deployment file",
+			flagValue:  "examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml",
+			flagExists: true,
+			mockResp: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
+			},
+			expected: "examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml",
+		},
+		{
+			name:       "success: match cloud build daily test blueprint",
+			flagValue:  "tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml",
+			flagExists: true,
+			mockResp: &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewBufferString(mockJSON)),
+			},
+			expected: "tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml",
+		},
 		{
 			name:       "success: exact match standard file",
 			flagValue:  "community/examples/ml-cluster.yml",


### PR DESCRIPTION
This pull request extends the telemetry system's capability to **discover and collect blueprint names from additional directory paths**. By including the `tools/cloud-build/daily-tests/blueprints/` directory in the search criteria, the system can now track a broader set of deployment configurations. The changes include necessary updates to the file discovery logic and corresponding test cases to ensure reliability.

Changes:

* **Expanded Blueprint Discovery**: Updated the configuration to include the `tools/cloud-build/daily-tests/blueprints/` directory when fetching example files from GitHub.
* **Enhanced Test Coverage**: Updated unit tests in both config and telemetry packages to validate the new blueprint paths and ensure correct file matching.