### PR TITLE
fix(job): remove topology labels from Kueue ResourceFlavor nodeLabels

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -699,10 +699,6 @@ func (g *GKEOrchestrator) resolveAccelerators(np gkeJobNodePool, cap MachineType
 		return 0, 0, "flavor-default", make(map[string]string), nil
 	}
 
-	if tpus > 0 && np.PlacementPolicy != nil && np.PlacementPolicy.TpuTopology != "" {
-		nodeLabels["cloud.google.com/gke-tpu-topology"] = np.PlacementPolicy.TpuTopology
-	}
-
 	return gpus, tpus, flavor, nodeLabels, nil
 }
 
@@ -1351,7 +1347,7 @@ func (g *GKEOrchestrator) GenerateGKENodeSelectorLabel(acceleratorType string) s
 
 func (g *GKEOrchestrator) prepareJobSetTemplateData(opts ManifestOptions, command []string, resourcesYAML string, isTPU, isGPU bool) jobSetTemplateData {
 	exclusiveTopology := ""
-	if !opts.IsDynamicSlicing {
+	if !opts.IsDynamicSlicing && !opts.IsStaticSlicing {
 		exclusiveTopology = "alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool"
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -3016,7 +3016,6 @@ func TestProcessNodePoolCapacity_FlavorsAndLabels(t *testing.T) {
 			wantFlavor: "flavor-tpu-v5-lite-podslice",
 			wantLabels: map[string]string{
 				"cloud.google.com/gke-tpu-accelerator": "tpu-v5-lite-podslice",
-				"cloud.google.com/gke-tpu-topology":    "2x2",
 			},
 			wantErr: false,
 		},

--- a/pkg/orchestrator/gke/infra_manager.go
+++ b/pkg/orchestrator/gke/infra_manager.go
@@ -558,8 +558,18 @@ func (g *GKEOrchestrator) renderResourceFlavor(name string, nodeLabels map[strin
 		},
 	}
 	if len(nodeLabels) > 0 {
-		rfMap["spec"] = map[string]interface{}{
-			"nodeLabels": nodeLabels,
+		filteredLabels := make(map[string]string)
+		for k, v := range nodeLabels {
+			if k != tpuTopologyLabel &&
+				!strings.HasPrefix(k, "cloud.google.com/gke-tpu-slice-") &&
+				!strings.HasPrefix(k, "cloud.google.com/gke-tpu-partition-") {
+				filteredLabels[k] = v
+			}
+		}
+		if len(filteredLabels) > 0 {
+			rfMap["spec"] = map[string]interface{}{
+				"nodeLabels": filteredLabels,
+			}
 		}
 	}
 	return yaml.Marshal(rfMap)

--- a/pkg/orchestrator/gke/infra_manager_test.go
+++ b/pkg/orchestrator/gke/infra_manager_test.go
@@ -704,3 +704,41 @@ func TestReplaceDeprecatedRbacProxyImage(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderResourceFlavor_TopologyFiltering(t *testing.T) {
+	orc := &GKEOrchestrator{}
+
+	inputLabels := map[string]string{
+		"cloud.google.com/gke-tpu-accelerator":      "tpu7x",
+		"cloud.google.com/gke-nodepool":             "tpu-pool",
+		"cloud.google.com/gke-tpu-topology":         "4x4x4",
+		"cloud.google.com/gke-tpu-slice-1x1-id":     "some-id",
+		"cloud.google.com/gke-tpu-partition-2x2-id": "some-partition-id",
+	}
+
+	bytes, err := orc.renderResourceFlavor("flavor-tpu7x", inputLabels)
+	if err != nil {
+		t.Fatalf("renderResourceFlavor failed: %v", err)
+	}
+
+	output := string(bytes)
+
+	// Allowed labels must be preserved
+	if !strings.Contains(output, "cloud.google.com/gke-tpu-accelerator: tpu7x") {
+		t.Errorf("expected cloud.google.com/gke-tpu-accelerator to be present, got:\n%s", output)
+	}
+	if !strings.Contains(output, "cloud.google.com/gke-nodepool: tpu-pool") {
+		t.Errorf("expected cloud.google.com/gke-nodepool to be present, got:\n%s", output)
+	}
+
+	// Blocked topology labels must be filtered out
+	if strings.Contains(output, "cloud.google.com/gke-tpu-topology") {
+		t.Errorf("cloud.google.com/gke-tpu-topology should be filtered out, got:\n%s", output)
+	}
+	if strings.Contains(output, "cloud.google.com/gke-tpu-slice-") {
+		t.Errorf("cloud.google.com/gke-tpu-slice-* labels should be filtered out, got:\n%s", output)
+	}
+	if strings.Contains(output, "cloud.google.com/gke-tpu-partition-") {
+		t.Errorf("cloud.google.com/gke-tpu-partition-* labels should be filtered out, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Description
Fixes an issue where `gcluster` injected node-pool specific physical topology labels (`cloud.google.com/gke-tpu-topology: <topology>`) into Kueue `ResourceFlavor.spec.nodeLabels`.

Because Kueue enforces `ResourceFlavor.spec.nodeLabels` across all workloads using that flavor, Kueue constrained multi-cube and multi-slice TPU workloads (e.g. `4x4x8` and `4x8x8`) to a single 16-node block (`4x4x4`), capping pod allocation at 16 nodes.

### Fix
1. Removed `cloud.google.com/gke-tpu-topology` label injection in `resolveAccelerators` (`pkg/orchestrator/gke/gke_job_orchestrator.go`).
2. Added defensive label filtering in `renderResourceFlavor` (`pkg/orchestrator/gke/infra_manager.go`) to prevent topology keys from entering Kueue `ResourceFlavor` specs.

### Verification
- Unit tests (`go test ./...`) passed cleanly.
- Verified on live cluster (`bodaborg-super-tpu7x-y6k`):
  - `4x4x8` workload launched and ran on **32 nodes** (previously capped at 16).
  - `4x8x8` workload launched and ran on **64 nodes** (previously capped at 16).