### PR TITLE
Align NVIDIA package installation sequence and methodology across a3u, a4h and a4x

### DIFF
--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -295,17 +295,14 @@ deployment_groups:
               - name: Install NVIDIA Packages
                 ansible.builtin.apt:
                   name: "{{ nvidia_packages }}"
-                  update_cache: yes
+                  state: present
                   allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
+                  name: "{{ item.split('=')[0] }}"
                   selection: hold
-                loop:
-                  - datacenter-gpu-manager-4-core
-                  - datacenter-gpu-manager-4-dev
-                  - datacenter-gpu-manager-4-cuda13
+                loop: "{{ nvidia_packages }}"
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -260,20 +260,27 @@ deployment_groups:
           - name: Install and Configure CUDA 13 / DCGM
             hosts: all
             become: true
+            vars:
+              cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run"
+              cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux.run"
+              nvidia_packages:
+                - datacenter-gpu-manager-4-core=1:4.6.1-1
+                - datacenter-gpu-manager-4-dev=1:4.6.1-1
+                - datacenter-gpu-manager-4-cuda13=1:4.6.1-1
             tasks:
               - name: Download CUDA runfile
                 ansible.builtin.get_url:
-                  url: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run
-                  dest: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  url: "{{ cuda_installer_url }}"
+                  dest: "{{ cuda_installer_file }}"
                   mode: '0755'
 
               - name: Install CUDA toolkit via runfile
                 ansible.builtin.command:
-                  cmd: /tmp/cuda_13.0.0_580.65.06_linux.run --silent --toolkit
+                  cmd: "{{ cuda_installer_file }} --silent --toolkit"
 
               - name: Remove CUDA runfile
                 ansible.builtin.file:
-                  path: /tmp/cuda_13.0.0_580.65.06_linux.run
+                  path: "{{ cuda_installer_file }}"
                   state: absent
 
               - name: Install NVIDIA repository keyring
@@ -285,22 +292,20 @@ deployment_groups:
                 ansible.builtin.apt:
                   update_cache: yes
 
-              - name: Install DCGM packages
+              - name: Install NVIDIA Packages
                 ansible.builtin.apt:
-                  name:
-                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
-                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
-                    - datacenter-gpu-manager-4-core=1:4.6.0-1
-                  state: present
+                  name: "{{ nvidia_packages }}"
+                  update_cache: yes
+                  allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
                   name: "{{ item }}"
                   selection: hold
                 loop:
-                  - datacenter-gpu-manager-4-cuda13
-                  - datacenter-gpu-manager-4-dev
                   - datacenter-gpu-manager-4-core
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-cuda13
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -317,17 +317,14 @@ deployment_groups:
               - name: Install NVIDIA Packages
                 ansible.builtin.apt:
                   name: "{{ nvidia_packages }}"
-                  update_cache: yes
+                  state: present
                   allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
+                  name: "{{ item.split('=')[0] }}"
                   selection: hold
-                loop:
-                  - datacenter-gpu-manager-4-core
-                  - datacenter-gpu-manager-4-dev
-                  - datacenter-gpu-manager-4-cuda13
+                loop: "{{ nvidia_packages }}"
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -285,6 +285,10 @@ deployment_groups:
             vars:
               cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux.run"
               cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux.run"
+              nvidia_packages:
+                - datacenter-gpu-manager-4-core=1:4.6.1-1
+                - datacenter-gpu-manager-4-dev=1:4.6.1-1
+                - datacenter-gpu-manager-4-cuda13=1:4.6.1-1
             tasks:
               - name: Download CUDA runfile
                 ansible.builtin.get_url:
@@ -310,22 +314,20 @@ deployment_groups:
                 ansible.builtin.apt:
                   update_cache: yes
 
-              - name: Install DCGM packages
+              - name: Install NVIDIA Packages
                 ansible.builtin.apt:
-                  name:
-                    - datacenter-gpu-manager-4-cuda13=1:4.6.0-1
-                    - datacenter-gpu-manager-4-dev=1:4.6.0-1
-                    - datacenter-gpu-manager-4-core=1:4.6.0-1
-                  state: present
+                  name: "{{ nvidia_packages }}"
+                  update_cache: yes
+                  allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
                   name: "{{ item }}"
                   selection: hold
                 loop:
-                  - datacenter-gpu-manager-4-cuda13
-                  - datacenter-gpu-manager-4-dev
                   - datacenter-gpu-manager-4-core
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-cuda13
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -276,7 +276,10 @@ deployment_groups:
             vars:
               cuda_installer_url: "https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_580.65.06_linux_sbsa.run"
               cuda_installer_file: "/tmp/cuda_13.0.0_580.65.06_linux_sbsa.run"
-              dcgm_version: "1:4.6.0-1"
+              nvidia_packages:
+                - datacenter-gpu-manager-4-core=1:4.6.1-1
+                - datacenter-gpu-manager-4-dev=1:4.6.1-1
+                - datacenter-gpu-manager-4-cuda13=1:4.6.1-1
             tasks:
               - name: Download CUDA runfile
                 ansible.builtin.get_url:
@@ -302,22 +305,20 @@ deployment_groups:
                 ansible.builtin.apt:
                   update_cache: yes
 
-              - name: Install DCGM packages
+              - name: Install NVIDIA Packages
                 ansible.builtin.apt:
-                  name:
-                    - "datacenter-gpu-manager-4-cuda13={{ dcgm_version }}"
-                    - "datacenter-gpu-manager-4-dev={{ dcgm_version }}"
-                    - "datacenter-gpu-manager-4-core={{ dcgm_version }}"
-                  state: present
+                  name: "{{ nvidia_packages }}"
+                  update_cache: yes
+                  allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
                   name: "{{ item }}"
                   selection: hold
                 loop:
-                  - datacenter-gpu-manager-4-cuda13
-                  - datacenter-gpu-manager-4-dev
                   - datacenter-gpu-manager-4-core
+                  - datacenter-gpu-manager-4-dev
+                  - datacenter-gpu-manager-4-cuda13
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |

--- a/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-highgpu-4g/a4xhigh-slurm-blueprint.yaml
@@ -308,17 +308,14 @@ deployment_groups:
               - name: Install NVIDIA Packages
                 ansible.builtin.apt:
                   name: "{{ nvidia_packages }}"
-                  update_cache: yes
+                  state: present
                   allow_downgrade: yes
 
               - name: Freeze DCGM packages
                 ansible.builtin.dpkg_selections:
-                  name: "{{ item }}"
+                  name: "{{ item.split('=')[0] }}"
                   selection: hold
-                loop:
-                  - datacenter-gpu-manager-4-core
-                  - datacenter-gpu-manager-4-dev
-                  - datacenter-gpu-manager-4-cuda13
+                loop: "{{ nvidia_packages }}"
       - type: ansible-local
         destination: enable_dcgm.yml
         content: |


### PR DESCRIPTION
- Standardized Sequence: All blueprints must define the nvidia_packages list in the exact same, tested order.
- Single APT Transaction: We must avoid using a loop. Passing the entire list to the apt module at once allows the system to see all version pins simultaneously and resolve dependencies perfectly.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
