### PR TITLE
refactor: update Cloud Build logsBucket configuration

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -25,8 +25,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -30,8 +30,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -24,8 +24,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -24,8 +24,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -23,8 +23,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -20,8 +20,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build gcluster base image

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -27,8 +27,7 @@ substitutions:
 timeout: 86400s
 queueTtl: 86400s  # 24hr
 
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -27,8 +27,7 @@ substitutions:
 timeout: 86400s
 queueTtl: 86400s  # 24hr
 
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build an image containing the current workspace

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -38,8 +38,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -27,8 +27,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -31,8 +31,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -30,8 +30,7 @@ substitutions:
 timeout: 86400s
 queueTtl: 86400s  # 24hr
 
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build an image containing the current workspace

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -32,8 +32,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -27,8 +27,7 @@ substitutions:
 timeout: 86400s
 queueTtl: 86400s  # 24hr
 
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -26,8 +26,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -30,8 +30,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -28,8 +28,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -29,8 +29,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -26,8 +26,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -29,8 +29,7 @@ substitutions:
 timeout: 86400s
 queueTtl: 86400s  # 24hr
 
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -35,8 +35,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -32,8 +32,7 @@ substitutions:
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
-options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
 
 steps:
 # 1. Build and push workspace container containing the current code layer


### PR DESCRIPTION
This PR updates the Cloud Build logs configuration for Kueue-migrated daily test builds. We are moving away from the defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET configuration block and instead explicitly defining the logsBucket property to target the Google-managed Cloud Build logs bucket.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
