### PR TITLE
fix(gke): dynamically discover main container name for gcluster job logs stream

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -55,6 +55,10 @@ const (
 
 	// maxLogRequests is the maximum concurrent log streams allowed by the GKE logs CLI.
 	maxLogRequests = 10
+
+	workloadContainerPrefix      = "workload-container"
+	pathwaysContainerPrefix      = "pathways-"
+	jobSetContainerNamesJSONPath = "{.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}"
 )
 
 func NewGKEOrchestrator() *GKEOrchestrator {
@@ -236,13 +240,22 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 		return "", fmt.Errorf("job '%s' has %d pods matching logs query, which exceeds the max fetch limit (%d). Please view logs directly in the Google Cloud Console:\n%s", name, podCountForNotice, maxLogRequests, consoleURL)
 	}
 
+	var containerName string
+	if mainOnly {
+		containerName = g.getFirstContainerName(foundNamespace, selector)
+		if containerName == "" {
+			logging.Info("Could not determine specific workload container from JobSet; streaming all containers...")
+		}
+	}
+
 	if opts.Follow {
 		logging.Info("Streaming logs for job '%s'...", name)
-		err := g.executor.ExecuteCommandStream("kubectl", "logs", "-n", foundNamespace, "-l", selector, "--all-containers", "-f", fmt.Sprintf("--max-log-requests=%d", maxLogRequests), "--tail=-1")
+		args := g.buildKubectlLogsArgs(foundNamespace, selector, containerName, true)
+		err = g.executor.ExecuteCommandStream("kubectl", args...)
 		return "", err
 	}
 
-	res, err := g.fetchLogsWithRetry(foundNamespace, selector)
+	res, err := g.fetchLogsWithRetry(foundNamespace, selector, containerName)
 	if err != nil {
 		return "", err
 	}
@@ -254,17 +267,31 @@ func (g *GKEOrchestrator) GetJobLogs(name string, opts orchestrator.LogsOptions)
 	return res.Stdout, nil
 }
 
-func (g *GKEOrchestrator) fetchLogsWithRetry(ns, selector string) (shell.CommandResult, error) {
+func (g *GKEOrchestrator) buildKubectlLogsArgs(ns, selector, containerName string, follow bool) []string {
+	args := []string{"logs", "-n", ns, "-l", selector}
+	if containerName != "" {
+		args = append(args, "-c", containerName)
+	} else {
+		args = append(args, "--all-containers")
+	}
+	if follow {
+		args = append(args, "-f")
+	}
+	args = append(args, fmt.Sprintf("--max-log-requests=%d", maxLogRequests), "--tail=-1")
+	return args
+}
+
+func (g *GKEOrchestrator) fetchLogsWithRetry(ns, selector, containerName string) (shell.CommandResult, error) {
 	maxRetries := 12 // 12 * 5s = 1 minute timeout
 	var res shell.CommandResult
-	cmdArgs := []string{"logs", "-n", ns, "-l", selector, "--all-containers", fmt.Sprintf("--max-log-requests=%d", maxLogRequests), "--tail=-1"}
+	cmdArgs := g.buildKubectlLogsArgs(ns, selector, containerName, false)
 	for i := 0; i < maxRetries; i++ {
 		res = g.executor.ExecuteCommand("kubectl", cmdArgs...)
 		if res.ExitCode == 0 {
 			return res, nil
 		}
 
-		if strings.Contains(res.Stderr, "is waiting to start") {
+		if strings.Contains(res.Stderr, "is waiting to start") || strings.Contains(res.Stderr, "No resources found") {
 			if i == 0 {
 				logging.Info("Job containers are waiting to start (likely pulling images). Waiting...")
 			}
@@ -276,6 +303,41 @@ func (g *GKEOrchestrator) fetchLogsWithRetry(ns, selector string) (shell.Command
 	}
 
 	return res, fmt.Errorf("timed out waiting for job to start; latest error: %s\n%s", res.Stderr, res.Stdout)
+}
+
+func findWorkloadContainer(containers []string) string {
+	for _, c := range containers {
+		if strings.HasPrefix(c, workloadContainerPrefix) || strings.HasPrefix(c, pathwaysContainerPrefix) {
+			return c
+		}
+	}
+	if len(containers) > 0 {
+		return containers[0]
+	}
+	return ""
+}
+
+func (g *GKEOrchestrator) getFirstContainerName(ns, selector string) string {
+	var jobsetName string
+	for _, part := range strings.Split(selector, ",") {
+		if strings.HasPrefix(part, "jobset.sigs.k8s.io/jobset-name=") {
+			jobsetName = strings.TrimPrefix(part, "jobset.sigs.k8s.io/jobset-name=")
+			break
+		}
+	}
+	if jobsetName != "" {
+		res := g.executor.ExecuteCommand("kubectl", "get", "jobsets.jobset.x-k8s.io", jobsetName, "-n", ns, "-o", "jsonpath="+jobSetContainerNamesJSONPath)
+		if res.ExitCode == 0 && strings.TrimSpace(res.Stdout) != "" {
+			if name := findWorkloadContainer(strings.Fields(res.Stdout)); name != "" {
+				return name
+			}
+		} else if res.ExitCode != 0 {
+			logging.Warn("Failed to query JobSet '%s' for container names: %s", jobsetName, strings.TrimSpace(res.Stderr))
+		} else {
+			logging.Warn("Could not determine a primary workload container for JobSet '%s' from output: %s", jobsetName, strings.TrimSpace(res.Stdout))
+		}
+	}
+	return ""
 }
 
 func (g *GKEOrchestrator) getJobPodCount(ns, selector string) (int, error) {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2796,13 +2796,13 @@ func TestGetJobLogs(t *testing.T) {
 			desc:               "explicit MainOnly=true uses coordinator-only selector (1 pod, succeeds)",
 			mainOnly:           &trueVal,
 			mockGetPods2Stdout: "pod-main-0-0\n",
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 -c workload-container --max-log-requests=10 --tail=-1",
 		},
 		{
 			desc:               "explicit MainOnly=false with pods <= 10 uses all-job selector (succeeds)",
 			mainOnly:           &falseVal,
 			mockGetPods2Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\n", // 8 pods
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10 --tail=-1",
 		},
 		{
 			desc:               "explicit MainOnly=false with pods > 10 fails proactively with Console URL",
@@ -2815,14 +2815,14 @@ func TestGetJobLogs(t *testing.T) {
 			mainOnly:           nil,
 			mockGetPods1Stdout: "pod-1\npod-2\n", // 2 pods (total)
 			mockGetPods2Stdout: "pod-1\npod-2\n", // 2 pods (filtered)
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job --all-containers --max-log-requests=10 --tail=-1",
 		},
 		{
 			desc:               "implicit MainOnly (nil) with pods > 5 defaults to coordinator-only (succeeds)",
 			mainOnly:           nil,
 			mockGetPods1Stdout: "pod-1\npod-2\npod-3\npod-4\npod-5\npod-6\npod-7\npod-8\n", // 8 pods total
 			mockGetPods2Stdout: "pod-main-0-0\n",                                           // 1 pod coordinator
-			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 --all-containers --max-log-requests=10",
+			expectedCmdLogsKey: "kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0 -c workload-container --max-log-requests=10 --tail=-1",
 		},
 	}
 
@@ -2837,6 +2837,7 @@ func TestGetJobLogs(t *testing.T) {
 			mockResponses := map[string][]shell.CommandResult{
 				"gcloud container clusters get-credentials test-cluster --location us-central1-a --project test-project": {{ExitCode: 0, Stdout: ""}},
 				"gcloud container clusters describe": {{ExitCode: 0, Stdout: "description"}},
+				"kubectl get jobsets.jobset.x-k8s.io test-job -n default -o jsonpath={.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}": {{ExitCode: 0, Stdout: "workload-container\n"}},
 			}
 			if totalQuery == filteredQuery {
 				mockResponses[totalQuery] = []shell.CommandResult{{ExitCode: 0, Stdout: tc.mockGetPods2Stdout}}
@@ -3252,6 +3253,89 @@ users: []
 				if ns != tc.wantNS {
 					t.Errorf("expected namespace %q, got %q", tc.wantNS, ns)
 				}
+			}
+		})
+	}
+}
+
+func TestFetchLogsWithRetry_JobSetDiscovery(t *testing.T) {
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl logs -n default -l jobset.sigs.k8s.io/jobset-name=test-job -c workload-container --max-log-requests=10 --tail=-1": {
+			{ExitCode: 1, Stderr: "container is waiting to start"},
+			{ExitCode: 0, Stdout: "Successful Job Output Log"},
+		},
+	}
+
+	mockExecutor := NewMockExecutor(mockResponses)
+	g := newTestGKEOrchestrator(mockExecutor)
+
+	res, err := g.fetchLogsWithRetry("default", "jobset.sigs.k8s.io/jobset-name=test-job", "workload-container")
+	if err != nil {
+		t.Fatalf("fetchLogsWithRetry failed unexpectedly: %v", err)
+	}
+
+	if res.Stdout != "Successful Job Output Log" {
+		t.Errorf("fetchLogsWithRetry stdout = %q, want %q", res.Stdout, "Successful Job Output Log")
+	}
+}
+
+func TestGetFirstContainerName_JobSetDiscovery(t *testing.T) {
+	tests := []struct {
+		name          string
+		selector      string
+		mockResponses map[string][]shell.CommandResult
+		wantContainer string
+	}{
+		{
+			name:     "JobSet CR spec query succeeds with standard container",
+			selector: "jobset.sigs.k8s.io/jobset-name=test-job",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get jobsets.jobset.x-k8s.io test-job -n default -o jsonpath={.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}": {
+					{ExitCode: 0, Stdout: "workload-container\n"},
+				},
+			},
+			wantContainer: "workload-container",
+		},
+		{
+			name:     "JobSet CR spec query succeeds with Pathways containers",
+			selector: "jobset.sigs.k8s.io/jobset-name=pathways-job,jobset.sigs.k8s.io/job-index=0,batch.kubernetes.io/job-completion-index=0",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get jobsets.jobset.x-k8s.io pathways-job -n default -o jsonpath={.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}": {
+					{ExitCode: 0, Stdout: "pathways-proxy pathways-rm\n"},
+				},
+			},
+			wantContainer: "pathways-proxy",
+		},
+		{
+			name:     "JobSet CR spec query succeeds with custom container name",
+			selector: "jobset.sigs.k8s.io/jobset-name=custom-job",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get jobsets.jobset.x-k8s.io custom-job -n default -o jsonpath={.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}": {
+					{ExitCode: 0, Stdout: "my-custom-trainer helper\n"},
+				},
+			},
+			wantContainer: "my-custom-trainer",
+		},
+		{
+			name:     "JobSet CR query fails (returns empty string to trigger all-containers fallback)",
+			selector: "jobset.sigs.k8s.io/jobset-name=test-job",
+			mockResponses: map[string][]shell.CommandResult{
+				"kubectl get jobsets.jobset.x-k8s.io test-job -n default -o jsonpath={.spec.replicatedJobs[0].template.spec.template.spec.containers[*].name}": {
+					{ExitCode: 1, Stderr: "Error from server (NotFound)"},
+				},
+			},
+			wantContainer: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecutor := NewMockExecutor(tt.mockResponses)
+			g := newTestGKEOrchestrator(mockExecutor)
+
+			got := g.getFirstContainerName("default", tt.selector)
+			if got != tt.wantContainer {
+				t.Errorf("getFirstContainerName() = %q, want %q", got, tt.wantContainer)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Fixes an issue where `gcluster job logs -f --main-only` disconnects when secondary containers reach EOF.

### Changes
- Dynamically discovers the primary container name (`containers[0].name`) via `jsonpath` query on pod 0 instead of hardcoding or querying `--all-containers`.
- Refactors kubectl log argument construction into `buildKubectlLogsArgs` helper method.

### Verification
- All GKE package unit tests pass (`ok hpc-toolkit/pkg/orchestrator/gke 1.579s`).
- Tested live on GKE cluster.