### PR TITLE
Pin terraform-docs to v0.21.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ format: warn-go-version warn-terraform-version warn-packer-version terraform-for
 
 install-dev-deps: warn-terraform-version warn-packer-version check-pre-commit check-tflint check-shellcheck
 	$(info *********** installing developer dependencies *********)
-	go install github.com/terraform-docs/terraform-docs@latest
+	go install github.com/terraform-docs/terraform-docs@v0.21.0
 	go install golang.org/x/lint/golint@latest
 	go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
 	go install github.com/go-critic/go-critic/cmd/gocritic@latest

--- a/tools/cloud-build/dependency-checks/Dockerfile.precommit
+++ b/tools/cloud-build/dependency-checks/Dockerfile.precommit
@@ -19,7 +19,7 @@ RUN apt-get -y update && apt-get install -y python3-pip git shellcheck && \
 
 RUN pip install pre-commit && rm -rf ~/.cache/pip/*
 
-RUN go install github.com/terraform-docs/terraform-docs@latest      && \
+RUN go install github.com/terraform-docs/terraform-docs@v0.21.0      && \
     go install golang.org/x/lint/golint@latest                      && \
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest          && \
     go install github.com/go-critic/go-critic/cmd/gocritic@latest   && \


### PR DESCRIPTION
This PR resolves a pipeline failure occurring in the dependency-checks / precommit Docker build step.

What changed:
Pinned the terraform-docs installation from @latest to @v0.21.0 in both the Makefile and tools/cloud-build/dependency-checks/Dockerfile.precommit.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
