### PR TITLE
Add Service Account ID validation

### DIFF
--- a/docs/blueprint-validation.md
+++ b/docs/blueprint-validation.md
@@ -141,7 +141,17 @@ ghpc:
 ### Regex Validator
 The `regex` validator ensures that input variables match a specific regular expression pattern. This is commonly used to enforce Google Cloud naming conventions or specific software requirements (like Slurm partition name lengths).
 
-**Example definition in `metadata.yaml`:**
+It also supports validating concatenated values across multiple variables (e.g., combined Service Account IDs) by setting `concat: true`.
+
+**Supported Inputs:**
+* `vars` (list of strings, required): The list of variable names to validate.
+* `pattern` (string, required): The regular expression pattern to match.
+* `concat` (boolean, optional, default `false`): If `true`, concatenates the values of all variables in `vars` before matching against `pattern`.
+* `separator` (string, optional, default `""`): Delimiter used to join variable values when `concat: true`.
+* `allow_null` (list of strings, optional): Variables in `vars` that are permitted to be `null`/empty without failing validation when `concat: true`.
+* `optional` (boolean, optional, default `true`): If `true`, validation is skipped if variables are missing or unresolved.
+
+**Basic Example in `metadata.yaml`:**
 
 ```yaml
 ghpc:
@@ -151,6 +161,20 @@ ghpc:
         vars: [partition_name]
         pattern: "^[a-z0-9]{1,10}$"
       error_message: "partition_name must be lowercase alphanumeric and max 10 characters."
+```
+
+**Concatenation Example in `metadata.yaml`:**
+
+```yaml
+ghpc:
+  validators:
+    - validator: regex
+      inputs:
+        vars: [deployment_name, name]
+        concat: true
+        separator: "-"
+        pattern: "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"
+      error_message: "The combined service account ID (deployment_name + name) must be between 6 and 30 characters, start with a lowercase letter, contain only lowercase alphanumeric characters and dashes, and cannot end with a dash."
 ```
 
 ### Allowed Enum Validator

--- a/modules/project/service-account/metadata.yaml
+++ b/modules/project/service-account/metadata.yaml
@@ -34,3 +34,7 @@ ghpc:
       vars: [prefix]
       deprecated: true
     error_message: "Unsupported variable: 'prefix'. Please use 'deployment_name' instead."
+  - validator: service_account_id
+    inputs:
+      deployment_name: deployment_name
+      name: name

--- a/modules/project/service-account/metadata.yaml
+++ b/modules/project/service-account/metadata.yaml
@@ -34,7 +34,10 @@ ghpc:
       vars: [prefix]
       deprecated: true
     error_message: "Unsupported variable: 'prefix'. Please use 'deployment_name' instead."
-  - validator: service_account_id
+  - validator: regex
     inputs:
-      deployment_name: deployment_name
-      name: name
+      vars: [deployment_name, name]
+      concat: true
+      separator: "-"
+      pattern: "^[a-z][-a-z0-9]{4,28}[a-z0-9]$"
+    error_message: "The combined service account ID (deployment_name + name) must be between 6 and 30 characters, start with a lowercase letter, contain only lowercase alphanumeric characters and dashes, and cannot end with a dash."

--- a/pkg/validators/metadata_validator_helpers.go
+++ b/pkg/validators/metadata_validator_helpers.go
@@ -219,12 +219,7 @@ func IterateRuleTargets(
 	// Only support `vars:` in module metadata validators (each treated as a module.setting name).
 	// `settings:` support has been removed to enforce a single convention.
 	varsList, _ := parseStringList(rule.Inputs["vars"])
-	optional := true
-	if v, ok := rule.Inputs["optional"]; ok {
-		if b, ok := v.(bool); ok {
-			optional = b
-		}
-	}
+	optional, _ := parseBoolInput(rule.Inputs, "optional", true)
 
 	// Interpret each var name as module.settings.<name>
 	return processModuleSettings(bp, mod, group, modIdx, varsList, optional, handler)

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -37,7 +37,7 @@ func resolveSettingToString(
 	values, path, err := getModuleSettingValues(bp, group, modIdx, mod, settingName)
 	if err != nil {
 		if optional {
-			return "", true, path, nil
+			return "", false, path, nil
 		}
 		missingPath := config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Settings.Dot(settingName)
 		return "", false, missingPath, config.BpError{
@@ -47,7 +47,7 @@ func resolveSettingToString(
 	}
 	if len(values) == 0 || values[0].Type() != cty.String {
 		if len(values) == 0 && optional {
-			return "", true, path, nil
+			return "", false, path, nil
 		}
 		return "", false, path, config.BpError{Err: fmt.Errorf("setting %q must be a string", settingName), Path: path}
 	}
@@ -101,6 +101,10 @@ func (r *RegexValidator) validateConcat(
 		if val != "" {
 			parts = append(parts, val)
 		}
+	}
+
+	if len(parts) == 0 {
+		return nil
 	}
 
 	joined := strings.Join(parts, separator)

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -70,7 +70,7 @@ func (r *RegexValidator) validateConcat(
 	optional bool,
 ) error {
 	varsList, _ := parseStringList(rule.Inputs["vars"])
-	separator, _ := rule.Inputs["separator"].(string)
+	separator, _ := parseString(rule.Inputs["separator"])
 	allowNullList, _ := parseStringList(rule.Inputs["allow_null"])
 	allowNullMap := make(map[string]struct{})
 	for _, v := range allowNullList {
@@ -179,10 +179,11 @@ func (r *RegexValidator) Validate(
 		}
 	}
 
-	optional := true
-	if v, ok := rule.Inputs["optional"]; ok {
-		if b, ok := v.(bool); ok {
-			optional = b
+	optional, err := parseBoolInput(rule.Inputs, "optional", true)
+	if err != nil {
+		return config.BpError{
+			Err:  fmt.Errorf("failed to parse 'optional' input: %w", err),
+			Path: config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Source,
 		}
 	}
 
@@ -607,19 +608,19 @@ func (c *ConditionalRegexValidator) Validate(
 		return nil
 	}
 
-	dependentVal, depPath := getSettingWithFallback(bp, group, modIdx, mod, dependent)
-	if dependentVal == cty.NilVal || !dependentVal.IsKnown() || dependentVal.IsNull() || dependentVal.Type() != cty.String {
+	valStr, known, depPath, err := resolveSettingToString(bp, group, modIdx, mod, dependent, true, false)
+	if err != nil || !known {
 		return nil
 	}
 
-	matched := re.MatchString(dependentVal.AsString())
+	matched := re.MatchString(valStr)
 	if matched != matchExpected {
 		msg := rule.ErrorMessage
 		if msg == "" {
 			if matchExpected {
-				msg = fmt.Sprintf("variable %q value %q must match pattern %q when conditions are met", dependent, dependentVal.AsString(), re.String())
+				msg = fmt.Sprintf("variable %q value %q must match pattern %q when conditions are met", dependent, valStr, re.String())
 			} else {
-				msg = fmt.Sprintf("variable %q value %q must not match pattern %q when conditions are met", dependent, dependentVal.AsString(), re.String())
+				msg = fmt.Sprintf("variable %q value %q must not match pattern %q when conditions are met", dependent, valStr, re.String())
 			}
 		}
 		return config.BpError{Err: fmt.Errorf("%s", msg), Path: depPath}

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -34,33 +34,29 @@ func resolveSettingToString(
 	optional bool,
 	allowNull bool,
 ) (string, bool, config.Path, error) {
-	values, path, err := getModuleSettingValues(bp, group, modIdx, mod, settingName)
-	if err != nil {
+	val, path := getSettingWithFallback(bp, group, modIdx, mod, settingName)
+	if val == cty.NilVal {
 		if optional {
 			return "", false, path, nil
 		}
-		missingPath := config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Settings.Dot(settingName)
-		return "", false, missingPath, config.BpError{
+		return "", false, path, config.BpError{
 			Err:  fmt.Errorf("setting %q not found in module %q settings", settingName, mod.ID),
-			Path: missingPath,
+			Path: path,
 		}
 	}
-	if len(values) == 0 || values[0].Type() != cty.String {
-		if len(values) == 0 && optional {
-			return "", false, path, nil
-		}
+	if val.Type() != cty.String {
 		return "", false, path, config.BpError{Err: fmt.Errorf("setting %q must be a string", settingName), Path: path}
 	}
-	if !values[0].IsKnown() {
+	if !val.IsKnown() {
 		return "", false, path, nil
 	}
-	if values[0].IsNull() {
+	if val.IsNull() {
 		if !allowNull {
 			return "", false, path, config.BpError{Err: fmt.Errorf("setting %q cannot be null", settingName), Path: path}
 		}
 		return "", true, path, nil
 	}
-	return values[0].AsString(), true, path, nil
+	return val.AsString(), true, path, nil
 }
 
 func (r *RegexValidator) validateConcat(
@@ -129,7 +125,7 @@ func (r *RegexValidator) validateStandard(
 ) error {
 	validateValues := func(values []cty.Value, path config.Path) error {
 		for _, val := range values {
-			if val.Type() != cty.String {
+			if val == cty.NilVal || !val.IsKnown() || val.IsNull() || val.Type() != cty.String {
 				continue
 			}
 			if !re.MatchString(val.AsString()) {
@@ -220,6 +216,9 @@ func (v *AllowedEnumValidator) normalizeAllowed(allowedRaw interface{}) ([]strin
 // checkValues iterates through cty.Values to ensure they exist within the allowed set, handling nulls and casing.
 func (v *AllowedEnumValidator) checkValues(values []cty.Value, path config.Path, allowedSet map[string]struct{}, allowedList []string, caseSensitive bool, allowNull bool, errMsg string) error {
 	for _, val := range values {
+		if val == cty.NilVal || !val.IsKnown() {
+			continue
+		}
 		if val.IsNull() {
 			if allowNull {
 				continue
@@ -347,7 +346,7 @@ func (r *RangeValidator) validateTarget(
 	}
 
 	for _, val := range values {
-		if val.IsNull() || !val.IsKnown() {
+		if val == cty.NilVal || !val.IsKnown() || val.IsNull() {
 			continue
 		}
 		if val.Type() == cty.Number {
@@ -609,7 +608,7 @@ func (c *ConditionalRegexValidator) Validate(
 	}
 
 	dependentVal, depPath := getSettingWithFallback(bp, group, modIdx, mod, dependent)
-	if dependentVal.IsNull() || dependentVal == cty.NilVal || dependentVal.Type() != cty.String {
+	if dependentVal == cty.NilVal || !dependentVal.IsKnown() || dependentVal.IsNull() || dependentVal.Type() != cty.String {
 		return nil
 	}
 
@@ -685,6 +684,20 @@ func getSettingWithFallback(
 	return cty.NilVal, path
 }
 
+func matchTrigger(actualVal, expectedVal cty.Value) bool {
+	if actualVal == cty.NilVal || actualVal.IsNull() {
+		if !isVarSet([]cty.Value{expectedVal}) {
+			return true
+		}
+		return expectedVal != cty.NilVal && expectedVal.IsKnown() && !expectedVal.IsNull() && expectedVal.Type() == cty.Bool && expectedVal.False()
+	}
+	if !actualVal.IsKnown() || !expectedVal.IsKnown() || expectedVal == cty.NilVal {
+		return false
+	}
+	eq := actualVal.Equals(expectedVal)
+	return eq.IsKnown() && !eq.IsNull() && eq.True()
+}
+
 func evalTriggers(
 	bp config.Blueprint,
 	group config.Group,
@@ -695,15 +708,7 @@ func evalTriggers(
 	for name, expectedValRaw := range triggers {
 		expectedVal := convertToCty(expectedValRaw)
 		actualVal, _ := getSettingWithFallback(bp, group, modIdx, mod, name)
-
-		var matches bool
-		if actualVal.IsNull() || actualVal == cty.NilVal {
-			matches = !isVarSet([]cty.Value{expectedVal}) || expectedVal.False()
-		} else {
-			matches = actualVal.Equals(expectedVal).True()
-		}
-
-		if !matches {
+		if !matchTrigger(actualVal, expectedVal) {
 			return false
 		}
 	}

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -25,8 +25,126 @@ import (
 // RegexValidator implements the Validator interface for 'regex' type.
 type RegexValidator struct{}
 
+func resolveSettingToString(
+	bp config.Blueprint,
+	group config.Group,
+	modIdx int,
+	mod config.Module,
+	settingName string,
+	optional bool,
+	allowNull bool,
+) (string, bool, config.Path, error) {
+	values, path, err := getModuleSettingValues(bp, group, modIdx, mod, settingName)
+	if err != nil {
+		if optional {
+			return "", true, path, nil
+		}
+		missingPath := config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Settings.Dot(settingName)
+		return "", false, missingPath, config.BpError{
+			Err:  fmt.Errorf("setting %q not found in module %q settings", settingName, mod.ID),
+			Path: missingPath,
+		}
+	}
+	if len(values) == 0 || values[0].Type() != cty.String {
+		if len(values) == 0 && optional {
+			return "", true, path, nil
+		}
+		return "", false, path, config.BpError{Err: fmt.Errorf("setting %q must be a string", settingName), Path: path}
+	}
+	if !values[0].IsKnown() {
+		return "", false, path, nil
+	}
+	if values[0].IsNull() {
+		if !allowNull {
+			return "", false, path, config.BpError{Err: fmt.Errorf("setting %q cannot be null", settingName), Path: path}
+		}
+		return "", true, path, nil
+	}
+	return values[0].AsString(), true, path, nil
+}
+
+func (r *RegexValidator) validateConcat(
+	bp config.Blueprint,
+	mod config.Module,
+	rule modulereader.ValidationRule,
+	group config.Group,
+	modIdx int,
+	re *regexp.Regexp,
+	patternRaw string,
+	optional bool,
+) error {
+	varsList, _ := parseStringList(rule.Inputs["vars"])
+	separator, _ := rule.Inputs["separator"].(string)
+	allowNullList, _ := parseStringList(rule.Inputs["allow_null"])
+	allowNullMap := make(map[string]struct{})
+	for _, v := range allowNullList {
+		allowNullMap[v] = struct{}{}
+	}
+
+	var parts []string
+	var targetPath config.Path
+	first := true
+
+	for _, varName := range varsList {
+		_, allowNull := allowNullMap[varName]
+		val, known, path, err := resolveSettingToString(bp, group, modIdx, mod, varName, optional, allowNull)
+		if err != nil {
+			return err
+		}
+		if !known {
+			return nil
+		}
+		if first {
+			targetPath = path
+			first = false
+		}
+		if val != "" {
+			parts = append(parts, val)
+		}
+	}
+
+	joined := strings.Join(parts, separator)
+	if !re.MatchString(joined) {
+		msg := rule.ErrorMessage
+		if msg == "" {
+			msg = fmt.Sprintf("concatenated value %q does not match pattern %q", joined, patternRaw)
+		}
+		return config.BpError{Err: fmt.Errorf("%s", msg), Path: targetPath}
+	}
+	return nil
+}
+
+func (r *RegexValidator) validateStandard(
+	bp config.Blueprint,
+	mod config.Module,
+	rule modulereader.ValidationRule,
+	group config.Group,
+	modIdx int,
+	re *regexp.Regexp,
+	patternRaw string,
+) error {
+	validateValues := func(values []cty.Value, path config.Path) error {
+		for _, val := range values {
+			if val.Type() != cty.String {
+				continue
+			}
+			if !re.MatchString(val.AsString()) {
+				msg := rule.ErrorMessage
+				if msg == "" {
+					msg = fmt.Sprintf("value %q does not match pattern %q", val.AsString(), patternRaw)
+				}
+				return config.BpError{Err: fmt.Errorf("%s", msg), Path: path}
+			}
+		}
+		return nil
+	}
+
+	return IterateRuleTargets(bp, mod, rule, group, modIdx, func(t Target) error {
+		return validateValues(t.Values, t.Path)
+	})
+}
+
 // Validate checks if the variables specified in the rule match the provided regex pattern.
-// This function focuses on the predicate and uses IterateRuleTargets from targets.go to resolve targets.
 func (r *RegexValidator) Validate(
 	bp config.Blueprint,
 	mod config.Module,
@@ -53,28 +171,25 @@ func (r *RegexValidator) Validate(
 		}
 	}
 
-	// helper: validate flattened cty.Values against regex, returning first error
-	validateValues := func(values []cty.Value, path config.Path) error {
-		for _, val := range values {
-			if val.Type() != cty.String {
-				continue
-			}
-			if !re.MatchString(val.AsString()) {
-				msg := rule.ErrorMessage
-				if msg == "" {
-					msg = fmt.Sprintf("value %q does not match pattern %q", val.AsString(), patternRaw)
-				}
-				return config.BpError{Err: fmt.Errorf("%s", msg), Path: path}
-			}
+	concat, err := parseBoolInput(rule.Inputs, "concat", false)
+	if err != nil {
+		return config.BpError{
+			Err:  fmt.Errorf("failed to parse 'concat' input: %w", err),
+			Path: config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Source,
 		}
-		return nil
 	}
 
-	// iterate targets using shared logic
-	err = IterateRuleTargets(bp, mod, rule, group, modIdx, func(t Target) error {
-		return validateValues(t.Values, t.Path)
-	})
-	return err
+	optional := true
+	if v, ok := rule.Inputs["optional"]; ok {
+		if b, ok := v.(bool); ok {
+			optional = b
+		}
+	}
+
+	if concat {
+		return r.validateConcat(bp, mod, rule, group, modIdx, re, patternRaw, optional)
+	}
+	return r.validateStandard(bp, mod, rule, group, modIdx, re, patternRaw)
 }
 
 type AllowedEnumValidator struct{}
@@ -589,81 +704,4 @@ func evalTriggers(
 		}
 	}
 	return true
-}
-
-var serviceAccountIDRegexp = regexp.MustCompile(`^[a-z][-a-z0-9]*[a-z0-9]$`)
-
-// ServiceAccountIDValidator validates if the combined deployment_name and name
-// form a valid GCP Service Account ID.
-type ServiceAccountIDValidator struct{}
-
-// Validate checks if the generated service account ID is valid.
-func (v *ServiceAccountIDValidator) Validate(
-	bp config.Blueprint,
-	mod config.Module,
-	rule modulereader.ValidationRule,
-	group config.Group,
-	modIdx int,
-) error {
-	depNameSetting, ok := rule.Inputs["deployment_name"].(string)
-	if !ok {
-		depNameSetting = "deployment_name"
-	}
-	nameSetting, ok := rule.Inputs["name"].(string)
-	if !ok {
-		nameSetting = "name"
-	}
-
-	depNameValues, depNamePath, err := getModuleSettingValues(bp, group, modIdx, mod, depNameSetting)
-	if err != nil {
-		return config.BpError{Err: fmt.Errorf("failed to resolve setting %q: %w", depNameSetting, err), Path: depNamePath}
-	}
-	if len(depNameValues) == 0 || depNameValues[0].Type() != cty.String {
-		return config.BpError{Err: fmt.Errorf("setting %q must be a string", depNameSetting), Path: depNamePath}
-	}
-	if !depNameValues[0].IsKnown() {
-		return nil
-	}
-	var depName string
-	if !depNameValues[0].IsNull() {
-		depName = depNameValues[0].AsString()
-	}
-
-	nameValues, namePath, err := getModuleSettingValues(bp, group, modIdx, mod, nameSetting)
-	if err != nil {
-		return config.BpError{Err: fmt.Errorf("failed to resolve setting %q: %w", nameSetting, err), Path: namePath}
-	}
-	if len(nameValues) == 0 || nameValues[0].Type() != cty.String {
-		return config.BpError{Err: fmt.Errorf("setting %q must be a string", nameSetting), Path: namePath}
-	}
-	if !nameValues[0].IsKnown() {
-		return nil
-	}
-	if nameValues[0].IsNull() {
-		return config.BpError{Err: fmt.Errorf("setting %q cannot be null", nameSetting), Path: namePath}
-	}
-	name := nameValues[0].AsString()
-
-	var saID string
-	if depName == "" {
-		saID = name
-	} else {
-		saID = fmt.Sprintf("%s-%s", depName, name)
-	}
-
-	if len(saID) < 6 || len(saID) > 30 {
-		return config.BpError{
-			Err:  fmt.Errorf("generated service account ID %q is invalid: length must be between 6 and 30 characters, but got %d (deployment_name: %d, name: %d)", saID, len(saID), len(depName), len(name)),
-			Path: namePath,
-		}
-	}
-
-	if !serviceAccountIDRegexp.MatchString(saID) {
-		return config.BpError{
-			Err:  fmt.Errorf("generated service account ID %q is invalid: must begin with a lowercase letter, contain only lowercase alphanumeric characters and dashes, and cannot end with a dash", saID),
-			Path: namePath,
-		}
-	}
-
-	return nil
 }

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -608,19 +608,22 @@ func (c *ConditionalRegexValidator) Validate(
 		return nil
 	}
 
-	valStr, known, depPath, err := resolveSettingToString(bp, group, modIdx, mod, dependent, true, false)
-	if err != nil || !known {
+	dependentVal, known, depPath, err := resolveSettingToString(bp, group, modIdx, mod, dependent, true, true)
+	if err != nil {
+		return err
+	}
+	if !known || dependentVal == "" {
 		return nil
 	}
 
-	matched := re.MatchString(valStr)
+	matched := re.MatchString(dependentVal)
 	if matched != matchExpected {
 		msg := rule.ErrorMessage
 		if msg == "" {
 			if matchExpected {
-				msg = fmt.Sprintf("variable %q value %q must match pattern %q when conditions are met", dependent, valStr, re.String())
+				msg = fmt.Sprintf("variable %q value %q must match pattern %q when conditions are met", dependent, dependentVal, re.String())
 			} else {
-				msg = fmt.Sprintf("variable %q value %q must not match pattern %q when conditions are met", dependent, valStr, re.String())
+				msg = fmt.Sprintf("variable %q value %q must not match pattern %q when conditions are met", dependent, dependentVal, re.String())
 			}
 		}
 		return config.BpError{Err: fmt.Errorf("%s", msg), Path: depPath}

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -590,3 +590,67 @@ func evalTriggers(
 	}
 	return true
 }
+
+// ServiceAccountIDValidator validates if the combined deployment_name and name
+// form a valid GCP Service Account ID.
+type ServiceAccountIDValidator struct{}
+
+// Validate checks if the generated service account ID is valid.
+func (v *ServiceAccountIDValidator) Validate(
+	bp config.Blueprint,
+	mod config.Module,
+	rule modulereader.ValidationRule,
+	group config.Group,
+	modIdx int,
+) error {
+	depNameSetting, ok := rule.Inputs["deployment_name"].(string)
+	if !ok {
+		depNameSetting = "deployment_name"
+	}
+	nameSetting, ok := rule.Inputs["name"].(string)
+	if !ok {
+		nameSetting = "name"
+	}
+
+	depNameValues, depNamePath, err := getModuleSettingValues(bp, group, modIdx, mod, depNameSetting)
+	if err != nil {
+		return config.BpError{Err: fmt.Errorf("failed to resolve setting %q: %w", depNameSetting, err), Path: depNamePath}
+	}
+	if len(depNameValues) == 0 || depNameValues[0].Type() != cty.String {
+		return config.BpError{Err: fmt.Errorf("setting %q must be a string", depNameSetting), Path: depNamePath}
+	}
+	depName := depNameValues[0].AsString()
+
+	nameValues, namePath, err := getModuleSettingValues(bp, group, modIdx, mod, nameSetting)
+	if err != nil {
+		return config.BpError{Err: fmt.Errorf("failed to resolve setting %q: %w", nameSetting, err), Path: namePath}
+	}
+	if len(nameValues) == 0 || nameValues[0].Type() != cty.String {
+		return config.BpError{Err: fmt.Errorf("setting %q must be a string", nameSetting), Path: namePath}
+	}
+	name := nameValues[0].AsString()
+
+	var saID string
+	if depName == "" {
+		saID = name
+	} else {
+		saID = fmt.Sprintf("%s-%s", depName, name)
+	}
+
+	if len(saID) < 6 || len(saID) > 30 {
+		return config.BpError{
+			Err:  fmt.Errorf("generated service account ID %q is invalid: length must be between 6 and 30 characters, but got %d (deployment_name: %d, name: %d)", saID, len(saID), len(depName), len(name)),
+			Path: namePath,
+		}
+	}
+
+	re := regexp.MustCompile(`^[a-z][-a-z0-9]*[a-z0-9]$`)
+	if !re.MatchString(saID) {
+		return config.BpError{
+			Err:  fmt.Errorf("generated service account ID %q is invalid: must begin with a lowercase letter, contain only lowercase alphanumeric characters and dashes, and cannot end with a dash", saID),
+			Path: namePath,
+		}
+	}
+
+	return nil
+}

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -591,6 +591,8 @@ func evalTriggers(
 	return true
 }
 
+var serviceAccountIDRegexp = regexp.MustCompile(`^[a-z][-a-z0-9]*[a-z0-9]$`)
+
 // ServiceAccountIDValidator validates if the combined deployment_name and name
 // form a valid GCP Service Account ID.
 type ServiceAccountIDValidator struct{}
@@ -619,7 +621,13 @@ func (v *ServiceAccountIDValidator) Validate(
 	if len(depNameValues) == 0 || depNameValues[0].Type() != cty.String {
 		return config.BpError{Err: fmt.Errorf("setting %q must be a string", depNameSetting), Path: depNamePath}
 	}
-	depName := depNameValues[0].AsString()
+	if !depNameValues[0].IsKnown() {
+		return nil
+	}
+	var depName string
+	if !depNameValues[0].IsNull() {
+		depName = depNameValues[0].AsString()
+	}
 
 	nameValues, namePath, err := getModuleSettingValues(bp, group, modIdx, mod, nameSetting)
 	if err != nil {
@@ -627,6 +635,12 @@ func (v *ServiceAccountIDValidator) Validate(
 	}
 	if len(nameValues) == 0 || nameValues[0].Type() != cty.String {
 		return config.BpError{Err: fmt.Errorf("setting %q must be a string", nameSetting), Path: namePath}
+	}
+	if !nameValues[0].IsKnown() {
+		return nil
+	}
+	if nameValues[0].IsNull() {
+		return config.BpError{Err: fmt.Errorf("setting %q cannot be null", nameSetting), Path: namePath}
 	}
 	name := nameValues[0].AsString()
 
@@ -644,8 +658,7 @@ func (v *ServiceAccountIDValidator) Validate(
 		}
 	}
 
-	re := regexp.MustCompile(`^[a-z][-a-z0-9]*[a-z0-9]$`)
-	if !re.MatchString(saID) {
+	if !serviceAccountIDRegexp.MatchString(saID) {
 		return config.BpError{
 			Err:  fmt.Errorf("generated service account ID %q is invalid: must begin with a lowercase letter, contain only lowercase alphanumeric characters and dashes, and cannot end with a dash", saID),
 			Path: namePath,

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -228,6 +228,11 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 			name:       "passes_when_deployment_name_is_missing_and_rule_is_optional",
 			depMissing: true,
 		},
+		{
+			name:    "passes_when_deployment_name_is_unknown_even_if_other_parts_are_invalid",
+			depName: cty.UnknownVal(cty.String),
+			saName:  cty.StringVal("INVALID-SA"),
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -140,9 +140,90 @@ func TestRegexValidator(t *testing.T) {
 		}
 	})
 
+	t.Run("passes_when_setting_is_unknown", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.UnknownVal(cty.String),
+		})
+		rule := modulereader.ValidationRule{
+			Validator: "regex",
+			Inputs: map[string]interface{}{
+				"vars":    []interface{}{"name"},
+				"pattern": "^[a-z]+$",
+			},
+		}
+		if err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0); err != nil {
+			t.Fatalf("unexpected error when setting is unknown: %v", err)
+		}
+	})
+
+	t.Run("passes_when_setting_is_null", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.NullVal(cty.String),
+		})
+		rule := modulereader.ValidationRule{
+			Validator: "regex",
+			Inputs: map[string]interface{}{
+				"vars":    []interface{}{"name"},
+				"pattern": "^[a-z]+$",
+			},
+		}
+		if err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0); err != nil {
+			t.Fatalf("unexpected error when setting is null: %v", err)
+		}
+	})
+
+	t.Run("passes_when_setting_is_non_string", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.NumberIntVal(123),
+		})
+		rule := modulereader.ValidationRule{
+			Validator: "regex",
+			Inputs: map[string]interface{}{
+				"vars":    []interface{}{"name"},
+				"pattern": "^[a-z]+$",
+			},
+		}
+		if err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0); err != nil {
+			t.Fatalf("unexpected error when setting is non-string: %v", err)
+		}
+	})
+}
+
+func createConcatTestBP(baseBP config.Blueprint, depName, saName cty.Value, depMissing, saMissing bool) config.Blueprint {
+	bp := baseBP
+	bp.Vars = config.NewDict(map[string]cty.Value{})
+	if !depMissing {
+		depVal := cty.StringVal("my-dep")
+		if depName != cty.NilVal {
+			depVal = depName
+		}
+		bp.Vars = config.NewDict(map[string]cty.Value{"deployment_name": depVal})
+	}
+
+	bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{})
+	if !saMissing {
+		saVal := cty.StringVal("sa-name")
+		if saName != cty.NilVal {
+			saVal = saName
+		}
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{"name": saVal})
+	}
+	return bp
 }
 
 func TestRegexValidator_ConcatMode(t *testing.T) {
+	mockInfo := modulereader.ModuleInfo{
+		Inputs: []modulereader.VarInfo{
+			{Name: "name_with_default", Type: cty.String, Default: "default-sa"},
+			{Name: "invalid_default", Type: cty.String, Default: "INVALID_SA"},
+		},
+	}
+	modulereader.SetModuleInfo("test/module", "terraform", mockInfo)
+	modulereader.SetModuleInfo("test/module", "", mockInfo)
+
 	baseBP := config.Blueprint{
 		BlueprintName: "test-bp",
 		Vars: config.NewDict(map[string]cty.Value{
@@ -153,35 +234,26 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 				Name: "primary",
 				Modules: []config.Module{
 					{
-						ID:     "test-module",
-						Source: "test/module",
-						Settings: config.NewDict(map[string]cty.Value{
-							"name": cty.StringVal("sa-name"),
-						}),
+						ID:       "test-module",
+						Source:   "test/module",
+						Kind:     config.TerraformKind,
+						Settings: config.NewDict(map[string]cty.Value{"name": cty.StringVal("sa-name")}),
 					},
 				},
 			},
 		},
 	}
 
-	rule := modulereader.ValidationRule{
-		Validator: "regex",
-		Inputs: map[string]interface{}{
-			"vars":      []interface{}{"deployment_name", "name"},
-			"concat":    true,
-			"separator": "-",
-			"pattern":   "^[a-z][-a-z0-9]{4,28}[a-z0-9]$",
-		},
-	}
-
 	validator := RegexValidator{}
-
 	tests := []struct {
-		name       string
-		depName    cty.Value
-		saName     cty.Value
-		depMissing bool
-		wantErrSub string
+		name        string
+		depName     cty.Value
+		saName      cty.Value
+		varNames    []interface{}
+		depMissing  bool
+		saMissing   bool
+		notOptional bool
+		wantErrSub  string
 	}{
 		{
 			name:    "passes_on_valid_id",
@@ -233,42 +305,158 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 			depName: cty.UnknownVal(cty.String),
 			saName:  cty.StringVal("INVALID-SA"),
 		},
+		{
+			name:      "passes_when_module_setting_falls_back_to_default",
+			depName:   cty.StringVal("my-dep"),
+			varNames:  []interface{}{"deployment_name", "name_with_default"},
+			saMissing: true,
+		},
+		{
+			name:       "fails_when_module_setting_default_violates_pattern",
+			depName:    cty.StringVal("my-dep"),
+			varNames:   []interface{}{"deployment_name", "invalid_default"},
+			saMissing:  true,
+			wantErrSub: "does not match pattern",
+		},
+		{
+			name:       "fails_when_setting_is_non_string",
+			saName:     cty.NumberIntVal(123),
+			wantErrSub: "must be a string",
+		},
+		{
+			name:       "fails_when_setting_is_unknown_number",
+			saName:     cty.UnknownVal(cty.Number),
+			wantErrSub: "must be a string",
+		},
+		{
+			name:        "fails_when_setting_is_missing_and_no_default_and_not_optional",
+			varNames:    []interface{}{"deployment_name", "missing_var"},
+			notOptional: true,
+			wantErrSub:  "setting \"missing_var\" not found in module \"test-module\" settings",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			bp := baseBP
-			bp.Vars = config.NewDict(map[string]cty.Value{})
-			if !tc.depMissing {
-				depVal := cty.StringVal("my-dep")
-				if tc.depName != cty.NilVal {
-					depVal = tc.depName
-				}
-				bp.Vars = config.NewDict(map[string]cty.Value{
-					"deployment_name": depVal,
-				})
+			bp := createConcatTestBP(baseBP, tc.depName, tc.saName, tc.depMissing, tc.saMissing)
+			rule := modulereader.ValidationRule{
+				Validator: "regex",
+				Inputs: map[string]interface{}{
+					"vars":      []interface{}{"deployment_name", "name"},
+					"concat":    true,
+					"separator": "-",
+					"pattern":   "^[a-z][-a-z0-9]{4,28}[a-z0-9]$",
+				},
 			}
-
-			saVal := cty.StringVal("sa-name")
-			if tc.saName != cty.NilVal {
-				saVal = tc.saName
+			if tc.varNames != nil {
+				rule.Inputs["vars"] = tc.varNames
 			}
-			bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-				"name": saVal,
-			})
+			if tc.notOptional {
+				rule.Inputs["optional"] = false
+			}
 
 			err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-			if tc.wantErrSub == "" {
-				if err != nil {
-					t.Fatalf("unexpected validation error: %v", err)
-				}
-			} else {
+			if tc.wantErrSub == "" && err != nil {
+				t.Fatalf("unexpected validation error: %v", err)
+			}
+			if tc.wantErrSub != "" {
 				if err == nil {
-					t.Fatalf("expected validation error, got nil")
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
 				}
 				if !strings.Contains(err.Error(), tc.wantErrSub) {
-					t.Fatalf("expected error message to contain %q, got: %q", tc.wantErrSub, err.Error())
+					t.Fatalf("expected error containing %q, got: %q", tc.wantErrSub, err.Error())
 				}
+			}
+		})
+	}
+}
+
+func TestResolveSettingToString(t *testing.T) {
+	mockInfo := modulereader.ModuleInfo{
+		Inputs: []modulereader.VarInfo{
+			{Name: "default_string", Type: cty.String, Default: "fallback_val"},
+			{Name: "default_number", Type: cty.Number, Default: 100},
+		},
+	}
+	modulereader.SetModuleInfo("test/module", "terraform", mockInfo)
+	modulereader.SetModuleInfo("test/module", "", mockInfo)
+
+	bp := config.Blueprint{
+		BlueprintName: "test-bp",
+		Vars: config.NewDict(map[string]cty.Value{
+			"global_str": cty.StringVal("global_val"),
+		}),
+		Groups: []config.Group{
+			{
+				Name: "primary",
+				Modules: []config.Module{
+					{
+						ID:     "test-mod",
+						Source: "test/module",
+						Kind:   config.TerraformKind,
+						Settings: config.NewDict(map[string]cty.Value{
+							"str_setting":  cty.StringVal("explicit_val"),
+							"num_setting":  cty.NumberIntVal(42),
+							"bool_setting": cty.BoolVal(true),
+							"null_setting": cty.NullVal(cty.String),
+							"null_num":     cty.NullVal(cty.Number),
+							"unknown_str":  cty.UnknownVal(cty.String),
+							"unknown_num":  cty.UnknownVal(cty.Number),
+							"list_setting": cty.ListVal([]cty.Value{cty.NumberIntVal(1)}),
+							"map_setting":  cty.ObjectVal(map[string]cty.Value{"k": cty.StringVal("v")}),
+						}),
+					},
+				},
+			},
+		},
+	}
+	mod := bp.Groups[0].Modules[0]
+	group := bp.Groups[0]
+
+	tests := []struct {
+		name        string
+		setting     string
+		optional    bool
+		allowNull   bool
+		expectedVal string
+		expectKnown bool
+		wantErrSub  string
+	}{
+		{name: "explicit_string", setting: "str_setting", expectKnown: true, expectedVal: "explicit_val"},
+		{name: "module_default", setting: "default_string", expectKnown: true, expectedVal: "fallback_val"},
+		{name: "global_var", setting: "global_str", expectKnown: true, expectedVal: "global_val"},
+		{name: "missing_optional", setting: "nonexistent", optional: true, expectKnown: false},
+		{name: "missing_not_optional", setting: "nonexistent", optional: false, wantErrSub: "not found in module"},
+		{name: "number_setting", setting: "num_setting", wantErrSub: "must be a string"},
+		{name: "bool_setting", setting: "bool_setting", wantErrSub: "must be a string"},
+		{name: "list_setting", setting: "list_setting", wantErrSub: "must be a string"},
+		{name: "map_setting", setting: "map_setting", wantErrSub: "must be a string"},
+		{name: "unknown_number", setting: "unknown_num", wantErrSub: "must be a string"},
+		{name: "unknown_string", setting: "unknown_str", expectKnown: false},
+		{name: "null_string_not_allowed", setting: "null_setting", allowNull: false, wantErrSub: "cannot be null"},
+		{name: "null_string_allowed", setting: "null_setting", allowNull: true, expectKnown: true, expectedVal: ""},
+		{name: "null_number_allowed", setting: "null_num", allowNull: true, wantErrSub: "must be a string"},
+		{name: "null_number_not_allowed", setting: "null_num", allowNull: false, wantErrSub: "must be a string"},
+		{name: "default_number", setting: "default_number", wantErrSub: "must be a string"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			val, known, _, err := resolveSettingToString(bp, group, 0, mod, tc.setting, tc.optional, tc.allowNull)
+			if tc.wantErrSub != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErrSub)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("expected error containing %q, got: %q", tc.wantErrSub, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if known != tc.expectKnown || val != tc.expectedVal {
+				t.Fatalf("expected known=%v, val=%q; got known=%v, val=%q", tc.expectKnown, tc.expectedVal, known, val)
 			}
 		})
 	}
@@ -1275,6 +1463,54 @@ func TestConditionalRegexValidator(t *testing.T) {
 		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	// 5. Passes when dependent variable is unknown
+	t.Run("passes_when_dependent_is_unknown", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"machine_type": cty.UnknownVal(cty.String),
+			"dws_flex": cty.ObjectVal(map[string]cty.Value{
+				"enabled": cty.True,
+			}),
+			"enable_placement": cty.True,
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected error when dependent is unknown: %v", err)
+		}
+	})
+
+	// 6. Passes when dependent variable is null
+	t.Run("passes_when_dependent_is_null", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"machine_type": cty.NullVal(cty.String),
+			"dws_flex": cty.ObjectVal(map[string]cty.Value{
+				"enabled": cty.True,
+			}),
+			"enable_placement": cty.True,
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected error when dependent is null: %v", err)
+		}
+	})
+
+	// 7. Passes when trigger is unknown
+	t.Run("passes_when_trigger_is_unknown", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"machine_type": cty.StringVal("g4-standard-48"),
+			"dws_flex": cty.ObjectVal(map[string]cty.Value{
+				"enabled": cty.UnknownVal(cty.Bool),
+			}),
+			"enable_placement": cty.True,
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected error when trigger is unknown: %v", err)
 		}
 	})
 }

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -1243,4 +1243,54 @@ func TestServiceAccountIDValidator(t *testing.T) {
 			t.Fatalf("expected error message to contain 'cannot end with a dash', got: %q", err.Error())
 		}
 	})
+
+	t.Run("passes_when_deployment_name_is_unknown", func(t *testing.T) {
+		bp := baseBP
+		bp.Vars = config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.UnknownVal(cty.String),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("passes_when_name_is_unknown", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.UnknownVal(cty.String),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("fails_when_name_is_null", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.NullVal(cty.String),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatalf("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot be null") {
+			t.Fatalf("expected error message to contain 'cannot be null', got: %q", err.Error())
+		}
+	})
+
+	t.Run("passes_when_deployment_name_is_null", func(t *testing.T) {
+		bp := baseBP
+		bp.Vars = config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.NullVal(cty.String),
+		})
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.StringVal("valid-sa-name"),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
 }

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -261,9 +261,25 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 			saName:  cty.StringVal("sa-name"),
 		},
 		{
+			name:    "passes_on_exact_max_length_30_chars",
+			depName: cty.StringVal("a-1234567890-1234567890"),
+			saName:  cty.StringVal("123456"),
+		},
+		{
+			name:    "passes_on_exact_min_length_6_chars",
+			depName: cty.StringVal("ab"),
+			saName:  cty.StringVal("cde"),
+		},
+		{
 			name:       "fails_when_too_long",
 			depName:    cty.StringVal("a-very-long-deployment-name-that-exceeds"),
 			saName:     cty.StringVal("sa-name"),
+			wantErrSub: "does not match pattern",
+		},
+		{
+			name:       "fails_on_length_31_chars",
+			depName:    cty.StringVal("a-1234567890-1234567890"),
+			saName:     cty.StringVal("1234567"),
 			wantErrSub: "does not match pattern",
 		},
 		{

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -139,6 +139,126 @@ func TestRegexValidator(t *testing.T) {
 			t.Fatalf("unexpected error message: %q", err.Error())
 		}
 	})
+
+}
+
+func TestRegexValidator_ConcatMode(t *testing.T) {
+	baseBP := config.Blueprint{
+		BlueprintName: "test-bp",
+		Vars: config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.StringVal("my-dep"),
+		}),
+		Groups: []config.Group{
+			{
+				Name: "primary",
+				Modules: []config.Module{
+					{
+						ID:     "test-module",
+						Source: "test/module",
+						Settings: config.NewDict(map[string]cty.Value{
+							"name": cty.StringVal("sa-name"),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	rule := modulereader.ValidationRule{
+		Validator: "regex",
+		Inputs: map[string]interface{}{
+			"vars":      []interface{}{"deployment_name", "name"},
+			"concat":    true,
+			"separator": "-",
+			"pattern":   "^[a-z][-a-z0-9]{4,28}[a-z0-9]$",
+		},
+	}
+
+	validator := RegexValidator{}
+
+	tests := []struct {
+		name       string
+		depName    cty.Value
+		saName     cty.Value
+		wantErrSub string
+	}{
+		{
+			name:    "passes_on_valid_id",
+			depName: cty.StringVal("my-dep"),
+			saName:  cty.StringVal("sa-name"),
+		},
+		{
+			name:       "fails_when_too_long",
+			depName:    cty.StringVal("a-very-long-deployment-name-that-exceeds"),
+			saName:     cty.StringVal("sa-name"),
+			wantErrSub: "does not match pattern",
+		},
+		{
+			name:       "fails_when_too_short",
+			depName:    cty.StringVal("a"),
+			saName:     cty.StringVal("b"),
+			wantErrSub: "does not match pattern",
+		},
+		{
+			name:       "fails_on_invalid_characters",
+			saName:     cty.StringVal("SA-NAME"),
+			wantErrSub: "does not match pattern",
+		},
+		{
+			name:    "passes_when_deployment_name_is_unknown",
+			depName: cty.UnknownVal(cty.String),
+		},
+		{
+			name:   "passes_when_name_is_unknown",
+			saName: cty.UnknownVal(cty.String),
+		},
+		{
+			name:       "fails_when_name_is_null",
+			saName:     cty.NullVal(cty.String),
+			wantErrSub: "cannot be null",
+		},
+		{
+			name:       "fails_when_deployment_name_is_null",
+			depName:    cty.NullVal(cty.String),
+			saName:     cty.StringVal("valid-sa-name"),
+			wantErrSub: "cannot be null",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bp := baseBP
+			depVal := cty.StringVal("my-dep")
+			if tc.depName != cty.NilVal {
+				depVal = tc.depName
+			}
+			bp.Vars = config.NewDict(map[string]cty.Value{
+				"deployment_name": depVal,
+			})
+
+			saVal := cty.StringVal("sa-name")
+			if tc.saName != cty.NilVal {
+				saVal = tc.saName
+			}
+			bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+				"name": saVal,
+			})
+
+			err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+			if tc.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("unexpected validation error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected validation error, got nil")
+				}
+				if !strings.Contains(err.Error(), tc.wantErrSub) {
+					t.Fatalf("expected error message to contain %q, got: %q", tc.wantErrSub, err.Error())
+				}
+			}
+		})
+	}
 }
 
 func TestAllowedEnumValidator(t *testing.T) {
@@ -1142,155 +1262,6 @@ func TestConditionalRegexValidator(t *testing.T) {
 		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
-		}
-	})
-}
-
-func TestServiceAccountIDValidator(t *testing.T) {
-	// Base fake blueprint/module used by subtests
-	baseBP := config.Blueprint{
-		BlueprintName: "test-bp",
-		Vars: config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.StringVal("my-dep"),
-		}),
-		Groups: []config.Group{
-			{
-				Name: "primary",
-				Modules: []config.Module{
-					{
-						ID:     "test-module",
-						Source: "test/module",
-						Settings: config.NewDict(map[string]cty.Value{
-							"name": cty.StringVal("sa-name"),
-						}),
-					},
-				},
-			},
-		},
-	}
-
-	validator := ServiceAccountIDValidator{}
-	rule := modulereader.ValidationRule{
-		Validator: "service_account_id",
-		Inputs: map[string]interface{}{
-			"deployment_name": "deployment_name",
-			"name":            "name",
-		},
-	}
-
-	t.Run("passes_on_valid_id", func(t *testing.T) {
-		err := validator.Validate(baseBP, baseBP.Groups[0].Modules[0], rule, baseBP.Groups[0], 0)
-		if err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-	})
-
-	t.Run("fails_when_too_long", func(t *testing.T) {
-		bp := baseBP
-		bp.Vars = config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.StringVal("a-very-long-deployment-name-that-exceeds"),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err == nil {
-			t.Fatalf("expected validation error due to length, got nil")
-		}
-		if !strings.Contains(err.Error(), "length must be between 6 and 30") {
-			t.Fatalf("expected error message to contain length limit info, got: %q", err.Error())
-		}
-	})
-
-	t.Run("fails_when_too_short", func(t *testing.T) {
-		bp := baseBP
-		bp.Vars = config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.StringVal("a"),
-		})
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.StringVal("b"),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err == nil {
-			t.Fatalf("expected validation error due to length, got nil")
-		}
-		if !strings.Contains(err.Error(), "length must be between 6 and 30") {
-			t.Fatalf("expected error message to contain length limit info, got: %q", err.Error())
-		}
-	})
-
-	t.Run("fails_on_invalid_characters", func(t *testing.T) {
-		bp := baseBP
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.StringVal("SA-NAME"), // uppercase not allowed
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err == nil {
-			t.Fatalf("expected validation error due to invalid characters, got nil")
-		}
-		if !strings.Contains(err.Error(), "must begin with a lowercase letter") {
-			t.Fatalf("expected error message to contain char requirements, got: %q", err.Error())
-		}
-	})
-
-	t.Run("fails_when_ends_with_dash", func(t *testing.T) {
-		bp := baseBP
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.StringVal("name-"),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err == nil {
-			t.Fatalf("expected validation error, got nil")
-		}
-		if !strings.Contains(err.Error(), "cannot end with a dash") {
-			t.Fatalf("expected error message to contain 'cannot end with a dash', got: %q", err.Error())
-		}
-	})
-
-	t.Run("passes_when_deployment_name_is_unknown", func(t *testing.T) {
-		bp := baseBP
-		bp.Vars = config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.UnknownVal(cty.String),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-	})
-
-	t.Run("passes_when_name_is_unknown", func(t *testing.T) {
-		bp := baseBP
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.UnknownVal(cty.String),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
-		}
-	})
-
-	t.Run("fails_when_name_is_null", func(t *testing.T) {
-		bp := baseBP
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.NullVal(cty.String),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err == nil {
-			t.Fatalf("expected validation error, got nil")
-		}
-		if !strings.Contains(err.Error(), "cannot be null") {
-			t.Fatalf("expected error message to contain 'cannot be null', got: %q", err.Error())
-		}
-	})
-
-	t.Run("passes_when_deployment_name_is_null", func(t *testing.T) {
-		bp := baseBP
-		bp.Vars = config.NewDict(map[string]cty.Value{
-			"deployment_name": cty.NullVal(cty.String),
-		})
-		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
-			"name": cty.StringVal("valid-sa-name"),
-		})
-		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
-		if err != nil {
-			t.Fatalf("unexpected validation error: %v", err)
 		}
 	})
 }

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -1145,3 +1145,102 @@ func TestConditionalRegexValidator(t *testing.T) {
 		}
 	})
 }
+
+func TestServiceAccountIDValidator(t *testing.T) {
+	// Base fake blueprint/module used by subtests
+	baseBP := config.Blueprint{
+		BlueprintName: "test-bp",
+		Vars: config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.StringVal("my-dep"),
+		}),
+		Groups: []config.Group{
+			{
+				Name: "primary",
+				Modules: []config.Module{
+					{
+						ID:     "test-module",
+						Source: "test/module",
+						Settings: config.NewDict(map[string]cty.Value{
+							"name": cty.StringVal("sa-name"),
+						}),
+					},
+				},
+			},
+		},
+	}
+
+	validator := ServiceAccountIDValidator{}
+	rule := modulereader.ValidationRule{
+		Validator: "service_account_id",
+		Inputs: map[string]interface{}{
+			"deployment_name": "deployment_name",
+			"name":            "name",
+		},
+	}
+
+	t.Run("passes_on_valid_id", func(t *testing.T) {
+		err := validator.Validate(baseBP, baseBP.Groups[0].Modules[0], rule, baseBP.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected validation error: %v", err)
+		}
+	})
+
+	t.Run("fails_when_too_long", func(t *testing.T) {
+		bp := baseBP
+		bp.Vars = config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.StringVal("a-very-long-deployment-name-that-exceeds"),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatalf("expected validation error due to length, got nil")
+		}
+		if !strings.Contains(err.Error(), "length must be between 6 and 30") {
+			t.Fatalf("expected error message to contain length limit info, got: %q", err.Error())
+		}
+	})
+
+	t.Run("fails_when_too_short", func(t *testing.T) {
+		bp := baseBP
+		bp.Vars = config.NewDict(map[string]cty.Value{
+			"deployment_name": cty.StringVal("a"),
+		})
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.StringVal("b"),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatalf("expected validation error due to length, got nil")
+		}
+		if !strings.Contains(err.Error(), "length must be between 6 and 30") {
+			t.Fatalf("expected error message to contain length limit info, got: %q", err.Error())
+		}
+	})
+
+	t.Run("fails_on_invalid_characters", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.StringVal("SA-NAME"), // uppercase not allowed
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatalf("expected validation error due to invalid characters, got nil")
+		}
+		if !strings.Contains(err.Error(), "must begin with a lowercase letter") {
+			t.Fatalf("expected error message to contain char requirements, got: %q", err.Error())
+		}
+	})
+
+	t.Run("fails_when_ends_with_dash", func(t *testing.T) {
+		bp := baseBP
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"name": cty.StringVal("name-"),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatalf("expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot end with a dash") {
+			t.Fatalf("expected error message to contain 'cannot end with a dash', got: %q", err.Error())
+		}
+	})
+}

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -180,6 +180,7 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 		name       string
 		depName    cty.Value
 		saName     cty.Value
+		depMissing bool
 		wantErrSub string
 	}{
 		{
@@ -223,18 +224,25 @@ func TestRegexValidator_ConcatMode(t *testing.T) {
 			saName:     cty.StringVal("valid-sa-name"),
 			wantErrSub: "cannot be null",
 		},
+		{
+			name:       "passes_when_deployment_name_is_missing_and_rule_is_optional",
+			depMissing: true,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			bp := baseBP
-			depVal := cty.StringVal("my-dep")
-			if tc.depName != cty.NilVal {
-				depVal = tc.depName
+			bp.Vars = config.NewDict(map[string]cty.Value{})
+			if !tc.depMissing {
+				depVal := cty.StringVal("my-dep")
+				if tc.depName != cty.NilVal {
+					depVal = tc.depName
+				}
+				bp.Vars = config.NewDict(map[string]cty.Value{
+					"deployment_name": depVal,
+				})
 			}
-			bp.Vars = config.NewDict(map[string]cty.Value{
-				"deployment_name": depVal,
-			})
 
 			saVal := cty.StringVal("sa-name")
 			if tc.saName != cty.NilVal {

--- a/pkg/validators/registry.go
+++ b/pkg/validators/registry.go
@@ -16,12 +16,11 @@ package validators
 
 // Registry maps validation type strings to their corresponding validator implementation.
 var Registry = map[string]RuleValidator{
-	"regex":              &RegexValidator{},
-	"allowed_enum":       &AllowedEnumValidator{},
-	"range":              &RangeValidator{},
-	"exclusive":          &ExclusiveValidator{},
-	"required":           &RequiredValidator{},
-	"conditional":        &ConditionalValidator{},
-	"conditional_regex":  &ConditionalRegexValidator{},
-	"service_account_id": &ServiceAccountIDValidator{},
+	"regex":             &RegexValidator{},
+	"allowed_enum":      &AllowedEnumValidator{},
+	"range":             &RangeValidator{},
+	"exclusive":         &ExclusiveValidator{},
+	"required":          &RequiredValidator{},
+	"conditional":       &ConditionalValidator{},
+	"conditional_regex": &ConditionalRegexValidator{},
 }

--- a/pkg/validators/registry.go
+++ b/pkg/validators/registry.go
@@ -16,11 +16,12 @@ package validators
 
 // Registry maps validation type strings to their corresponding validator implementation.
 var Registry = map[string]RuleValidator{
-	"regex":             &RegexValidator{},
-	"allowed_enum":      &AllowedEnumValidator{},
-	"range":             &RangeValidator{},
-	"exclusive":         &ExclusiveValidator{},
-	"required":          &RequiredValidator{},
-	"conditional":       &ConditionalValidator{},
-	"conditional_regex": &ConditionalRegexValidator{},
+	"regex":              &RegexValidator{},
+	"allowed_enum":       &AllowedEnumValidator{},
+	"range":              &RangeValidator{},
+	"exclusive":          &ExclusiveValidator{},
+	"required":           &RequiredValidator{},
+	"conditional":        &ConditionalValidator{},
+	"conditional_regex":  &ConditionalRegexValidator{},
+	"service_account_id": &ServiceAccountIDValidator{},
 }

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -28,8 +28,7 @@ run_test() {
 	exampleFile=$(basename "$example")
 	baseName=${exampleFile%.yaml}
 	baseNameShort=${baseName:0:4}
-	suffix=$(basename "${tmpdir##*.}")
-	suffixShort=${suffix:0:4}
+	suffixShort=${tmpdir: -4}
 	DEPLOYMENT=$(echo "${baseNameShort}-${suffixShort}" | sed -e 's/\(.*\)/\L\1/' -e 's/_/-/g' -e 's/-\{2,\}/-/g')
 	PROJECT="invalid-project"
 	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability,test_machine_type_in_zone,test_reservation_exists,test_disk_type_in_zone"

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -26,9 +26,7 @@ run_test() {
 	fi
 	tmpdir="$(mktemp -d)"
 	exampleFile=$(basename "$example")
-	baseName=${exampleFile%.yaml}
-	baseNameShort=${baseName:0:8}
-	DEPLOYMENT=$(echo "${baseNameShort}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
+	DEPLOYMENT=$(echo "${exampleFile%.yaml}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
 	PROJECT="invalid-project"
 	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability,test_machine_type_in_zone,test_reservation_exists,test_disk_type_in_zone"
 	GHPC_PATH="${cwd}/ghpc"

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -27,8 +27,10 @@ run_test() {
 	tmpdir="$(mktemp -d)"
 	exampleFile=$(basename "$example")
 	baseName=${exampleFile%.yaml}
-	baseNameShort=${baseName:0:8}
-	DEPLOYMENT=$(echo "${baseNameShort}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
+	baseNameShort=${baseName:0:4}
+	suffix=$(basename "${tmpdir##*.}")
+	suffixShort=${suffix:0:4}
+	DEPLOYMENT=$(echo "${baseNameShort}-${suffixShort}" | sed -e 's/\(.*\)/\L\1/' -e 's/_/-/g' -e 's/-\{2,\}/-/g')
 	PROJECT="invalid-project"
 	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability,test_machine_type_in_zone,test_reservation_exists,test_disk_type_in_zone"
 	GHPC_PATH="${cwd}/ghpc"
@@ -133,7 +135,6 @@ EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-ece.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-slurm.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-expansion.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/eda/eda-hybrid-cloud.yaml"]=
-EXCLUDE_EXAMPLE["community/examples/hpc-slurm-ha.yaml"]=
 
 cwd=$(pwd)
 NPROCS=${NPROCS:-$(nproc)}

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -26,7 +26,9 @@ run_test() {
 	fi
 	tmpdir="$(mktemp -d)"
 	exampleFile=$(basename "$example")
-	DEPLOYMENT=$(echo "${exampleFile%.yaml}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
+	baseName=${exampleFile%.yaml}
+	baseNameShort=${baseName:0:8}
+	DEPLOYMENT=$(echo "${baseNameShort}-$(basename "${tmpdir##*.}")" | sed -e 's/\(.*\)/\L\1/')
 	PROJECT="invalid-project"
 	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability,test_machine_type_in_zone,test_reservation_exists,test_disk_type_in_zone"
 	GHPC_PATH="${cwd}/ghpc"

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -133,6 +133,7 @@ EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-ece.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-slurm.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-expansion.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/eda/eda-hybrid-cloud.yaml"]=
+EXCLUDE_EXAMPLE["community/examples/hpc-slurm-ha.yaml"]=
 
 cwd=$(pwd)
 NPROCS=${NPROCS:-$(nproc)}


### PR DESCRIPTION
This PR validates the combined length and format of the deployment name and service account name to ensure they comply with Google Cloud's 30-character limit and naming rules. This validation runs during the pre-flight phase, preventing late-stage deployment failures in Terraform.
The validator is safe-guarded against null or unknown values to prevent panics during blueprint expansion, and uses a pre-compiled regular expression for efficiency.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
