### PR TITLE
fix: use TensorCore count for TPU v4 and v5p shorthand mappings

### DIFF
--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -80,9 +80,7 @@ var AcceleratorShorthandMap = map[string]string{
 
 	// TPU mappings
 	"v4-8":        "ct4p-hightpu-4t",
-	"v5p-1":       "ct5p-hightpu-1t",
-	"v5p-2":       "ct5p-hightpu-2t",
-	"v5p-4":       "ct5p-hightpu-4t",
+	"v5p-8":       "ct5p-hightpu-4t",
 	"v5litepod-1": "ct5lp-hightpu-1t",
 	"v5litepod-4": "ct5lp-hightpu-4t",
 	"v5litepod-8": "ct5lp-hightpu-8t",
@@ -351,8 +349,8 @@ func parseShorthand(accelaratorType string) (size int, err error) {
 		return 0, fmt.Errorf("invalid chips value for accelerator type %s: %w", accelaratorType, err)
 	}
 
-	// For TPU v4 (v4-8), the shorthand suffix represents cores. We need to divide by 2 to get chips.
-	if accelaratorType == "v4-8" {
+	// For TPU v4 and v5p, the shorthand suffix represents cores. We need to divide by 2 to get chips.
+	if strings.HasPrefix(accelaratorType, "v4-") || strings.HasPrefix(accelaratorType, "v5p-") {
 		size = size / 2
 	}
 

--- a/pkg/config/hardware.go
+++ b/pkg/config/hardware.go
@@ -351,6 +351,9 @@ func parseShorthand(accelaratorType string) (size int, err error) {
 
 	// For TPU v4 and v5p, the shorthand suffix represents cores. We need to divide by 2 to get chips.
 	if strings.HasPrefix(accelaratorType, "v4-") || strings.HasPrefix(accelaratorType, "v5p-") {
+		if size%2 != 0 {
+			return 0, fmt.Errorf("TPU v4 and v5p shorthand core count must be even, got %d", size)
+		}
 		size = size / 2
 	}
 

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -358,9 +358,16 @@ func TestResolveTopologyForChips(t *testing.T) {
 			wantErr:    true,
 		},
 		{
-			name:       "v4 3 chips (Fail)",
+			name:       "v4 3 cores (Fail)",
 			prefix:     "v4",
 			totalChips: 3,
+			wantShape:  "",
+			wantErr:    true,
+		},
+		{
+			name:       "v5p 7 cores (Fail)",
+			prefix:     "v5p",
+			totalChips: 7,
 			wantShape:  "",
 			wantErr:    true,
 		},

--- a/pkg/config/hardware_test.go
+++ b/pkg/config/hardware_test.go
@@ -309,6 +309,27 @@ func TestResolveTopologyForChips(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "v4 16 cores (8 chips)",
+			prefix:     "v4",
+			totalChips: 16,
+			wantShape:  "2x2x2",
+			wantErr:    false,
+		},
+		{
+			name:       "v5p 8 cores (4 chips)",
+			prefix:     "v5p",
+			totalChips: 8,
+			wantShape:  "2x2x1",
+			wantErr:    false,
+		},
+		{
+			name:       "v5p 16 cores (8 chips)",
+			prefix:     "v5p",
+			totalChips: 16,
+			wantShape:  "2x2x2",
+			wantErr:    false,
+		},
+		{
 			name:       "tpu7x 2048 chips",
 			prefix:     "tpu7x",
 			totalChips: 2048,
@@ -397,7 +418,7 @@ func TestMatchesTPUFamily(t *testing.T) {
 		{"v5litepod matches 2D", "v5litepod-16", valid2DTPUFamilies, true},
 		{"l4 does not match 2D", "l4-1", valid2DTPUFamilies, false},
 		{"v4 matches 3D", "v4-8", valid3DTPUFamilies, true},
-		{"v5p matches 3D", "v5p-4", valid3DTPUFamilies, true},
+		{"v5p matches 3D", "v5p-8", valid3DTPUFamilies, true},
 		{"v6e does not match 3D", "v6e-8", valid3DTPUFamilies, false},
 	}
 	for _, tt := range tests {
@@ -434,6 +455,7 @@ func TestGetCandidatesForShorthand(t *testing.T) {
 	}{
 		{"v5litepod", []string{"ct5lp-hightpu-1t", "ct5lp-hightpu-4t", "ct5lp-hightpu-8t"}},
 		{"v4", []string{"ct4p-hightpu-4t"}},
+		{"v5p", []string{"ct5p-hightpu-4t"}},
 		{"l4", []string{"g2-standard-12", "g2-standard-24", "g2-standard-48", "g2-standard-96"}},
 		{"unknown", nil},
 	}

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -39,8 +39,8 @@ func TestResolveMachineName(t *testing.T) {
 		},
 		{
 			name:            "TPU shorthand mapping",
-			acceleratorType: "v5p-1",
-			wantMachineName: "ct5p-hightpu-1t",
+			acceleratorType: "v5p-8",
+			wantMachineName: "ct5p-hightpu-4t",
 		},
 		{
 			name:            "Unknown type falls back to input",


### PR DESCRIPTION
### Summary
This PR fixes an issue where `gcluster` incorrectly provisions double the required resources for TPU v5p workloads when using shorthand compute types (e.g., `--compute-type=v5p-8` provisioning 2 VMs instead of 1). 

### Root Cause
1.  `AcceleratorShorthandMap` was missing `v5p-8` and contained incorrect/fictitious mappings for `v5p-1`, `v5p-2`, and `v5p-4`.
2.  `parseShorthand()` only performed core-to-chip conversion (dividing by 2) for `v4-8`, omitting TPU v5p (which also uses TensorCore naming). This also affected larger TPU v4 shorthand configurations.

### Changes
*   Updated `AcceleratorShorthandMap` in `pkg/config/hardware.go` to map `v5p-8` to `ct5p-hightpu-4t` (4 chips = 8 TensorCores) and removed invalid `v5p-1`, `v5p-2`, and `v5p-4` entries.
*   Updated `parseShorthand()` to use prefix matching (`v4-` and `v5p-`) to correctly divide the shorthand suffix by 2 for all TPU v4 and v5p configurations.
*   Added unit tests in `pkg/config/hardware_test.go` to verify `v4-16`, `v5p-8`, and `v5p-16` shorthand resolutions.
*   Updated GKE resource resolver tests in `pkg/orchestrator/gke/resource_resolver_test.go` to use the valid `v5p-8` shorthand.

### Verification Results
All unit tests passed successfully:
*   `go test ./pkg/config/...`
*   `go test ./pkg/orchestrator/gke/...`

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
