### PR TITLE
Update TTL in auth/slurm to fix A3H node drain timeout

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/htc-slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/htc-slurm.conf.tpl
@@ -35,7 +35,7 @@ MessageTimeout=60
 SlurmctldHost={control_host}({control_addr})
 
 AuthType=auth/{auth_key}
-AuthInfo=cred_expire=120
+AuthInfo=cred_expire=120,ttl=120
 AuthAltTypes=auth/jwt
 CredType=cred/{auth_key}
 MpiDefault={mpi_default}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/etc/long-prolog-slurm.conf.tpl
@@ -41,7 +41,7 @@ SlurmctldHost={control_host}({control_addr})
 
 
 AuthType=auth/{auth_key}
-AuthInfo=cred_expire=600
+AuthInfo=cred_expire=600,ttl=600
 AuthAltTypes=auth/jwt
 CredType=cred/{auth_key}
 MpiDefault={mpi_default}

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurm.conf.tpl
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/etc/slurm.conf.tpl
@@ -37,7 +37,7 @@ MessageTimeout=60
 {slurmctld_hosts}
 
 AuthType=auth/{auth_key}
-AuthInfo=cred_expire=120
+AuthInfo=cred_expire=120,ttl=120
 AuthAltTypes=auth/jwt
 CredType=cred/{auth_key}
 MpiDefault={mpi_default}


### PR DESCRIPTION
Update TTL in auth/slurm to fix A3H node drain timeout

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
