### PR TITLE
feat(remote-desktop): browser-based noVNC desktops for Slurm clusters

### DIFF
--- a/community/examples/remote-desktop/README.md
+++ b/community/examples/remote-desktop/README.md
@@ -1,0 +1,146 @@
+# Remote Desktop Examples
+
+These blueprints deploy browser-based Linux desktops alongside a Slurm cluster,
+using the [novnc-runtime](../../modules/remote-desktop/novnc-runtime/README.md)
+and [novnc-desktop](../../modules/remote-desktop/novnc-desktop/README.md)
+modules. Users reach an XFCE session over noVNC in a browser, with sessions
+created per user from their OS Login identity.
+
+## Architecture
+
+Each blueprint deploys a Slurm cluster with one or both desktop types:
+
+- **Login desktop**: `novnc-runtime` layered onto the Slurm login node, using
+  TigerVNC. Suited to 2D and general interactive use.
+- **Visualization desktop**: `novnc-desktop` on a dedicated VM, using TurboVNC.
+  Suited to 3D, and the only backend supporting GPU acceleration on GCE.
+
+Both hosts run a per-user broker that publishes endpoint metadata into
+`/shared/ghpc-remote-desktop/endpoints`. Each display listens on a `0700`
+per-user unix socket with no TCP port, so it is not reachable by other local
+users on a shared login node.
+
+## Blueprints
+
+- [hpc-slurm-remote-desktop.yaml](./hpc-slurm-remote-desktop.yaml): login and
+  visualization desktops, reached over an IAP tunnel.
+
+Both blueprints use `novnc_identity_mode: trusted_proxy`: the broker trusts an
+unverified identity header and the shared secret is the only control. Reached
+over an SSH tunnel with no proxy in front, the identity headers must be supplied
+by hand. Treat these as validation blueprints, not a production posture.
+
+## GPU desktops
+
+The visualization desktop can use hardware OpenGL. Rather than ship a
+near-identical second blueprint, apply these four changes to
+`hpc-slurm-remote-desktop.yaml`:
+
+```yaml
+vars:
+  # Debian is the only slurm-gcp family shipping an NVIDIA driver with graphics
+  # (not merely compute) support. A compute driver ships no libEGL_nvidia and
+  # cannot render.
+  slurm_image:
+    family: slurm-gcp-6-12-debian-12
+    project: schedmd-slurm-public
+  viz_machine_type: g2-standard-8
+
+# on the viz-desktop module
+      enable_gpu_acceleration: true
+      on_host_maintenance: TERMINATE
+```
+
+`vnc_backend: turbovnc` is required and is already the visualization desktop's
+setting. TurboVNC reaches the GPU through VirtualGL's EGL back end; TigerVNC
+offloads GL only through `-rendernode`, which needs a DRM render node that GCE's
+NVIDIA images never create. Without a usable GPU the session falls back to
+software rendering rather than failing, and the broker logs why at startup.
+
+## Getting Started
+
+Before you start, make sure your prerequisites and dependencies are set up:
+[Set up Cluster Toolkit](https://cloud.google.com/cluster-toolkit/docs/setup/configure-environment).
+
+Set the following blueprint variables:
+
+- `project_id`, `region` and `zone`
+- `desktop_proxy_secret`, generated with `openssl rand -base64 48`. The brokers
+  will not start without it.
+
+## Deployment Instructions
+
+> [!WARNING]
+> Deploying these blueprints uses billable components of Google Cloud, including
+> Compute Engine instances that run continuously until destroyed. GPU machine
+> types are billed at a significantly higher rate.
+
+Create and deploy a blueprint, replacing `BLUEPRINT` with the file you want:
+
+```bash
+./gcluster create community/examples/remote-desktop/BLUEPRINT.yaml -w
+./gcluster deploy BLUEPRINT
+```
+
+## Verify
+
+On each desktop host, confirm the broker is running and has published its
+endpoint:
+
+```bash
+systemctl status ghpc-desktop-broker
+sudo journalctl -u ghpc-desktop-broker --no-pager
+ls /shared/ghpc-remote-desktop/endpoints/
+```
+
+Reach a desktop through an IAP tunnel and
+browse to `http://localhost:6080/vnc.html`:
+
+```bash
+gcloud compute start-iap-tunnel LOGIN-NODE 6080 --local-host-port=localhost:6080 --zone ZONE
+```
+
+## Reaching a desktop in a browser
+
+The broker requires the identity headers on every request, including the
+websocket upgrade, so browsing straight to the tunnelled port returns 403. That
+is the cost of `trusted_proxy` with no proxy in front, and it is deliberate.
+
+To confirm the broker itself works, `curl` is enough:
+
+```bash
+SECRET=$(gcloud secrets versions access latest \
+  --secret ghpc-desktop-proxy-secret --project PROJECT_ID)
+
+curl -s http://localhost:6080/healthz          # -> ok
+
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "X-Cluster-Desktop-Secret: $SECRET" \
+  -H "X-Cluster-Desktop-Email: you@example.com" \
+  -H "X-Cluster-Desktop-Username: YOUR_OSLOGIN_NAME" \
+  http://localhost:6080/vnc.html               # -> 200, and starts your session
+```
+
+For an actual desktop in a browser, run
+[local-desktop-proxy.conf](./local-desktop-proxy.conf) on your own machine in
+front of the tunnel; it injects the headers, including on the websocket. Fill in
+the three `CHANGEME` values, then:
+
+```bash
+nginx -c /full/path/to/local-desktop-proxy.conf
+# browse to http://localhost:8888/vnc.html
+```
+
+That proxy is deliberately local rather than a VM in the blueprint. A proxy
+deployed in the cluster would have to assert a fixed identity - making anyone who
+can reach its port that user - and would hold the shared secret, so the secret
+would stop being a control. An authenticating proxy that verifies who the user
+is belongs with a verified identity mode, not with `trusted_proxy`.
+
+## Teardown Instructions
+
+Replace `BLUEPRINT` with the `deployment_name` used in the blueprint vars block.
+
+```bash
+./gcluster destroy BLUEPRINT
+```

--- a/community/examples/remote-desktop/README.md
+++ b/community/examples/remote-desktop/README.md
@@ -75,11 +75,13 @@ Set the following blueprint variables:
 > Compute Engine instances that run continuously until destroyed. GPU machine
 > types are billed at a significantly higher rate.
 
-Create and deploy a blueprint, replacing `BLUEPRINT` with the file you want:
+Create and deploy a blueprint. Replace `BLUEPRINT` with the file you want, and
+`DEPLOYMENT_NAME` with the `deployment_name` set in that blueprint's `vars`
+block - for `hpc-slurm-remote-desktop.yaml` that is `hpc-slurm-remote-desktop`:
 
 ```bash
 ./gcluster create community/examples/remote-desktop/BLUEPRINT.yaml -w
-./gcluster deploy BLUEPRINT
+./gcluster deploy DEPLOYMENT_NAME
 ```
 
 ## Verify
@@ -139,8 +141,9 @@ is belongs with a verified identity mode, not with `trusted_proxy`.
 
 ## Teardown Instructions
 
-Replace `BLUEPRINT` with the `deployment_name` used in the blueprint vars block.
+Replace `DEPLOYMENT_NAME` with the `deployment_name` used in the blueprint's
+`vars` block.
 
 ```bash
-./gcluster destroy BLUEPRINT
+./gcluster destroy DEPLOYMENT_NAME
 ```

--- a/community/examples/remote-desktop/hpc-slurm-remote-desktop.yaml
+++ b/community/examples/remote-desktop/hpc-slurm-remote-desktop.yaml
@@ -1,0 +1,222 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: hpc-slurm-remote-desktop
+
+vars:
+  # Set to true to enable the secure Slurm Native Authentication standard.
+  enable_slurm_auth: true
+  project_id:  ## Set GCP Project ID Here ##
+  deployment_name: hpc-slurm-remote-desktop
+  region: us-central1
+  zone: us-central1-a
+
+  slurm_cluster_name: slurmdesktop
+  slurm_image:
+    family: slurm-gcp-6-12-hpc-rocky-linux-9
+    project: schedmd-slurm-public
+
+  controller_machine_type: e2-standard-4
+  login_machine_type: n2-standard-4
+  compute_machine_type: n2-standard-4
+  viz_machine_type: n2-standard-8
+
+  controller_startup_scripts_timeout: 1800
+  login_startup_scripts_timeout: 1800
+  compute_startup_scripts_timeout: 1800
+
+  homefs_name: $(vars.deployment_name)-homefs
+  sharedfs_name: $(vars.deployment_name)-sharedfs
+  shared_root: /shared
+  desktop_endpoint_dir: /shared/ghpc-remote-desktop/endpoints
+
+  # Read from Secret Manager by each instance at boot, so no secret value
+  # appears in this blueprint or in Terraform state. Create it with:
+  #   openssl rand -base64 48 | gcloud secrets create ghpc-desktop-proxy-secret \
+  #     --project PROJECT_ID --replication-policy automatic --data-file=-
+  secret_project_id: $(vars.project_id)
+  desktop_proxy_secret_id: ghpc-desktop-proxy-secret
+
+  # IAP's TCP-forwarding range only. This blueprint runs the brokers in 'trusted_proxy' mode.
+  # Do not widen this to RFC1918 without putting an authenticating proxy in front.
+  # (hpc-slurm-remote-desktop-gateway.yaml may be more suitable for this)
+  desktop_allowed_ingress_cidrs:
+  - 35.235.240.0/20
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: services-api
+    source: community/modules/project/service-enablement
+    settings:
+      gcp_service_list:
+      - secretmanager.googleapis.com
+
+  # Both desktop hosts read the proxy secret through this account. Attaching a
+  # service account replaces the default compute account, so everything the
+  # instances rely on has to be granted here - including reading the
+  # startup-script bucket, which is easy to miss.
+  - id: desktop-service-account
+    source: modules/project/service-account
+    settings:
+      project_id: $(vars.project_id)
+      deployment_name: $(vars.deployment_name)
+      name: desktop
+      project_roles:
+      - storage.objectViewer
+      - secretmanager.secretAccessor
+      - logging.logWriter
+      - monitoring.metricWriter
+
+  - id: network
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.deployment_name)-net
+      subnetwork_name: $(vars.deployment_name)-subnet
+
+  - id: homefs
+    source: community/modules/file-system/nfs-server
+    use: [network]
+    outputs:
+    - network_storage
+    settings:
+      name: $(vars.homefs_name)
+      metadata:
+        enable-oslogin: "TRUE"
+      local_mounts:
+      - /home
+
+  - id: sharedfs
+    source: community/modules/file-system/nfs-server
+    use: [network]
+    outputs:
+    - network_storage
+    settings:
+      name: $(vars.sharedfs_name)
+      metadata:
+        enable-oslogin: "TRUE"
+      local_mounts:
+      - $(vars.shared_root)
+
+  - id: desktop-firewall
+    source: modules/network/firewall-rules
+    use: [network]
+    settings:
+      ingress_rules:
+      - name: $(vars.deployment_name)-desktop-brokers
+        description: Allow IAP-tunnelled noVNC access to desktop brokers
+        source_ranges: $(vars.desktop_allowed_ingress_cidrs)
+        target_tags:
+        - ghpc-novnc-desktop
+        allow:
+        - protocol: tcp
+          ports:
+          - "6080"
+
+  - id: compute-nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network, homefs, sharedfs]
+    settings:
+      instance_image: $(vars.slurm_image)
+      machine_type: $(vars.compute_machine_type)
+      advanced_machine_features:
+        threads_per_core: 1
+      on_host_maintenance: MIGRATE
+      node_count_static: 1
+      node_count_dynamic_max: 0
+      allow_automatic_updates: false
+
+  - id: compute-partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute-nodeset]
+    settings:
+      partition_name: compute
+      exclusive: false
+      is_default: true
+
+  - id: login-desktop-runtime
+    source: community/modules/remote-desktop/novnc-runtime
+    settings:
+      secret_project_id: $(vars.secret_project_id)
+      novnc_proxy_secret_id: $(vars.desktop_proxy_secret_id)
+      novnc_identity_mode: trusted_proxy
+      desktop_endpoint_dir: $(vars.desktop_endpoint_dir)
+      desktop_endpoint_name: login
+      slurm_auth_mode: auto
+      vnc_backend: tigervnc
+
+  - id: login-desktop-startup
+    source: modules/scripts/startup-script
+    settings:
+      runners: $(login-desktop-runtime.startup_runners)
+
+  - id: slurm-login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      instance_image: $(vars.slurm_image)
+      machine_type: $(vars.login_machine_type)
+      allow_automatic_updates: false
+      enable_login_public_ips: false
+      service_account_email: $(desktop-service-account.service_account_email)
+      service_account_scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+      tags:
+      - ghpc-novnc-desktop
+
+  - id: slurm-controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [network, homefs, sharedfs, slurm-login, compute-partition]
+    settings:
+      enable_slurm_auth: $(vars.enable_slurm_auth)
+      slurm_cluster_name: $(vars.slurm_cluster_name)
+      instance_image: $(vars.slurm_image)
+      machine_type: $(vars.controller_machine_type)
+      allow_automatic_updates: false
+      enable_controller_public_ips: false
+      login_startup_script: $(login-desktop-startup.startup_script)
+      controller_startup_scripts_timeout: $(vars.controller_startup_scripts_timeout)
+      login_startup_scripts_timeout: $(vars.login_startup_scripts_timeout)
+      compute_startup_scripts_timeout: $(vars.compute_startup_scripts_timeout)
+      login_network_storage:
+      - server_ip: $(homefs.network_storage[0].server_ip)
+        remote_mount: $(homefs.network_storage[0].remote_mount)
+        local_mount: $(homefs.network_storage[0].local_mount)
+        fs_type: $(homefs.network_storage[0].fs_type)
+        mount_options: $(homefs.network_storage[0].mount_options)
+      - server_ip: $(sharedfs.network_storage[0].server_ip)
+        remote_mount: $(sharedfs.network_storage[0].remote_mount)
+        local_mount: $(sharedfs.network_storage[0].local_mount)
+        fs_type: $(sharedfs.network_storage[0].fs_type)
+        mount_options: $(sharedfs.network_storage[0].mount_options)
+
+  - id: viz-desktop
+    source: community/modules/remote-desktop/novnc-desktop
+    use: [network, homefs, sharedfs]
+    settings:
+      instance_image: $(vars.slurm_image)
+      machine_type: $(vars.viz_machine_type)
+      allowed_ingress_cidrs: []
+      enable_public_ips: false
+      service_account_email: $(desktop-service-account.service_account_email)
+      service_account_scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+      desktop_endpoint_dir: $(vars.desktop_endpoint_dir)
+      desktop_endpoint_name: viz
+      secret_project_id: $(vars.secret_project_id)
+      novnc_proxy_secret_id: $(vars.desktop_proxy_secret_id)
+      novnc_identity_mode: trusted_proxy
+      vnc_backend: turbovnc

--- a/community/examples/remote-desktop/local-desktop-proxy.conf
+++ b/community/examples/remote-desktop/local-desktop-proxy.conf
@@ -1,0 +1,66 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Runs on YOUR OWN machine, in front of an SSH tunnel to a desktop host, so a
+# browser can reach a desktop in "trusted_proxy" mode.
+#
+# The broker requires the identity headers on every request, including the
+# websocket upgrade, and a browser cannot set them - so browsing straight to the
+# tunnelled port returns 403 by design. This adds them.
+#
+# Deliberately local rather than a VM in the blueprint. A proxy deployed in the
+# cluster would have to assert a fixed identity, which would make anyone who can
+# reach its port that user, and it would hold the shared secret, so the secret
+# would stop being a control. Running it on your own machine behind your own SSH
+# tunnel keeps the trust boundary where it already is. For a real authenticating
+# proxy, put an OIDC or IAP-fronted one in front of the broker and use a verified
+# identity mode instead.
+#
+# Usage:
+#   1. Open the tunnel:
+#        gcloud compute ssh HOST --project PROJECT --zone ZONE \
+#          --tunnel-through-iap -- -L 6080:localhost:6080
+#   2. Fill in the three values marked CHANGEME below.
+#   3. nginx -c /full/path/to/local-desktop-proxy.conf
+#   4. Browse to http://localhost:8888/vnc.html
+
+events {}
+
+http {
+  server {
+    listen 8888;
+
+    location / {
+      proxy_pass http://127.0.0.1:6080;
+
+      # Required: noVNC connects over a websocket, which will not upgrade
+      # without these.
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade    $http_upgrade;
+      proxy_set_header Connection "upgrade";
+
+      # gcloud secrets versions access latest --secret ghpc-desktop-proxy-secret
+      proxy_set_header X-Cluster-Desktop-Secret   "CHANGEME_PROXY_SECRET";
+      # Your Google account, and your OS Login username on the desktop host
+      # ("id -un" there). The username is passed explicitly because OS Login
+      # does not always derive it from the email.
+      proxy_set_header X-Cluster-Desktop-Email    "CHANGEME_you@example.com";
+      proxy_set_header X-Cluster-Desktop-Username "CHANGEME_oslogin_username";
+
+      # A desktop session is long-lived; the default 60s would drop it.
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}

--- a/community/modules/internal/desktop-broker/README.md
+++ b/community/modules/internal/desktop-broker/README.md
@@ -1,0 +1,156 @@
+## Description
+
+Shared implementation behind the browser-desktop modules. Not intended to be
+used directly from a blueprint; use
+[novnc-runtime](../../remote-desktop/novnc-runtime/README.md) or
+[novnc-desktop](../../remote-desktop/novnc-desktop/README.md), which are the
+public interfaces onto it.
+
+It emits the startup-script runners that install an XFCE desktop, a VNC backend,
+the selected front end, and a per-user session broker. The broker establishes who
+is asking, joins that identity to a POSIX account through OS Login, and starts
+exactly one desktop session per user.
+
+### Why this is shared
+
+The two front ends differ in how a desktop is *reached*, not in how one is
+*created*. Identity, OS Login, session state, slot allocation, the user
+environment and reaping are the same either way — that was roughly 70% of each
+front end's broker before this module existed, including the JWT verification
+that decides who gets a desktop. Keeping two copies of that in step is not a
+trade worth making.
+
+### The broker package
+
+`files/desktop_broker/` is a Python package, run as
+`python3 -m desktop_broker.main --config /etc/ghpc-desktop-broker/config.json`:
+
+```text
+main.py         entry point: python3 -m desktop_broker.main --config ...
+config.py       validated configuration; every invalid combination fails at
+                startup rather than on a user's first request
+errors.py       the one error type with an HTTP status and a safe message
+identity/       resolver.py dispatches to one module per trust model, each
+                returning the same shape: trusted_proxy
+oslogin.py      Google identity -> POSIX account, re-evaluated per hand-off
+sessions/       store.py (records, locks, slots), userenv.py (privileged work
+                on a user's account), lifecycle.py (start/reuse/reap)
+backends/       registry.py chooses between tigervnc and turbovnc; gpu.py
+                detects what hardware OpenGL is actually available
+novnc.py        serving the noVNC client and relaying RFB over a websocket
+app.py          the only module that knows about every component
+```
+
+### No `__init__.py`, and no `__main__.py`
+
+Two constraints shape how this package is laid out and delivered, and both are
+easy to trip over:
+
+1. **`gcluster` embeds these modules with `go:embed`, which silently skips any
+   file whose name begins with an underscore.** An `__init__.py` would never
+   reach a deployed host - the package would arrive with its subpackages'
+   initialisers missing and fail to import. So there are none: this is a
+   [PEP 420](https://peps.python.org/pep-0420/) implicit namespace package, and
+   the entry point is `main.py`, invoked as `python3 -m desktop_broker.main`.
+   Anything that would naturally live in an `__init__.py` lives in a named
+   module instead - `backends/registry.py`, `identity/resolver.py`.
+
+2. **`modules/scripts/startup-script` keys its staged objects on
+   `basename(destination)`.** Several files sharing a basename collide on that
+   key and Terraform refuses the plan. The package is therefore written by a
+   single runner, with each file embedded base64-encoded, rather than one `data`
+   runner per file.
+
+The install runner fails loudly if the package arrives incomplete, so a future
+change that reintroduces an underscore-prefixed file produces a clear error
+rather than an import failure at service start.
+
+### Tests
+
+`files/tests/` is a pytest suite covering configuration validation, identity
+resolution, OS Login indexing and lookup order, session records and slot
+allocation, the generated `xstartup`, and backend command construction.
+
+```bash
+cd community/modules/internal/desktop-broker/files && pytest tests/
+```
+
+One of these exists because a live host found what review did not:
+`test_tigervnc_closes_its_tcp_listener` pins the `-rfbport -1` flag, whose
+absence silently exposes every display on a local TCP port.
+
+### Identity
+
+Only `trusted_proxy` is implemented: the broker checks a shared secret and then
+takes the user's identity from request headers without verifying it. That is
+only safe where an authenticating proxy is the sole route to the broker, and the
+module logs a warning at startup saying so.
+
+The identity layer is deliberately one module per trust model, so a verified
+mode is a new file plus one entry in `_RESOLVERS`.
+
+### Secrets
+
+`proxy_secret_id` is required: the broker reads secrets from Secret Manager on
+the instance, so no value enters Terraform state or the startup script staged in
+Cloud Storage. The instance service account needs
+`roles/secretmanager.secretAccessor`, and `roles/storage.objectViewer` to read
+the staged runners — attaching a custom service account replaces the default
+compute account, which would have had the storage access already.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [terraform_data.input_validation](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/resources/data) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_broker_listen_port"></a> [broker\_listen\_port](#input\_broker\_listen\_port) | Port on which the broker accepts requests from the fronting proxy. | `number` | `6080` | no |
+| <a name="input_desktop_endpoint_dir"></a> [desktop\_endpoint\_dir](#input\_desktop\_endpoint\_dir) | Optional directory where the runtime publishes DESKTOP\_* endpoint metadata. | `string` | `null` | no |
+| <a name="input_desktop_endpoint_name"></a> [desktop\_endpoint\_name](#input\_desktop\_endpoint\_name) | Endpoint metadata file name used when desktop\_endpoint\_dir is set. | `string` | `"desktop"` | no |
+| <a name="input_enable_gpu_acceleration"></a> [enable\_gpu\_acceleration](#input\_enable\_gpu\_acceleration) | Use hardware OpenGL for desktop sessions where a usable GPU is present. | `bool` | `false` | no |
+| <a name="input_identity_mode"></a> [identity\_mode](#input\_identity\_mode) | How the broker establishes which user a request belongs to. Only<br/>"trusted\_proxy" is supported: the identity is taken from request headers<br/>with no verification, so it is only safe where an authenticating proxy is<br/>the sole route to the broker. | `string` | `"trusted_proxy"` | no |
+| <a name="input_install_root"></a> [install\_root](#input\_install\_root) | Directory under which the broker and front-end assets are installed. | `string` | `"/opt/ghpc-remote-desktop"` | no |
+| <a name="input_max_user_sessions"></a> [max\_user\_sessions](#input\_max\_user\_sessions) | Maximum number of concurrent per-user desktop sessions. | `number` | `32` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured. | <pre>list(object({<br/>    server_ip             = string<br/>    remote_mount          = string<br/>    local_mount           = string<br/>    fs_type               = string<br/>    mount_options         = string<br/>    client_install_runner = map(string)<br/>    mount_runner          = map(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_novnc_version"></a> [novnc\_version](#input\_novnc\_version) | noVNC release version to install. Only used when front\_end is novnc. | `string` | `"1.7.0"` | no |
+| <a name="input_proxy_secret"></a> [proxy\_secret](#input\_proxy\_secret) | Shared secret the broker requires in the X-Cluster-Desktop-Secret header,<br/>supplied directly. Mutually exclusive with proxy\_secret\_id.<br/><br/>Use this where the caller already owns the value and has to hold the<br/>plaintext anyway - a front end that sends the header on every request, for<br/>instance, gains nothing from a round trip through Secret Manager. Otherwise<br/>prefer proxy\_secret\_id: a literal is carried in the startup script staged in<br/>Cloud Storage and appears in Terraform state. | `string` | `null` | no |
+| <a name="input_proxy_secret_id"></a> [proxy\_secret\_id](#input\_proxy\_secret\_id) | Secret Manager secret ID holding the shared secret the broker requires in<br/>the X-Cluster-Desktop-Secret header. Mutually exclusive with proxy\_secret.<br/><br/>Fetched on the instance at boot, so the value never enters Terraform state<br/>or the startup script staged in Cloud Storage. The instance service account<br/>needs roles/secretmanager.secretAccessor. | `string` | `null` | no |
+| <a name="input_proxy_secret_version"></a> [proxy\_secret\_version](#input\_proxy\_secret\_version) | Version of proxy\_secret\_id to read. | `string` | `"latest"` | no |
+| <a name="input_secret_project_id"></a> [secret\_project\_id](#input\_secret\_project\_id) | Project holding the Secret Manager secrets. Defaults to the instance's own project. | `string` | `null` | no |
+| <a name="input_session_idle_timeout_seconds"></a> [session\_idle\_timeout\_seconds](#input\_session\_idle\_timeout\_seconds) | Idle timeout after which a session is cleaned up. 0 disables cleanup. | `number` | `43200` | no |
+| <a name="input_session_resolution"></a> [session\_resolution](#input\_session\_resolution) | Desktop resolution used for each per-user session. | `string` | `"1920x1080"` | no |
+| <a name="input_slurm_auth_mode"></a> [slurm\_auth\_mode](#input\_slurm\_auth\_mode) | Slurm authentication mode on the host: none, munge, native or auto. | `string` | `"none"` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Optional additional startup script prepended before the desktop runtime setup. | `string` | `null` | no |
+| <a name="input_vnc_backend"></a> [vnc\_backend](#input\_vnc\_backend) | VNC server backend for per-user sessions: tigervnc or turbovnc. | `string` | `"tigervnc"` | no |
+| <a name="input_vnc_display_number"></a> [vnc\_display\_number](#input\_vnc\_display\_number) | First X display number reserved for per-user sessions. | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_broker_listen_port"></a> [broker\_listen\_port](#output\_broker\_listen\_port) | Port on which the broker accepts requests from the fronting proxy. |
+| <a name="output_healthcheck_path"></a> [healthcheck\_path](#output\_healthcheck\_path) | Unauthenticated broker path that responds once the broker is running. |
+| <a name="output_startup_runners"></a> [startup\_runners](#output\_startup\_runners) | Ordered startup-script runners that install the desktop runtime, the selected front end and the per-user broker. |
+| <a name="output_vnc_backend"></a> [vnc\_backend](#output\_vnc\_backend) | VNC backend used for per-user desktop sessions. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/internal/desktop-broker/files/desktop_broker/app.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/app.py
@@ -1,0 +1,144 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wiring the pieces together into an aiohttp application.
+
+Deliberately the only place that knows about every component, so the components
+themselves stay independently testable.
+"""
+
+import asyncio
+import logging
+
+from aiohttp import web
+
+from . import oslogin
+from .backends import registry as backends
+from .errors import BrokerError
+from .identity import resolver as identity
+from .novnc import NoVncFrontend
+from .sessions.lifecycle import SessionManager
+from .sessions.store import SessionStore
+from .sessions.userenv import UserEnvironment
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+
+async def run_blocking(func, *args):
+    """Run a blocking call off the event loop."""
+    to_thread = getattr(asyncio, "to_thread", None)
+    if to_thread is not None:
+        return await to_thread(func, *args)
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, lambda: func(*args))
+
+
+class Broker:
+    """Request handling: authenticate, ensure a session, hand off."""
+
+    def __init__(self, config):
+        self.config = config
+
+        config.log_dir.mkdir(parents=True, exist_ok=True)
+
+        self.vnc_backend = backends.create(
+            config.vnc_backend,
+            config.session_resolution,
+            gpu_acceleration=config.gpu_acceleration,
+        )
+        self.identity = identity.Resolver(config)
+        self.store = SessionStore(config.state_dir, config.max_user_sessions)
+        self.user_environment = UserEnvironment(
+            config.runtime_dir, self.vnc_backend
+        )
+        self.sessions = SessionManager(
+            config=config,
+            store=self.store,
+            user_environment=self.user_environment,
+            oslogin_directory=oslogin.Directory(),
+            vnc_backend=self.vnc_backend,
+            passwd_lookup=oslogin.lookup_passwd,
+        )
+        self.frontend = NoVncFrontend(config)
+
+        self._report_gpu_posture()
+
+    def _report_gpu_posture(self):
+        # Say so when requested GPU acceleration will not happen. Falling back
+        # to software rendering is the right behaviour, but it is silent, and a
+        # software desktop is easily mistaken for a slow one.
+        reason = self.vnc_backend.acceleration_diagnostic()
+        if reason:
+            LOG.warning(
+                "enable_gpu_acceleration is set but sessions will use SOFTWARE "
+                "rendering: %s",
+                reason,
+            )
+        elif self.vnc_backend.accelerated():
+            LOG.info(
+                "Hardware OpenGL enabled for desktop sessions (backend=%s).",
+                self.vnc_backend.name,
+            )
+
+    async def start(self):
+        await self.sessions.start_cleanup(run_blocking)
+
+    async def stop(self):
+        await self.sessions.stop_cleanup()
+
+    async def authenticate(self, request):
+        presented = identity.presented_from_headers(request.headers)
+        # Verification may fetch signing certificates, so keep it off the loop.
+        return await run_blocking(self.identity.resolve, presented)
+
+    async def ensure_session(self, resolved):
+        async with self.store.user_lock(resolved["email"]):
+            return await run_blocking(self.sessions.ensure_sync, resolved)
+
+    async def handle_health(self, request):
+        # Deliberately unauthenticated and free of detail: a fronting proxy
+        # needs to know the broker is up without holding the proxy secret.
+        return web.Response(text="ok\n")
+
+    async def handle(self, request):
+        try:
+            resolved = await self.authenticate(request)
+            session = await self.ensure_session(resolved)
+            return await self.frontend.handle(request, session)
+        except BrokerError as err:
+            return web.Response(status=err.status, text=f"{err.message}\n")
+        except Exception:
+            LOG.exception("Unhandled desktop broker failure")
+            return web.Response(
+                status=500,
+                text="The desktop broker encountered an unexpected error.\n",
+            )
+
+
+def build(config):
+    broker = Broker(config)
+    app = web.Application()
+    app["desktop_broker"] = broker
+    app.router.add_get("/healthz", broker.handle_health)
+    app.router.add_route("*", "/{path:.*}", broker.handle)
+
+    async def on_startup(app):
+        await app["desktop_broker"].start()
+
+    async def on_cleanup(app):
+        await app["desktop_broker"].stop()
+
+    app.on_startup.append(on_startup)
+    app.on_cleanup.append(on_cleanup)
+    return app

--- a/community/modules/internal/desktop-broker/files/desktop_broker/backends/base.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/backends/base.py
@@ -1,0 +1,150 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""What every VNC server flavour has to provide.
+
+Each display listens on a 0700 unix socket with no TCP listener and no RFB
+password. Access control is filesystem permission, enforced by the kernel on
+connect(), and the broker - which relays RFB itself - is the only
+network-reachable way in.
+"""
+
+from . import gpu
+
+
+class VNCBackend:
+    name = None
+
+    # "-rfbport" value that closes the TCP listener, or None when the backend
+    # needs no such flag.
+    #
+    # TigerVNC: "-rfbunixpath" ADDS a socket and leaves TCP bound, so only
+    # "-rfbport -1" closes it. Dropping that flag silently leaves the display
+    # reachable by any local user - it is load-bearing.
+    #
+    # TurboVNC: "-rfbunixpath" suppresses TCP on its own. Verified on a live
+    # node: even an explicit positive "-rfbport" does not bind. It also refuses
+    # to start with "-rfbport -1", so it gets no flag at all.
+    tcp_disabled_port = None
+
+    # How this flavour spells "no RFB authentication".
+    security_args = ()
+
+    def __init__(self, session_resolution, gpu_acceleration=False):
+        self.session_resolution = session_resolution
+        self.gpu_acceleration = bool(gpu_acceleration)
+
+    # -- binaries ----------------------------------------------------------
+
+    def vncserver_command(self):
+        raise NotImplementedError
+
+    def kill_command(self, display_number):
+        return [self.vncserver_command(), "-kill", f":{display_number}"]
+
+    def render_node_args(self, render_node):
+        return []
+
+    def accelerated(self):
+        """Whether hardware GL should be used.
+
+        Requires both that the module asked for it and that a device this
+        backend can actually use is present. On a host with no GPU, or with the
+        driver absent, the software path must be used instead.
+        """
+        return self.gpu_acceleration and gpu.gpu_display() is not None
+
+    def acceleration_diagnostic(self):
+        """Why requested hardware GL will not happen, or None if it will.
+
+        Reported so the broker can say so at startup: an unexplained fall back
+        to software rendering is very hard to tell apart from a slow desktop.
+        """
+        if not self.gpu_acceleration:
+            return None
+        if gpu.gpu_display() is None:
+            return (
+                "no usable GPU device was found (neither a /dev/dri render node "
+                "nor /dev/nvidia*). The image most likely has no NVIDIA driver, "
+                "or only a compute driver without graphics support - a compute "
+                "driver ships no libEGL_nvidia and cannot render."
+            )
+        return None
+
+    # -- the desktop session ----------------------------------------------
+
+    def session_command(self):
+        """Argv for the desktop session, as written into ~/.vnc/xstartup."""
+        return ["dbus-launch", "startxfce4"]
+
+    def session_environment(self):
+        """Extra environment for the desktop session (not the X server)."""
+        return {}
+
+    def environment(self):
+        """Extra environment for the vncserver invocation.
+
+        Keyed on accelerated(), not on the presence of a render node. Xvnc's
+        children inherit this, and xstartup is one of them, so forcing software
+        Mesa here would contradict the session's own hardware GL setup: on GCE
+        there is no render node even when a GPU is present and VirtualGL is
+        rendering on it.
+
+        NOTE: this does NOT prevent the Xvnc crash described in start_command.
+        LIBGL_ALWAYS_SOFTWARE only affects client-side Mesa - the applications -
+        not the X server's own driver probing; "-extension GLX" is what keeps
+        the server alive. It is set purely so session apps on a GPU-less host do
+        not attempt hardware GL.
+        """
+        if self.accelerated():
+            return {}
+        return {"LIBGL_ALWAYS_SOFTWARE": "1"}
+
+    # -- starting ----------------------------------------------------------
+
+    def transport_args(self, session):
+        return [
+            "-rfbunixpath",
+            str(session["vnc_socket"]),
+            *(
+                # See tcp_disabled_port. The vncserver wrapper injects its own
+                # "-rfbport <5900+display>", so this must come later on the
+                # command line to win.
+                ["-rfbport", str(self.tcp_disabled_port)]
+                if self.tcp_disabled_port is not None
+                else []
+            ),
+            *self.security_args,
+        ]
+
+    def start_command(self, session):
+        command = [
+            self.vncserver_command(),
+            f":{session['display_number']}",
+            "-geometry",
+            self.session_resolution,
+            *self.transport_args(session),
+        ]
+        render_node = gpu.first_render_node()
+        if render_node:
+            command.extend(self.render_node_args(render_node))
+        else:
+            # On a host that has the NVIDIA driver libraries but no device, Xvnc
+            # segfaults while initialising GLX. Verified on a GPU-less n2
+            # carrying libEGL_nvidia 550.90.12 with no /dev/dri: both backends
+            # die with "Caught signal 11" without this flag and start cleanly
+            # with it. DRI3 cannot be disabled the same way - these builds
+            # reject "-extension DRI3" and initialise it regardless.
+            command.extend(["-extension", "GLX"])
+        return command

--- a/community/modules/internal/desktop-broker/files/desktop_broker/backends/gpu.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/backends/gpu.py
@@ -1,0 +1,63 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Detecting what hardware OpenGL is actually available."""
+
+import shutil
+from pathlib import Path
+
+
+def which(binary_name, fallback):
+    return shutil.which(binary_name) or fallback
+
+
+def first_render_node():
+    try:
+        # /dev/dri holds only cardN and renderDN, so "render*" selects the
+        # render nodes exactly.
+        return next(iter(sorted(Path("/dev/dri").glob("render*"))), None)
+    except OSError:
+        return None
+
+
+def gpu_display():
+    """VGL_DISPLAY value naming a usable GPU, or None if there is none.
+
+    Prefers a DRM render node when one exists, because it names the device
+    unambiguously. GCE's NVIDIA images do not provide one - nvidia_drm is built
+    without KMS, exposes no "modeset" parameter and creates no /dev/dri - so
+    fall back to an EGL device ID, which VirtualGL also accepts and which is
+    enumerated through EGL itself with no dependency on DRM.
+    """
+    render_node = first_render_node()
+    if render_node:
+        return str(render_node)
+    # EGL access goes through /dev/nvidia*, which is world-readable, so no
+    # supplementary group membership is needed (unlike /dev/dri, which is
+    # root:render). egl0 is the first enumerated device; these images carry a
+    # single GPU.
+    if Path("/dev/nvidia0").exists() or Path("/dev/nvidiactl").exists():
+        return "egl0"
+    return None
+
+
+def virtualgl_run():
+    return shutil.which("vglrun") or "/opt/VirtualGL/bin/vglrun"
+
+
+def virtualgl_available():
+    return (
+        shutil.which("vglrun") is not None
+        or Path("/opt/VirtualGL/bin/vglrun").exists()
+    )

--- a/community/modules/internal/desktop-broker/files/desktop_broker/backends/registry.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/backends/registry.py
@@ -1,0 +1,47 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Choosing a VNC server flavour.
+
+Named rather than living in a package __init__: gcluster embeds these modules
+into its binary with go:embed, which silently skips any file whose name starts
+with an underscore. An __init__.py would never reach a deployed host, so this
+package relies on PEP 420 implicit namespace packages instead.
+"""
+
+from .base import VNCBackend
+from .tigervnc import TigerVNCBackend
+from .turbovnc import TurboVNCBackend
+
+BACKENDS = {
+    TigerVNCBackend.name: TigerVNCBackend,
+    TurboVNCBackend.name: TurboVNCBackend,
+}
+
+__all__ = ["VNCBackend", "TigerVNCBackend", "TurboVNCBackend", "create"]
+
+
+def create(name, session_resolution, gpu_acceleration=False):
+    normalized = str(name or "").strip().lower()
+    try:
+        backend_class = BACKENDS[normalized]
+    except KeyError as err:
+        raise ValueError(
+            f"Unsupported VNC backend: {name!r}. Expected one of: "
+            f"{', '.join(sorted(BACKENDS))}."
+        ) from err
+    return backend_class(
+        session_resolution=session_resolution,
+        gpu_acceleration=gpu_acceleration,
+    )

--- a/community/modules/internal/desktop-broker/files/desktop_broker/backends/tigervnc.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/backends/tigervnc.py
@@ -1,0 +1,48 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import gpu
+from .base import VNCBackend
+
+
+class TigerVNCBackend(VNCBackend):
+    name = "tigervnc"
+
+    tcp_disabled_port = -1
+    security_args = ("-UseBlacklist=0", "-SecurityTypes", "None")
+
+    def vncserver_command(self):
+        return gpu.which("vncserver", "/usr/bin/vncserver")
+
+    def render_node_args(self, render_node):
+        return ["-rendernode", str(render_node)]
+
+    # This backend's only GL offload is "-rendernode", so unlike the base class
+    # an EGL device is no use to it: acceleration requires a real DRM render
+    # node. Without this override it would report accelerated() on a host where
+    # it cannot in fact accelerate anything.
+    def accelerated(self):
+        return self.gpu_acceleration and gpu.first_render_node() is not None
+
+    def acceleration_diagnostic(self):
+        if not self.gpu_acceleration:
+            return None
+        if gpu.first_render_node() is None:
+            return (
+                "this backend offloads GL only through '-rendernode', which "
+                "needs a DRM render node, and none is present - GCE's NVIDIA "
+                "images build nvidia_drm without KMS so /dev/dri is never "
+                'created. Set vnc_backend="turbovnc" for GPU desktops.'
+            )
+        return None

--- a/community/modules/internal/desktop-broker/files/desktop_broker/backends/turbovnc.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/backends/turbovnc.py
@@ -1,0 +1,66 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import gpu
+from .base import VNCBackend
+
+
+class TurboVNCBackend(VNCBackend):
+    name = "turbovnc"
+
+    security_args = ("-securitytypes", "none")
+
+    def vncserver_command(self):
+        return gpu.which("vncserver", "/opt/TurboVNC/bin/vncserver")
+
+    def acceleration_diagnostic(self):
+        reason = super().acceleration_diagnostic()
+        if reason or not self.gpu_acceleration:
+            return reason
+        if not gpu.virtualgl_available():
+            return (
+                "a GPU is present but VirtualGL is not installed, so GL cannot "
+                "be redirected to it. Check the desktop runtime setup step: the "
+                "VirtualGL install is deliberately non-fatal, so it warns and "
+                "continues rather than failing the whole runtime."
+            )
+        return None
+
+    # TurboVNC's Xvnc takes no "-rendernode", so render_node_args stays empty
+    # and hardware GL is obtained a different way: VirtualGL interposes GLX
+    # calls from applications and executes them on the GPU.
+    def session_command(self):
+        base = super().session_command()
+        if not self.accelerated() or not gpu.virtualgl_available():
+            # Asked for acceleration but VirtualGL is not installed, or no
+            # usable device. Fall back to software rather than producing a
+            # session that will not start.
+            return base
+        # "+wm" is required when wrapping a whole desktop session rather than a
+        # single application; without it VirtualGL does not interpose the
+        # children the window manager launches.
+        return [gpu.virtualgl_run(), "+wm"] + base
+
+    def session_environment(self):
+        if not self.accelerated() or not gpu.virtualgl_available():
+            return {}
+        gpu_display = gpu.gpu_display()
+        if not gpu_display:
+            return {}
+        # VirtualGL's EGL back end. Deliberately *not* the classic GLX back end:
+        # that would need a second X server bound to the GPU plus nvidia-xconfig
+        # and vglserver_config, all of it long-lived host infrastructure. The EGL
+        # back end renders straight to the device, so the broker keeps starting
+        # one Xvnc per user ad hoc and nothing else.
+        return {"VGL_DISPLAY": gpu_display}

--- a/community/modules/internal/desktop-broker/files/desktop_broker/config.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/config.py
@@ -1,0 +1,94 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Runtime configuration, validated once at startup.
+
+Every invalid combination is rejected here rather than at the point of use, so
+a misconfigured broker fails when the service starts instead of when the first
+user tries to open a desktop.
+"""
+
+import json
+from pathlib import Path
+
+IDENTITY_MODES = frozenset({"trusted_proxy"})
+
+
+class ConfigError(ValueError):
+    """Configuration that cannot produce a working broker."""
+
+
+def _require(value, name):
+    text = str(value or "").strip()
+    if not text:
+        raise ConfigError(f"{name} is required.")
+    return text
+
+
+class Config:
+    """Validated broker configuration.
+
+    Attribute access rather than dict lookups, so a typo is an AttributeError at
+    startup instead of a silent None deep inside a request.
+    """
+
+    def __init__(self, raw):
+        self.raw = dict(raw)
+
+        self.state_dir = Path(raw["state_dir"])
+        self.log_dir = Path(raw["log_dir"])
+        self.runtime_dir = Path(raw["runtime_dir"])
+
+        self.proxy_secret = _require(raw.get("proxy_secret"), "proxy_secret")
+
+        self.identity_mode = (
+            str(raw.get("identity_mode") or "trusted_proxy").strip().lower()
+        )
+        if self.identity_mode not in IDENTITY_MODES:
+            raise ConfigError(
+                f"Unsupported identity_mode: {self.identity_mode!r}. Expected "
+                f"one of: {', '.join(sorted(IDENTITY_MODES))}."
+            )
+
+        self.listen_host = raw.get("listen_host", "0.0.0.0")
+        self.listen_port = int(raw["listen_port"])
+
+        self.base_display_number = int(raw["base_display_number"])
+        if self.base_display_number < 1:
+            raise ConfigError(
+                "base_display_number must be at least 1; display :0 is "
+                "reserved for a physical console."
+            )
+        self.max_user_sessions = int(raw["max_user_sessions"])
+        if self.max_user_sessions < 1:
+            raise ConfigError("max_user_sessions must be at least 1.")
+        self.session_idle_timeout_seconds = int(
+            raw["session_idle_timeout_seconds"]
+        )
+        self.session_resolution = raw["session_resolution"]
+
+        self.vnc_backend = (
+            str(raw.get("vnc_backend") or "tigervnc").strip().lower()
+        )
+        self.gpu_acceleration = bool(raw.get("gpu_acceleration", False))
+
+        self.novnc_dir = Path(_require(raw.get("novnc_dir"), "novnc_dir")).resolve()
+
+    def display_number(self, slot):
+        return self.base_display_number + int(slot)
+
+
+def load(config_path):
+    with open(config_path, "r", encoding="utf-8") as handle:
+        return Config(json.load(handle))

--- a/community/modules/internal/desktop-broker/files/desktop_broker/errors.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/errors.py
@@ -1,0 +1,28 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The one error type callers are expected to translate into a response."""
+
+
+class BrokerError(Exception):
+    """An error with an HTTP status and a message safe to show a user.
+
+    Messages reach the browser, so they say what to do about the problem and
+    never include tokens, secrets or internal paths.
+    """
+
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+        self.message = message

--- a/community/modules/internal/desktop-broker/files/desktop_broker/identity/common.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/identity/common.py
@@ -1,0 +1,35 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers shared by the identity modes."""
+
+
+def default_oslogin_username(email):
+    # Google's default OS Login username transform for an email identity:
+    # "user.name@example.com" -> "user_name_example_com".
+    return email.replace("@", "_").replace(".", "_")
+
+
+def identity(email="", login_uid="", username_hint=None):
+    """The single shape every mode returns.
+
+    email        stable key for the session record
+    login_uid    Google numeric subject, the authoritative OS Login join
+    username_hint POSIX name to fall back on when no subject is available
+    """
+    return {
+        "email": email,
+        "login_uid": login_uid,
+        "username_hint": username_hint,
+    }

--- a/community/modules/internal/desktop-broker/files/desktop_broker/identity/resolver.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/identity/resolver.py
@@ -1,0 +1,77 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Establishing who is asking.
+
+One module per trust model, each returning the same identity shape. Adding a
+model means adding a module and an entry in _RESOLVERS - nothing else in the
+broker changes.
+
+Named rather than living in a package __init__: gcluster embeds these modules
+with go:embed, which silently skips files whose names start with an underscore,
+so an __init__.py would never reach a deployed host.
+"""
+
+import hmac
+import logging
+
+from ..errors import BrokerError
+from . import trusted_proxy
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+_RESOLVERS = {
+    "trusted_proxy": trusted_proxy.resolve,
+}
+
+# Headers the broker reads. Named once here so the set is auditable.
+HEADERS = {
+    "secret": "X-Cluster-Desktop-Secret",
+    "email": "X-Cluster-Desktop-Email",
+    "login_uid": "X-Cluster-Desktop-Login-Uid",
+    "username": "X-Cluster-Desktop-Username",
+}
+
+
+def presented_from_headers(headers):
+    """Extract every header the resolvers may look at."""
+    return {
+        key: str(headers.get(header, "") or "").strip()
+        for key, header in HEADERS.items()
+    }
+
+
+class Resolver:
+    """Applies the configured trust model to a request's headers."""
+
+    def __init__(self, config):
+        self.config = config
+        self._resolve = _RESOLVERS[config.identity_mode]
+
+        if config.identity_mode == "trusted_proxy":
+            LOG.warning(
+                "identity_mode=trusted_proxy: desktop identity is taken from "
+                "request headers with no token verification. Only use this "
+                "where an authenticating proxy is the sole route to this "
+                "broker."
+            )
+
+    def resolve(self, presented):
+        """Verify the shared secret, then apply the configured trust model."""
+        if not hmac.compare_digest(
+            presented["secret"].encode("utf-8"),
+            self.config.proxy_secret.encode("utf-8"),
+        ):
+            raise BrokerError(403, "Missing or invalid desktop proxy secret.")
+        return self._resolve(presented, self.config)

--- a/community/modules/internal/desktop-broker/files/desktop_broker/identity/trusted_proxy.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/identity/trusted_proxy.py
@@ -1,0 +1,38 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Identity taken from request headers, unverified.
+
+Only safe where an authenticating proxy is the sole route to the broker; the
+shared proxy secret is otherwise the only control.
+"""
+
+from ..errors import BrokerError
+from .common import default_oslogin_username, identity
+
+
+def resolve(presented, config):
+    email = presented["email"].lower()
+    if not email:
+        raise BrokerError(403, "Missing desktop user identity header.")
+    # The proxy is trusted to have authenticated the user, so it is also the
+    # best source for the POSIX account name. Deriving one from the email is
+    # only correct for projects that have not customised the OS Login username
+    # format, so prefer an explicit header.
+    username_hint = presented["username"] or default_oslogin_username(email)
+    return identity(
+        email=email,
+        login_uid=presented["login_uid"],
+        username_hint=username_hint,
+    )

--- a/community/modules/internal/desktop-broker/files/desktop_broker/main.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/main.py
@@ -1,0 +1,63 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Entrypoint: python3 -m desktop_broker.main --config /path/to/config.json
+
+Not __main__.py, for the same reason there are no __init__.py files here:
+gcluster embeds these modules with go:embed, which skips underscore-prefixed
+names, so a file called __main__.py would never reach a deployed host.
+"""
+
+import argparse
+import logging
+
+from aiohttp import web
+
+from . import app as broker_app
+from . import config as broker_config
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(prog="desktop_broker.main")
+    parser.add_argument(
+        "--config",
+        required=True,
+        help="Path to the desktop broker JSON config file.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    try:
+        config = broker_config.load(args.config)
+        app = broker_app.build(config)
+    except broker_config.ConfigError as err:
+        LOG.error("Desktop broker configuration is invalid: %s", err)
+        raise SystemExit(1) from err
+
+    web.run_app(
+        app,
+        host=config.listen_host,
+        port=config.listen_port,
+        access_log=LOG,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/community/modules/internal/desktop-broker/files/desktop_broker/novnc.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/novnc.py
@@ -1,0 +1,114 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Serving noVNC and relaying RFB over a websocket.
+
+This front end is the transport: the browser talks websocket to the broker and
+the broker talks RFB to the display's 0700 socket. Nothing else can reach the
+display, so authentication happens once, before the relay starts.
+"""
+
+import asyncio
+import logging
+
+from aiohttp import WSMsgType, web
+
+from .errors import BrokerError
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+RELAY_CHUNK_BYTES = 65536
+
+
+class NoVncFrontend:
+    name = "novnc"
+    healthcheck_path = "/vnc.html?path=websockify"
+
+    def __init__(self, config):
+        self.novnc_dir = config.novnc_dir
+
+    def _resolve_static_file(self, path):
+        candidate = (self.novnc_dir / path.lstrip("/")).resolve()
+        try:
+            candidate.relative_to(self.novnc_dir)
+        except ValueError:
+            # Path traversal out of the served directory.
+            raise BrokerError(404, "Not found.")
+        if candidate.is_dir():
+            candidate = candidate / "vnc.html"
+        if not candidate.is_file():
+            raise BrokerError(404, "Not found.")
+        return candidate
+
+    async def handle(self, request, session):
+        if request.headers.get("Upgrade", "").lower() == "websocket":
+            return await self._bridge(request, session)
+        path = request.match_info.get("path", "") or "vnc.html"
+        return web.FileResponse(self._resolve_static_file(path))
+
+    async def _bridge(self, request, session):
+        socket_path = session["vnc_socket"]
+        try:
+            reader, writer = await asyncio.open_unix_connection(socket_path)
+        except OSError as err:
+            raise BrokerError(502, "The desktop session is not reachable.") from err
+
+        client_ws = web.WebSocketResponse(
+            protocols=("binary",), heartbeat=30, max_msg_size=0
+        )
+        await client_ws.prepare(request)
+
+        async def client_to_display():
+            async for message in client_ws:
+                if message.type == WSMsgType.BINARY:
+                    writer.write(message.data)
+                    await writer.drain()
+                elif message.type == WSMsgType.TEXT:
+                    writer.write(message.data.encode("utf-8"))
+                    await writer.drain()
+                else:
+                    break
+
+        async def display_to_client():
+            while True:
+                chunk = await reader.read(RELAY_CHUNK_BYTES)
+                if not chunk:
+                    break
+                await client_ws.send_bytes(chunk)
+
+        relay_tasks = [
+            asyncio.create_task(client_to_display()),
+            asyncio.create_task(display_to_client()),
+        ]
+        try:
+            # Whichever direction finishes first ends the session. The other
+            # would otherwise block forever on a read that never completes.
+            done, pending = await asyncio.wait(
+                relay_tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            for task in done:
+                relay_error = task.exception()
+                if relay_error is not None:
+                    LOG.info("Desktop relay ended: %s", relay_error)
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+            await client_ws.close()
+        return client_ws

--- a/community/modules/internal/desktop-broker/files/desktop_broker/oslogin.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/oslogin.py
@@ -1,0 +1,174 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Joining a Google identity to a POSIX account through OS Login.
+
+This is the authorisation decision: a user gets a desktop as the account OS
+Login says they are, and gets none if OS Login does not know them. It is
+re-evaluated on every hand-off rather than cached in a database, so revoking
+access in IAM revokes it here.
+"""
+
+import json
+import logging
+import pwd
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from .errors import BrokerError
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+USERS_URL = (
+    "http://metadata.google.internal/computeMetadata/v1/oslogin/users"
+)
+CACHE_SECONDS = 60
+
+
+class Directory:
+    """OS Login profiles for this instance, indexed for lookup."""
+
+    def __init__(self, users_url=USERS_URL, cache_seconds=CACHE_SECONDS):
+        self.users_url = users_url
+        self.cache_seconds = cache_seconds
+        self._cache = {"by_subject": {}, "by_username": {}, "expires_at": 0}
+
+    def _fetch(self):
+        query = urllib.parse.urlencode({"pagesize": 1024})
+        request = urllib.request.Request(
+            f"{self.users_url}?{query}",
+            headers={"Metadata-Flavor": "Google"},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as err:
+            if err.code == 403:
+                raise BrokerError(
+                    502,
+                    "Desktop OS Login metadata lookup was denied. Check the "
+                    "desktop host OS Login and metadata configuration.",
+                ) from err
+            raise BrokerError(
+                502, f"OS Login metadata lookup failed with HTTP {err.code}."
+            ) from err
+        except urllib.error.URLError as err:
+            raise BrokerError(
+                502, f"OS Login metadata lookup failed: {err.reason}"
+            ) from err
+
+    def load(self, refresh=False):
+        if (
+            not refresh
+            and time.time() < self._cache["expires_at"]
+            and (self._cache["by_subject"] or self._cache["by_username"])
+        ):
+            return self._cache
+
+        payload = self._fetch()
+        by_subject = {}
+        by_username = {}
+        for profile in payload.get("loginProfiles", []):
+            profile_name = profile.get("name")
+            if not profile_name:
+                continue
+
+            accounts = [
+                account
+                for account in profile.get("posixAccounts", [])
+                if account.get("operatingSystemType") in [None, "", "LINUX"]
+            ]
+            if not accounts:
+                continue
+
+            primary = [a for a in accounts if a.get("primary")]
+            account = dict(primary[0] if primary else accounts[0])
+            username = account.get("username")
+            if not username:
+                continue
+
+            account["profile_name"] = profile_name
+            # "name" on a login profile is the Google account's numeric
+            # subject, which is exactly the "sub" claim on a verified ID token.
+            # That makes it the only authoritative join between a Google
+            # identity and a POSIX account: login profiles carry no email or
+            # userName field of their own.
+            by_subject[str(profile_name)] = account
+            by_username[username] = account
+
+        self._cache = {
+            "by_subject": by_subject,
+            "by_username": by_username,
+            "expires_at": time.time() + self.cache_seconds,
+        }
+        return self._cache
+
+    def resolve(self, login_uid, username_hint=None):
+        """Find the POSIX account for an identity.
+
+        Tries the numeric subject first because it is authoritative, then the
+        username hint, which is only as trustworthy as the mode that supplied
+        it. Refreshes once before giving up, so a user who has just been granted
+        access does not have to wait out the cache.
+        """
+        if not login_uid and not username_hint:
+            raise BrokerError(
+                403,
+                "Missing desktop OS Login identity. Sign in with Google and "
+                "try again.",
+            )
+
+        for refresh in (False, True):
+            profiles = self.load(refresh=refresh)
+            if login_uid:
+                account = profiles["by_subject"].get(str(login_uid))
+                if account:
+                    return account
+            if username_hint:
+                account = profiles["by_username"].get(username_hint)
+                if account:
+                    return account
+
+        raise BrokerError(
+            403, "No OS Login profile was found for this Google identity."
+        )
+
+
+def lookup_passwd(username):
+    """The local passwd entry for a username, prompting nsswitch if needed."""
+    try:
+        return pwd.getpwnam(username)
+    except KeyError:
+        # getent forces the OS Login NSS module to populate its cache; a
+        # freshly granted account is often not in it yet.
+        result = subprocess.run(
+            ["getent", "passwd", username],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if result.returncode != 0:
+            raise BrokerError(
+                403,
+                "Your OS Login account is not available on this desktop host.",
+            )
+        try:
+            return pwd.getpwnam(username)
+        except KeyError as err:
+            raise BrokerError(
+                403, "Your OS Login account could not be resolved locally."
+            ) from err

--- a/community/modules/internal/desktop-broker/files/desktop_broker/sessions/lifecycle.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/sessions/lifecycle.py
@@ -1,0 +1,225 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Starting, reusing and reaping one desktop session per user."""
+
+import asyncio
+import logging
+import socket
+import time
+from pathlib import Path
+
+from ..errors import BrokerError
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+START_TIMEOUT_SECONDS = 15
+CLEANUP_INTERVAL_SECONDS = 300
+
+
+class SessionManager:
+    """Owns the lifecycle of per-user desktop sessions.
+
+    Composes the pieces rather than inheriting from them, so each can be tested
+    on its own: a store for records, a user environment for privileged work, a
+    backend for the VNC flavour, a credential issuer for RFB auth.
+    """
+
+    def __init__(
+        self,
+        config,
+        store,
+        user_environment,
+        oslogin_directory,
+        vnc_backend,
+        passwd_lookup,
+    ):
+        self.config = config
+        self.store = store
+        self.user_environment = user_environment
+        self.oslogin = oslogin_directory
+        self.vnc_backend = vnc_backend
+        self.passwd_lookup = passwd_lookup
+        self._cleanup_task = None
+
+    # -- readiness ---------------------------------------------------------
+
+    def _endpoint_ready(self, session):
+        return self._socket_ready(session.get("vnc_socket"))
+
+    def _socket_ready(self, socket_path):
+        if not socket_path:
+            return False
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connection.settimeout(0.5)
+        try:
+            connection.connect(str(socket_path))
+            return True
+        except OSError:
+            return False
+        finally:
+            connection.close()
+
+    def _wait_until_ready(self, session):
+        deadline = time.monotonic() + START_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            if self._endpoint_ready(session):
+                return True
+            time.sleep(0.25)
+        return False
+
+    def is_ready(self, session):
+        return bool(session) and self._endpoint_ready(session)
+
+    # -- start and stop ----------------------------------------------------
+
+    def _kill(self, session):
+        self.user_environment.run_as(
+            session["username"],
+            session["home_dir"],
+            self.vnc_backend.kill_command(session["display_number"]),
+            check=False,
+        )
+
+    def _start(self, session):
+        self._kill(session)
+
+        # A crashed Xvnc leaves its socket behind and the next bind fails.
+        try:
+            Path(session["vnc_socket"]).unlink()
+        except FileNotFoundError:
+            pass
+        except OSError as err:
+            raise BrokerError(
+                502,
+                f"Failed to clear stale desktop socket "
+                f"{session['vnc_socket']}: {err}",
+            ) from err
+
+        self.user_environment.run_as(
+            session["username"],
+            session["home_dir"],
+            self.vnc_backend.start_command(session),
+            check=True,
+            environment=self.vnc_backend.environment(),
+        )
+
+    def stop(self, session):
+        self._kill(session)
+        socket_path = session.get("vnc_socket")
+        if socket_path:
+            try:
+                Path(socket_path).unlink()
+            except OSError:
+                pass
+        self.store.delete(session["email"])
+
+    # -- ensure ------------------------------------------------------------
+
+    def ensure_sync(self, identity):
+        email = identity["email"]
+        session = self.store.load(email)
+        if self.is_ready(session):
+            session["last_accessed"] = int(time.time())
+            self.store.save(session)
+            return session
+
+        profile = self.oslogin.resolve(
+            identity.get("login_uid"), identity.get("username_hint")
+        )
+        passwd_entry = self.passwd_lookup(profile["username"])
+        home_dir = (
+            passwd_entry.pw_dir
+            or profile.get("homeDirectory")
+            or f"/home/{passwd_entry.pw_name}"
+        )
+        self.user_environment.ensure_home(
+            passwd_entry.pw_name,
+            home_dir,
+            passwd_entry.pw_uid,
+            passwd_entry.pw_gid,
+        )
+        user_runtime_dir = self.user_environment.ensure_runtime_dir(
+            passwd_entry.pw_uid, passwd_entry.pw_gid
+        )
+
+        # Reserve the slot and persist the record before starting anything, so
+        # two users arriving together cannot claim one display.
+        with self.store.allocation_lock:
+            existing = self.store.load(email)
+            slot = (
+                existing["slot"]
+                if existing and existing.get("slot") is not None
+                else self.store.allocate_slot(email)
+            )
+            display_number = self.config.display_number(slot)
+            session = {
+                "email": email,
+                "slot": int(slot),
+                "username": passwd_entry.pw_name,
+                "uid": passwd_entry.pw_uid,
+                "gid": passwd_entry.pw_gid,
+                "home_dir": home_dir,
+                "display_number": display_number,
+                "last_accessed": int(time.time()),
+            }
+            session["vnc_socket"] = str(user_runtime_dir / "vnc.sock")
+            self.store.save(session)
+
+        if not self._endpoint_ready(session):
+            self._start(session)
+
+        if not self._wait_until_ready(session):
+            raise BrokerError(
+                502, "The desktop session failed to start correctly."
+            )
+
+        session["last_accessed"] = int(time.time())
+        self.store.save(session)
+        return session
+
+    # -- background reaping ------------------------------------------------
+
+    async def start_cleanup(self, run_blocking):
+        self._cleanup_task = asyncio.create_task(self._cleanup_loop(run_blocking))
+
+    async def stop_cleanup(self):
+        if self._cleanup_task is not None:
+            self._cleanup_task.cancel()
+            try:
+                await self._cleanup_task
+            except asyncio.CancelledError:
+                pass
+
+    async def _cleanup_loop(self, run_blocking):
+        timeout = self.config.session_idle_timeout_seconds
+        if timeout <= 0:
+            return
+        while True:
+            await asyncio.sleep(CLEANUP_INTERVAL_SECONDS)
+            now = int(time.time())
+            # Off the event loop: listing sessions globs the state directory
+            # and reads every file in it.
+            sessions = await run_blocking(self.store.list)
+            for session in sessions:
+                if now - int(session.get("last_accessed", 0)) < timeout:
+                    continue
+                try:
+                    async with self.store.user_lock(session["email"]):
+                        await run_blocking(self.stop, session)
+                except Exception:
+                    LOG.exception(
+                        "Failed to clean up idle desktop session for %s",
+                        session.get("email"),
+                    )

--- a/community/modules/internal/desktop-broker/files/desktop_broker/sessions/store.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/sessions/store.py
@@ -1,0 +1,110 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Session records, per-user locks and display-slot allocation."""
+
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import threading
+
+from ..errors import BrokerError
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+
+class SessionStore:
+    """One JSON record per user, in a root-only directory.
+
+    Records name the user, their uid, their display number and - on a backend
+    without one-time passwords - their RFB password, so the directory is 0700
+    and each file 0600.
+    """
+
+    def __init__(self, state_dir, max_user_sessions):
+        self.state_dir = state_dir
+        self.max_user_sessions = int(max_user_sessions)
+        self._user_locks = {}
+        # Slot allocation reads every record, and the per-user lock does not
+        # serialise different users, so two arriving together would otherwise
+        # both see the same slot as free.
+        self._allocation_lock = threading.Lock()
+
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.state_dir, 0o700)
+
+    def path_for(self, email):
+        digest = hashlib.sha256(email.lower().encode("utf-8")).hexdigest()
+        return self.state_dir / f"{digest}.json"
+
+    def load(self, email):
+        path = self.path_for(email)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as err:
+            LOG.warning("Failed to read session file %s: %s", path, err)
+            return None
+
+    def save(self, session):
+        path = self.path_for(session["email"])
+        payload = json.dumps(session, sort_keys=True, indent=2)
+        temp_path = path.with_suffix(".tmp")
+        temp_path.write_text(payload, encoding="utf-8")
+        os.chmod(temp_path, 0o600)
+        temp_path.replace(path)
+
+    def delete(self, email):
+        try:
+            self.path_for(email).unlink()
+        except FileNotFoundError:
+            pass
+
+    def list(self):
+        sessions = []
+        for path in self.state_dir.glob("*.json"):
+            try:
+                sessions.append(json.loads(path.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError) as err:
+                LOG.warning("Failed to parse desktop session state %s: %s", path, err)
+        return sessions
+
+    def user_lock(self, email):
+        lock = self._user_locks.get(email)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._user_locks[email] = lock
+        return lock
+
+    @property
+    def allocation_lock(self):
+        return self._allocation_lock
+
+    def allocate_slot(self, email):
+        """Lowest free display slot, ignoring this user's own existing one."""
+        used = {
+            int(session["slot"])
+            for session in self.list()
+            if session.get("email") != email and session.get("slot") is not None
+        }
+        for slot in range(self.max_user_sessions):
+            if slot not in used:
+                return slot
+        raise BrokerError(
+            503,
+            "The desktop node has reached its configured user-session capacity.",
+        )

--- a/community/modules/internal/desktop-broker/files/desktop_broker/sessions/userenv.py
+++ b/community/modules/internal/desktop-broker/files/desktop_broker/sessions/userenv.py
@@ -1,0 +1,152 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Running things as the session's user, and preparing their environment."""
+
+import logging
+import os
+import shlex
+import subprocess
+from pathlib import Path
+
+from ..errors import BrokerError
+
+LOG = logging.getLogger("ghpc-desktop-broker")
+
+
+class UserEnvironment:
+    """Everything the broker does on behalf of, or to, a user's account."""
+
+    def __init__(self, runtime_dir, vnc_backend):
+        self.runtime_dir = runtime_dir
+        self.vnc_backend = vnc_backend
+
+        self.runtime_dir.mkdir(parents=True, exist_ok=True)
+        # Traversable, so each user can reach their own 0700 subdirectory.
+        os.chmod(self.runtime_dir, 0o755)
+
+    def run_as(
+        self,
+        username,
+        home_dir,
+        args,
+        check=True,
+        environment=None,
+        input_text=None,
+        capture_output=False,
+    ):
+        env_args = [
+            "env",
+            f"HOME={home_dir}",
+            f"USER={username}",
+            f"LOGNAME={username}",
+            "SHELL=/bin/bash",
+        ]
+        for key, value in sorted((environment or {}).items()):
+            env_args.append(f"{key}={value}")
+        command = ["runuser", "-u", username, "--", *env_args, *args]
+        return subprocess.run(
+            command,
+            check=check,
+            input=input_text,
+            capture_output=capture_output,
+            text=capture_output or input_text is not None,
+        )
+
+    def xstartup_contents(self):
+        """The ~/.vnc/xstartup this broker writes.
+
+        Sources /etc/profile before starting the desktop. On a Slurm login node
+        that is what puts sbatch, environment modules and a non-default
+        SLURM_CONF into the session - a non-login runuser invocation inherits
+        none of it. Doing it here rather than leaving it to the terminal also
+        covers GUI applications launched from the desktop menu, which is what a
+        pre- or post-processor shelling out to srun needs.
+
+        Guarded and non-fatal: a profile script that exits non-zero must not
+        stop the desktop from starting.
+        """
+        exports = "".join(
+            f"export {key}={shlex.quote(str(value))}\n"
+            for key, value in sorted(
+                self.vnc_backend.session_environment().items()
+            )
+        )
+        argv = " ".join(
+            shlex.quote(part) for part in self.vnc_backend.session_command()
+        )
+        return (
+            "#!/bin/sh\n"
+            "unset SESSION_MANAGER\n"
+            "unset DBUS_SESSION_BUS_ADDRESS\n"
+            "if [ -r /etc/profile ]; then\n"
+            "  . /etc/profile || true\n"
+            "fi\n"
+            f"{exports}"
+            f"exec {argv}\n"
+        )
+
+    def ensure_home(self, username, home_dir, uid, gid):
+        home_path = Path(home_dir)
+        try:
+            # Only the home directory is created as root, since its parent is
+            # not user-writable. Everything below it is created by the user, so
+            # a symlinked .vnc or xstartup cannot redirect a root write or
+            # chown.
+            if not home_path.exists():
+                home_path.mkdir(parents=True, exist_ok=True)
+                os.chown(home_path, uid, gid)
+                os.chmod(home_path, 0o700)
+            vnc_dir = home_path / ".vnc"
+            xstartup = vnc_dir / "xstartup"
+            self.run_as(
+                username,
+                home_dir,
+                [
+                    "sh",
+                    "-c",
+                    'mkdir -p "$1" && chmod 0700 "$1" && cat >"$2" '
+                    '&& chmod 0755 "$2"',
+                    "sh",
+                    vnc_dir.as_posix(),
+                    xstartup.as_posix(),
+                ],
+                input_text=self.xstartup_contents(),
+            )
+        except (OSError, subprocess.CalledProcessError) as err:
+            raise BrokerError(
+                502, f"Failed to prepare home directory {home_dir}: {err}"
+            ) from err
+
+    def ensure_runtime_dir(self, uid, gid):
+        """Per-user node-local scratch for sockets and password files.
+
+        Deliberately not $HOME: home directories are typically a shared NFS
+        mount here, where a unix socket is not a usable local rendezvous, and
+        where a password file would be readable as that uid from every other
+        node and would survive a reboot. On tmpfs it is node-local and gone when
+        the host restarts.
+        """
+        user_runtime_dir = self.runtime_dir / str(uid)
+        try:
+            user_runtime_dir.mkdir(parents=True, exist_ok=True)
+            os.chown(user_runtime_dir, uid, gid)
+            os.chmod(user_runtime_dir, 0o700)
+        except OSError as err:
+            raise BrokerError(
+                502,
+                f"Failed to prepare desktop runtime directory "
+                f"{user_runtime_dir}: {err}",
+            ) from err
+        return user_runtime_dir

--- a/community/modules/internal/desktop-broker/files/tests/conftest.py
+++ b/community/modules/internal/desktop-broker/files/tests/conftest.py
@@ -1,0 +1,53 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures. Puts the broker package on sys.path for the whole suite."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+FILES_DIR = Path(__file__).resolve().parent.parent
+if str(FILES_DIR) not in sys.path:
+    sys.path.insert(0, str(FILES_DIR))
+
+
+
+
+def base_config(tmp_path, **overrides):
+    """The minimum a Config needs, plus whatever a test wants to change."""
+    raw = {
+        "state_dir": str(tmp_path / "state"),
+        "log_dir": str(tmp_path / "log"),
+        "runtime_dir": str(tmp_path / "run"),
+        "novnc_dir": str(tmp_path / "novnc"),
+        "proxy_secret": "test-proxy-secret",
+        "identity_mode": "trusted_proxy",
+        "listen_port": 6080,
+        "base_display_number": 1,
+        "max_user_sessions": 32,
+        "session_idle_timeout_seconds": 43200,
+        "session_resolution": "1920x1080",
+        "vnc_backend": "tigervnc",
+    }
+    raw.update(overrides)
+    return raw
+
+
+
+
+@pytest.fixture
+def novnc_raw(tmp_path):
+    return base_config(tmp_path)

--- a/community/modules/internal/desktop-broker/files/tests/test_backends.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_backends.py
@@ -1,0 +1,104 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VNC backend command construction.
+
+The transport flags are security-relevant: a missing "-rfbport -1" leaves
+TigerVNC's TCP listener bound, which would make the display reachable by any
+local user on a shared login node instead of only through its 0700 socket.
+"""
+
+import pytest
+
+from desktop_broker.backends import registry as backends
+
+SESSION = {"display_number": 1, "vnc_socket": "/run/x/1/vnc.sock"}
+
+
+def make(name):
+    return backends.create(name, "1920x1080")
+
+
+def test_unknown_backend_rejected():
+    with pytest.raises(ValueError, match="Unsupported VNC backend"):
+        backends.create("realvnc", "1920x1080")
+
+
+@pytest.mark.parametrize("name", ["tigervnc", "turbovnc"])
+def test_display_listens_on_a_socket_with_no_password(name):
+    command = " ".join(make(name).start_command(SESSION))
+    assert "-rfbunixpath /run/x/1/vnc.sock" in command
+    # Access control is the 0700 socket directory, so there is nothing to
+    # authenticate against and no password to leak.
+    assert "-rfbauth" not in command
+
+
+def test_tigervnc_closes_its_tcp_listener():
+    # "-rfbunixpath" ADDS a socket and leaves TCP bound; only "-rfbport -1"
+    # closes it. Losing this silently exposes the display to other local users.
+    command = make("tigervnc").start_command(SESSION)
+    assert "-rfbport" in command
+    assert command[command.index("-rfbport") + 1] == "-1"
+    assert "None" in command  # -SecurityTypes None
+
+
+def test_turbovnc_needs_no_port_flag():
+    # TurboVNC suppresses TCP on its own and refuses to start with -rfbport -1.
+    assert "-rfbport" not in make("turbovnc").start_command(SESSION)
+
+
+def test_turbovnc_disables_rfb_authentication():
+    command = " ".join(make("turbovnc").start_command(SESSION))
+    assert "-securitytypes none" in command
+
+
+def test_gpu_off_means_no_acceleration_and_no_complaint():
+    backend = backends.create("turbovnc", "1920x1080", gpu_acceleration=False)
+    assert backend.accelerated() is False
+    assert backend.acceleration_diagnostic() is None
+
+
+def test_tigervnc_explains_it_cannot_use_an_egl_device(monkeypatch):
+    from desktop_broker.backends import gpu
+
+    # A GPU present as an EGL device but no DRM render node: the GCE NVIDIA
+    # image case. TurboVNC can use it through VirtualGL, TigerVNC cannot.
+    monkeypatch.setattr(gpu, "first_render_node", lambda: None)
+    monkeypatch.setattr(gpu, "gpu_display", lambda: "egl0")
+
+    tiger = backends.create("tigervnc", "1920x1080", gpu_acceleration=True)
+    assert tiger.accelerated() is False
+    assert "rendernode" in tiger.acceleration_diagnostic()
+
+    turbo = backends.create("turbovnc", "1920x1080", gpu_acceleration=True)
+    assert turbo.accelerated() is True
+
+
+def test_software_rendering_is_forced_when_not_accelerated():
+    backend = backends.create("turbovnc", "1920x1080", gpu_acceleration=False)
+    assert backend.environment() == {"LIBGL_ALWAYS_SOFTWARE": "1"}
+
+
+def test_glx_disabled_when_no_render_node(monkeypatch):
+    from desktop_broker.backends import gpu
+
+    # Without this flag Xvnc segfaults on a GPU-less host that carries NVIDIA
+    # driver libraries.
+    monkeypatch.setattr(gpu, "first_render_node", lambda: None)
+    command = make("tigervnc").start_command(SESSION)
+    assert command[-2:] == ["-extension", "GLX"]
+
+
+def test_session_command_is_the_xfce_desktop():
+    assert make("tigervnc").session_command() == ["dbus-launch", "startxfce4"]

--- a/community/modules/internal/desktop-broker/files/tests/test_config.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_config.py
@@ -1,0 +1,72 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration validation.
+
+Every case here is a misconfiguration that would otherwise surface as a broken
+desktop for a user rather than a failure to start.
+"""
+
+import pytest
+from conftest import base_config
+
+from desktop_broker.config import Config, ConfigError
+
+
+
+def test_proxy_secret_required(tmp_path):
+    with pytest.raises(ConfigError, match="proxy_secret is required"):
+        Config(base_config(tmp_path, proxy_secret=""))
+
+
+
+def test_unknown_identity_mode_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="Unsupported identity_mode"):
+        Config(base_config(tmp_path, identity_mode="password"))
+
+
+
+
+
+
+
+
+
+def test_display_zero_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="display :0 is"):
+        Config(base_config(tmp_path, base_display_number=0))
+
+
+def test_zero_sessions_rejected(tmp_path):
+    with pytest.raises(ConfigError, match="max_user_sessions"):
+        Config(base_config(tmp_path, max_user_sessions=0))
+
+
+def test_defaults(tmp_path):
+    config = Config(base_config(tmp_path))
+    assert config.identity_mode == "trusted_proxy"
+    assert config.vnc_backend == "tigervnc"
+
+
+def test_novnc_dir_required(tmp_path):
+    raw = base_config(tmp_path)
+    del raw["novnc_dir"]
+    with pytest.raises(ConfigError, match="novnc_dir is required"):
+        Config(raw)
+
+
+def test_display_number_follows_the_slot(tmp_path):
+    config = Config(base_config(tmp_path, base_display_number=1))
+    assert config.display_number(0) == 1
+    assert config.display_number(31) == 32

--- a/community/modules/internal/desktop-broker/files/tests/test_identity.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_identity.py
@@ -1,0 +1,90 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Identity resolution.
+
+Only trusted_proxy exists so far: the shared secret is checked, then the
+identity is taken from headers. What is tested is the secret comparison and
+which inputs are allowed to influence the answer.
+"""
+
+import pytest
+from conftest import base_config
+
+from desktop_broker.identity import resolver as identity
+from desktop_broker.config import Config
+from desktop_broker.errors import BrokerError
+from desktop_broker.identity import common, trusted_proxy
+
+
+def presented(**overrides):
+    values = {key: "" for key in identity.HEADERS}
+    values.update(overrides)
+    return values
+
+
+def test_headers_are_read_case_insensitively():
+    # aiohttp gives a case-insensitive mapping; a plain dict here proves we
+    # look up the documented names rather than lower-casing by accident.
+    extracted = identity.presented_from_headers(
+        {"X-Cluster-Desktop-Email": " user@example.com "}
+    )
+    assert extracted["email"] == "user@example.com"
+
+
+def test_default_oslogin_username_transform():
+    assert (
+        common.default_oslogin_username("user.name@example.com")
+        == "user_name_example_com"
+    )
+
+
+def test_wrong_secret_is_rejected_before_any_verification(tmp_path):
+    resolver = identity.Resolver(Config(base_config(tmp_path)))
+    with pytest.raises(BrokerError, match="proxy secret") as excinfo:
+        resolver.resolve(presented(secret="wrong", email="a@b.com"))
+    assert excinfo.value.status == 403
+
+
+def test_correct_secret_reaches_the_configured_mode(tmp_path):
+    resolver = identity.Resolver(Config(base_config(tmp_path)))
+    resolved = resolver.resolve(
+        presented(secret="test-proxy-secret", email="User@Example.com")
+    )
+    assert resolved["email"] == "user@example.com"
+
+
+# -- trusted_proxy --------------------------------------------------------
+
+
+def test_trusted_proxy_requires_an_email(tmp_path):
+    config = Config(base_config(tmp_path))
+    with pytest.raises(BrokerError, match="identity header"):
+        trusted_proxy.resolve(presented(), config)
+
+
+def test_trusted_proxy_prefers_an_explicit_username(tmp_path):
+    config = Config(base_config(tmp_path))
+    resolved = trusted_proxy.resolve(
+        presented(email="a.b@example.com", username="custom_name"), config
+    )
+    # Deriving from the email is only correct where the OS Login username
+    # format is untouched, so an explicit header must win.
+    assert resolved["username_hint"] == "custom_name"
+
+
+def test_trusted_proxy_derives_a_username_when_absent(tmp_path):
+    config = Config(base_config(tmp_path))
+    resolved = trusted_proxy.resolve(presented(email="a.b@example.com"), config)
+    assert resolved["username_hint"] == "a_b_example_com"

--- a/community/modules/internal/desktop-broker/files/tests/test_oslogin.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_oslogin.py
@@ -1,0 +1,144 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Joining a Google identity to a POSIX account.
+
+This is the authorisation decision, so the indexing and the lookup order are
+both load-bearing.
+"""
+
+import pytest
+
+from desktop_broker import oslogin
+from desktop_broker.errors import BrokerError
+
+PROFILES = {
+    "loginProfiles": [
+        {
+            "name": "117253417745780664166",
+            "posixAccounts": [
+                {
+                    "username": "alice_example_com",
+                    "uid": 1001,
+                    "homeDirectory": "/home/alice_example_com",
+                    "operatingSystemType": "LINUX",
+                    "primary": True,
+                },
+                {
+                    "username": "alice_secondary",
+                    "uid": 1002,
+                    "operatingSystemType": "LINUX",
+                },
+            ],
+        },
+        {
+            "name": "220000000000000000001",
+            "posixAccounts": [
+                {"username": "bob_example_com", "uid": 1003}
+            ],
+        },
+        # No POSIX accounts at all: must not appear in either index.
+        {"name": "330000000000000000002", "posixAccounts": []},
+        # Windows-only account: not usable for a Linux desktop.
+        {
+            "name": "440000000000000000003",
+            "posixAccounts": [
+                {"username": "win_user", "operatingSystemType": "WINDOWS"}
+            ],
+        },
+    ]
+}
+
+
+class FakeDirectory(oslogin.Directory):
+    def __init__(self, payload=None, **kwargs):
+        super().__init__(**kwargs)
+        self.payload = payload if payload is not None else PROFILES
+        self.fetches = 0
+
+    def _fetch(self):
+        self.fetches += 1
+        return self.payload
+
+
+def test_profiles_index_by_subject_and_username():
+    cache = FakeDirectory().load()
+    assert "117253417745780664166" in cache["by_subject"]
+    assert "alice_example_com" in cache["by_username"]
+
+
+def test_primary_account_wins():
+    account = FakeDirectory().resolve("117253417745780664166")
+    assert account["username"] == "alice_example_com"
+
+
+def test_first_account_used_when_none_is_primary():
+    account = FakeDirectory().resolve("220000000000000000001")
+    assert account["username"] == "bob_example_com"
+
+
+def test_profiles_without_posix_accounts_are_skipped():
+    cache = FakeDirectory().load()
+    assert "330000000000000000002" not in cache["by_subject"]
+
+
+def test_non_linux_accounts_are_skipped():
+    cache = FakeDirectory().load()
+    assert "win_user" not in cache["by_username"]
+
+
+def test_subject_is_preferred_over_a_username_hint():
+    # The subject is authoritative; the hint is only as trustworthy as the mode
+    # that supplied it.
+    account = FakeDirectory().resolve(
+        "117253417745780664166", username_hint="bob_example_com"
+    )
+    assert account["username"] == "alice_example_com"
+
+
+def test_username_hint_used_when_no_subject():
+    account = FakeDirectory().resolve("", username_hint="bob_example_com")
+    assert account["username"] == "bob_example_com"
+
+
+def test_no_identity_at_all_is_rejected():
+    with pytest.raises(BrokerError, match="Missing desktop OS Login identity"):
+        FakeDirectory().resolve("", None)
+
+
+def test_unknown_identity_is_rejected():
+    with pytest.raises(BrokerError, match="No OS Login profile"):
+        FakeDirectory().resolve("999", username_hint="nobody")
+
+
+def test_lookup_refreshes_once_before_giving_up():
+    """A just-granted account should not have to wait out the cache."""
+    directory = FakeDirectory()
+    with pytest.raises(BrokerError):
+        directory.resolve("999")
+    assert directory.fetches == 2
+
+
+def test_results_are_cached_between_lookups():
+    directory = FakeDirectory()
+    directory.resolve("117253417745780664166")
+    directory.resolve("117253417745780664166")
+    assert directory.fetches == 1
+
+
+def test_cache_expiry_forces_a_refetch():
+    directory = FakeDirectory(cache_seconds=-1)
+    directory.resolve("117253417745780664166")
+    directory.resolve("117253417745780664166")
+    assert directory.fetches == 2

--- a/community/modules/internal/desktop-broker/files/tests/test_sessions.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_sessions.py
@@ -1,0 +1,91 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Session records and slot allocation."""
+
+import os
+import stat
+
+import pytest
+
+from desktop_broker.errors import BrokerError
+from desktop_broker.sessions.store import SessionStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return SessionStore(tmp_path / "state", max_user_sessions=4)
+
+
+def test_state_directory_is_root_only(store):
+    mode = stat.S_IMODE(os.stat(store.state_dir).st_mode)
+    # Records name uids and, on the tcp transport, RFB passwords.
+    assert mode == 0o700
+
+
+def test_records_round_trip(store):
+    store.save({"email": "a@b.com", "slot": 0, "username": "a_b_com"})
+    assert store.load("a@b.com")["username"] == "a_b_com"
+
+
+def test_record_files_are_not_group_readable(store):
+    store.save({"email": "a@b.com", "slot": 0})
+    mode = stat.S_IMODE(os.stat(store.path_for("a@b.com")).st_mode)
+    assert mode == 0o600
+
+
+def test_email_lookup_is_case_insensitive(store):
+    store.save({"email": "User@Example.com", "slot": 0})
+    assert store.path_for("user@example.com") == store.path_for("User@Example.com")
+
+
+def test_missing_record_is_none(store):
+    assert store.load("nobody@example.com") is None
+
+
+def test_corrupt_record_does_not_raise(store):
+    path = store.path_for("a@b.com")
+    path.write_text("{not json", encoding="utf-8")
+    assert store.load("a@b.com") is None
+
+
+def test_delete_is_idempotent(store):
+    store.delete("never@existed.com")
+
+
+def test_slots_are_allocated_lowest_first(store):
+    assert store.allocate_slot("a@b.com") == 0
+    store.save({"email": "a@b.com", "slot": 0})
+    assert store.allocate_slot("c@d.com") == 1
+
+
+def test_a_user_does_not_block_their_own_slot(store):
+    store.save({"email": "a@b.com", "slot": 2})
+    # Reconnecting must not consume a second slot.
+    assert store.allocate_slot("a@b.com") == 0
+
+
+def test_gaps_are_reused(store):
+    for slot, email in enumerate(["a@b.com", "c@d.com", "e@f.com"]):
+        store.save({"email": email, "slot": slot})
+    store.delete("c@d.com")
+    assert store.allocate_slot("new@example.com") == 1
+
+
+def test_capacity_is_enforced(store):
+    for slot in range(4):
+        store.save({"email": f"u{slot}@example.com", "slot": slot})
+    with pytest.raises(BrokerError, match="user-session capacity") as excinfo:
+        store.allocate_slot("one.too.many@example.com")
+    assert excinfo.value.status == 503

--- a/community/modules/internal/desktop-broker/files/tests/test_userenv.py
+++ b/community/modules/internal/desktop-broker/files/tests/test_userenv.py
@@ -1,0 +1,109 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The user's session environment."""
+
+import os
+import stat
+
+import pytest
+
+from desktop_broker.sessions.userenv import UserEnvironment
+
+
+class _Backend:
+    def session_command(self):
+        return ["dbus-launch", "startxfce4"]
+
+    def session_environment(self):
+        return {"VGL_DISPLAY": "egl0"}
+
+
+@pytest.fixture
+def env(tmp_path):
+    return UserEnvironment(tmp_path / "run", _Backend())
+
+
+@pytest.fixture
+def xstartup(env):
+    return env.xstartup_contents()
+
+
+def test_runtime_dir_is_traversable(env):
+    # Parent of the per-user 0700 directories, so it must stay traversable.
+    assert stat.S_IMODE(os.stat(env.runtime_dir).st_mode) == 0o755
+
+
+def test_per_user_runtime_dir_is_private(env, tmp_path):
+    created = env.ensure_runtime_dir(os.getuid(), os.getgid())
+    assert stat.S_IMODE(os.stat(created).st_mode) == 0o700
+    assert created.parent == env.runtime_dir
+
+
+def test_xstartup_sources_the_login_profile(xstartup):
+    # Without this a login-node desktop has no sbatch and no environment
+    # modules: runuser is a non-login invocation and inherits neither.
+    assert ". /etc/profile" in xstartup
+
+
+def test_xstartup_is_non_fatal_about_the_profile(xstartup):
+    # A profile script exiting non-zero must not stop the desktop starting.
+    assert "|| true" in xstartup
+    assert "[ -r /etc/profile ]" in xstartup
+
+
+def test_xstartup_exports_backend_environment(xstartup):
+    assert "export VGL_DISPLAY=egl0" in xstartup
+
+
+def test_xstartup_execs_the_session_last(xstartup):
+    assert xstartup.rstrip().endswith("exec dbus-launch startxfce4")
+
+
+def test_xstartup_clears_inherited_session_bus(xstartup):
+    assert "unset DBUS_SESSION_BUS_ADDRESS" in xstartup
+    assert "unset SESSION_MANAGER" in xstartup
+
+
+def test_xstartup_quotes_session_arguments(tmp_path):
+    class Awkward(_Backend):
+        def session_command(self):
+            return ["run", "a b; rm -rf /"]
+
+        def session_environment(self):
+            return {"K": "v; rm -rf /"}
+
+    contents = UserEnvironment(tmp_path / "run2", Awkward()).xstartup_contents()
+    # Neither the argv nor the environment may break out of its shell word.
+    assert "'a b; rm -rf /'" in contents
+    assert "export K='v; rm -rf /'" in contents
+
+
+def test_run_as_builds_a_runuser_invocation(env, monkeypatch):
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr("desktop_broker.sessions.userenv.subprocess.run", fake_run)
+    env.run_as("alice", "/home/alice", ["id"], environment={"X": "1"})
+
+    command = captured["command"]
+    assert command[:4] == ["runuser", "-u", "alice", "--"]
+    assert "HOME=/home/alice" in command
+    assert "USER=alice" in command
+    assert "X=1" in command
+    assert command[-1] == "id"

--- a/community/modules/internal/desktop-broker/main.tf
+++ b/community/modules/internal/desktop-broker/main.tf
@@ -1,0 +1,338 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  install_root    = trimsuffix(var.install_root, "/")
+  slurm_auth_mode = lower(trimspace(var.slurm_auth_mode))
+  vnc_backend     = lower(trimspace(var.vnc_backend))
+  identity_mode   = lower(trimspace(var.identity_mode))
+
+
+  broker_dir          = "/etc/ghpc-desktop-broker"
+  broker_config_path  = "${local.broker_dir}/config.json"
+  broker_app_dir      = "${local.install_root}/desktop-broker"
+  broker_package_dir  = "${local.broker_app_dir}/desktop_broker"
+  broker_state_dir    = "/var/lib/ghpc-remote-desktop"
+  broker_log_dir      = "/var/log/ghpc-remote-desktop"
+  broker_runtime_dir  = "/run/ghpc-remote-desktop"
+  broker_service_path = "/etc/systemd/system/ghpc-desktop-broker.service"
+  broker_venv_dir     = "${local.install_root}/desktop-broker-venv"
+  broker_python_path  = "${local.broker_venv_dir}/bin/python3"
+  broker_pip_path     = "${local.broker_venv_dir}/bin/pip"
+
+  novnc_dir = "${local.install_root}/novnc"
+
+
+  mount_retry_attempts = 30
+  mount_retry_seconds  = 10
+
+  read_secret_sh = templatefile("${path.module}/templates/read-secret.sh.tftpl", {
+    secret_project_id = var.secret_project_id == null ? "" : var.secret_project_id
+  })
+
+  # Nothing else on the host has to be up before the broker.
+  requires_units = ""
+}
+
+# ---------------------------------------------------------------- XFCE + VNC
+locals {
+  backend_installers = {
+    tigervnc = {
+      dnf = file("${path.module}/templates/installers/tigervnc-dnf.sh")
+      apt = file("${path.module}/templates/installers/tigervnc-apt.sh")
+    }
+    turbovnc = {
+      dnf = file("${path.module}/templates/installers/turbovnc-dnf.sh")
+      apt = file("${path.module}/templates/installers/turbovnc-apt.sh")
+    }
+  }
+
+  # Only TurboVNC needs VirtualGL: TigerVNC's Xvnc offloads GL itself given
+  # "-rendernode", so installing VirtualGL alongside it would be dead weight.
+  install_virtualgl = var.enable_gpu_acceleration && local.vnc_backend == "turbovnc"
+
+  virtualgl_dnf = local.install_virtualgl ? file("${path.module}/templates/installers/virtualgl-dnf.sh") : ""
+  virtualgl_apt = local.install_virtualgl ? file("${path.module}/templates/installers/virtualgl-apt.sh") : ""
+
+  desktop_runtime_runners = [
+    {
+      type        = "shell"
+      destination = "desktop-runtime-setup.sh"
+      content = templatefile("${path.module}/templates/desktop-runtime-setup.sh.tftpl", {
+        vnc_backend        = local.vnc_backend
+        dnf_install_script = join("\n", compact([local.backend_installers[local.vnc_backend].dnf, local.virtualgl_dnf]))
+        apt_install_script = join("\n", compact([local.backend_installers[local.vnc_backend].apt, local.virtualgl_apt]))
+      })
+    }
+  ]
+}
+
+# ------------------------------------------------------- storage and Slurm
+locals {
+  user_startup_script_runners = var.startup_script == null ? [] : [
+    {
+      type        = "shell"
+      content     = var.startup_script
+      destination = "user_startup_script.sh"
+    }
+  ]
+
+  network_storage_client_install_runners = [
+    for index, ns in var.network_storage : merge(ns.client_install_runner, {
+      destination = "${index}-${ns.client_install_runner.destination}"
+    }) if ns.client_install_runner != null
+  ]
+
+  network_storage_mount_runners = [
+    for index, ns in var.network_storage : {
+      type        = "shell"
+      destination = "${index}-${ns.mount_runner.destination}"
+      content = templatefile("${path.module}/templates/retry-mount-runner.sh.tftpl", {
+        runner_content_b64 = base64encode(
+          can(ns.mount_runner.content) ? ns.mount_runner.content : file(ns.mount_runner.source)
+        )
+        runner_args     = lookup(ns.mount_runner, "args", "")
+        retry_attempts  = local.mount_retry_attempts
+        retry_seconds   = local.mount_retry_seconds
+        continue_on_err = contains([for option in split(",", ns.mount_options) : trimspace(option)], "nofail")
+      })
+    } if ns.mount_runner != null
+  ]
+
+  slurm_auth_runners = contains(["native", "auto"], local.slurm_auth_mode) ? [
+    {
+      type        = "shell"
+      destination = "slurm-auth-mode.sh"
+      content     = <<-EOT
+        #!/bin/bash
+        set -euo pipefail
+
+        slurm_auth_mode=${jsonencode(local.slurm_auth_mode)}
+
+        detect_auth_type() {
+          local config_path
+          for config_path in /usr/local/etc/slurm.conf /etc/slurm/slurm.conf; do
+            if [[ -f "$config_path" ]]; then
+              awk -F= '
+                BEGIN { IGNORECASE = 1 }
+                $1 ~ /^[[:space:]]*AuthType[[:space:]]*$/ {
+                  gsub(/[[:space:]]/, "", $2)
+                  print tolower($2)
+                  exit
+                }
+              ' "$config_path"
+              return 0
+            fi
+          done
+          return 1
+        }
+
+        auth_type=""
+        case "$slurm_auth_mode" in
+          native)
+            auth_type="auth/slurm"
+            ;;
+          auto)
+            auth_type="$(detect_auth_type || true)"
+            ;;
+          *)
+            exit 0
+            ;;
+        esac
+
+        if [[ "$auth_type" != "auth/slurm" ]]; then
+          exit 0
+        fi
+
+        if systemctl list-unit-files munge.service >/dev/null 2>&1; then
+          systemctl disable --now munge.service || true
+          systemctl reset-failed munge.service || true
+        fi
+      EOT
+    },
+  ] : []
+}
+
+# ------------------------------------------------------------ the front end
+locals {
+  novnc_runners = [
+    {
+      type        = "shell"
+      destination = "novnc-install.sh"
+      content = templatefile("${path.module}/templates/novnc-install.sh.tftpl", {
+        install_root  = local.install_root
+        novnc_dir     = local.novnc_dir
+        novnc_version = var.novnc_version
+      })
+    }
+  ]
+
+}
+
+# ------------------------------------------------------------- the broker
+locals {
+  broker_package_files = fileset("${path.module}/files/desktop_broker", "**/*.py")
+
+  # Written by a single runner rather than one "data" runner per file.
+  # modules/scripts/startup-script keys its staged objects on
+  # basename(destination), and a Python package has an __init__.py in every
+  # subpackage, so per-file runners make that key collide and Terraform rejects
+  # the plan. Embedding the files base64-encoded in one script sidesteps the
+  # key entirely and needs no extra provider.
+  broker_package_runners = [
+    {
+      type        = "shell"
+      destination = "broker-package.sh"
+      content = templatefile("${path.module}/templates/broker-package.sh.tftpl", {
+        package_dir = local.broker_package_dir
+        files = {
+          for relative_path in local.broker_package_files :
+          relative_path => base64encode(file("${path.module}/files/desktop_broker/${relative_path}"))
+        }
+      })
+    }
+  ]
+
+  # One flat map rather than a conditional merge: Terraform cannot unify two
+  # ternary branches with different attributes, and the broker ignores keys that
+  # do not apply to its front end.
+  broker_config = {
+    base_display_number          = var.vnc_display_number
+    gpu_acceleration             = var.enable_gpu_acceleration
+    identity_mode                = local.identity_mode
+    listen_host                  = "0.0.0.0"
+    listen_port                  = var.broker_listen_port
+    log_dir                      = local.broker_log_dir
+    max_user_sessions            = var.max_user_sessions
+    runtime_dir                  = local.broker_runtime_dir
+    session_idle_timeout_seconds = var.session_idle_timeout_seconds
+    session_resolution           = var.session_resolution
+    state_dir                    = local.broker_state_dir
+    vnc_backend                  = local.vnc_backend
+
+    novnc_dir = local.novnc_dir
+
+    # proxy_secret and json_secret_key are deliberately absent: the install
+    # runner fetches them on the instance and merges them in before the broker
+    # starts. Putting them here would place them in Terraform state and in the
+    # startup script staged in Cloud Storage.
+  }
+
+  broker_runners = concat(
+    local.broker_package_runners,
+    [
+      {
+        type        = "data"
+        content     = jsonencode(local.broker_config)
+        destination = local.broker_config_path
+      },
+      {
+        type        = "shell"
+        destination = "broker-install.sh"
+        content = templatefile("${path.module}/templates/broker-install.sh.tftpl", {
+          install_root        = local.install_root
+          broker_dir          = local.broker_dir
+          broker_config_path  = local.broker_config_path
+          broker_app_dir      = local.broker_app_dir
+          broker_state_dir    = local.broker_state_dir
+          broker_log_dir      = local.broker_log_dir
+          broker_runtime_dir  = local.broker_runtime_dir
+          broker_service_path = local.broker_service_path
+          broker_venv_dir     = local.broker_venv_dir
+          broker_python_path  = local.broker_python_path
+          broker_pip_path     = local.broker_pip_path
+          broker_listen_port  = var.broker_listen_port
+          requires_units      = local.requires_units
+          read_secret_sh      = local.read_secret_sh
+
+          proxy_secret_id      = var.proxy_secret_id == null ? "" : var.proxy_secret_id
+          proxy_secret_version = var.proxy_secret_version
+
+          # Literals travel base64-encoded. A secret is arbitrary bytes, and
+          # embedding one in a double-quoted shell assignment would let a value
+          # containing $(...) or a backtick execute during install.
+          proxy_secret_b64 = var.proxy_secret == null ? "" : base64encode(var.proxy_secret)
+        })
+      },
+    ],
+  )
+}
+
+# ------------------------------------------------------ service discovery
+locals {
+  endpoint_publish_runners = var.desktop_endpoint_dir == null ? [] : [
+    {
+      type        = "shell"
+      destination = "publish-desktop-endpoint.sh"
+      content     = <<-EOT
+        #!/bin/bash
+        set -euo pipefail
+
+        endpoint_dir=${jsonencode(var.desktop_endpoint_dir)}
+        endpoint_name=${jsonencode(var.desktop_endpoint_name)}
+        endpoint_port=${jsonencode(var.broker_listen_port)}
+
+        install -d -m 0755 "$endpoint_dir"
+
+        instance_name=$(curl -fsS -H "Metadata-Flavor: Google" \
+          "http://metadata.google.internal/computeMetadata/v1/instance/name")
+        instance_ip=$(curl -fsS -H "Metadata-Flavor: Google" \
+          "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip")
+
+        cat > "$${endpoint_dir}/$${endpoint_name}.env" <<EOF_ENDPOINT
+        DESKTOP_NAME=$${instance_name}
+        DESKTOP_HOST=$${instance_ip}
+        DESKTOP_PORT=$${endpoint_port}
+        EOF_ENDPOINT
+      EOT
+    },
+  ]
+
+  startup_runners = concat(
+    local.network_storage_client_install_runners,
+    local.network_storage_mount_runners,
+    local.user_startup_script_runners,
+    local.slurm_auth_runners,
+    local.desktop_runtime_runners,
+    local.novnc_runners,
+    local.broker_runners,
+    local.endpoint_publish_runners,
+  )
+}
+
+resource "terraform_data" "input_validation" {
+  input = {
+    identity_mode = local.identity_mode
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (var.proxy_secret == null) != (var.proxy_secret_id == null)
+      error_message = "Set exactly one of proxy_secret or proxy_secret_id. Prefer proxy_secret_id, which keeps the value out of Terraform state and out of the startup script staged in Cloud Storage; use proxy_secret where the caller already holds the plaintext anyway."
+    }
+
+
+
+
+
+
+    precondition {
+      condition     = var.vnc_display_number >= 1
+      error_message = "vnc_display_number must be at least 1. Display :0 is reserved for a physical console."
+    }
+
+
+
+  }
+}

--- a/community/modules/internal/desktop-broker/outputs.tf
+++ b/community/modules/internal/desktop-broker/outputs.tf
@@ -1,0 +1,33 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "startup_runners" {
+  description = "Ordered startup-script runners that install the desktop runtime, the selected front end and the per-user broker."
+  value       = local.startup_runners
+}
+
+output "broker_listen_port" {
+  description = "Port on which the broker accepts requests from the fronting proxy."
+  value       = var.broker_listen_port
+}
+
+output "vnc_backend" {
+  description = "VNC backend used for per-user desktop sessions."
+  value       = local.vnc_backend
+}
+
+output "healthcheck_path" {
+  description = "Unauthenticated broker path that responds once the broker is running."
+  value       = "/healthz"
+}

--- a/community/modules/internal/desktop-broker/templates/broker-install.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/broker-install.sh.tftpl
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Installs the per-user desktop broker package and its virtualenv.
+set -euo pipefail
+
+install_root=${jsonencode(install_root)}
+broker_dir=${jsonencode(broker_dir)}
+broker_config_path=${jsonencode(broker_config_path)}
+broker_app_dir=${jsonencode(broker_app_dir)}
+broker_state_dir=${jsonencode(broker_state_dir)}
+broker_log_dir=${jsonencode(broker_log_dir)}
+broker_runtime_dir=${jsonencode(broker_runtime_dir)}
+broker_service_path=${jsonencode(broker_service_path)}
+broker_venv_dir=${jsonencode(broker_venv_dir)}
+broker_python_path=${jsonencode(broker_python_path)}
+broker_pip_path=${jsonencode(broker_pip_path)}
+requires_units=${jsonencode(requires_units)}
+
+proxy_secret_id=${jsonencode(proxy_secret_id)}
+proxy_secret_version=${jsonencode(proxy_secret_version)}
+
+# A literal arrives base64-encoded: a secret is arbitrary bytes, and expanding
+# one inside a double-quoted assignment would let a value containing $(...) or a
+# backtick execute here.
+proxy_secret_b64=${jsonencode(proxy_secret_b64)}
+
+${read_secret_sh}
+
+if command -v dnf >/dev/null 2>&1; then
+  dnf install -y curl python3 python3-pip tar
+elif command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y curl python3 python3-pip python3-venv tar
+else
+  echo "Unsupported package manager for the desktop broker" >&2
+  exit 1
+fi
+
+install -d -m 0755 "$install_root" "$broker_dir" "$broker_app_dir" "$broker_log_dir" "$broker_venv_dir"
+# Session records name each user, their uid, their display number and - on the
+# tcp transport - their RFB password.
+install -d -m 0700 "$broker_state_dir"
+# Parent of the per-user 0700 runtime directories, so it must stay traversable.
+# On tmpfs, so a socket or password file cannot outlive a reboot.
+install -d -m 0755 "$broker_runtime_dir"
+
+# The package is staged as individual files, so tighten permissions across the
+# whole tree rather than per file.
+find "$broker_app_dir" -type d -exec chmod 0755 {} +
+find "$broker_app_dir" -type f -name '*.py' -exec chmod 0644 {} +
+
+python3 -m venv "$broker_venv_dir"
+"$broker_pip_path" install --upgrade pip
+"$broker_pip_path" install 'aiohttp~=3.10'
+
+
+# ---------------------------------------------------------------- secrets
+# The staged config carries no secrets; they are fetched here and merged in
+# before the broker is ever started. Passed through the environment rather than
+# argv so they do not appear in "ps" output.
+if [ -n "$proxy_secret_b64" ]; then
+  GHPC_PROXY_SECRET="$(printf '%s' "$proxy_secret_b64" | base64 -d)"
+else
+  GHPC_PROXY_SECRET="$(read_secret "$proxy_secret_id" "$proxy_secret_version")"
+fi
+export GHPC_PROXY_SECRET
+
+
+python3 - "$broker_config_path" <<'EOF_INJECT_SECRETS'
+import json
+import os
+import sys
+
+config_path = sys.argv[1]
+with open(config_path, encoding="utf-8") as handle:
+    config = json.load(handle)
+
+config["proxy_secret"] = os.environ["GHPC_PROXY_SECRET"]
+
+temp_path = config_path + ".tmp"
+with open(temp_path, "w", encoding="utf-8") as handle:
+    json.dump(config, handle, indent=2, sort_keys=True)
+os.chmod(temp_path, 0o600)
+os.replace(temp_path, config_path)
+EOF_INJECT_SECRETS
+unset GHPC_PROXY_SECRET
+
+# Holds the desktop proxy secret.
+chmod 0600 "$broker_config_path"
+
+# ---------------------------------------------------------------- service
+cat >"$broker_service_path" <<EOF_BROKER_SERVICE
+[Unit]
+Description=GHPC per-user desktop broker
+After=network-online.target $requires_units
+Wants=network-online.target
+$([ -n "$requires_units" ] && echo "Requires=$requires_units")
+
+[Service]
+Type=simple
+Environment=PYTHONPATH=$broker_app_dir
+Environment=PYTHONDONTWRITEBYTECODE=1
+ExecStart=$broker_python_path -m desktop_broker.main --config $broker_config_path
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF_BROKER_SERVICE
+
+systemctl daemon-reload
+systemctl enable --now ghpc-desktop-broker.service
+
+# Fail the runner rather than leave a broker that is not actually serving.
+for _ in $(seq 1 30); do
+  if curl -fsS -o /dev/null "http://127.0.0.1:${jsonencode(broker_listen_port)}/healthz"; then
+    echo "Desktop broker is serving on port ${jsonencode(broker_listen_port)}"
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "Desktop broker did not become healthy" >&2
+journalctl -u ghpc-desktop-broker.service --no-pager | tail -50 >&2
+exit 1

--- a/community/modules/internal/desktop-broker/templates/broker-package.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/broker-package.sh.tftpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Writes the desktop broker Python package.
+#
+# Delivered as one runner rather than one per file because
+# modules/scripts/startup-script keys its staged objects on
+# basename(destination), so several files sharing a basename would collide on
+# that key and Terraform would refuse the plan.
+#
+# Note also that this package has no __init__.py and no __main__.py. gcluster
+# embeds these modules into its binary with go:embed, which silently skips any
+# file whose name begins with an underscore - such a file would never reach a
+# deployed host at all. The package therefore relies on PEP 420 implicit
+# namespace packages, and its entry point is main.py.
+#
+# Each file is embedded base64-encoded. The heredoc delimiter is safe by
+# construction: it contains an underscore, which is not in the base64 alphabet,
+# so it can never appear inside the payload.
+set -euo pipefail
+
+package_dir=${jsonencode(package_dir)}
+
+install -d -m 0755 "$package_dir"
+
+%{ for path, encoded in files ~}
+install -d -m 0755 "$(dirname "$package_dir/${path}")"
+base64 -d >"$package_dir/${path}" <<'EOF_GHPC_BROKER_B64'
+${encoded}
+EOF_GHPC_BROKER_B64
+chmod 0644 "$package_dir/${path}"
+%{ endfor ~}
+
+# Fail loudly here rather than leaving systemd to report an import error.
+for required in main.py app.py config.py oslogin.py; do
+  if [ ! -s "$package_dir/$required" ]; then
+    echo "Broker package is incomplete: $package_dir/$required is missing or empty" >&2
+    exit 1
+  fi
+done
+
+echo "Broker package written to $package_dir ($(find "$package_dir" -name '*.py' | wc -l | tr -d ' ') files)"

--- a/community/modules/internal/desktop-broker/templates/desktop-runtime-setup.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/desktop-runtime-setup.sh.tftpl
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+vnc_backend=${jsonencode(vnc_backend)}
+
+if command -v dnf >/dev/null 2>&1; then
+  dnf install -y curl
+  dnf install -y epel-release || true
+${indent(2, dnf_install_script)}
+elif command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+${indent(2, apt_install_script)}
+else
+  echo "Unsupported package manager for desktop runtime backend $vnc_backend" >&2
+  exit 1
+fi

--- a/community/modules/internal/desktop-broker/templates/installers/tigervnc-apt.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/tigervnc-apt.sh
@@ -1,0 +1,24 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+apt-get install -y \
+	dbus-x11 \
+	tigervnc-standalone-server \
+	tigervnc-tools \
+	xauth \
+	xfce4 \
+	xterm

--- a/community/modules/internal/desktop-broker/templates/installers/tigervnc-dnf.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/tigervnc-dnf.sh
@@ -1,0 +1,28 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+dnf install -y \
+	dbus-x11 \
+	tigervnc-server \
+	thunar \
+	xauth \
+	xorg-x11-fonts-Type1 \
+	xfce4-panel \
+	xfce4-session \
+	xfce4-settings \
+	xfdesktop \
+	xterm

--- a/community/modules/internal/desktop-broker/templates/installers/turbovnc-apt.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/turbovnc-apt.sh
@@ -1,0 +1,55 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TurboVNC is installed from its published release package, pinned and checksum
+# verified, rather than from a third-party apt repository.
+#
+# Upstream distributes through packagecloud.io, which means adding a repository
+# and a signing key. That was actively harmful here: the key has to be handled
+# without invoking gpg, because "gpg --dearmor" aborts on OFE-provisioned nodes.
+# gpg resolves the calling user through NSS at startup, and when it runs just
+# after the host's NSS configuration has been rewritten (OS Login/SSSD) it dies
+# with "Illegal status in __nss_next". That is SIGABRT, so under "set -euo
+# pipefail" the whole runtime install failed with exit 134 and the node came up
+# with no desktop at all. The failure is timing-dependent, so it could not be
+# reproduced by hand.
+#
+# A single pinned .deb removes the repository, the key, and that entire failure
+# mode, and makes the installed version explicit rather than "whatever the
+# repository serves today".
+#
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+install_turbovnc() {
+	local version=3.3.1
+	local sha256=5d99050312360a07c28aca484b944816aa32e9fe07912e3ed50e6bfda45f80ad
+	local deb="/tmp/turbovnc_${version}_amd64.deb"
+
+	curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused -o "$deb" \
+		"https://github.com/TurboVNC/turbovnc/releases/download/${version}/turbovnc_${version}_amd64.deb"
+	echo "${sha256}  ${deb}" | sha256sum -c - >/dev/null
+	# apt-get, not dpkg -i, so the package's own dependencies are resolved.
+	apt-get install -y "$deb"
+	rm -f "$deb"
+}
+
+apt-get install -y curl
+install_turbovnc
+
+apt-get install -y \
+	dbus-x11 \
+	xauth \
+	xfce4 \
+	xterm

--- a/community/modules/internal/desktop-broker/templates/installers/turbovnc-dnf.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/turbovnc-dnf.sh
@@ -1,0 +1,49 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TurboVNC is installed from its published release package, pinned and checksum
+# verified, rather than from a third-party yum repository.
+#
+# Upstream's alternative is a .repo file fetched from raw.githubusercontent.com,
+# which pins nothing and brings its own signing key. A single pinned .rpm makes
+# the installed version explicit and needs no repository or key.
+#
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+install_turbovnc() {
+	local version=3.3.1
+	local sha256=cb975ccc3570f35d7b47fb56d4e2f7d5121418e3e6a831a3f24b831251ddbc4b
+	local rpm="/tmp/turbovnc-${version}.x86_64.rpm"
+
+	curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused -o "$rpm" \
+		"https://github.com/TurboVNC/turbovnc/releases/download/${version}/turbovnc-${version}.x86_64.rpm"
+	echo "${sha256}  ${rpm}" | sha256sum -c - >/dev/null
+	dnf install -y "$rpm"
+	rm -f "$rpm"
+}
+
+dnf install -y curl
+install_turbovnc
+
+dnf install -y \
+	dbus-x11 \
+	thunar \
+	xauth \
+	xorg-x11-fonts-Type1 \
+	xfce4-panel \
+	xfce4-session \
+	xfce4-settings \
+	xfdesktop \
+	xterm

--- a/community/modules/internal/desktop-broker/templates/installers/virtualgl-apt.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/virtualgl-apt.sh
@@ -1,0 +1,53 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VirtualGL provides hardware OpenGL for backends that cannot offload it
+# themselves (TurboVNC has no "-rendernode" equivalent). Its EGL back end
+# renders against a DRM render node directly, so no second X server bound to the
+# GPU is needed.
+#
+# No NVIDIA driver is installed here: use an image that already carries one, such
+# as slurm-gcp-6-12-ubuntu-2204-lts-nvidia-570. Without a driver there is no
+# render node and the desktop falls back to software rendering.
+#
+# NOTE: this file is read with file(), not templatefile(), so shell variables use
+# a single "$" - "$${...}" would survive into the rendered script and bash would
+# expand "$$" as the pid.
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+install_virtualgl() {
+	local version=3.1.4
+	local sha256=02edc6b599571c385389af1a006f07a70c298e1d97c580a9bfd4b39d835c51e6
+	local deb="/tmp/virtualgl_${version}_amd64.deb"
+
+	apt-get install -y curl || return 1
+	curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused -o "$deb" \
+		"https://github.com/VirtualGL/virtualgl/releases/download/${version}/virtualgl_${version}_amd64.deb" || return 1
+	echo "${sha256}  ${deb}" | sha256sum -c - >/dev/null || return 1
+	# apt-get, not dpkg -i, so the package's own dependencies are resolved.
+	apt-get install -y "$deb" || return 1
+	rm -f "$deb"
+}
+
+# Deliberately non-fatal. VirtualGL is an enhancement, and the broker already
+# falls back to software rendering when vglrun is absent. Letting a failure here
+# abort the script under "set -euo pipefail" would take down the rest of the
+# runtime - the VNC server, noVNC and the broker itself - and leave no desktop at
+# all rather than a slower one.
+if install_virtualgl; then
+	echo "VirtualGL installed; hardware OpenGL available if a render node exists."
+else
+	echo "WARNING: VirtualGL install failed; desktop sessions will use software rendering." >&2
+fi

--- a/community/modules/internal/desktop-broker/templates/installers/virtualgl-dnf.sh
+++ b/community/modules/internal/desktop-broker/templates/installers/virtualgl-dnf.sh
@@ -1,0 +1,50 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# VirtualGL provides hardware OpenGL for backends that cannot offload it
+# themselves (TurboVNC has no "-rendernode" equivalent). Its EGL back end
+# renders against a DRM render node directly, so no second X server bound to the
+# GPU is needed.
+#
+# No NVIDIA driver is installed here. Note that the Rocky slurm-gcp images ship
+# NVIDIA userspace libraries without a driver or device, which is not enough for
+# hardware GL - the published family carrying a driver is
+# slurm-gcp-6-12-ubuntu-2204-lts-nvidia-570. Without a render node the desktop
+# falls back to software rendering.
+#
+# NOTE: this file is read with file(), not templatefile(), so shell variables use
+# a single "$" - "$${...}" would survive into the rendered script and bash would
+# expand "$$" as the pid.
+# Sourced into the runtime setup script rather than executed, so it has no
+# shebang of its own.
+# shellcheck shell=bash
+install_virtualgl() {
+	local version=3.1.4
+	local sha256=349b9cacb508058a071e4414294d417d9b8db45dd35d2e9296b0ee1c6743fdbd
+	local rpm="/tmp/VirtualGL-${version}.x86_64.rpm"
+
+	dnf install -y curl || return 1
+	curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused -o "$rpm" \
+		"https://github.com/VirtualGL/virtualgl/releases/download/${version}/VirtualGL-${version}.x86_64.rpm" || return 1
+	echo "${sha256}  ${rpm}" | sha256sum -c - >/dev/null || return 1
+	dnf install -y "$rpm" || return 1
+	rm -f "$rpm"
+}
+
+# Deliberately non-fatal - see the apt installer for why.
+if install_virtualgl; then
+	echo "VirtualGL installed; hardware OpenGL available if a render node exists."
+else
+	echo "WARNING: VirtualGL install failed; desktop sessions will use software rendering." >&2
+fi

--- a/community/modules/internal/desktop-broker/templates/novnc-install.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/novnc-install.sh.tftpl
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Installs the noVNC browser client, which the broker serves directly.
+set -euo pipefail
+
+install_root=${jsonencode(install_root)}
+novnc_dir=${jsonencode(novnc_dir)}
+novnc_version=${jsonencode(novnc_version)}
+
+if command -v dnf >/dev/null 2>&1; then
+  dnf install -y curl tar
+elif command -v apt-get >/dev/null 2>&1; then
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y curl tar
+fi
+
+install -d -m 0755 "$install_root"
+curl -fsSL --retry 5 --retry-delay 5 --retry-connrefused \
+  "https://github.com/novnc/noVNC/archive/refs/tags/v$novnc_version.tar.gz" \
+  | tar xz -C "$install_root"
+rm -rf "$novnc_dir"
+mv "$install_root/noVNC-$novnc_version" "$novnc_dir"
+ln -sf "$novnc_dir/vnc.html" "$novnc_dir/index.html"

--- a/community/modules/internal/desktop-broker/templates/read-secret.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/read-secret.sh.tftpl
@@ -1,0 +1,30 @@
+# Reads a Secret Manager secret using the instance's own service account.
+#
+# Fetching on the instance rather than passing values through the module keeps
+# them out of Terraform state and out of the startup script staged in Cloud
+# Storage. The instance service account needs
+# roles/secretmanager.secretAccessor on each secret.
+#
+# Uses the REST API directly rather than "gcloud secrets", which is not present
+# on every image this runtime supports.
+secret_project_id=${jsonencode(secret_project_id)}
+
+if [ -z "$secret_project_id" ]; then
+  secret_project_id="$(curl -fsS -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/project/project-id")"
+fi
+
+read_secret() {
+  local secret_id="$1"
+  local secret_version="$2"
+  local access_token
+
+  access_token="$(curl -fsS -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" |
+    python3 -c 'import json, sys; print(json.load(sys.stdin)["access_token"])')"
+
+  curl -fsS \
+    -H "Authorization: Bearer $access_token" \
+    "https://secretmanager.googleapis.com/v1/projects/$secret_project_id/secrets/$secret_id/versions/$secret_version:access" |
+    python3 -c 'import base64, json, sys; sys.stdout.write(base64.b64decode(json.load(sys.stdin)["payload"]["data"]).decode().rstrip())'
+}

--- a/community/modules/internal/desktop-broker/templates/retry-mount-runner.sh.tftpl
+++ b/community/modules/internal/desktop-broker/templates/retry-mount-runner.sh.tftpl
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+runner_path="$(mktemp /tmp/ghpc-netstorage-mount.XXXXXX.sh)"
+
+cleanup() {
+  rm -f "$runner_path"
+}
+
+trap cleanup EXIT
+
+cat <<'EOF_GHPC_RUNNER' | base64 -d > "$runner_path"
+${runner_content_b64}
+EOF_GHPC_RUNNER
+
+chmod 0755 "$runner_path"
+
+# Some hosts, such as Slurm login nodes, may have already mounted the same
+# source on the same target via another startup path before this wrapper runs.
+# In that case, the underlying mount helper can reject the duplicate /etc/fstab
+# entry because of option drift (for example `_netdev` added elsewhere, or the
+# kernel reporting `nfs4` for an `nfs` mount). Treat an already-mounted
+# matching source/target as success before invoking the wrapped helper.
+if [ -n "${runner_args}" ]; then
+  # shellcheck disable=SC2086
+  eval "set -- ${runner_args}"
+  if [ "$#" -ge 4 ]; then
+    source_spec="$2"
+    if [ "$4" != "gcsfuse" ]; then
+      source_spec="$1:$2"
+    fi
+    target_mount="$3"
+    if findmnt --source "$source_spec" --target "$target_mount" >/dev/null 2>&1; then
+      echo "Mount runner skipping $source_spec -> $target_mount; already mounted"
+      exit 0
+    fi
+  fi
+fi
+
+last_exit_code=1
+for attempt in $(seq 1 ${retry_attempts}); do
+  if "$runner_path" ${runner_args}; then
+    exit 0
+  fi
+  last_exit_code=$?
+  if [ "$attempt" -lt ${retry_attempts} ]; then
+    echo "Mount runner attempt $attempt/${retry_attempts} failed; retrying in ${retry_seconds}s"
+    sleep ${retry_seconds}
+  fi
+done
+
+%{ if continue_on_err ~}
+echo "Mount runner failed after ${retry_attempts} attempts, but continuing because nofail is set"
+exit 0
+%{ else ~}
+exit "$last_exit_code"
+%{ endif ~}

--- a/community/modules/internal/desktop-broker/variables.tf
+++ b/community/modules/internal/desktop-broker/variables.tf
@@ -1,0 +1,172 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "install_root" {
+  description = "Directory under which the broker and front-end assets are installed."
+  type        = string
+  default     = "/opt/ghpc-remote-desktop"
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured."
+  type = list(object({
+    server_ip             = string
+    remote_mount          = string
+    local_mount           = string
+    fs_type               = string
+    mount_options         = string
+    client_install_runner = map(string)
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "startup_script" {
+  description = "Optional additional startup script prepended before the desktop runtime setup."
+  type        = string
+  default     = null
+}
+
+variable "slurm_auth_mode" {
+  description = "Slurm authentication mode on the host: none, munge, native or auto."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "munge", "native", "auto"], lower(trimspace(var.slurm_auth_mode)))
+    error_message = "slurm_auth_mode must be one of: none, munge, native, auto."
+  }
+}
+
+variable "vnc_backend" {
+  description = "VNC server backend for per-user sessions: tigervnc or turbovnc."
+  type        = string
+  default     = "tigervnc"
+
+  validation {
+    condition     = contains(["tigervnc", "turbovnc"], lower(trimspace(var.vnc_backend)))
+    error_message = "vnc_backend must be one of: tigervnc, turbovnc."
+  }
+}
+
+variable "enable_gpu_acceleration" {
+  description = "Use hardware OpenGL for desktop sessions where a usable GPU is present."
+  type        = bool
+  default     = false
+}
+
+variable "session_resolution" {
+  description = "Desktop resolution used for each per-user session."
+  type        = string
+  default     = "1920x1080"
+}
+
+variable "vnc_display_number" {
+  description = "First X display number reserved for per-user sessions."
+  type        = number
+  default     = 1
+}
+
+variable "max_user_sessions" {
+  description = "Maximum number of concurrent per-user desktop sessions."
+  type        = number
+  default     = 32
+}
+
+variable "session_idle_timeout_seconds" {
+  description = "Idle timeout after which a session is cleaned up. 0 disables cleanup."
+  type        = number
+  default     = 43200
+}
+
+variable "broker_listen_port" {
+  description = "Port on which the broker accepts requests from the fronting proxy."
+  type        = number
+  default     = 6080
+}
+
+variable "identity_mode" {
+  description = <<-EOT
+    How the broker establishes which user a request belongs to. Only
+    "trusted_proxy" is supported: the identity is taken from request headers
+    with no verification, so it is only safe where an authenticating proxy is
+    the sole route to the broker.
+    EOT
+  type        = string
+  default     = "trusted_proxy"
+
+  validation {
+    condition     = contains(["trusted_proxy"], lower(trimspace(var.identity_mode)))
+    error_message = "identity_mode must be trusted_proxy."
+  }
+}
+
+variable "secret_project_id" {
+  description = "Project holding the Secret Manager secrets. Defaults to the instance's own project."
+  type        = string
+  default     = null
+}
+
+variable "proxy_secret" {
+  description = <<-EOT
+    Shared secret the broker requires in the X-Cluster-Desktop-Secret header,
+    supplied directly. Mutually exclusive with proxy_secret_id.
+
+    Use this where the caller already owns the value and has to hold the
+    plaintext anyway - a front end that sends the header on every request, for
+    instance, gains nothing from a round trip through Secret Manager. Otherwise
+    prefer proxy_secret_id: a literal is carried in the startup script staged in
+    Cloud Storage and appears in Terraform state.
+    EOT
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "proxy_secret_id" {
+  description = <<-EOT
+    Secret Manager secret ID holding the shared secret the broker requires in
+    the X-Cluster-Desktop-Secret header. Mutually exclusive with proxy_secret.
+
+    Fetched on the instance at boot, so the value never enters Terraform state
+    or the startup script staged in Cloud Storage. The instance service account
+    needs roles/secretmanager.secretAccessor.
+    EOT
+  type        = string
+  default     = null
+}
+
+variable "proxy_secret_version" {
+  description = "Version of proxy_secret_id to read."
+  type        = string
+  default     = "latest"
+}
+
+variable "novnc_version" {
+  description = "noVNC release version to install. Only used when front_end is novnc."
+  type        = string
+  default     = "1.7.0"
+}
+
+variable "desktop_endpoint_dir" {
+  description = "Optional directory where the runtime publishes DESKTOP_* endpoint metadata."
+  type        = string
+  default     = null
+}
+
+variable "desktop_endpoint_name" {
+  description = "Endpoint metadata file name used when desktop_endpoint_dir is set."
+  type        = string
+  default     = "desktop"
+}

--- a/community/modules/internal/desktop-broker/versions.tf
+++ b/community/modules/internal/desktop-broker/versions.tf
@@ -1,0 +1,18 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.12.2"
+
+}

--- a/community/modules/remote-desktop/novnc-desktop/README.md
+++ b/community/modules/remote-desktop/novnc-desktop/README.md
@@ -1,0 +1,161 @@
+## Description
+
+Creates a VM that serves per-user XFCE desktops through noVNC.
+
+This is the standalone-host wrapper for
+`community/modules/remote-desktop/novnc-runtime`. It follows the standard CTK
+composition pattern:
+
+- runtime module
+- `modules/scripts/startup-script`
+- `modules/compute/vm-instance`
+
+## Use when
+
+Use this module when the desktop should run on its own VM rather than on an
+existing host such as a Slurm login node.
+
+## Key inputs
+
+- `instance_image`
+- `machine_type`
+- `network_self_link` / `subnetwork_self_link` or `network_interfaces`
+- `network_storage`
+- `desktop_endpoint_dir`
+- `desktop_endpoint_name`
+- `novnc_proxy_secret` or `novnc_proxy_secret_id` (exactly one)
+- `novnc_identity_mode`
+- `slurm_auth_mode`
+- `vnc_backend`
+- `enable_gpu_acceleration` (hardware OpenGL; needs `turbovnc` - see [internal/desktop-broker](../../internal/desktop-broker/README.md))
+
+## Outputs
+
+- `startup_script`
+- `instance_name`
+- `internal_ip`
+- `external_ip`
+- `novnc_listen_port`
+- `novnc_proxy_secret` / `novnc_proxy_secret_id`
+- `healthcheck_path`
+- `iap_tunnel_command`
+
+## Example
+
+```yaml
+- id: desktop
+  source: community/modules/remote-desktop/novnc-desktop
+  use: [network]
+  settings:
+    enable_public_ips: false
+    vnc_backend: turbovnc
+    novnc_proxy_secret_id: ghpc-desktop-proxy-secret
+```
+
+## Access
+
+The supported production model is an authenticated reverse proxy in front of the
+broker. One of `novnc_proxy_secret` or `novnc_proxy_secret_id` is required, and the secret must be sent in
+`X-Cluster-Desktop-Secret` on every request.
+
+`novnc_identity_mode` is `trusted_proxy`, the only mode implemented: the proxy
+injects `X-Cluster-Desktop-Email` and the broker trusts it unverified. That is
+only safe where the proxy is the sole route to the broker port. See the
+[novnc-runtime README](../novnc-runtime/README.md) for what that implies.
+
+For OFE-managed access, keep `enable_public_ips` disabled and use OFE as the
+only public HTTPS entrypoint.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.83 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 3.83 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_client_startup_script"></a> [client\_startup\_script](#module\_client\_startup\_script) | ../../../../modules/scripts/startup-script | n/a |
+| <a name="module_instances"></a> [instances](#module\_instances) | ../../../../modules/compute/vm-instance | n/a |
+| <a name="module_novnc_runtime"></a> [novnc\_runtime](#module\_novnc\_runtime) | ../novnc-runtime | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_firewall.novnc_ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_add_deployment_name_before_prefix"></a> [add\_deployment\_name\_before\_prefix](#input\_add\_deployment\_name\_before\_prefix) | If true, names are prefixed with deployment\_name for uniqueness. | `bool` | `true` | no |
+| <a name="input_allowed_ingress_cidrs"></a> [allowed\_ingress\_cidrs](#input\_allowed\_ingress\_cidrs) | Private CIDR ranges allowed to reach the noVNC desktop broker listener. | `list(string)` | <pre>[<br/>  "10.0.0.0/8",<br/>  "172.16.0.0/12",<br/>  "192.168.0.0/16"<br/>]</pre> | no |
+| <a name="input_auto_delete_boot_disk"></a> [auto\_delete\_boot\_disk](#input\_auto\_delete\_boot\_disk) | Controls if boot disk should be auto-deleted when instance is deleted. | `bool` | `true` | no |
+| <a name="input_bandwidth_tier"></a> [bandwidth\_tier](#input\_bandwidth\_tier) | Bandwidth tier to use for the instance. | `string` | `"not_enabled"` | no |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Cluster Toolkit deployment name. | `string` | n/a | yes |
+| <a name="input_desktop_endpoint_dir"></a> [desktop\_endpoint\_dir](#input\_desktop\_endpoint\_dir) | Optional directory where the runtime publishes DESKTOP\_* endpoint metadata for service discovery. | `string` | `null` | no |
+| <a name="input_desktop_endpoint_name"></a> [desktop\_endpoint\_name](#input\_desktop\_endpoint\_name) | Endpoint metadata file name used when desktop\_endpoint\_dir is set. | `string` | `"desktop"` | no |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | Size of disk for instances. | `number` | `100` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | Disk type for instances. | `string` | `"pd-balanced"` | no |
+| <a name="input_enable_gpu_acceleration"></a> [enable\_gpu\_acceleration](#input\_enable\_gpu\_acceleration) | Use hardware OpenGL for desktop sessions. Requires an instance\_image with an<br/>NVIDIA driver and a GPU on the machine type. See the novnc-runtime module. | `bool` | `false` | no |
+| <a name="input_enable_oslogin"></a> [enable\_oslogin](#input\_enable\_oslogin) | Enable or Disable OS Login with ENABLE or DISABLE. | `string` | `"ENABLE"` | no |
+| <a name="input_enable_public_ips"></a> [enable\_public\_ips](#input\_enable\_public\_ips) | If true, instances receive public IPs. | `bool` | `false` | no |
+| <a name="input_guest_accelerator"></a> [guest\_accelerator](#input\_guest\_accelerator) | List of the type and count of accelerator cards attached to the instance. | <pre>list(object({<br/>    type  = string<br/>    count = number<br/>  }))</pre> | `[]` | no |
+| <a name="input_install_root"></a> [install\_root](#input\_install\_root) | Directory under which noVNC assets are installed. | `string` | `"/opt/ghpc-remote-desktop"` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances. | `number` | `1` | no |
+| <a name="input_instance_image"></a> [instance\_image](#input\_instance\_image) | Image used to build the noVNC desktop node.<br/><br/>Expected fields:<br/>name: The name of the image. Mutually exclusive with family.<br/>family: The image family to use. Mutually exclusive with name.<br/>project: The project where the image is hosted. | `map(string)` | <pre>{<br/>  "name": "debian-12-bookworm-v20250610",<br/>  "project": "debian-cloud"<br/>}</pre> | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the instances. | `map(string)` | `{}` | no |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | Machine type to use for desktop instance creation. | `string` | `"e2-standard-4"` | no |
+| <a name="input_max_user_sessions"></a> [max\_user\_sessions](#input\_max\_user\_sessions) | Maximum number of concurrent per-user desktop sessions the desktop host will support. | `number` | `32` | no |
+| <a name="input_metadata"></a> [metadata](#input\_metadata) | Metadata provided as a map. | `map(string)` | `{}` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Optional name prefix for VM resources. | `string` | `"desktop"` | no |
+| <a name="input_network_interfaces"></a> [network\_interfaces](#input\_network\_interfaces) | Explicit network interfaces. If set, network\_self\_link and subnetwork\_self\_link are ignored by the VM module. | <pre>list(object({<br/>    network            = string,<br/>    subnetwork         = string,<br/>    subnetwork_project = string,<br/>    network_ip         = string,<br/>    nic_type           = string,<br/>    stack_type         = string,<br/>    queue_count        = number,<br/>    access_config = list(object({<br/>      nat_ip                 = string,<br/>      public_ptr_domain_name = string,<br/>      network_tier           = string<br/>    })),<br/>    ipv6_access_config = list(object({<br/>      public_ptr_domain_name = string,<br/>      network_tier           = string<br/>    })),<br/>    alias_ip_range = list(object({<br/>      ip_cidr_range         = string,<br/>      subnetwork_range_name = string<br/>    }))<br/>  }))</pre> | `[]` | no |
+| <a name="input_network_self_link"></a> [network\_self\_link](#input\_network\_self\_link) | The self link of the network to attach the VM. | `string` | `"default"` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured. | <pre>list(object({<br/>    server_ip             = string<br/>    remote_mount          = string<br/>    local_mount           = string<br/>    fs_type               = string<br/>    mount_options         = string<br/>    client_install_runner = map(string)<br/>    mount_runner          = map(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_novnc_identity_mode"></a> [novnc\_identity\_mode](#input\_novnc\_identity\_mode) | How the desktop broker establishes which user a request belongs to. Only<br/>"trusted\_proxy" is supported: the identity is taken from request headers<br/>with no verification, so it is only safe where an authenticating proxy is<br/>the sole route to the broker. | `string` | `"trusted_proxy"` | no |
+| <a name="input_novnc_listen_port"></a> [novnc\_listen\_port](#input\_novnc\_listen\_port) | Port exposed by the desktop broker for browser access to noVNC. | `number` | `6080` | no |
+| <a name="input_novnc_proxy_secret"></a> [novnc\_proxy\_secret](#input\_novnc\_proxy\_secret) | Shared secret the desktop broker requires in the X-Cluster-Desktop-Secret<br/>header, supplied directly. Mutually exclusive with novnc\_proxy\_secret\_id.<br/><br/>Use this where the caller already owns the value and must hold the plaintext<br/>anyway - a front end that sends the header on every request gains nothing<br/>from a round trip through Secret Manager. Otherwise prefer the \_id form: a<br/>literal is carried in the startup script staged in Cloud Storage and appears<br/>in Terraform state. | `string` | `null` | no |
+| <a name="input_novnc_proxy_secret_id"></a> [novnc\_proxy\_secret\_id](#input\_novnc\_proxy\_secret\_id) | Secret Manager secret ID holding the shared secret the desktop broker<br/>requires in the X-Cluster-Desktop-Secret header. Fetched on the instance at<br/>boot, so the value never enters Terraform state.<br/><br/>Create it with:<br/>  openssl rand -base64 48 \| gcloud secrets create SECRET\_ID --data-file=-<br/><br/>The instance service account needs roles/secretmanager.secretAccessor.<br/>Mutually exclusive with novnc\_proxy\_secret. | `string` | `null` | no |
+| <a name="input_novnc_proxy_secret_version"></a> [novnc\_proxy\_secret\_version](#input\_novnc\_proxy\_secret\_version) | Version of novnc\_proxy\_secret\_id to read. | `string` | `"latest"` | no |
+| <a name="input_novnc_version"></a> [novnc\_version](#input\_novnc\_version) | noVNC release version to install. | `string` | `"1.7.0"` | no |
+| <a name="input_on_host_maintenance"></a> [on\_host\_maintenance](#input\_on\_host\_maintenance) | Describes maintenance behavior for the instance. | `string` | `"MIGRATE"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which Google Cloud resources will be created. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Default region for creating resources. | `string` | n/a | yes |
+| <a name="input_secret_project_id"></a> [secret\_project\_id](#input\_secret\_project\_id) | Project holding the Secret Manager secrets below. Defaults to the deployment project. | `string` | `null` | no |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Service account e-mail address to attach to the VM. | `string` | `null` | no |
+| <a name="input_service_account_scopes"></a> [service\_account\_scopes](#input\_service\_account\_scopes) | Scopes to attach to the VM service account. | `set(string)` | <pre>[<br/>  "https://www.googleapis.com/auth/cloud-platform"<br/>]</pre> | no |
+| <a name="input_session_idle_timeout_seconds"></a> [session\_idle\_timeout\_seconds](#input\_session\_idle\_timeout\_seconds) | Idle timeout after which a per-user desktop session is cleaned up. Set to 0 to disable cleanup. | `number` | `43200` | no |
+| <a name="input_session_resolution"></a> [session\_resolution](#input\_session\_resolution) | Desktop resolution used for each per-user XFCE session. | `string` | `"1920x1080"` | no |
+| <a name="input_slurm_auth_mode"></a> [slurm\_auth\_mode](#input\_slurm\_auth\_mode) | Optional Slurm authentication mode forwarded to novnc-runtime: none, munge, native, or auto. | `string` | `"none"` | no |
+| <a name="input_spot"></a> [spot](#input\_spot) | Provision VMs using discounted Spot pricing. | `bool` | `false` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Optional additional startup script prepended before the desktop runtime setup. | `string` | `null` | no |
+| <a name="input_subnetwork_self_link"></a> [subnetwork\_self\_link](#input\_subnetwork\_self\_link) | The self link of the subnetwork to attach the VM. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Network tags applied to the VM. | `list(string)` | `[]` | no |
+| <a name="input_threads_per_core"></a> [threads\_per\_core](#input\_threads\_per\_core) | Sets the number of threads per physical core. | `number` | `2` | no |
+| <a name="input_vnc_backend"></a> [vnc\_backend](#input\_vnc\_backend) | VNC server backend used for per-user desktop sessions: tigervnc or turbovnc. | `string` | `"tigervnc"` | no |
+| <a name="input_vnc_display_number"></a> [vnc\_display\_number](#input\_vnc\_display\_number) | First X display number reserved for per-user VNC sessions. | `number` | `1` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Default zone for creating resources. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_external_ip"></a> [external\_ip](#output\_external\_ip) | External IP addresses of created desktop instances, if enabled. |
+| <a name="output_healthcheck_path"></a> [healthcheck\_path](#output\_healthcheck\_path) | Relative noVNC path that should respond when the broker is healthy. |
+| <a name="output_iap_tunnel_command"></a> [iap\_tunnel\_command](#output\_iap\_tunnel\_command) | Example SSH tunnel command for low-level broker access through IAP. |
+| <a name="output_instance_name"></a> [instance\_name](#output\_instance\_name) | Name of the first instance created, if any. |
+| <a name="output_internal_ip"></a> [internal\_ip](#output\_internal\_ip) | Internal IP addresses of created desktop instances. |
+| <a name="output_novnc_listen_port"></a> [novnc\_listen\_port](#output\_novnc\_listen\_port) | Port exposed by the desktop broker for noVNC browser access. |
+| <a name="output_startup_script"></a> [startup\_script](#output\_startup\_script) | Script to load and run all desktop runtime runners. |
+| <a name="output_vnc_backend"></a> [vnc\_backend](#output\_vnc\_backend) | VNC backend used by the desktop host. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/remote-desktop/novnc-desktop/main.tf
+++ b/community/modules/remote-desktop/novnc-desktop/main.tf
@@ -1,0 +1,114 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  # This label allows for billing report tracking based on module.
+  labels = merge(var.labels, { ghpc_module = "novnc-desktop", ghpc_role = "remote-desktop" })
+}
+
+locals {
+  remote_desktop_tag = "ghpc-novnc-desktop"
+}
+
+module "novnc_runtime" {
+  source = "../novnc-runtime"
+
+  network_storage              = var.network_storage
+  enable_gpu_acceleration      = var.enable_gpu_acceleration
+  desktop_endpoint_dir         = var.desktop_endpoint_dir
+  desktop_endpoint_name        = var.desktop_endpoint_name
+  install_root                 = var.install_root
+  max_user_sessions            = var.max_user_sessions
+  novnc_identity_mode          = var.novnc_identity_mode
+  novnc_listen_port            = var.novnc_listen_port
+  secret_project_id            = var.secret_project_id
+  novnc_proxy_secret           = var.novnc_proxy_secret
+  novnc_proxy_secret_id        = var.novnc_proxy_secret_id
+  novnc_proxy_secret_version   = var.novnc_proxy_secret_version
+  novnc_version                = var.novnc_version
+  session_idle_timeout_seconds = var.session_idle_timeout_seconds
+  session_resolution           = var.session_resolution
+  slurm_auth_mode              = var.slurm_auth_mode
+  startup_script               = var.startup_script
+  vnc_backend                  = var.vnc_backend
+  vnc_display_number           = var.vnc_display_number
+}
+
+module "instances" {
+  source = "../../../../modules/compute/vm-instance"
+
+  instance_count                    = var.instance_count
+  name_prefix                       = var.name_prefix
+  add_deployment_name_before_prefix = var.add_deployment_name_before_prefix
+  provisioning_model                = var.spot ? "SPOT" : null
+
+  deployment_name = var.deployment_name
+  project_id      = var.project_id
+  region          = var.region
+  zone            = var.zone
+  labels          = local.labels
+
+  machine_type           = var.machine_type
+  service_account_email  = var.service_account_email
+  service_account_scopes = var.service_account_scopes
+  metadata               = var.metadata
+  startup_script         = module.client_startup_script.startup_script
+  enable_oslogin         = var.enable_oslogin
+
+  instance_image        = var.instance_image
+  disk_size_gb          = var.disk_size_gb
+  disk_type             = var.disk_type
+  auto_delete_boot_disk = var.auto_delete_boot_disk
+
+  disable_public_ips   = !var.enable_public_ips
+  network_self_link    = var.network_self_link
+  subnetwork_self_link = var.subnetwork_self_link
+  network_interfaces   = var.network_interfaces
+  bandwidth_tier       = var.bandwidth_tier
+  tags                 = distinct(concat(var.tags, [local.remote_desktop_tag]))
+
+  threads_per_core    = var.threads_per_core
+  guest_accelerator   = var.guest_accelerator
+  on_host_maintenance = var.on_host_maintenance
+
+  network_storage = []
+}
+
+module "client_startup_script" {
+  source = "../../../../modules/scripts/startup-script"
+
+  deployment_name = var.deployment_name
+  project_id      = var.project_id
+  region          = var.region
+  labels          = local.labels
+
+  runners = module.novnc_runtime.startup_runners
+}
+
+resource "google_compute_firewall" "novnc_ingress" {
+  count = length(var.allowed_ingress_cidrs) > 0 && length(var.network_interfaces) == 0 ? 1 : 0
+
+  project = var.project_id
+  name    = "${substr(var.deployment_name, 0, 40)}-novnc"
+  network = var.network_self_link
+
+  direction     = "INGRESS"
+  source_ranges = var.allowed_ingress_cidrs
+  target_tags   = [local.remote_desktop_tag]
+
+  allow {
+    protocol = "tcp"
+    ports    = [tostring(var.novnc_listen_port)]
+  }
+}

--- a/community/modules/remote-desktop/novnc-desktop/metadata.yaml
+++ b/community/modules/remote-desktop/novnc-desktop/metadata.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+spec:
+  requirements:
+    services:
+    - compute.googleapis.com
+    - secretmanager.googleapis.com
+    - storage.googleapis.com

--- a/community/modules/remote-desktop/novnc-desktop/metadata.yaml
+++ b/community/modules/remote-desktop/novnc-desktop/metadata.yaml
@@ -20,3 +20,53 @@ spec:
     - compute.googleapis.com
     - secretmanager.googleapis.com
     - storage.googleapis.com
+ghpc:
+  validators:
+  # Catches the more common mistake (both set) at gcluster-create time. The
+  # opposite mistake (neither set) is still caught, one step later, by this
+  # module's own Terraform precondition, which requires exactly one; there is
+  # no "at least one of" metadata validator to bring that check forward too.
+  - validator: exclusive
+    inputs:
+      vars: [novnc_proxy_secret, novnc_proxy_secret_id]
+    error_message: "At most one of 'novnc_proxy_secret' or 'novnc_proxy_secret_id' can be set. Exactly one is required; prefer 'novnc_proxy_secret_id', which keeps the value out of Terraform state."
+  - validator: allowed_enum
+    inputs:
+      vars: [vnc_backend]
+      case_sensitive: false
+      allowed:
+      - tigervnc
+      - turbovnc
+      allow_null: false
+    error_message: "Allowed values for vnc_backend are 'tigervnc' or 'turbovnc'."
+  - validator: allowed_enum
+    inputs:
+      vars: [novnc_identity_mode]
+      case_sensitive: false
+      allowed:
+      - trusted_proxy
+      allow_null: false
+    error_message: "novnc_identity_mode must be trusted_proxy. This module does not yet support any other identity mode."
+  - validator: allowed_enum
+    inputs:
+      vars: [slurm_auth_mode]
+      case_sensitive: false
+      allowed:
+      - none
+      - munge
+      - native
+      - auto
+      allow_null: false
+    error_message: "Allowed values for slurm_auth_mode are 'none', 'munge', 'native', or 'auto'."
+  - validator: allowed_enum
+    inputs:
+      vars: [on_host_maintenance]
+      allowed:
+      - MIGRATE
+      - TERMINATE
+      allow_null: false
+    error_message: "Allowed values for on_host_maintenance are 'MIGRATE' or 'TERMINATE'."
+  - validator: exclusive
+    inputs:
+      vars: [instance_image.name, instance_image.family]
+    error_message: "In 'instance_image', at most one of the \"family\" or \"name\" fields can be set."

--- a/community/modules/remote-desktop/novnc-desktop/outputs.tf
+++ b/community/modules/remote-desktop/novnc-desktop/outputs.tf
@@ -1,0 +1,61 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "startup_script" {
+  description = "Script to load and run all desktop runtime runners."
+  value       = module.client_startup_script.startup_script
+}
+
+output "instance_name" {
+  description = "Name of the first instance created, if any."
+  value       = var.instance_count > 0 ? module.instances.name[0] : null
+}
+
+output "internal_ip" {
+  description = "Internal IP addresses of created desktop instances."
+  value       = module.instances.internal_ip
+}
+
+output "external_ip" {
+  description = "External IP addresses of created desktop instances, if enabled."
+  value       = module.instances.external_ip
+}
+
+output "novnc_listen_port" {
+  description = "Port exposed by the desktop broker for noVNC browser access."
+  value       = module.novnc_runtime.novnc_listen_port
+}
+
+output "vnc_backend" {
+  description = "VNC backend used by the desktop host."
+  value       = module.novnc_runtime.vnc_backend
+}
+
+output "healthcheck_path" {
+  description = "Relative noVNC path that should respond when the broker is healthy."
+  value       = module.novnc_runtime.healthcheck_path
+}
+
+output "iap_tunnel_command" {
+  description = "Example SSH tunnel command for low-level broker access through IAP."
+  value = var.instance_count > 0 ? join(" ", [
+    "gcloud", "compute", "ssh",
+    module.instances.name[0],
+    "--project", var.project_id,
+    "--zone", var.zone,
+    "--tunnel-through-iap",
+    "--",
+    "-L", "${var.novnc_listen_port}:localhost:${var.novnc_listen_port}",
+  ]) : null
+}

--- a/community/modules/remote-desktop/novnc-desktop/variables.tf
+++ b/community/modules/remote-desktop/novnc-desktop/variables.tf
@@ -1,0 +1,377 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "Project in which Google Cloud resources will be created."
+  type        = string
+}
+
+variable "deployment_name" {
+  description = "Cluster Toolkit deployment name."
+  type        = string
+}
+
+variable "region" {
+  description = "Default region for creating resources."
+  type        = string
+}
+
+variable "zone" {
+  description = "Default zone for creating resources."
+  type        = string
+}
+
+variable "instance_count" {
+  description = "Number of instances."
+  type        = number
+  default     = 1
+}
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured."
+  type = list(object({
+    server_ip             = string
+    remote_mount          = string
+    local_mount           = string
+    fs_type               = string
+    mount_options         = string
+    client_install_runner = map(string)
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "instance_image" {
+  description = <<-EOD
+    Image used to build the noVNC desktop node.
+
+    Expected fields:
+    name: The name of the image. Mutually exclusive with family.
+    family: The image family to use. Mutually exclusive with name.
+    project: The project where the image is hosted.
+    EOD
+  type        = map(string)
+  default = {
+    project = "debian-cloud"
+    name    = "debian-12-bookworm-v20250610"
+  }
+}
+
+variable "disk_size_gb" {
+  description = "Size of disk for instances."
+  type        = number
+  default     = 100
+}
+
+variable "disk_type" {
+  description = "Disk type for instances."
+  type        = string
+  default     = "pd-balanced"
+}
+
+variable "auto_delete_boot_disk" {
+  description = "Controls if boot disk should be auto-deleted when instance is deleted."
+  type        = bool
+  default     = true
+}
+
+variable "name_prefix" {
+  description = "Optional name prefix for VM resources."
+  type        = string
+  default     = "desktop"
+}
+
+variable "add_deployment_name_before_prefix" {
+  description = "If true, names are prefixed with deployment_name for uniqueness."
+  type        = bool
+  default     = true
+}
+
+variable "enable_public_ips" {
+  description = "If true, instances receive public IPs."
+  type        = bool
+  default     = false
+}
+
+variable "machine_type" {
+  description = "Machine type to use for desktop instance creation."
+  type        = string
+  default     = "e2-standard-4"
+}
+
+variable "labels" {
+  description = "Labels to add to the instances."
+  type        = map(string)
+  default     = {}
+}
+
+variable "service_account_email" {
+  description = "Service account e-mail address to attach to the VM."
+  type        = string
+  default     = null
+}
+
+variable "service_account_scopes" {
+  description = "Scopes to attach to the VM service account."
+  type        = set(string)
+  default = [
+    "https://www.googleapis.com/auth/cloud-platform",
+  ]
+}
+
+variable "network_self_link" {
+  description = "The self link of the network to attach the VM."
+  type        = string
+  default     = "default"
+}
+
+variable "subnetwork_self_link" {
+  description = "The self link of the subnetwork to attach the VM."
+  type        = string
+  default     = null
+}
+
+variable "network_interfaces" {
+  description = "Explicit network interfaces. If set, network_self_link and subnetwork_self_link are ignored by the VM module."
+  type = list(object({
+    network            = string,
+    subnetwork         = string,
+    subnetwork_project = string,
+    network_ip         = string,
+    nic_type           = string,
+    stack_type         = string,
+    queue_count        = number,
+    access_config = list(object({
+      nat_ip                 = string,
+      public_ptr_domain_name = string,
+      network_tier           = string
+    })),
+    ipv6_access_config = list(object({
+      public_ptr_domain_name = string,
+      network_tier           = string
+    })),
+    alias_ip_range = list(object({
+      ip_cidr_range         = string,
+      subnetwork_range_name = string
+    }))
+  }))
+  default = []
+}
+
+variable "metadata" {
+  description = "Metadata provided as a map."
+  type        = map(string)
+  default     = {}
+}
+
+variable "startup_script" {
+  description = "Optional additional startup script prepended before the desktop runtime setup."
+  type        = string
+  default     = null
+}
+
+variable "slurm_auth_mode" {
+  description = "Optional Slurm authentication mode forwarded to novnc-runtime: none, munge, native, or auto."
+  type        = string
+  default     = "none"
+}
+
+variable "guest_accelerator" {
+  description = "List of the type and count of accelerator cards attached to the instance."
+  type = list(object({
+    type  = string
+    count = number
+  }))
+  default = []
+}
+
+variable "bandwidth_tier" {
+  description = "Bandwidth tier to use for the instance."
+  type        = string
+  default     = "not_enabled"
+}
+
+variable "threads_per_core" {
+  description = "Sets the number of threads per physical core."
+  type        = number
+  default     = 2
+}
+
+variable "on_host_maintenance" {
+  description = "Describes maintenance behavior for the instance."
+  type        = string
+  default     = "MIGRATE"
+}
+
+variable "tags" {
+  description = "Network tags applied to the VM."
+  type        = list(string)
+  default     = []
+}
+
+variable "spot" {
+  description = "Provision VMs using discounted Spot pricing."
+  type        = bool
+  default     = false
+}
+
+variable "enable_oslogin" {
+  description = "Enable or Disable OS Login with ENABLE or DISABLE."
+  type        = string
+  default     = "ENABLE"
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "Private CIDR ranges allowed to reach the noVNC desktop broker listener."
+  type        = list(string)
+  default = [
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+  ]
+}
+
+variable "install_root" {
+  description = "Directory under which noVNC assets are installed."
+  type        = string
+  default     = "/opt/ghpc-remote-desktop"
+}
+
+variable "vnc_backend" {
+  description = "VNC server backend used for per-user desktop sessions: tigervnc or turbovnc."
+  type        = string
+  default     = "tigervnc"
+
+  validation {
+    condition     = contains(["tigervnc", "turbovnc"], lower(trimspace(var.vnc_backend)))
+    error_message = "vnc_backend must be one of: tigervnc, turbovnc."
+  }
+}
+
+variable "session_resolution" {
+  description = "Desktop resolution used for each per-user XFCE session."
+  type        = string
+  default     = "1920x1080"
+}
+
+variable "vnc_display_number" {
+  description = "First X display number reserved for per-user VNC sessions."
+  type        = number
+  default     = 1
+}
+
+variable "novnc_listen_port" {
+  description = "Port exposed by the desktop broker for browser access to noVNC."
+  type        = number
+  default     = 6080
+}
+
+variable "novnc_version" {
+  description = "noVNC release version to install."
+  type        = string
+  default     = "1.7.0"
+}
+
+variable "secret_project_id" {
+  description = "Project holding the Secret Manager secrets below. Defaults to the deployment project."
+  type        = string
+  default     = null
+}
+
+variable "novnc_proxy_secret" {
+  description = <<-EOT
+    Shared secret the desktop broker requires in the X-Cluster-Desktop-Secret
+    header, supplied directly. Mutually exclusive with novnc_proxy_secret_id.
+
+    Use this where the caller already owns the value and must hold the plaintext
+    anyway - a front end that sends the header on every request gains nothing
+    from a round trip through Secret Manager. Otherwise prefer the _id form: a
+    literal is carried in the startup script staged in Cloud Storage and appears
+    in Terraform state.
+    EOT
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "novnc_proxy_secret_id" {
+  description = <<-EOT
+    Secret Manager secret ID holding the shared secret the desktop broker
+    requires in the X-Cluster-Desktop-Secret header. Fetched on the instance at
+    boot, so the value never enters Terraform state.
+
+    Create it with:
+      openssl rand -base64 48 | gcloud secrets create SECRET_ID --data-file=-
+
+    The instance service account needs roles/secretmanager.secretAccessor.
+    Mutually exclusive with novnc_proxy_secret.
+    EOT
+  type        = string
+  default     = null
+}
+
+variable "novnc_proxy_secret_version" {
+  description = "Version of novnc_proxy_secret_id to read."
+  type        = string
+  default     = "latest"
+}
+
+variable "novnc_identity_mode" {
+  description = <<-EOT
+    How the desktop broker establishes which user a request belongs to. Only
+    "trusted_proxy" is supported: the identity is taken from request headers
+    with no verification, so it is only safe where an authenticating proxy is
+    the sole route to the broker.
+    EOT
+  type        = string
+  default     = "trusted_proxy"
+
+  validation {
+    condition     = contains(["trusted_proxy"], lower(trimspace(var.novnc_identity_mode)))
+    error_message = "novnc_identity_mode must be trusted_proxy."
+  }
+}
+
+variable "desktop_endpoint_dir" {
+  description = "Optional directory where the runtime publishes DESKTOP_* endpoint metadata for service discovery."
+  type        = string
+  default     = null
+}
+
+variable "desktop_endpoint_name" {
+  description = "Endpoint metadata file name used when desktop_endpoint_dir is set."
+  type        = string
+  default     = "desktop"
+}
+
+variable "max_user_sessions" {
+  description = "Maximum number of concurrent per-user desktop sessions the desktop host will support."
+  type        = number
+  default     = 32
+}
+
+variable "session_idle_timeout_seconds" {
+  description = "Idle timeout after which a per-user desktop session is cleaned up. Set to 0 to disable cleanup."
+  type        = number
+  default     = 43200
+}
+
+variable "enable_gpu_acceleration" {
+  description = <<-EOT
+    Use hardware OpenGL for desktop sessions. Requires an instance_image with an
+    NVIDIA driver and a GPU on the machine type. See the novnc-runtime module.
+    EOT
+  type        = bool
+  default     = false
+}

--- a/community/modules/remote-desktop/novnc-desktop/versions.tf
+++ b/community/modules/remote-desktop/novnc-desktop/versions.tf
@@ -1,0 +1,24 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.12.2"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 3.83"
+    }
+  }
+}

--- a/community/modules/remote-desktop/novnc-runtime/README.md
+++ b/community/modules/remote-desktop/novnc-runtime/README.md
@@ -1,0 +1,160 @@
+## Description
+
+### Implementation
+
+The desktop runtime, the per-user broker and the VNC installers live in
+[internal/desktop-broker](../../internal/desktop-broker/README.md). This module
+is the public interface onto it; the broker package and its pytest suite are
+documented there.
+
+Builds the startup-script runners for a per-user XFCE + noVNC desktop runtime.
+This module does not create any VM resources.
+
+Use it to layer the desktop runtime onto an existing host, such as a Slurm
+login node.
+
+## Includes
+
+- `community/modules/internal/desktop-broker`
+- noVNC
+- the per-user desktop broker service
+- optional endpoint metadata publishing
+- optional Slurm auth cleanup for Native Auth hosts
+
+## Session transport
+
+Each user's Xvnc listens on a unix socket at
+`/run/ghpc-remote-desktop/<uid>/vnc.sock`, in a directory owned by that user
+with mode `0700`, and its TCP listener is disabled outright. The broker runs as
+root, authenticates the request, and then relays the browser's websocket
+straight to that socket.
+
+There is no loopback TCP port for a display, which matters on a shared login
+node: a TCP port on `127.0.0.1` is reachable by every local user, whereas the
+socket is gated by the kernel on `connect()`.
+
+A consequence worth knowing: an off-host VNC client running on another VM
+cannot reach these displays at all. A client on the desktop host itself can,
+since it can open the socket. Supporting a genuinely off-host consumer would
+mean an authenticated TCP mode, which means extending the backend classes in
+`files/desktop_broker/backends/`.
+
+## Key inputs
+
+- `startup_script`
+  - optional script run before the desktop runtime setup
+- `network_storage`
+  - storage mounts required before the desktop starts
+- `slurm_auth_mode`
+  - `none`, `munge`, `native`, or `auto`
+- `vnc_backend`
+  - `tigervnc` or `turbovnc`
+- `enable_gpu_acceleration`
+  - hardware OpenGL via VirtualGL; requires `vnc_backend = "turbovnc"` and an
+    image with a graphics-capable NVIDIA driver. Falls back to software
+    otherwise. See `internal/desktop-broker`.
+- `desktop_endpoint_dir`
+  - optional directory for `<desktop_endpoint_name>.env`
+- `desktop_endpoint_name`
+  - logical endpoint name
+- `novnc_proxy_secret` or `novnc_proxy_secret_id`
+  - **exactly one required.** Shared secret for the
+    `X-Cluster-Desktop-Secret` header; the broker refuses to start without
+    one. Prefer the `_id` form, which keeps the value out of Terraform state.
+- `novnc_identity_mode`
+  - `trusted_proxy` (the only mode implemented)
+
+## Identity
+
+Only `trusted_proxy` is implemented. The broker checks the shared secret in
+`X-Cluster-Desktop-Secret` and then takes the user's identity from
+`X-Cluster-Desktop-Email`, with `X-Cluster-Desktop-Username` naming the POSIX
+account and `X-Cluster-Desktop-Login-Uid` supplying the OS Login subject when
+the caller knows it. None of that is verified.
+
+That is only safe where an authenticating proxy is the **sole** route to the
+broker port, because anything able to reach it and present the shared secret can
+claim to be any user. The broker logs a warning at startup saying exactly this.
+
+Reached over an SSH tunnel with no proxy in front, as the example blueprints do,
+the identity headers have to be supplied by hand - so a browser alone cannot
+open a desktop. Treat those blueprints as validation, not a production posture.
+
+The identity layer is one module per trust model returning a single shape, so a
+verified mode is a new file plus one entry in `_RESOLVERS`. Nothing else in the
+broker changes.
+
+## Outputs
+
+- `startup_runners`
+- `novnc_listen_port`
+- `novnc_proxy_secret_id`
+- `healthcheck_path`
+
+## Example
+
+```yaml
+- id: login-desktop-runtime
+  source: community/modules/remote-desktop/novnc-runtime
+  settings:
+    slurm_auth_mode: auto
+    vnc_backend: tigervnc
+    desktop_endpoint_dir: /shared/ghpc-remote-desktop/endpoints
+    desktop_endpoint_name: login
+    novnc_proxy_secret_id: $(vars.desktop_proxy_secret)
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_desktop_broker"></a> [desktop\_broker](#module\_desktop\_broker) | ../../internal/desktop-broker | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_desktop_endpoint_dir"></a> [desktop\_endpoint\_dir](#input\_desktop\_endpoint\_dir) | Optional directory where the runtime publishes DESKTOP\_* endpoint metadata for service discovery. | `string` | `null` | no |
+| <a name="input_desktop_endpoint_name"></a> [desktop\_endpoint\_name](#input\_desktop\_endpoint\_name) | Endpoint metadata file name used when desktop\_endpoint\_dir is set. | `string` | `"desktop"` | no |
+| <a name="input_enable_gpu_acceleration"></a> [enable\_gpu\_acceleration](#input\_enable\_gpu\_acceleration) | Use hardware OpenGL for desktop sessions. Requires a GPU on the host and an<br/>image whose NVIDIA driver has graphics (not merely compute) support; falls<br/>back to software rendering otherwise. Requires vnc\_backend = "turbovnc".<br/>See community/examples/remote-desktop/README.md for which image to use. | `bool` | `false` | no |
+| <a name="input_install_root"></a> [install\_root](#input\_install\_root) | Directory under which noVNC assets are installed. | `string` | `"/opt/ghpc-remote-desktop"` | no |
+| <a name="input_max_user_sessions"></a> [max\_user\_sessions](#input\_max\_user\_sessions) | Maximum number of concurrent per-user desktop sessions the host VM will support. | `number` | `32` | no |
+| <a name="input_network_storage"></a> [network\_storage](#input\_network\_storage) | An array of network attached storage mounts to be configured. | <pre>list(object({<br/>    server_ip             = string<br/>    remote_mount          = string<br/>    local_mount           = string<br/>    fs_type               = string<br/>    mount_options         = string<br/>    client_install_runner = map(string)<br/>    mount_runner          = map(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_novnc_identity_mode"></a> [novnc\_identity\_mode](#input\_novnc\_identity\_mode) | How the desktop broker establishes which user a request belongs to. Only<br/>"trusted\_proxy" is supported: the identity is taken from request headers<br/>with no verification, so it is only safe where an authenticating proxy is<br/>the sole route to the broker. | `string` | `"trusted_proxy"` | no |
+| <a name="input_novnc_listen_port"></a> [novnc\_listen\_port](#input\_novnc\_listen\_port) | Port exposed by the desktop broker for browser access to noVNC. | `number` | `6080` | no |
+| <a name="input_novnc_proxy_secret"></a> [novnc\_proxy\_secret](#input\_novnc\_proxy\_secret) | Shared secret the desktop broker requires in the X-Cluster-Desktop-Secret<br/>header, supplied directly. Mutually exclusive with novnc\_proxy\_secret\_id.<br/><br/>Use this where the caller already owns the value and must hold the plaintext<br/>anyway - a front end that sends the header on every request gains nothing<br/>from a round trip through Secret Manager. Otherwise prefer the \_id form: a<br/>literal is carried in the startup script staged in Cloud Storage and appears<br/>in Terraform state. | `string` | `null` | no |
+| <a name="input_novnc_proxy_secret_id"></a> [novnc\_proxy\_secret\_id](#input\_novnc\_proxy\_secret\_id) | Secret Manager secret ID holding the shared secret the desktop broker<br/>requires in the X-Cluster-Desktop-Secret header. Fetched on the instance at<br/>boot, so the value never enters Terraform state or the startup script staged<br/>in Cloud Storage.<br/><br/>Create it with:<br/>  openssl rand -base64 48 \| gcloud secrets create SECRET\_ID --data-file=-<br/><br/>The instance service account needs roles/secretmanager.secretAccessor.<br/>Mutually exclusive with novnc\_proxy\_secret. | `string` | `null` | no |
+| <a name="input_novnc_proxy_secret_version"></a> [novnc\_proxy\_secret\_version](#input\_novnc\_proxy\_secret\_version) | Version of novnc\_proxy\_secret\_id to read. | `string` | `"latest"` | no |
+| <a name="input_novnc_version"></a> [novnc\_version](#input\_novnc\_version) | noVNC release version to install. | `string` | `"1.7.0"` | no |
+| <a name="input_secret_project_id"></a> [secret\_project\_id](#input\_secret\_project\_id) | Project holding the Secret Manager secrets below. Defaults to the instance's own project. | `string` | `null` | no |
+| <a name="input_session_idle_timeout_seconds"></a> [session\_idle\_timeout\_seconds](#input\_session\_idle\_timeout\_seconds) | Idle timeout after which a per-user desktop session is cleaned up. Set to 0 to disable cleanup. | `number` | `43200` | no |
+| <a name="input_session_resolution"></a> [session\_resolution](#input\_session\_resolution) | Desktop resolution used for each per-user XFCE session. | `string` | `"1920x1080"` | no |
+| <a name="input_slurm_auth_mode"></a> [slurm\_auth\_mode](#input\_slurm\_auth\_mode) | Optional Slurm authentication mode for hosts that also participate in a Slurm cluster.<br/><br/>Supported values:<br/>- none:   no Slurm-specific handling<br/>- munge:  host is expected to use MUNGE authentication<br/>- native: host is expected to use Slurm Native Authentication and the runtime disables stale munge.service state<br/>- auto:   detect AuthType from slurm.conf at startup and apply the Native Auth cleanup only when needed | `string` | `"none"` | no |
+| <a name="input_startup_script"></a> [startup\_script](#input\_startup\_script) | Optional additional startup script prepended before the desktop runtime setup. | `string` | `null` | no |
+| <a name="input_vnc_backend"></a> [vnc\_backend](#input\_vnc\_backend) | VNC server backend used for per-user desktop sessions: tigervnc or turbovnc. | `string` | `"tigervnc"` | no |
+| <a name="input_vnc_display_number"></a> [vnc\_display\_number](#input\_vnc\_display\_number) | First X display number reserved for per-user VNC sessions. | `number` | `1` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_healthcheck_path"></a> [healthcheck\_path](#output\_healthcheck\_path) | Unauthenticated broker path that responds once the broker is running. |
+| <a name="output_novnc_listen_port"></a> [novnc\_listen\_port](#output\_novnc\_listen\_port) | Port exposed by the desktop broker for noVNC browser access. |
+| <a name="output_startup_runners"></a> [startup\_runners](#output\_startup\_runners) | Startup-script runners required to install and launch the noVNC desktop runtime. |
+| <a name="output_vnc_backend"></a> [vnc\_backend](#output\_vnc\_backend) | VNC backend used by the noVNC desktop runtime. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/remote-desktop/novnc-runtime/main.tf
+++ b/community/modules/remote-desktop/novnc-runtime/main.tf
@@ -1,0 +1,44 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The desktop runtime, the per-user broker and the VNC installers live in
+# internal/desktop-broker. This module is the public interface onto it.
+module "desktop_broker" {
+  source = "../../internal/desktop-broker"
+
+  install_root = var.install_root
+
+  network_storage = var.network_storage
+  startup_script  = var.startup_script
+  slurm_auth_mode = var.slurm_auth_mode
+
+  vnc_backend                  = var.vnc_backend
+  enable_gpu_acceleration      = var.enable_gpu_acceleration
+  session_resolution           = var.session_resolution
+  vnc_display_number           = var.vnc_display_number
+  max_user_sessions            = var.max_user_sessions
+  session_idle_timeout_seconds = var.session_idle_timeout_seconds
+
+  broker_listen_port = var.novnc_listen_port
+  novnc_version      = var.novnc_version
+  identity_mode      = var.novnc_identity_mode
+
+  secret_project_id    = var.secret_project_id
+  proxy_secret         = var.novnc_proxy_secret
+  proxy_secret_id      = var.novnc_proxy_secret_id
+  proxy_secret_version = var.novnc_proxy_secret_version
+
+  desktop_endpoint_dir  = var.desktop_endpoint_dir
+  desktop_endpoint_name = var.desktop_endpoint_name
+}

--- a/community/modules/remote-desktop/novnc-runtime/metadata.yaml
+++ b/community/modules/remote-desktop/novnc-runtime/metadata.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+spec:
+  requirements:
+    services:
+    - secretmanager.googleapis.com

--- a/community/modules/remote-desktop/novnc-runtime/metadata.yaml
+++ b/community/modules/remote-desktop/novnc-runtime/metadata.yaml
@@ -18,3 +18,41 @@ spec:
   requirements:
     services:
     - secretmanager.googleapis.com
+ghpc:
+  validators:
+  # Catches the more common mistake (both set) at gcluster-create time. The
+  # opposite mistake (neither set) is still caught, one step later, by this
+  # module's own Terraform precondition, which requires exactly one; there is
+  # no "at least one of" metadata validator to bring that check forward too.
+  - validator: exclusive
+    inputs:
+      vars: [novnc_proxy_secret, novnc_proxy_secret_id]
+    error_message: "At most one of 'novnc_proxy_secret' or 'novnc_proxy_secret_id' can be set. Exactly one is required; prefer 'novnc_proxy_secret_id', which keeps the value out of Terraform state."
+  - validator: allowed_enum
+    inputs:
+      vars: [vnc_backend]
+      case_sensitive: false
+      allowed:
+      - tigervnc
+      - turbovnc
+      allow_null: false
+    error_message: "Allowed values for vnc_backend are 'tigervnc' or 'turbovnc'."
+  - validator: allowed_enum
+    inputs:
+      vars: [novnc_identity_mode]
+      case_sensitive: false
+      allowed:
+      - trusted_proxy
+      allow_null: false
+    error_message: "novnc_identity_mode must be trusted_proxy. This module does not yet support any other identity mode."
+  - validator: allowed_enum
+    inputs:
+      vars: [slurm_auth_mode]
+      case_sensitive: false
+      allowed:
+      - none
+      - munge
+      - native
+      - auto
+      allow_null: false
+    error_message: "Allowed values for slurm_auth_mode are 'none', 'munge', 'native', or 'auto'."

--- a/community/modules/remote-desktop/novnc-runtime/outputs.tf
+++ b/community/modules/remote-desktop/novnc-runtime/outputs.tf
@@ -1,0 +1,33 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "startup_runners" {
+  description = "Startup-script runners required to install and launch the noVNC desktop runtime."
+  value       = module.desktop_broker.startup_runners
+}
+
+output "novnc_listen_port" {
+  description = "Port exposed by the desktop broker for noVNC browser access."
+  value       = module.desktop_broker.broker_listen_port
+}
+
+output "vnc_backend" {
+  description = "VNC backend used by the noVNC desktop runtime."
+  value       = module.desktop_broker.vnc_backend
+}
+
+output "healthcheck_path" {
+  description = "Unauthenticated broker path that responds once the broker is running."
+  value       = module.desktop_broker.healthcheck_path
+}

--- a/community/modules/remote-desktop/novnc-runtime/variables.tf
+++ b/community/modules/remote-desktop/novnc-runtime/variables.tf
@@ -1,0 +1,234 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "network_storage" {
+  description = "An array of network attached storage mounts to be configured."
+  type = list(object({
+    server_ip             = string
+    remote_mount          = string
+    local_mount           = string
+    fs_type               = string
+    mount_options         = string
+    client_install_runner = map(string)
+    mount_runner          = map(string)
+  }))
+  default = []
+}
+
+variable "startup_script" {
+  description = "Optional additional startup script prepended before the desktop runtime setup."
+  type        = string
+  default     = null
+}
+
+variable "slurm_auth_mode" {
+  description = <<-EOD
+    Optional Slurm authentication mode for hosts that also participate in a Slurm cluster.
+
+    Supported values:
+    - none:   no Slurm-specific handling
+    - munge:  host is expected to use MUNGE authentication
+    - native: host is expected to use Slurm Native Authentication and the runtime disables stale munge.service state
+    - auto:   detect AuthType from slurm.conf at startup and apply the Native Auth cleanup only when needed
+    EOD
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "munge", "native", "auto"], lower(trimspace(var.slurm_auth_mode)))
+    error_message = "slurm_auth_mode must be one of: none, munge, native, auto."
+  }
+}
+
+variable "install_root" {
+  description = "Directory under which noVNC assets are installed."
+  type        = string
+  default     = "/opt/ghpc-remote-desktop"
+
+  validation {
+    condition     = trimspace(var.install_root) != "" && can(regex("^/", trimspace(var.install_root)))
+    error_message = "install_root must be a non-empty absolute path."
+  }
+}
+
+variable "vnc_backend" {
+  description = "VNC server backend used for per-user desktop sessions: tigervnc or turbovnc."
+  type        = string
+  default     = "tigervnc"
+
+  validation {
+    condition     = contains(["tigervnc", "turbovnc"], lower(trimspace(var.vnc_backend)))
+    error_message = "vnc_backend must be one of: tigervnc, turbovnc."
+  }
+}
+
+variable "session_resolution" {
+  description = "Desktop resolution used for each per-user XFCE session."
+  type        = string
+  default     = "1920x1080"
+
+  validation {
+    condition     = can(regex("^[1-9][0-9]*x[1-9][0-9]*$", var.session_resolution))
+    error_message = "session_resolution must be in WIDTHxHEIGHT form."
+  }
+}
+
+variable "vnc_display_number" {
+  description = "First X display number reserved for per-user VNC sessions."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.vnc_display_number >= 1
+    error_message = "vnc_display_number must be greater than or equal to 1."
+  }
+}
+
+variable "novnc_listen_port" {
+  description = "Port exposed by the desktop broker for browser access to noVNC."
+  type        = number
+  default     = 6080
+
+  validation {
+    condition     = var.novnc_listen_port >= 1 && var.novnc_listen_port <= 65535
+    error_message = "novnc_listen_port must be between 1 and 65535."
+  }
+}
+
+variable "novnc_version" {
+  description = "noVNC release version to install."
+  type        = string
+  default     = "1.7.0"
+
+  validation {
+    condition     = trimspace(var.novnc_version) != ""
+    error_message = "novnc_version must be a non-empty string."
+  }
+}
+
+variable "secret_project_id" {
+  description = "Project holding the Secret Manager secrets below. Defaults to the instance's own project."
+  type        = string
+  default     = null
+}
+
+variable "novnc_proxy_secret" {
+  description = <<-EOT
+    Shared secret the desktop broker requires in the X-Cluster-Desktop-Secret
+    header, supplied directly. Mutually exclusive with novnc_proxy_secret_id.
+
+    Use this where the caller already owns the value and must hold the plaintext
+    anyway - a front end that sends the header on every request gains nothing
+    from a round trip through Secret Manager. Otherwise prefer the _id form: a
+    literal is carried in the startup script staged in Cloud Storage and appears
+    in Terraform state.
+    EOT
+  type        = string
+  sensitive   = true
+  default     = null
+}
+
+variable "novnc_proxy_secret_id" {
+  description = <<-EOT
+    Secret Manager secret ID holding the shared secret the desktop broker
+    requires in the X-Cluster-Desktop-Secret header. Fetched on the instance at
+    boot, so the value never enters Terraform state or the startup script staged
+    in Cloud Storage.
+
+    Create it with:
+      openssl rand -base64 48 | gcloud secrets create SECRET_ID --data-file=-
+
+    The instance service account needs roles/secretmanager.secretAccessor.
+    Mutually exclusive with novnc_proxy_secret.
+    EOT
+  type        = string
+  default     = null
+}
+
+variable "novnc_proxy_secret_version" {
+  description = "Version of novnc_proxy_secret_id to read."
+  type        = string
+  default     = "latest"
+}
+
+variable "novnc_identity_mode" {
+  description = <<-EOT
+    How the desktop broker establishes which user a request belongs to. Only
+    "trusted_proxy" is supported: the identity is taken from request headers
+    with no verification, so it is only safe where an authenticating proxy is
+    the sole route to the broker.
+    EOT
+  type        = string
+  default     = "trusted_proxy"
+
+  validation {
+    condition     = contains(["trusted_proxy"], lower(trimspace(var.novnc_identity_mode)))
+    error_message = "novnc_identity_mode must be trusted_proxy."
+  }
+}
+
+variable "desktop_endpoint_dir" {
+  description = "Optional directory where the runtime publishes DESKTOP_* endpoint metadata for service discovery."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.desktop_endpoint_dir == null || (trimspace(var.desktop_endpoint_dir) != "" && can(regex("^/", trimspace(var.desktop_endpoint_dir))))
+    error_message = "desktop_endpoint_dir must be null or a non-empty absolute path."
+  }
+}
+
+variable "desktop_endpoint_name" {
+  description = "Endpoint metadata file name used when desktop_endpoint_dir is set."
+  type        = string
+  default     = "desktop"
+
+  validation {
+    condition     = trimspace(var.desktop_endpoint_name) != "" && can(regex("^[A-Za-z0-9][A-Za-z0-9._-]*$", trimspace(var.desktop_endpoint_name)))
+    error_message = "desktop_endpoint_name must be a non-empty file-safe name."
+  }
+}
+
+variable "max_user_sessions" {
+  description = "Maximum number of concurrent per-user desktop sessions the host VM will support."
+  type        = number
+  default     = 32
+
+  validation {
+    condition     = var.max_user_sessions > 0
+    error_message = "max_user_sessions must be greater than zero."
+  }
+}
+
+variable "session_idle_timeout_seconds" {
+  description = "Idle timeout after which a per-user desktop session is cleaned up. Set to 0 to disable cleanup."
+  type        = number
+  default     = 43200
+
+  validation {
+    condition     = var.session_idle_timeout_seconds >= 0
+    error_message = "session_idle_timeout_seconds must be zero or greater."
+  }
+}
+
+variable "enable_gpu_acceleration" {
+  description = <<-EOT
+    Use hardware OpenGL for desktop sessions. Requires a GPU on the host and an
+    image whose NVIDIA driver has graphics (not merely compute) support; falls
+    back to software rendering otherwise. Requires vnc_backend = "turbovnc".
+    See community/examples/remote-desktop/README.md for which image to use.
+    EOT
+  type        = bool
+  default     = false
+}

--- a/community/modules/remote-desktop/novnc-runtime/versions.tf
+++ b/community/modules/remote-desktop/novnc-runtime/versions.tf
@@ -1,0 +1,17 @@
+# Copyright 2026 "Google LLC"
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.12.2"
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,6 +36,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [cae-slurm.yaml](#cae-slurmyaml-) ![core-badge]
   * [hpc-build-slurm-image.yaml](#hpc-build-slurm-imageyaml--) ![community-badge] ![experimental-badge]
   * [hpc-slurm-ubuntu2204.yaml](#hpc-slurm-ubuntu2204yaml-) ![community-badge]
+  * [hpc-slurm-remote-desktop.yaml](#hpc-slurm-remote-desktopyaml--) ![community-badge] ![experimental-badge]
   * [hpc-amd-slurm.yaml](#hpc-amd-slurmyaml-) ![community-badge]
   * [hpc-slurm-sharedvpc.yaml](#hpc-slurm-sharedvpcyaml--) ![community-badge] ![experimental-badge]
   * [client-google-cloud-storage.yaml](#client-google-cloud-storageyaml--) ![community-badge] ![experimental-badge]
@@ -934,6 +935,25 @@ For this example the following is needed in the selected region:
   needed for `compute` partition_
 * Compute Engine API: Resource policies: **one for each job in parallel** -
   _only needed for `compute` partition_
+
+### [hpc-slurm-remote-desktop.yaml] ![community-badge] ![experimental-badge]
+
+This example provisions a Slurm cluster whose login node also serves browser
+based Linux desktops, alongside a dedicated visualisation node for heavier
+graphical work.
+
+Each user gets their own XFCE session, reached over
+[noVNC] in a browser. Sessions on the login node can see the scheduler, so a
+user can run `sbatch` and `squeue` from a terminal inside the desktop.
+
+The desktop broker takes the user's identity from request headers and requires
+a shared secret, so it must only be reached through a proxy that authenticates
+the user. The blueprint does not expose it publicly: see the
+[remote desktop README] for how to reach a desktop over an IAP tunnel.
+
+[hpc-slurm-remote-desktop.yaml]: ../community/examples/remote-desktop/hpc-slurm-remote-desktop.yaml
+[remote desktop README]: ../community/examples/remote-desktop/README.md
+[noVNC]: https://novnc.com/
 
 ### [hpc-amd-slurm.yaml] ![community-badge]
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -212,8 +212,16 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
 
 * **[chrome-remote-desktop]** ![community-badge] ![experimental-badge] : Creates
   a GPU accelerated Chrome Remote Desktop.
+* **[novnc-runtime]** ![community-badge] ![experimental-badge] : Builds the
+  startup-script runners for a per-user XFCE + noVNC desktop runtime, to be
+  layered onto an existing host such as a Slurm login node.
+* **[novnc-desktop]** ![community-badge] ![experimental-badge] : Creates a
+  standalone VM that serves per-user XFCE desktops through noVNC using the
+  [novnc-runtime] module.
 
 [chrome-remote-desktop]: ../community/modules/remote-desktop/chrome-remote-desktop/README.md
+[novnc-runtime]: ../community/modules/remote-desktop/novnc-runtime/README.md
+[novnc-desktop]: ../community/modules/remote-desktop/novnc-desktop/README.md
 
 ### Scheduler
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-novnc-desktop.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-novnc-desktop.yml
@@ -1,0 +1,147 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Check the desktop broker is running
+  become: true
+  ansible.builtin.command: systemctl is-active ghpc-desktop-broker
+  changed_when: false
+  register: broker_state
+  retries: 20
+  delay: 15
+  until: broker_state.rc == 0
+
+- name: Check the broker answers its health check
+  ansible.builtin.uri:
+    url: http://127.0.0.1:6080/healthz
+    return_content: true
+  register: broker_health
+  retries: 20
+  delay: 15
+  until: broker_health.status == 200 and 'ok' in broker_health.content
+
+- name: Check noVNC was installed
+  become: true
+  ansible.builtin.stat:
+    path: /opt/ghpc-remote-desktop/novnc/vnc.html
+  register: novnc_page
+
+- name: Assert the noVNC client is present
+  ansible.builtin.assert:
+    that: novnc_page.stat.exists
+    fail_msg: noVNC was not installed under the install root.
+
+# The secret is fetched on the instance, so the staged config starts without it
+# and the install runner merges it in. Confirm that happened, without printing
+# the value.
+- name: Read the shape of the injected proxy secret
+  become: true
+  ansible.builtin.command: >-
+    python3 -c "import json;print(len(json.load(open('/etc/ghpc-desktop-broker/config.json')).get('proxy_secret','')))"
+  changed_when: false
+  register: secret_length
+
+- name: Check the secret was fetched from Secret Manager
+  ansible.builtin.assert:
+    that: secret_length.stdout | int > 0
+    fail_msg: >-
+      The broker config has no proxy secret; the Secret Manager fetch in the
+      install runner did not complete.
+
+- name: Check the broker config is not world readable
+  become: true
+  ansible.builtin.stat:
+    path: /etc/ghpc-desktop-broker/config.json
+  register: broker_config_stat
+
+- name: Assert the broker config mode is 0600
+  ansible.builtin.assert:
+    that: broker_config_stat.stat.mode == '0600'
+    fail_msg: "Expected the broker config to be 0600, got {{ broker_config_stat.stat.mode }}"
+
+# End to end: ask the broker for a session as this OS Login account and confirm
+# it starts one and serves the noVNC client. The username header is passed
+# explicitly because a service account's OS Login name is not derivable from its
+# email.
+- name: Request a desktop session from the broker
+  become: true
+  ansible.builtin.shell: |
+    set -o pipefail
+    secret="$(python3 -c "import json;print(json.load(open('/etc/ghpc-desktop-broker/config.json'))['proxy_secret'])")"
+    curl -sS -o /tmp/novnc-page.html -w '%{http_code}' \
+      -H "X-Cluster-Desktop-Secret: ${secret}" \
+      -H "X-Cluster-Desktop-Email: {{ ansible_user_id }}@test.invalid" \
+      -H "X-Cluster-Desktop-Username: {{ ansible_user_id }}" \
+      http://127.0.0.1:6080/vnc.html
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: session_request
+  retries: 10
+  delay: 20
+  until: session_request.stdout == '200'
+
+- name: Check the broker served the noVNC client
+  become: true
+  ansible.builtin.command: grep -qi novnc /tmp/novnc-page.html
+  changed_when: false
+
+- name: Check a per-user display socket was created
+  become: true
+  ansible.builtin.shell: |
+    set -o pipefail
+    find /run/ghpc-remote-desktop -name vnc.sock -type s | head -1
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: display_socket
+
+- name: Assert the display is a unix socket
+  ansible.builtin.assert:
+    that: display_socket.stdout | length > 0
+    fail_msg: No per-user vnc.sock was created under the broker runtime directory.
+
+# The point of the socket transport: the display must have no TCP listener at
+# all, so it is unreachable by other local users on a shared login node.
+- name: Look for any RFB TCP listener
+  become: true
+  ansible.builtin.shell: |
+    set -o pipefail
+    ss -ltn | grep -E ':59[0-9][0-9]' || true
+  args:
+    executable: /bin/bash
+  changed_when: false
+  register: rfb_listeners
+
+- name: Assert no display bound a TCP port
+  ansible.builtin.assert:
+    that: rfb_listeners.stdout | length == 0
+    fail_msg: >-
+      A display is listening on TCP ({{ rfb_listeners.stdout }}). The socket
+      transport must not bind an RFB port, or the desktop becomes reachable by
+      any local user.
+
+- name: Check the socket directory is private to its owner
+  become: true
+  ansible.builtin.stat:
+    path: "{{ display_socket.stdout | dirname }}"
+  register: socket_dir
+
+- name: Assert the socket directory is 0700
+  ansible.builtin.assert:
+    that: socket_dir.stat.mode == '0700'
+    fail_msg: >-
+      Expected the per-user runtime directory to be 0700, got
+      {{ socket_dir.stat.mode }}. This permission is what stops other local
+      users reaching the display.

--- a/tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+blueprint_name: novnc-desktop
+
+vars:
+  deployment_name: novnc-desktop
+  # This secret must already exist in the test project; the test does not create
+  # it. See tools/cloud-build/daily-tests/tests/novnc-desktop.yml.
+  desktop_proxy_secret_id: ghpc-test-desktop-proxy-secret
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  - id: desktop-service-account
+    source: modules/project/service-account
+    settings:
+      project_id: $(vars.project_id)
+      deployment_name: $(vars.deployment_name)
+      name: desktop
+      project_roles:
+      # The startup-script module stages its runners in Cloud Storage, so any
+      # instance that runs them needs to read that bucket. Overriding
+      # service_account_email removes the access the default compute service
+      # account would have had, so it has to be granted here.
+      - storage.objectViewer
+      - secretmanager.secretAccessor
+      # The Ops Agent is preinstalled on these images; without these it retries
+      # its exports indefinitely and floods the serial console.
+      - logging.logWriter
+      - monitoring.metricWriter
+
+  - id: desktop
+    source: community/modules/remote-desktop/novnc-desktop
+    use: [network]
+    settings:
+      machine_type: n2-standard-4
+      enable_public_ips: false
+      service_account_email: $(desktop-service-account.service_account_email)
+      service_account_scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+      secret_project_id: $(vars.project_id)
+      novnc_proxy_secret_id: $(vars.desktop_proxy_secret_id)
+      novnc_identity_mode: trusted_proxy
+      vnc_backend: tigervnc
+
+  # Makes terraform wait until the whole desktop runtime has installed: the
+  # XFCE stack, the VNC backend, noVNC and the broker.
+  - id: wait
+    source: community/modules/scripts/wait-for-startup
+    use: [desktop]
+    settings:
+      timeout: 2400

--- a/tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml
@@ -48,11 +48,10 @@ deployment_groups:
 
   - id: desktop
     source: community/modules/remote-desktop/novnc-desktop
-    use: [network]
+    use: [network, desktop-service-account]
     settings:
       machine_type: n2-standard-4
       enable_public_ips: false
-      service_account_email: $(desktop-service-account.service_account_email)
       service_account_scopes:
       - https://www.googleapis.com/auth/cloud-platform
       secret_project_id: $(vars.project_id)

--- a/tools/cloud-build/daily-tests/builds/novnc-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/novnc-desktop.yaml
@@ -1,0 +1,299 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+tags:
+- m.novnc-desktop
+- m.service-account
+- m.vpc
+- m.wait-for-startup
+- vm
+
+substitutions:
+  _TEST_PREFIX: "" # Default to no prefix
+
+timeout: 86400s
+queueTtl: 86400s  # 24hr
+logsBucket: "gs://$PROJECT_NUMBER.cloudbuild-logs.googleusercontent.com"
+
+steps:
+# 1. Build and push workspace container containing the current code layer
+- id: build-workspace-image
+  name: gcr.io/cloud-builders/docker
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -eo pipefail
+    docker build -t us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID -f- . <<EOF
+    FROM us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:latest
+    COPY . /workspace
+    WORKDIR /workspace
+    EOF
+    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+# 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
+- id: generate-job-manifest
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  args:
+  - -c
+  - |
+    set -eo pipefail
+    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
+
+    # Determine the priority class based on the test prefix.
+    if [ "${_TEST_PREFIX}" == "hotfix-" ]; then
+      PRIORITY_LINE="priorityClassName: emergency-hotfix-priority"
+    else
+      PRIORITY_LINE=""
+    fi
+
+    SA_UNIQUE_ID=$(gcloud iam service-accounts describe "$$SA_EMAIL" --project="$PROJECT_ID" --format="value(uniqueId)")
+    OSLOGIN_USER="sa_$${SA_UNIQUE_ID}"
+
+    cat <<EOF > job.yaml
+    apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: novnc-$$BUILD_ID_SHORT
+      namespace: default
+      labels:
+        kueue.x-k8s.io/queue-name: local-queue-test-locks
+        build-id: "$BUILD_ID"
+    spec:
+      suspend: true # Required for Kueue: the job must be created in suspended state for Kueue to manage it
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        spec:
+          $$PRIORITY_LINE
+          terminationGracePeriodSeconds: 1800 # Grants 30 minutes for terraform destroy to finish gracefully if cancelled
+          serviceAccountName: test-kueue-cluster-runner-ksa
+          restartPolicy: Never
+          containers:
+          - name: runner
+            image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+            env:
+            - name: ANSIBLE_HOST_KEY_CHECKING
+              value: "false"
+            - name: ANSIBLE_CONFIG
+              value: "/workspace/tools/cloud-build/ansible.cfg"
+            - name: _TEST_PREFIX
+              value: "${_TEST_PREFIX}"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
+            - name: GCLUSTER_GCS_PATH
+              value: "$$GCLUSTER_GCS_PATH"
+            - name: TRIAGE_GCS_BUCKET
+              value: "$$TRIAGE_GCS_BUCKET"
+            - name: TRIAGE_PROJECT_NUMBER
+              value: "$$TRIAGE_PROJECT_NUMBER"
+            - name: TRIAGE_INVOKER_SA
+              value: "$$TRIAGE_INVOKER_SA"
+            - name: TRIAGE_CLOUD_RUN_URL
+              value: "$$TRIAGE_CLOUD_RUN_URL"
+            command: ["/bin/bash", "-c"]
+            args:
+            - |
+              set -x -e
+              echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/novnc-desktop.yaml"
+              cd /workspace
+
+              DEPLOYMENT_NAME="novnc-default-$$BUILD_ID_SHORT"
+
+              RUN_CLEANUP=true
+              # Trap function that runs the rescue playbook (terraform destroy)
+              # if the pod is terminated by Kueue, fails, or is cancelled.
+              cleanup_pod() {
+                local exit_code=\$$?
+                trap - EXIT SIGTERM SIGINT ERR
+                set +e
+
+                if [ "\$$RUN_CLEANUP" = "false" ]; then
+                  exit 0
+                fi
+                if [ \$$exit_code -eq 0 ]; then exit_code=1; fi
+
+                echo ""
+                echo "=========================================================================="
+                echo "CAUGHT SIGTERM OR SCRIPT ERROR!"
+                echo "Halting primary Ansible execution..."
+                echo "=========================================================================="
+                if [ -n "\$${ANSIBLE_PID:-}" ]; then
+                    kill -TERM \$$ANSIBLE_PID 2>/dev/null || true
+                    wait \$$ANSIBLE_PID 2>/dev/null || true
+                    echo "Waiting 15s for Terraform to release GCS backend state locks..."
+                    sleep 15
+                fi
+
+                echo ""
+                echo "INITIATING RESCUE PLAYBOOK: Destroying leaked infrastructure for \$$DEPLOYMENT_NAME..."
+                echo "- hosts: localhost" > /workspace/cleanup-playbook.yml
+                echo "  tasks:" >> /workspace/cleanup-playbook.yml
+                echo "  - ansible.builtin.include_tasks:" >> /workspace/cleanup-playbook.yml
+                echo "      file: tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_gcluster_failure.yml" >> /workspace/cleanup-playbook.yml
+
+                ansible-playbook /workspace/cleanup-playbook.yml -e deployment_name="\$$DEPLOYMENT_NAME" -e workspace="/workspace" || true
+
+                echo "Graceful cleanup finished."
+                exit \$$exit_code
+              }
+              trap cleanup_pod EXIT SIGTERM SIGINT
+
+              bash tools/get_binary.sh "${_TEST_PREFIX}"
+              BLUEPRINT=tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml
+              bash tools/add_ttl_label.sh \$$BLUEPRINT
+
+              ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
+                --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID os=default" \
+                --extra-vars="@tools/cloud-build/daily-tests/tests/novnc-desktop.yml" \
+                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
+                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
+                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
+                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+              ANSIBLE_PID=\$$!
+
+              wait \$$ANSIBLE_PID
+              RUN_CLEANUP=false
+            resources:
+              requests:
+                cpu: 200m
+                memory: "2Gi"
+                test-locks/novnc: 1
+              limits:
+                cpu: 1
+                memory: "2Gi"
+                test-locks/novnc: 1
+    EOF
+
+# 3. Submit and Monitor GKE Kueue Job with Retry
+- id: submit-and-monitor-gke-job
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  args:
+  - -c
+  - |
+    set -eo pipefail
+    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
+    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
+    JOB_NAME="novnc-$$BUILD_ID_SHORT"
+
+    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
+    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
+    cleanup_cb() {
+      echo ""
+      echo "=========================================================================="
+      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
+      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
+      echo "=========================================================================="
+      kubectl delete job "$$JOB_NAME" -n default || true
+      exit 1
+    }
+    trap cleanup_cb SIGTERM SIGINT
+
+    MAX_RETRIES=10
+    RETRY_DELAY=300
+    ATTEMPT=1
+
+    while true; do
+      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
+      kubectl apply -f /workspace/job.yaml
+
+      set +e
+      ( bash tools/cloud-build/monitor_kueue_job.sh \
+          test-kueue-cluster \
+          us-central1 \
+          "$$JOB_NAME" \
+          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
+      MONITOR_PID=$$!
+      wait $$MONITOR_PID
+      EXIT_CODE=$$?
+      set -e
+
+      if [ $$EXIT_CODE -eq 0 ]; then
+        echo "Job succeeded!"
+        break
+      fi
+
+      # Check if the failure was specifically due to a lack of GCP zone capacity.
+      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
+      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
+        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
+      else
+        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
+        exit 1
+      fi
+
+      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
+        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
+        exit 1
+      fi
+
+      sleep $$RETRY_DELAY
+      ATTEMPT=$$((ATTEMPT + 1))
+    done
+
+# 4. Cleanup the built image from Registry to save costs
+- id: cleanup-image
+  name: gcr.io/cloud-builders/gcloud
+  entrypoint: /bin/bash
+  allowFailure: true
+  args:
+  - -c
+  - |
+    set -eo pipefail
+    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
+    MAX_RETRIES=5
+    RETRY_DELAY=10
+    ATTEMPT=1
+
+    echo "Starting cleanup for image: $$IMAGE"
+
+    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
+      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
+
+      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
+        echo "Image successfully deleted."
+        exit 0
+      fi
+
+      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
+        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
+        sleep $$RETRY_DELAY
+      fi
+
+      ATTEMPT=$$((ATTEMPT + 1))
+    done
+
+    echo "Failed to delete image after $$MAX_RETRIES attempts."
+    echo "Image will be handled by Artifact Registry background cleanup policies."
+    exit 1
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest
+    env: 'SA_EMAIL'
+  - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
+    env: 'GCLUSTER_GCS_PATH'
+  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
+    env: 'TRIAGE_GCS_BUCKET'
+  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
+    env: 'TRIAGE_PROJECT_NUMBER'
+  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
+    env: 'TRIAGE_INVOKER_SA'
+  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
+    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/tests/novnc-desktop.yml
+++ b/tools/cloud-build/daily-tests/tests/novnc-desktop.yml
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# PREREQUISITE, not created by this test: the test project must hold the Secret
+# Manager secret below, since the module reads it on the instance rather than
+# taking its value through the blueprint.
+#
+#   openssl rand -base64 48 | gcloud secrets create ghpc-test-desktop-proxy-secret \
+#     --replication-policy automatic --data-file=-
+---
+test_name: "novnc-{{ os }}"
+deployment_name: "{{ test_name }}-{{ build }}"
+region: us-central1
+zone: us-central1-f
+workspace: /workspace
+blueprint_yaml: "{{ workspace }}/tools/cloud-build/daily-tests/blueprints/novnc-desktop.yaml"
+network: "{{ deployment_name }}-net"
+remote_node: "{{ deployment_name }}-desktop-0"
+post_deploy_tests:
+- test-validation/test-novnc-desktop.yml
+cli_deployment_vars:
+  region: "{{ region }}"
+  zone: "{{ zone }}"


### PR DESCRIPTION
## What this adds

Browser-based Linux desktops for Cluster Toolkit clusters: two public modules and the shared runtime they are built on.

| Module | Purpose |
| --- | --- |
| `community/modules/remote-desktop/novnc-runtime` | Emits startup-script runners that layer the desktop stack onto an **existing** VM — typically a Slurm login node, so desktop sessions keep the scheduler tooling. Creates no VM resources. |
| `community/modules/remote-desktop/novnc-desktop` | The same runtime plus a dedicated VM and firewall rule, for standalone visualisation nodes. |
| `community/modules/internal/desktop-broker` | The shared foundation both wrap. Not intended for direct use in blueprints. |

## Note on this PR replacing its own history

The earlier revision bundled the Guacamole front end, the OFE integration and an nginx gateway alongside this runtime. It was too large to review sensibly, so it has been split. 

## Secrets

Both modules take the shared secret either as a literal or as a Secret Manager secret ID fetched on the instance at boot. The `_id` form keeps the value out of Terraform state and out of the startup script staged in Cloud Storage, and is what the example and the integration test use.

## Testing

- **57 unit tests** for the broker (`community/modules/internal/desktop-broker/files/tests/`).
  Mutation-tested to confirm they are load-bearing: removing `-rfbport -1`,
  accepting any secret, making session records world-readable, changing the
  security type, and breaking the OS Login index were each caught.
- **A daily integration test** (`tools/cloud-build/daily-tests/.../novnc-desktop.*`).

## Packaging

TurboVNC, TigerVNC, VirtualGL and noVNC install from pinned upstream releases verified by SHA-256. No third-party apt/yum repositories are added and no GPG keys are imported. The only existing repository file this PR modifies is `examples/README.md`, to index the new example.

## Note for reviewer

The daily test will require a `hpc-test-desktop-proxy-secret` proxy secret added to test project's [Secret Manager](https://console.cloud.google.com/security/secret-manager/secrets). One can be created with `openssl rand -base64 48 | gcloud secrets create ghpc-desktop-proxy-secret`.