### PR TITLE
fix(telemetry): unify duplicate Stockout error categories

### DIFF
--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -2311,7 +2311,7 @@ func TestGetErrorType(t *testing.T) {
 		{
 			name:     "Text Match Stockout",
 			err:      errors.New("A c2-standard-60 VM instance is currently unavailable"),
-			expected: ErrTypeExtraStockout,
+			expected: ErrTypeStockout,
 		},
 		{
 			name:     "Text Match APIDisabled",

--- a/pkg/telemetry/error_categories.go
+++ b/pkg/telemetry/error_categories.go
@@ -321,7 +321,6 @@ const (
 	ErrTypeStartupScriptTimeout                      = "STARTUP_SCRIPT_TIMEOUT"
 	ErrTypeStateUploadFail                           = "STATE_UPLOAD_FAIL"
 	ErrTypeStaticAddressesQuotaExceeded              = "STATIC_ADDRESSES_QUOTA_EXCEEDED"
-	ErrTypeExtraStockout                             = "STOCKOUT"
 	ErrTypeStockoutGke                               = "STOCKOUT_GKE"
 	ErrTypeStockoutTpu                               = "STOCKOUT_TPU"
 	ErrTypeSubnetworkNicInstanceFailure              = "SUBNETWORK_NIC_INSTANCE_FAILURE"
@@ -399,10 +398,10 @@ var extraSubstringErrMatchers = []struct {
 	{"nodes to be ready, found", ErrTypeOmniaNodeReadyTimeout},
 	{"\u2502 Error: Unsupported attribute", ErrTypeTfWrongAttribute},
 	{"\u2502 Error: Inconsistent dependency lock file", ErrTypeTfInconsistentDependency},
-	{"VM instance is currently unavailable in the", ErrTypeExtraStockout},
-	{"A c2-standard-60 VM instance is currently unavailable", ErrTypeExtraStockout},
-	{"does not currently have sufficient capacity for the requested resources", ErrTypeExtraStockout},
-	{"nvidia-tesla-t4-vws accelerator(s) is currently unavailable in the", ErrTypeExtraStockout},
+	{"VM instance is currently unavailable in the", ErrTypeStockout},
+	{"A c2-standard-60 VM instance is currently unavailable", ErrTypeStockout},
+	{"does not currently have sufficient capacity for the requested resources", ErrTypeStockout},
+	{"nvidia-tesla-t4-vws accelerator(s) is currently unavailable in the", ErrTypeStockout},
 	{"try in another zone where Cloud TPU Nodes are offered", ErrTypeStockoutTpu},
 	{"not resumed by ResumeTimeout", ErrTypeUnknownStartupTimeoutTpu},
 	{"No resources found in default namespace.", ErrTypeNoResourcesInDefaultNamespace},


### PR DESCRIPTION

**Consolidation of Error Categories**: Removed the redundant '`ErrTypeExtraStockout`' constant and unified all related error matching logic to use '`ErrTypeStockout`'.
**Telemetry Update**: Updated error matchers and unit tests to reflect the consolidated '`ErrTypeStockout`' category, ensuring consistent telemetry reporting.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
