### PR TITLE
Zizmor security fixes for github workflows

### DIFF
--- a/.github/workflows/close-inactive-issues.yml
+++ b/.github/workflows/close-inactive-issues.yml
@@ -24,7 +24,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
       with:
         days-before-issue-stale: 30
         days-before-issue-close: 14

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: 'Checkout Repository'
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
     - name: 'Dependency Review'
-      uses: actions/dependency-review-action@v4
+      uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -37,6 +37,7 @@ jobs:
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Get Release Information
       id: release

--- a/.github/workflows/inactive-pr.yml
+++ b/.github/workflows/inactive-pr.yml
@@ -26,7 +26,9 @@ jobs:
       contents: read # Needed to checkout the repository
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
 
     - name: Run inactivity script
       env:

--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -35,15 +35,19 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
 
     - name: Add external label only for develop PRs
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_EVENT_PULL_REQUEST_USER_LOGIN: ${{ github.event.pull_request.user.login }}
+        GITHUB_EVENT_PULL_REQUEST_BASE_REF: ${{ github.event.pull_request.base.ref }}
       run: |
-          AUTHOR="${{ github.event.pull_request.user.login }}"
+          AUTHOR="${GITHUB_EVENT_PULL_REQUEST_USER_LOGIN}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          TARGET_BRANCH="${GITHUB_EVENT_PULL_REQUEST_BASE_REF}"
 
           echo "Author: $AUTHOR"
           echo "Target branch: $TARGET_BRANCH"

--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -14,7 +14,7 @@
 
 name: Label External PRs
 
-on:
+on: # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     branches:
     - develop

--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -14,7 +14,7 @@
 
 name: Label External PRs
 
-on: # zizmor: ignore[dangerous-triggers]
+on:
   pull_request_target:
     branches:
     - develop

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -40,6 +40,6 @@ concurrency:
 
 jobs:
   multi-approvers:
-    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
+    uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@543c2604d7324bab0739027d23c93b2a3ec8ca2e' # main
     with:
       org-members-path: 'GoogleCloudPlatform/cluster-toolkit/develop/cluster-toolkit-writers.json'

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -28,7 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+      with:
+        persist-credentials: false
     - name: Check PR description
       env:
         PR_BODY: ${{ github.event.pull_request.body }}

--- a/.github/workflows/pr-precommit.yml
+++ b/.github/workflows/pr-precommit.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 #v6.1.0
+      with:
+        persist-credentials: false
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
       with:
@@ -73,6 +75,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 #v6.1.0
+      with:
+        persist-credentials: false
     - name: Free Disk Space (Ubuntu)
       uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be #v1.3.1
       with:

--- a/.github/workflows/publish-release-notes.yml
+++ b/.github/workflows/publish-release-notes.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      with:
+        persist-credentials: false
 
     - name: Get Release Information
       id: release


### PR DESCRIPTION
### Description

This PR addresses all security findings identified by `zizmor` across the repository's GitHub Action workflows to ensure they comply with modern supply-chain security best practices. Currently there are 16 issues being reported: `0 informational, 6 low, 2 medium, 10 high`.  This PR fixes all but 1 issue related to pull_request_target in label-external.yml thereby reducing blast radius of issues significantly.

**Changes included:**
* **Zizmor Automated Fixes:** Applied `zizmor`'s automated remediations to resolve various configuration warnings across multiple workflow files addressing unpinned-uses, template-injection.

### Verification
* Ran `zizmor --gh-token=$(gh auth token) .github/workflows/` locally.
* Verified that the output reports only **1 findings** (all remaining findings correctly addressed).

```
vikramvs@vikramvs-cloudtop:~/cluster-toolkit$ zizmor --gh-token=$(gh auth token) .github/workflows/
 INFO zizmor: 🌈 zizmor v1.25.2
 INFO audit: zizmor: 🌈 completed .github/workflows/close-inactive-issues.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/dependency-review.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/draft-release-notes.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/inactive-pr.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/label-external.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/multi-approvers.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/pr-description-check.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/pr-label-validation.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/pr-precommit.yml
 INFO audit: zizmor: 🌈 completed .github/workflows/publish-release-notes.yml
error[dangerous-triggers]: use of fundamentally insecure workflow trigger
  --> .github/workflows/label-external.yml:17:1
   |
17 | / on:
18 | |   pull_request_target:
19 | |     branches:
20 | |     - develop
...  |
23 | |     - reopened
24 | |     - synchronize
   | |_________________^ pull_request_target is almost always used insecurely
   |
   = note: audit confidence → Medium

39 findings (38 suppressed): 0 informational, 0 low, 0 medium, 1 high
vikramvs@vikramvs-cloudtop:~/cluster-toolkit$ 
```
