### PR TITLE
zizmor security fix for label-external

### DIFF
--- a/.github/workflows/label-external.yml
+++ b/.github/workflows/label-external.yml
@@ -15,6 +15,11 @@
 name: Label External PRs
 
 on:
+  # zizmor: ignore[dangerous-triggers] -- checkout uses the default ref (base
+  # branch), never the PR head/fork commit, so untrusted code is never checked
+  # out or executed. The script only reads constrained values (PR author login,
+  # PR number, target branch name) from the event payload into shell variables;
+  # no PR-supplied content (title, body, files) is interpolated or executed.
   pull_request_target:
     branches:
     - develop


### PR DESCRIPTION
This PR fixes the Zizmor security warning in label-external.yml.
We added a comment explaining why the pull_request_target warning can be safely ignored here.
This workflow does not run or execute code from the PR/fork. It only reads basic PR information like the author, PR number, and target branch, and then adds a label.

After the changes, Zizmor was run again and there are 0 remaining security findings.
https://screenshot-v2.corp.google.com/1q6n2s7s029v8

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
