### PR TITLE
Increase SSH tunnel wait time, update retriable error regex

### DIFF
--- a/tools/cloud-build/check_retriable_error.sh
+++ b/tools/cloud-build/check_retriable_error.sh
@@ -29,7 +29,7 @@ fi
 # Define all retriable errors here.
 # Note: "Couldn't find a zone to deploy" and "ERROR: ZONE not found" are not included here
 # because find_available_zone.sh now internally loops and waits for zone capacity to maintain Kueue locks.
-RETRIABLE_ERRORS="ZONE_RESOURCE_POOL_EXHAUSTED|does not have enough resources available|not enough resources available|stockout|os-login.*ssh-keys.*add|resourceInUseByAnotherResource|Error acquiring the state lock|412 Precondition Failed|conditionNotMet|RATE_LIMIT_EXCEEDED|Mutate requests per minute|Error 429|HTTP 429|429 Too Many Requests|Error 50[0-9]|Internal error|backendError|Service Unavailable|connection reset by peer|TLS handshake timeout|overlaps with the existing allocated IP range|Connection refused|Connection timed out|Failed to connect to the host via ssh"
+RETRIABLE_ERRORS="ZONE_RESOURCE_POOL_EXHAUSTED|does not have enough resources available|not enough resources available|stockout|was created in the error state.*ERROR.*|srun: error: Node failure on|srun: error: Nodes .* are still not ready|os-login.*ssh-keys.*add|resourceInUseByAnotherResource|Error acquiring the state lock|412 Precondition Failed|conditionNotMet|RATE_LIMIT_EXCEEDED|Mutate requests per minute|Error 429|HTTP 429|429 Too Many Requests|Error 50[0-9]|Internal error|backendError|Service Unavailable|connection reset by peer|TLS handshake timeout|overlaps with the existing allocated IP range|Connection refused|Connection timed out|Failed to connect to the host via ssh"
 
 if grep -q -i -E "$RETRIABLE_ERRORS" "$LOG_FILE"; then
 	exit 0

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -52,9 +52,16 @@ class SSHManager:
         ]
 
         self.tunnel = subprocess.Popen(iap_tunnel_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        
-        # Sleep to give the tunnel a few seconds to set up
-        time.sleep(15)
+        # Wait for the tunnel to be established by polling the local port
+        start_time = time.time()
+        while time.time() - start_time < 15:
+            if self.tunnel.poll() is not None:
+                break
+            try:
+                with socket.create_connection(("localhost", self.local_port), timeout=1):
+                    break
+            except Exception:
+                time.sleep(0.5)
 
     def get_keypath(self):
         key_path = os.path.expanduser("~/.ssh/slurm_tests")

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -54,7 +54,7 @@ class SSHManager:
         self.tunnel = subprocess.Popen(iap_tunnel_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         
         # Sleep to give the tunnel a few seconds to set up
-        time.sleep(3)
+        time.sleep(15)
 
     def get_keypath(self):
         key_path = os.path.expanduser("~/.ssh/slurm_tests")


### PR DESCRIPTION
Slurm integration tests were failing intermittently due to SSH connection timeouts. Investigation revealed that the hardcoded 3-second timeout was insufficient for establishing IAP tunnels. Increased the timeout to 15 seconds, which resolved the flakiness.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
