### PR TITLE
fix(workflow): gh release create failure in draft-release-notes workflow after persist-credentials: false

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -57,6 +57,11 @@ jobs:
         echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+    - name: Setup git auth for gh CLI
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh auth setup-git
+
     - name: Create Draft Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix: Added persist-credentials: false to the checkout step for security hardening, but this broke Create Draft Release — gh release create --generate-notes internally shells out to local git to read commit history, 

which failed with fatal: could not read Username for 'https://github.com/' since no credentials were persisted.
https://screenshot-v2.corp.google.com/57klfi759gmdo

Added a gh auth setup-git step right before Create Draft Release to hand git a short-lived, scoped token (from GITHUB_TOKEN) only for that step — restoring --generate-notes functionality without reverting the security fix

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
