### PR TITLE
feat(examples): enable DRANET for TPU v6e 

### DIFF
--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -104,24 +104,6 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
-  - id: gke-tpu-v6e-net-1
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.deployment_name)-net-1
-      subnetworks:
-      - subnet_name: $(vars.deployment_name)-sub-1
-        subnet_region: $(vars.region)
-        subnet_ip: 192.168.64.0/18
-      firewall_rules:
-      - name: $(vars.deployment_name)-internal-1
-        ranges: [192.168.0.0/16]
-        allow:
-        - protocol: tcp
-          ports: ["0-65535"]
-        - protocol: udp
-          ports: ["0-65535"]
-        - protocol: icmp
-
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -175,6 +157,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_dataplane_v2: true
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)
@@ -185,7 +168,6 @@ deployment_groups:
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      additional_networks: $(gke-tpu-v6e-net-1.instance_additional_networks)
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: $(vars.version_prefix)
@@ -205,9 +187,9 @@ deployment_groups:
       disk_type: hyperdisk-balanced
       machine_type: $(vars.machine_type)
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
-      additional_networks: $(gke-tpu-v6e-net-1.instance_additional_networks)
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -87,24 +87,6 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
-  - id: gke-tpu-v6e-net-1
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.deployment_name)-net-1
-      subnetworks:
-      - subnet_name: $(vars.deployment_name)-sub-1
-        subnet_region: $(vars.region)
-        subnet_ip: 192.168.64.0/18
-      firewall_rules:
-      - name: $(vars.deployment_name)-internal-1
-        ranges: [192.168.0.0/16]
-        allow:
-        - protocol: tcp
-          ports: ["0-65535"]
-        - protocol: udp
-          ports: ["0-65535"]
-        - protocol: icmp
-
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -140,13 +122,13 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_dataplane_v2: true
       configure_workload_identity_sa: true
       namespace: $(vars.user_namespace)
       enable_ml_diagnostics: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      additional_networks: $(gke-tpu-v6e-net-1.instance_additional_networks)
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: "1.35."
@@ -166,9 +148,9 @@ deployment_groups:
       disk_type: hyperdisk-balanced
       machine_type: $(vars.machine_type)
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.v6e_node_pool_disk_size_gb)
-      additional_networks: $(gke-tpu-v6e-net-1.instance_additional_networks)
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:

--- a/examples/gke-tpu-v6e/kueue-job-sample.yaml
+++ b/examples/gke-tpu-v6e/kueue-job-sample.yaml
@@ -48,8 +48,8 @@ spec:
                 echo "Job complete."
               resources:
                 requests:
-                  google.com/tpu: "4" # 4 chips per pod * 4 pods = 16 chips
+                  google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips
                 limits:
-                  google.com/tpu: "4" # 4 chips per pod * 4 pods = 16 chips
+                  google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips
                 claims:
                 - name: netdev

--- a/examples/gke-tpu-v6e/kueue-job-sample.yaml
+++ b/examples/gke-tpu-v6e/kueue-job-sample.yaml
@@ -32,6 +32,9 @@ spec:
             nodeSelector:
               cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
               cloud.google.com/gke-tpu-topology: 4x4 # 4x4 = 16 chips
+            resourceClaims:
+            - name: netdev
+              resourceClaimTemplateName: default-netdev
             containers:
             - name: tpu-job
               image: ubuntu:22.04
@@ -45,6 +48,8 @@ spec:
                 echo "Job complete."
               resources:
                 requests:
-                  google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips
+                  google.com/tpu: "4" # 4 chips per pod * 4 pods = 16 chips
                 limits:
                   google.com/tpu: "4" # 4 chips per pod * 4 pods = 16 chips
+                claims:
+                - name: netdev

--- a/examples/gke-tpu-v6e/tpu-multislice.yaml
+++ b/examples/gke-tpu-v6e/tpu-multislice.yaml
@@ -34,11 +34,12 @@ spec:
         backoffLimit: 0
         template:
           spec:
-            hostNetwork: true
-            dnsPolicy: ClusterFirstWithHostNet
             nodeSelector:
               cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
               cloud.google.com/gke-tpu-topology: 4x4
+            resourceClaims:
+            - name: netdev
+              resourceClaimTemplateName: default-netdev
             containers:
             - name: jax-tpu
               image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:latest
@@ -57,3 +58,7 @@ spec:
               resources:
                 limits:
                   google.com/tpu: 4
+                requests:
+                  google.com/tpu: 4
+                claims:
+                - name: netdev


### PR DESCRIPTION
# feat(examples): enable DRANET for TPU v6e examples
Enable Dynamic Resource Allocation for Network Devices (DRANET) across the GKE TPU v6e examples and workload templates.
### Summary of Changes
* **Network Simplification**: Removed redundant secondary VPC (`gke-tpu-v6e-net-1`) and configured Dataplane V2 (`enable_dataplane_v2: true`) on the cluster.
* **DRANET Enablement**: Added `enable_dranet: true` to the TPU v6e node pool in `gke-tpu-v6e.yaml` and `gke-tpu-v6e-advanced.yaml`, automatically configuring the `netdev.google.com` `DeviceClass` and `default-netdev` `ResourceClaimTemplate`.
* **Kueue Integration**: Uncommented `config_path` to ensure automated provisioning of `ResourceFlavor` (`tpuv6e-flavor`), `ClusterQueue`, and `LocalQueue` (`user-queue`).
* **Workload Updates**:
  * `examples/gke-tpu-v6e/kueue-job-sample.yaml`: Added `default-netdev` resource claim and container claims.
  * `examples/gke-tpu-v6e/tpu-multislice.yaml`: Removed legacy `hostNetwork: true` / `ClusterFirstWithHostNet` networking in favor of standard container networking backed by DRANET claims.
### Testing
* Deployed 1-node TPU v6e cluster (`ct6e-standard-4t`, topology `2x2`, Spot) in `us-east1-d`.
* Verified `DeviceClass` (`netdev.google.com`) and `ResourceClaimTemplate` (`default-netdev`) creation.
* Submitted `kueue-job-sample.yaml` JobSet; verified automated admission into `user-queue` and successful execution with 4 TPU devices initialized via JAX.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
