### PR TITLE
feat(examples): enable DRANET for A3 Ultra examples

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -81,37 +81,6 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
-  - id: gke-a3-ultra-net-1
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.deployment_name)-net-1
-      ips_per_nat: 6
-      subnetworks:
-      - subnet_name: $(vars.deployment_name)-sub-1
-        subnet_region: $(vars.region)
-        subnet_ip: 192.168.64.0/18
-      firewall_rules:
-      - name: $(vars.deployment_name)-internal-1
-        ranges: [192.168.0.0/16]
-        allow:
-        - protocol: tcp
-          ports: ["0-65535"]
-        - protocol: udp
-          ports: ["0-65535"]
-        - protocol: icmp
-
-  - id: gke-a3-ultra-rdma-net
-    source: modules/network/gpu-rdma-vpc
-    settings:
-      network_name: $(vars.deployment_name)-rdma-net
-      network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
-      network_routing_mode: REGIONAL
-      subnetworks_template:
-        name_prefix: $(vars.deployment_name)-rdma-sub
-        count: 8
-        ip_range: 192.168.128.0/18
-        region: $(vars.region)
-
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -165,15 +134,12 @@ deployment_groups:
       enable_dcgm_monitoring: true
       enable_gcsfuse_csi: true
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
+      enable_dataplane_v2: true
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      additional_networks:
-        $(concat(gke-a3-ultra-net-1.instance_additional_networks,
-         gke-a3-ultra-rdma-net.subnetwork_interfaces_gke
-        ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: $(vars.version_prefix)
@@ -232,6 +198,7 @@ deployment_groups:
     settings:
       machine_type: a3-ultragpu-8g
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.a3ultra_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
@@ -242,10 +209,6 @@ deployment_groups:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:
         - name: $(vars.reservation)
-      additional_networks:
-        $(concat(gke-a3-ultra-net-1.instance_additional_networks,
-         gke-a3-ultra-rdma-net.subnetwork_interfaces_gke
-        ))
     outputs: [instructions]
 
   - id: workload-manager-install

--- a/examples/gke-a3-ultragpu/nccl-jobset-example.yaml
+++ b/examples/gke-a3-ultragpu/nccl-jobset-example.yaml
@@ -36,18 +36,6 @@ spec:
             annotations:
               kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
               networking.gke.io/default-interface: 'eth0'
-              networking.gke.io/interfaces: |
-                [
-                  {"interfaceName":"eth0","network":"default"},
-                  {"interfaceName":"eth2","network":"rdma-0"},
-                  {"interfaceName":"eth3","network":"rdma-1"},
-                  {"interfaceName":"eth4","network":"rdma-2"},
-                  {"interfaceName":"eth5","network":"rdma-3"},
-                  {"interfaceName":"eth6","network":"rdma-4"},
-                  {"interfaceName":"eth7","network":"rdma-5"},
-                  {"interfaceName":"eth8","network":"rdma-6"},
-                  {"interfaceName":"eth9","network":"rdma-7"}
-                ]
           spec:
             # Limit benchmark run duration
             activeDeadlineSeconds: 3600
@@ -84,6 +72,9 @@ spec:
             - name: proc-sys
               hostPath:
                 path: /proc/sys
+            resourceClaims:
+            - name: rdma
+              resourceClaimTemplateName: default-rdma
 
             initContainers:
             - name: gpu-healthcheck
@@ -218,3 +209,5 @@ spec:
                   nvidia.com/gpu: 8
                 requests:
                   nvidia.com/gpu: 8
+                claims:
+                - name: rdma

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
@@ -262,18 +262,6 @@ data:
                   annotations:
                     kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
                     networking.gke.io/default-interface: 'eth0'
-                    networking.gke.io/interfaces: |
-                      [
-                        \{"interfaceName":"eth0","network":"default"\},
-                        \{"interfaceName":"eth2","network":"{gpu_subnet_prefix}-0"\},
-                        \{"interfaceName":"eth3","network":"{gpu_subnet_prefix}-1"\},
-                        \{"interfaceName":"eth4","network":"{gpu_subnet_prefix}-2"\},
-                        \{"interfaceName":"eth5","network":"{gpu_subnet_prefix}-3"\},
-                        \{"interfaceName":"eth6","network":"{gpu_subnet_prefix}-4"\},
-                        \{"interfaceName":"eth7","network":"{gpu_subnet_prefix}-5"\},
-                        \{"interfaceName":"eth8","network":"{gpu_subnet_prefix}-6"\},
-                        \{"interfaceName":"eth9","network":"{gpu_subnet_prefix}-7"\}
-                      ]
                 spec:
                   restartPolicy: Never
                   nodeSelector:
@@ -321,6 +309,9 @@ data:
                   - name: hpl-config
                     configMap:
                       name: {experiment_name}
+                  resourceClaims:
+                  - name: rdma
+                    resourceClaimTemplateName: default-rdma
                   initContainers:
                   - name: gpu-healthcheck
                     image: alpine:latest
@@ -431,6 +422,8 @@ data:
                         nvidia.com/gpu: 8
                       requests:
                         nvidia.com/gpu: 8
+                      claims:
+                      - name: rdma
 
                   restartPolicy: Never
 

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
@@ -239,18 +239,6 @@ data:
                   annotations:
                     kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
                     networking.gke.io/default-interface: 'eth0'
-                    networking.gke.io/interfaces: |
-                      [
-                        \{"interfaceName":"eth0","network":"default"\},
-                        \{"interfaceName":"eth2","network":"{gpu_subnet_prefix}-0"\},
-                        \{"interfaceName":"eth3","network":"{gpu_subnet_prefix}-1"\},
-                        \{"interfaceName":"eth4","network":"{gpu_subnet_prefix}-2"\},
-                        \{"interfaceName":"eth5","network":"{gpu_subnet_prefix}-3"\},
-                        \{"interfaceName":"eth6","network":"{gpu_subnet_prefix}-4"\},
-                        \{"interfaceName":"eth7","network":"{gpu_subnet_prefix}-5"\},
-                        \{"interfaceName":"eth8","network":"{gpu_subnet_prefix}-6"\},
-                        \{"interfaceName":"eth9","network":"{gpu_subnet_prefix}-7"\}
-                      ]
                 spec:
                   restartPolicy: Never
                   nodeSelector:
@@ -295,6 +283,9 @@ data:
                   - name: local-ssd
                     hostPath:
                       path: /mnt/stateful_partition/kube-ephemeral-ssd
+                  resourceClaims:
+                  - name: rdma
+                    resourceClaimTemplateName: default-rdma
                   initContainers:
                   - name: gpu-healthcheck
                     image: alpine:latest
@@ -403,6 +394,8 @@ data:
                         nvidia.com/gpu: 8
                       requests:
                         nvidia.com/gpu: 8
+                      claims:
+                      - name: rdma
 
                   restartPolicy: Never
 

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
@@ -313,18 +313,6 @@ data:
                   annotations:
                     kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
                     networking.gke.io/default-interface: 'eth0'
-                    networking.gke.io/interfaces: |
-                      [
-                        \{"interfaceName":"eth0","network":"default"\},
-                        \{"interfaceName":"eth2","network":"{gpu_subnet_prefix}-0"\},
-                        \{"interfaceName":"eth3","network":"{gpu_subnet_prefix}-1"\},
-                        \{"interfaceName":"eth4","network":"{gpu_subnet_prefix}-2"\},
-                        \{"interfaceName":"eth5","network":"{gpu_subnet_prefix}-3"\},
-                        \{"interfaceName":"eth6","network":"{gpu_subnet_prefix}-4"\},
-                        \{"interfaceName":"eth7","network":"{gpu_subnet_prefix}-5"\},
-                        \{"interfaceName":"eth8","network":"{gpu_subnet_prefix}-6"\},
-                        \{"interfaceName":"eth9","network":"{gpu_subnet_prefix}-7"\}
-                      ]
                 spec:
                   restartPolicy: Never
                   nodeSelector:
@@ -372,6 +360,9 @@ data:
                   - name: nemo-config
                     configMap:
                       name: {experiment_name}
+                  resourceClaims:
+                  - name: rdma
+                    resourceClaimTemplateName: default-rdma
                   initContainers:
                   - name: gpu-healthcheck
                     image: alpine:latest
@@ -485,6 +476,8 @@ data:
                         nvidia.com/gpu: 8
                       requests:
                         nvidia.com/gpu: 8
+                      claims:
+                      - name: rdma
 
                   restartPolicy: Never
 

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -19,7 +19,6 @@ tags:
 - m.gke-cluster
 - m.gke-node-pool
 - m.service-account
-- m.gpu-rdma-vpc
 - m.kubectl-apply
 - m.vpc
 - m.cloud-storage-bucket

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -19,7 +19,6 @@ tags:
 - m.gke-cluster
 - m.gke-node-pool
 - m.service-account
-- m.gpu-rdma-vpc
 - m.kubectl-apply
 - m.vpc
 - m.cloud-storage-bucket


### PR DESCRIPTION
# feat(examples): enable DRANET for A3 Ultra examples
Enable Dynamic Resource Allocation for Network Devices (DRANET) across GKE A3 Ultra examples, NCCL test workloads, and benchmark recipes.
### Summary of Changes
* **Network Simplification**: Removed secondary VPC (`gke-a3-ultra-net-1`) and dedicated RDMA VPC network module (`gke-a3-ultra-rdma-net`), standardizing on a single VPC with Dataplane V2 (`enable_dataplane_v2: true`).
* **DRANET Enablement**: Added `enable_dranet: true` to the `a3-ultragpu-pool` module in `gke-a3-ultragpu.yaml`, which automatically provisions the `mrdma.google.com` `DeviceClass` and `default-rdma` `ResourceClaimTemplate`.
* **Workload & Benchmark Updates**:
  * `examples/gke-a3-ultragpu/nccl-jobset-example.yaml`: Removed multi-NIC interface annotations and `kubernetes.io/hostname` podset preferred topology; added `default-rdma` resource claim and container claims.
  * `examples/gke-a3-ultragpu/system_benchmarks/ramble-{hpl,nccl,nemo}.yaml`: Removed multi-NIC interfaces; added `default-rdma` resource claims and container claims.
* **Test Configurations**: Removed `- m.gpu-rdma-vpc` dependency tag from `tools/cloud-build/daily-tests/builds/gke-a3-ultragpu*.yaml`.
### Testing
* Deployed 2-node A3 Ultra cluster (`a3-ultragpu-8g`, Spot with `placement_policy: COMPACT`) in `europe-west4-a`.
* Verified `DeviceClass` (`mrdma.google.com`) and `ResourceClaimTemplate` (`default-rdma`) creation.
* Ran 2-node NCCL JobSet (`nccl-jobset-example.yaml`); verified all pods reached `Completed` and the JobSet completed successfully with high bandwidth across all RDMA interfaces.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
