### PR TITLE
Refactor image push and modularize image cleanup

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -166,36 +182,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -46,7 +46,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -182,36 +198,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -40,7 +40,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -167,36 +183,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -40,7 +40,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -165,36 +181,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -40,7 +40,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -163,36 +179,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -39,7 +39,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Job Manifest
 - id: generate-job-manifest
@@ -152,33 +168,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/gcluster-test:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/gcluster-test:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 3. Generate Job YAML
 - id: generate-job-manifest
@@ -166,37 +182,13 @@ steps:
   - $BUILD_ID
 
 # 5. Cleanup the built image from Registry to save costs
-- id: cleanup-images
+- id: cleanup-image
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
+  - 'IMAGE=us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/gcluster-test:$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/gcluster-test:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -236,36 +252,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     INNER_EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -229,36 +245,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -230,36 +246,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -45,7 +45,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -232,36 +248,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -45,7 +45,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -234,36 +250,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -46,7 +46,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -198,36 +214,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -189,36 +205,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -223,36 +239,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -46,7 +46,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -225,36 +241,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -190,36 +206,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -179,36 +195,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -186,36 +202,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -49,7 +49,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -212,36 +228,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -42,7 +42,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -212,36 +228,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -221,36 +237,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -221,36 +237,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     INNEREOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -235,36 +251,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -178,36 +194,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -42,7 +42,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -210,36 +226,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -54,7 +54,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -181,36 +197,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Job Manifest
 - id: generate-job-manifest
@@ -166,36 +182,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -47,7 +47,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -177,36 +193,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -46,7 +46,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Kueue Job Manifest
 - id: generate-job-manifest
@@ -167,36 +183,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -48,7 +48,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -170,36 +186,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -47,7 +47,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -224,36 +240,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -50,7 +50,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     DOCKEREOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -220,36 +236,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -212,36 +228,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -48,7 +48,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -222,36 +238,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -47,7 +47,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -220,36 +236,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -47,7 +47,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -188,36 +204,12 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
+  - tools/cloud-build/image_cleanup.sh
 
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -45,7 +45,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -212,36 +228,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -180,36 +196,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -42,7 +42,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -181,36 +197,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Job manifest
 - id: generate-job-manifest
@@ -211,36 +227,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -46,7 +46,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     DOCKERFILE
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -175,36 +191,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -167,36 +183,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -42,7 +42,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Job manifest
 - id: generate-job-manifest
@@ -167,36 +183,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -45,7 +45,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -169,36 +185,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -174,36 +190,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -40,7 +40,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -172,36 +188,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -42,7 +42,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Generate Job Manifest
 - id: generate-job-manifest
@@ -145,33 +161,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -171,36 +187,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -144,33 +160,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -229,35 +245,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -149,33 +165,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -172,36 +188,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -173,36 +189,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -41,7 +41,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -140,33 +156,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -43,7 +43,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -173,36 +189,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -51,7 +51,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -175,36 +191,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
@@ -44,7 +44,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -200,36 +216,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -48,7 +48,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -170,36 +186,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest

--- a/tools/cloud-build/daily-tests/builds/vm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/vm-storage.yaml
@@ -38,7 +38,23 @@ steps:
     COPY . /workspace
     WORKDIR /workspace
     EOF
-    docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
+
+    MAX_RETRIES=3
+    for i in $$(seq 1 $$MAX_RETRIES); do
+      echo "Push attempt $$i of $$MAX_RETRIES..."
+      if docker push us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID; then
+        echo "The image pushed successfully!"
+        break
+      fi
+
+      if [ "$$i" -eq "$$MAX_RETRIES" ]; then
+        echo "The image push failed after $$MAX_RETRIES attempts. (Check https://status.cloud.google.com/ for server outages)"
+        exit 1
+      fi
+
+      echo "The image push failed, retrying in 10 seconds..."
+      sleep 10
+    done
 
 # 2. Retrieve GCS Bucket name from Secret Manager and generate Job YAML
 - id: generate-job-manifest
@@ -192,36 +208,11 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   allowFailure: true
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'BUILD_ID=$BUILD_ID'
   args:
-  - -c
-  - |
-    set -eo pipefail
-    IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
-    MAX_RETRIES=5
-    RETRY_DELAY=10
-    ATTEMPT=1
-
-    echo "Starting cleanup for image: $$IMAGE"
-
-    while [ "$$ATTEMPT" -le "$$MAX_RETRIES" ]; do
-      echo "Attempt $$ATTEMPT of $$MAX_RETRIES..."
-
-      if gcloud artifacts docker images delete "$$IMAGE" --quiet; then
-        echo "Image successfully deleted."
-        exit 0
-      fi
-
-      if [ "$$ATTEMPT" -lt "$$MAX_RETRIES" ]; then
-        echo "Deletion failed. Retrying in $$RETRY_DELAY seconds..."
-        sleep $$RETRY_DELAY
-      fi
-
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-    echo "Failed to delete image after $$MAX_RETRIES attempts."
-    echo "Image will be handled by Artifact Registry background cleanup policies."
-    exit 1
+  - tools/cloud-build/image_cleanup.sh
 
 availableSecrets:
   secretManager:

--- a/tools/cloud-build/image_cleanup.sh
+++ b/tools/cloud-build/image_cleanup.sh
@@ -15,7 +15,7 @@
 
 set -eo pipefail
 
-IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
+IMAGE=${IMAGE:-"us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"}
 MAX_RETRIES=5
 RETRY_DELAY=10
 ATTEMPT=1

--- a/tools/cloud-build/image_cleanup.sh
+++ b/tools/cloud-build/image_cleanup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+IMAGE="us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID"
+MAX_RETRIES=5
+RETRY_DELAY=10
+ATTEMPT=1
+
+echo "Starting cleanup for image: $IMAGE"
+
+while [ "$ATTEMPT" -le "$MAX_RETRIES" ]; do
+	echo "Attempt $ATTEMPT of $MAX_RETRIES..."
+
+	if gcloud artifacts docker images delete "$IMAGE" --quiet; then
+		echo "Image successfully deleted."
+		exit 0
+	fi
+
+	if [ "$ATTEMPT" -lt "$MAX_RETRIES" ]; then
+		echo "Deletion failed. Retrying in $RETRY_DELAY seconds..."
+		sleep $RETRY_DELAY
+	fi
+
+	ATTEMPT=$((ATTEMPT + 1))
+done
+
+echo "Failed to delete image after $MAX_RETRIES attempts."
+echo "Image will be handled by Artifact Registry background cleanup policies."
+exit 1


### PR DESCRIPTION
This PR updates the build image push retry to the registry to avoid the random transient bad gateway errors failing the CI pipelines and also modularise the image cleanup build step.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
