### PR TITLE
Provision go 1.26 cloud build infrastructure

### DIFF
--- a/tools/cloud-build/provision/pr-go-build-test.tf
+++ b/tools/cloud-build/provision/pr-go-build-test.tf
@@ -15,7 +15,7 @@
 
 resource "google_cloudbuild_trigger" "pr_go_build_test" {
   # NOTE: make sure that go.mod:go and Makefile:MIN_GOLANG_VERSION match lowest version.
-  for_each = toset(["1.24"])
+  for_each = toset(["1.24", "1.26"])
 
   name        = "PR-Go-${replace(each.key, ".", "-")}-build-test"
   description = "Test that the PR builds with Go ${each.key}"


### PR DESCRIPTION
This is a pre-requisite pull request to natively roll out the `golang:1.26` Cloud Build CI trigger.

### What this PR does
- Introduces the Go `1.26` runtime to the Cloud Build provisioning array (running concurrently alongside `1.24`).
- Ensures the project's core CD deployment correctly instantiates the `PR-go-1-26-build-test` pipeline on GCP.

### Why it is needed
Currently, pending Go 1.26 upgrades and Dependabot CVE patches are blocked in CI because the Cloud Build infrastructure is hardcoded strictly to boot `golang:1.24` containers, causing compilation to crash against newer `go.mod` configurations. 
By merging this targeted infrastructure update into `develop` first, the backend deployment will automatically provision the 1.26 pipeline. Subsequent PRs demanding Go 1.26 will then natively hit the correct trigger and successfully pass their CI checks.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
