### PR TITLE
feat(job): add --skip-prereqs flag to bypass rigid environment validations

### DIFF
--- a/cmd/job/job.go
+++ b/cmd/job/job.go
@@ -27,6 +27,7 @@ var (
 	location     string
 	projectID    string
 	gkeNamespace string
+	skipPrereqs  bool
 )
 
 var gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
@@ -67,8 +68,10 @@ var JobCmd = &cobra.Command{
 		if projectID == "" {
 			return fmt.Errorf("project ID is required; please specify it using the --project flag or set a default value using 'gcluster job config set project <value>'")
 		}
-		if err := ensureBasicPrerequisites(cmd, projectID); err != nil {
-			return err
+		if !skipPrereqs {
+			if err := ensureBasicPrerequisites(cmd, projectID); err != nil {
+				return err
+			}
 		}
 
 		resolvedLoc, err := orc.Initialize(clusterName, location, projectID)
@@ -86,6 +89,7 @@ func init() {
 	JobCmd.PersistentFlags().StringVarP(&location, "location", "l", "", "Location (region or zone) of the GKE cluster.")
 	JobCmd.PersistentFlags().StringVarP(&projectID, "project", "p", "", "Google Cloud Project ID.")
 	JobCmd.PersistentFlags().StringVar(&gkeNamespace, "gke-namespace", "", "Target GKE namespace for the operation. If omitted, automatic detection is used.")
+	JobCmd.PersistentFlags().BoolVar(&skipPrereqs, "skip-prereqs", false, "Skip local environment prerequisite checks (gcloud, kubectl, docker auth, etc.) before taking action.")
 
 	JobCmd.AddCommand(SubmitCmd)
 	JobCmd.AddCommand(CancelJobCmd)

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -110,8 +110,10 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 		if err := validatePathwaysFlags(); err != nil {
 			return err
 		}
-		if err := ensurePrerequisites(cmd, projectID, location); err != nil {
-			return err
+		if !skipPrereqs {
+			if err := ensurePrerequisites(cmd, projectID, location); err != nil {
+				return err
+			}
 		}
 
 		if err := validateGKENAPFlags(); err != nil {

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -305,6 +305,7 @@ func setupSubmitTestEnv(t *testing.T) {
 	awaitJobCompletion = false
 	priority = "medium"
 	isPathwaysJob = false
+	skipPrereqs = false
 	pathways = orchestrator.PathwaysJobDefinition{MaxSliceRestarts: 1}
 	gkeNapProvisioning = ""
 	gkeNapReservation = ""
@@ -1103,5 +1104,86 @@ func TestSubmitCmd_PathwaysHeadless(t *testing.T) {
 
 	if !pathways.Headless {
 		t.Errorf("expected pathways.Headless to be true")
+	}
+}
+func TestSubmitCmd_SkipPrereqs_BypassesChecks(t *testing.T) {
+	setupSubmitTestEnv(t)
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	// Provide a completely empty/stale state. This would ordinarily trigger
+	// the prerequisite checks (like checking for gcloud) and fail.
+	store = &MockPrereqStore{State: PrereqState{}}
+
+	// Force an error in checks to guarantee it fails if they run!
+	oldADC := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = oldADC }()
+	getADCSetupCommandFunc = func() string {
+		return "echo force-failure"
+	}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "test-skip-true",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		"--skip-prereqs", "true",
+	)
+
+	// Since --skip-prereqs is true, all ensureBasicPrerequisites and ensurePrerequisites
+	// checks must be bypassed, making it succeed and reach the mock orchestrator.
+	if err != nil {
+		t.Fatalf("expected no error when --skip-prereqs is true, got: %v", err)
+	}
+}
+
+func TestSubmitCmd_SkipPrereqsFalse_RunsChecks(t *testing.T) {
+	setupSubmitTestEnv(t)
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	// Provide a completely empty/stale state.
+	store = &MockPrereqStore{State: PrereqState{}}
+
+	// Force an error in checks to guarantee it fails if they run!
+	oldADC := getADCSetupCommandFunc
+	defer func() { getADCSetupCommandFunc = oldADC }()
+	getADCSetupCommandFunc = func() string {
+		return "echo force-failure"
+	}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "test-skip-false",
+		"--image", "busybox",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "test-location",
+		"--project", "test-project",
+		// --skip-prereqs is false by default
+	)
+
+	// Since --skip-prereqs is false, the prerequisite checks will run.
+	// Since our MockStore state is empty, the CLI will try to run real gcloud checks
+	// which will fail either due to absence of gcloud or missing authentication in test env.
+	if err == nil {
+		t.Fatalf("expected an error (prerequisite check failure) since --skip-prereqs is false/omitted, but got nil")
 	}
 }

--- a/docs/gcluster_job_guide.md
+++ b/docs/gcluster_job_guide.md
@@ -28,6 +28,8 @@ If you use `--build-context` to build images on-the-fly, you must set:
 > If any required dependencies are missing or unconfigured, `gcluster` will identify them and print the necessary installation or remediation commands directly to your console for review and execution
 >
 > Successful checks are remembered in `~/.gcluster/job_prereq_state.json` to optimize subsequent runs. Checks are re-run if the state is older than 24 hours or if you switch projects.
+>
+> **Bypassing Checks:** If you are running `gcluster` in a complex environment (such as an automated CI/CD pipeline without a human `gcloud` session, a system with custom Docker credential helpers, or an environment with strict least-privilege IAM limits), you can completely bypass these validations by appending the `--skip-prereqs` flag.
 
 ### 1.1 Multi-Tier Checkpointing (MTC) Prerequisites
 
@@ -1139,6 +1141,7 @@ Pass the `--gke-custom-templates-path` flag to the `submit` command:
 | `-l, --location` | `string` | Google Cloud location (Zone or Region) of the GKE cluster. |
 | `-p, --project` | `string` | Google Cloud Project ID. |
 | `--gke-namespace` | `string` | Target GKE namespace for the operation. Supported across all job commands. If omitted, automatic detection is used. |
+| `--skip-prereqs` | `flag` | Bypasses local workstation pre-flight environment checks (e.g. gcloud SDK, IAM checks, Docker config). |
 
 ### 9.2 Configuration Commands
 *Use these commands to manage persistent defaults for your job submissions, avoiding the need to pass common flags repeatedly.*


### PR DESCRIPTION
This PR introduces a `--skip-prereqs` persistent flag to the `gcluster job` command group. When provided, this flag bypasses all local workstation pre-flight checks (such as checking for the `gcloud` SDK, checking Docker `credsStore`, and querying project-level Google Cloud APIs).

### Why is this needed? 
Currently, the `ensureBasicPrerequisites` and `ensurePrerequisites` functions act as a helpful safety net for local users to catch misconfigurations. However, this rigid checklist creates false negatives that block execution in complex environments. 

This flag provides a necessary escape hatch for:
1. **Automated CI/CD Pipelines:** Execution environments mapping tokens via Workload Identity that do not have human `gcloud auth` sessions or the SDK installed locally.
2. **Restricted IAM Environments:** Developers operating under strict least-privilege access (scoped directly to a GKE namespace) who routinely hit `403 Permission Denied` blocks when the CLI aggressively attempts to scan project-wide service APIs.
3. **Custom Developer Setups:** Advanced users orchestrating non-standard Docker credential helpers or pulling from proxy registries.

### What changed?
- Added the `skipPrereqs` boolean to `cmd/job/job.go` and bound it as a Cobra `PersistentFlag` so the bypass smoothly inherits down to all subcommands (`submit`, `cancel`, `inspect`, etc.).
- Wrapped `ensureBasicPrerequisites` and `ensurePrerequisites` in conditional blocks.
- **Testing:** Added 100% unit test coverage in `cmd/job/submit_test.go` (`TestSubmitCmd_SkipPrereqs_BypassesChecks` and `TestSubmitCmd_SkipPrereqsFalse_RunsChecks`). These tests set a heavily mocked stale environment rigged to throw a fatal error, proving that toggling the flag completely and safely bypasses the validation roadblock.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
