### PR TITLE
feat(examples): enable DRANET for TPU 7x examples

### DIFF
--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -102,24 +102,6 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
-  - id: gke-tpu-7x-net-1
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.deployment_name)-net-1
-      subnetworks:
-      - subnet_name: $(vars.deployment_name)-sub-1
-        subnet_region: $(vars.region)
-        subnet_ip: 192.168.64.0/18
-      firewall_rules:
-      - name: $(vars.deployment_name)-internal-1
-        ranges: [192.168.0.0/16]
-        allow:
-        - protocol: tcp
-          ports: ["0-65535"]
-        - protocol: udp
-          ports: ["0-65535"]
-        - protocol: icmp
-
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -176,13 +158,13 @@ deployment_groups:
       enable_persistent_disk_csi: true # enable Hyperdisk for the cluster
       enable_managed_lustre_csi: true  # enable Managed Lustre for the cluster
       enable_filestore_csi: true # enable Filestore for the cluster
+      enable_dataplane_v2: true
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      additional_networks: $(gke-tpu-7x-net-1.instance_additional_networks)
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: "1.35."
@@ -213,8 +195,8 @@ deployment_groups:
       disk_type: hyperdisk-balanced
       machine_type: $(vars.machine_type)
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
-      additional_networks: $(gke-tpu-7x-net-1.instance_additional_networks)
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:

--- a/examples/gke-tpu-7x/gke-tpu-7x-job.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-job.yaml
@@ -25,6 +25,9 @@ spec:
   nodeSelector:
     cloud.google.com/gke-tpu-accelerator: tpu7x
     cloud.google.com/gke-tpu-topology: <YOUR_TPU_TOPOLOGY> # E.g. 2x2x1
+  resourceClaims:
+  - name: netdev
+    resourceClaimTemplateName: default-netdev
   containers:
   - name: tpu-job
     image: python:3.12
@@ -44,3 +47,5 @@ spec:
         google.com/tpu: <CHIPS_PER_NODE> # e.g., 4 for tpu7x-standard-4t
       limits:
         google.com/tpu: <CHIPS_PER_NODE> # e.g., 4 for tpu7x-standard-4t
+      claims:
+      - name: netdev

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -120,6 +120,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_dataplane_v2: true
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)
@@ -156,6 +157,7 @@ deployment_groups:
       disk_type: hyperdisk-balanced
       machine_type: $(vars.machine_type)
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
       reservation_affinity:
         consume_reservation_type: SPECIFIC_RESERVATION

--- a/examples/gke-tpu-7x/kueue-job-sample.yaml
+++ b/examples/gke-tpu-7x/kueue-job-sample.yaml
@@ -32,6 +32,9 @@ spec:
             nodeSelector:
               cloud.google.com/gke-tpu-accelerator: tpu7x
               cloud.google.com/gke-tpu-topology: 2x2x1 # 4 chips
+            resourceClaims:
+            - name: netdev
+              resourceClaimTemplateName: default-netdev
             containers:
             - name: tpu-job
               image: ubuntu:22.04
@@ -48,3 +51,5 @@ spec:
                   google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips
                 limits:
                   google.com/tpu: "4" # 4 chips per pod * 1 pod = 4 chips
+                claims:
+                - name: netdev


### PR DESCRIPTION
### Description
Enables DRANET (Dynamic Resource Allocation for Networking) on GKE TPU 7x examples.

### Key Changes
* **Blueprints (`gke-tpu-7x.yaml` & `gke-tpu-7x-advanced.yaml`)**:
  * Added `enable_dataplane_v2: true` to the GKE cluster definition.
  * Added `enable_dranet: true` to the TPU 7x node pool definition.
  * Removed secondary VPC (`gke-tpu-7x-net-1`) and `additional_networks` references in the advanced example.
* **Workload Samples (`kueue-job-sample.yaml` & `gke-tpu-7x-job.yaml`)**:
  * Added DRANET `resourceClaims` using template `default-netdev`.
  * Added container claim bindings (`claims: [{name: netdev}]`).

### Testing
* Validated blueprint generation with `./gcluster create`.
* Verified test metadata validation via `validate_tests_metadata.py`.
* Passed unit tests (`go test ./...`).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
