### PR TITLE
NetApp Volumes: mount large-capacity volumes via Cloud DNS

### DIFF
--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -57,6 +57,11 @@ jobs:
         echo "rc_branch=$BRANCH" >> "$GITHUB_OUTPUT"
         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+    - name: Setup git auth for gh CLI
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh auth setup-git
+
     - name: Create Draft Release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/community/examples/eda/README.md
+++ b/community/examples/eda/README.md
@@ -27,7 +27,7 @@ Two example blueprints are provided.
 
 This blueprint assumes that all compute and data resides in the cloud.
 
-In the base deployment group (see [deployment stages](#deployment_stages)) it provisions a new network and multiple volumes to store your data. Adjust the volume sizes to suit your requirements before deployment. If your volumes are larger than 15 TiB, creating them as [large volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes) adds performance benefits. One limitation currently is that Slurm will only use the first IP of a large volume. If you need to utilize the full performance of the 6 IP addresses a large volume provides, you can instead utilize the approach with pre-existing volumes and CloudDNS mentioned in eda-hybrid-cloud blueprint description.
+In the base deployment group (see [deployment stages](#deployment_stages)) it provisions a new network and multiple volumes to store your data. Adjust the volume sizes to suit your requirements before deployment. If your volumes are larger than 15 TiB, creating them as [large volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes) adds performance benefits. The blueprint creates a private Cloud DNS zone and configures every volume with a DNS record. For large-capacity volumes, the record contains all NFS endpoint IPs so Slurm clients use the volume FQDN and are distributed across the endpoints through DNS round-robin.
 
 The cluster deployment group deploys a managed instance group which is managed by Slurm.
 
@@ -37,7 +37,7 @@ When scaling down the deployment, make sure to only destroy the *compute* deploy
 
 This blueprint assumes you are using NetApp Volumes [FlexCache](https://docs.cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview) to enable a [hybrid cloud EDA](https://community.netapp.com/t5/Tech-ONTAP-Blogs/NetApp-FlexCache-Enhancing-hybrid-EDA-with-Google-Cloud-NetApp-Volumes/ba-p/462768) environment.
 
-The base deployment group (see [deployment stages](#deployment_stages)) connects to an existing network and mounts multiple volumes. This blueprint assumes you have pre-existing volumes for "tools", "libraries", "home" and "scratch". Before deployment, update `server_ip` and `remote_mount` parameters of the respective volumes in the blueprint declarations to reflect the actual IP and export path of your existing volumes. Using existing volumes also avoids the danger of being deleted accidentally when deleting the base deployment group.
+The base deployment group (see [deployment stages](#deployment_stages)) connects to an existing network and mounts multiple volumes. This blueprint assumes you have pre-existing volumes for "tools", "libraries", "home" and "scratch". Before deployment, set each `*_server_ips` blueprint variable to the complete list of NFS endpoint IPs for that volume and update its `remote_mount` parameter with the export path. The blueprint creates private DNS records from those addresses and supplies the resulting FQDNs to the storage modules. Using existing volumes also avoids the danger of them being deleted accidentally when deleting the base deployment group.
 
 The volumes used can be regular NetApp Volume [volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview), [large volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes) or [FlexCache volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview).
 
@@ -52,7 +52,7 @@ FlexCache offers the following features which enable bursting on-premises worklo
 
 It can accelerate metadata- or throughput-heavy read workloads considerably.
 
-FlexCache and Large Volumes offer six IP addresses per volume which all provide access to the same data. Currently Cluster Toolkit only uses one of these IPs. Support for using all 6 IPs is planned for a later release. To spread your compute nodes over all IPs today, you can use CloudDNS to create an DNS record with all 6 IPs and specify that DNS name instead of individual IPs in the blueprint. CloudDNS will return one of the 6 IPs in a round-robin fashion on lookups.
+FlexCache and large-capacity volumes offer multiple IP addresses per volume, all of which provide access to the same data. The EDA blueprints publish these addresses in private Cloud DNS and mount the storage by FQDN instead of selecting one IP. Cloud DNS returns the addresses in round-robin order, distributing client mounts across the available endpoints. Resolver caching means the distribution is not guaranteed to be perfectly even.
 
 The cluster deployment group deploys a managed instance group which is managed by Slurm.
 
@@ -86,6 +86,7 @@ storage intact and b) you can build software before you deploy your cluster.
 >
 > - Compute Engine
 > - NetApp Volumes
+> - Cloud DNS
 >
 > To avoid continued billing after use closely follow the
 > [teardown instructions](#teardown-instructions). To generate a cost estimate based on
@@ -112,7 +113,7 @@ storage intact and b) you can build software before you deploy your cluster.
    make
    ```
 
-1. Change parameters in your blueprint file to reflect your requirements. Examples are VPC names for existing networks, H4D instance group node limits or export paths of existing NFS volumes.
+1. Change parameters in your blueprint file to reflect your requirements. Examples are VPC names for existing networks, H4D instance group node limits, or, for `eda-hybrid-cloud`, each volume's `*_server_ips` list and `remote_mount` export path.
 
 1. Generate the deployment folder after replacing `<blueprint>` with the name of the blueprint (`eda-all-on-cloud` or `eda-hybrid-cloud`) and `<project_id>`, `region` and `zone` with your project details.
 

--- a/community/examples/eda/eda-all-on-cloud.yaml
+++ b/community/examples/eda/eda-all-on-cloud.yaml
@@ -83,7 +83,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "toolsfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -98,7 +97,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "libraryfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -113,7 +111,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "homefs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false
@@ -126,7 +123,6 @@ deployment_groups:
     source: modules/file-system/netapp-volume
     use: [netapp_pool]
     settings:
-      region: $(vars.region)
       volume_name: "scratchfs"
       capacity_gib: 1024    # Adjust size as needed
       large_capacity: false

--- a/community/examples/eda/eda-all-on-cloud.yaml
+++ b/community/examples/eda/eda-all-on-cloud.yaml
@@ -68,6 +68,18 @@ deployment_groups:
       service_name: "netapp.servicenetworking.goog"
       deletion_policy: "ABANDON"
 
+  # Private DNS zone for NetApp volume NFS endpoints. Each volume below creates
+  # an A record containing all of its endpoint IPs and passes the resulting FQDN
+  # to Slurm clients through the USE directive.
+  - id: gcnv_dns_zone
+    source: modules/network/dns-managed-zone
+    settings:
+      zone_name: $(vars.deployment_name)-gcnv-dns
+      dns_name: gcnv.internal.
+      visibility: private
+      network_id: $(eda-net.network_id)
+      description: "Private DNS for NetApp volume NFS endpoints"
+
   # NetApp Storage Pool. All NetApp Volumes will be created in this pool.
   - id: netapp_pool
     source: modules/file-system/netapp-storage-pool
@@ -91,6 +103,8 @@ deployment_groups:
       unix_permissions: "0777"
       # Mount options are optimized for aggressive caching, assuming rare changes on the volume
       mount_options: "nocto,actimeo=600,hard,rsize=262144,wsize=262144,vers=3,tcp,mountproto=tcp"
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
 
   # NFS volume for shared libraries
   - id: libraryfs
@@ -105,6 +119,8 @@ deployment_groups:
       unix_permissions: "0777"
       # Mount options are optimized for aggressive caching, assuming rare changes on the volume
       mount_options: "nocto,actimeo=600,hard,rsize=262144,wsize=262144,vers=3,tcp,mountproto=tcp"
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
 
   # NFS volume for home directories
   - id: homefs
@@ -117,6 +133,8 @@ deployment_groups:
       local_mount: "/home"
       protocols: ["NFSV3"]
       unix_permissions: "0755"
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
 
   # NFS volume for scratch space
   - id: scratchfs
@@ -129,6 +147,8 @@ deployment_groups:
       local_mount: "/scratch"
       protocols: ["NFSV3"]
       unix_permissions: "0777"
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
 
 # ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 #
@@ -226,5 +246,6 @@ deployment_groups:
     - scratchfs
     settings:
       enable_controller_public_ips: true
+      enable_slurm_auth: true
       cloud_parameters:
         slurmd_timeout: 900

--- a/community/examples/eda/eda-hybrid-cloud.yaml
+++ b/community/examples/eda/eda-hybrid-cloud.yaml
@@ -23,6 +23,12 @@ vars:
   zone: us-central1-a  ## Set GCP Zone Here ##
   network: default ## Set name of existing VPC network here
   rdma_net_range: 192.168.128.0/18 # Specify an unused CIDR range for the RDMA network
+  gcnv_dns_name: gcnv.internal.
+  # List every NFS endpoint IP for each pre-existing volume or FlexCache.
+  toolsfs_server_ips:   ## Set list of NFS server IPs here ##
+  libraryfs_server_ips: ## Set list of NFS server IPs here ##
+  homefs_server_ips:    ## Set list of NFS server IPs here ##
+  scratchfs_server_ips: ## Set list of NFS server IPs here ##
 
 deployment_groups:
 
@@ -91,13 +97,42 @@ deployment_groups:
         subnet_ip: $(vars.rdma_net_range)
         region: $(vars.region)
 
+  # Publish every endpoint IP for each pre-existing volume or FlexCache under a
+  # private FQDN. DNS round-robin distributes Slurm clients across endpoints.
+  - id: gcnv_dns_zone
+    source: modules/network/dns-managed-zone
+    settings:
+      zone_name: $(vars.deployment_name)-gcnv-dns
+      dns_name: $(vars.gcnv_dns_name)
+      visibility: private
+      network_id: $(eda-net.network_id)
+      description: "Private DNS for NetApp volume and FlexCache NFS endpoints"
+      recordsets:
+      - name: toolsfs
+        type: A
+        ttl: 60
+        rrdatas: $(vars.toolsfs_server_ips)
+      - name: libraryfs
+        type: A
+        ttl: 60
+        rrdatas: $(vars.libraryfs_server_ips)
+      - name: homefs
+        type: A
+        ttl: 60
+        rrdatas: $(vars.homefs_server_ips)
+      - name: scratchfs
+        type: A
+        ttl: 60
+        rrdatas: $(vars.scratchfs_server_ips)
+
 # Connect existing Google Cloud NetApp Volumes
-# Replace server_ip, remote_mount, and local_mount values as needed for toolsfs, libraryfs, homefs, scratchfs
+# Set every endpoint IP in vars above, then replace remote_mount and local_mount
+# values as needed for toolsfs, libraryfs, homefs, and scratchfs.
 # Make sure the root inode of each volume has appropriate permissions for intended users, otherwise SLURM jobs may fail
   - id: toolsfs
     source: modules/file-system/pre-existing-network-storage
     settings:
-      server_ip:    # Set IP address of the NFS server here
+      server_ip: toolsfs.$(vars.gcnv_dns_name)
       remote_mount: # Set exported path of NFS share here
       local_mount: /tools
       fs_type: nfs
@@ -107,7 +142,7 @@ deployment_groups:
   - id: libraryfs
     source: modules/file-system/pre-existing-network-storage
     settings:
-      server_ip:    # Set IP address of the NFS server here
+      server_ip: libraryfs.$(vars.gcnv_dns_name)
       remote_mount: # Set exported path of NFS share here
       local_mount: /library
       fs_type: nfs
@@ -117,7 +152,7 @@ deployment_groups:
   - id: homefs
     source: modules/file-system/pre-existing-network-storage
     settings:
-      server_ip:    # Set IP address of the NFS server here
+      server_ip: homefs.$(vars.gcnv_dns_name)
       remote_mount: # Set exported path of NFS share here
       local_mount: /home
       fs_type: nfs
@@ -126,7 +161,7 @@ deployment_groups:
   - id: scratchfs
     source: modules/file-system/pre-existing-network-storage
     settings:
-      server_ip:    # Set IP address of the NFS server here
+      server_ip: scratchfs.$(vars.gcnv_dns_name)
       remote_mount: # Set exported path of NFS share here
       local_mount: /scratch
       fs_type: nfs
@@ -228,5 +263,6 @@ deployment_groups:
     - scratchfs
     settings:
       enable_controller_public_ips: true
+      enable_slurm_auth: true
       cloud_parameters:
         slurmd_timeout: 900

--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -5,7 +5,7 @@ storage.
 
 The Toolkit contains modules that will **provision**:
 
-- [Google Cloud NetApp Volumes (GCP managed enterprise NFS and SMB)][netapp-volumes]
+- [Google Cloud NetApp Volumes (GCP managed enterprise NFS)][netapp-volumes]
 - [Filestore (GCP managed NFS)][filestore]
 - [Managed Lustre][managed-lustre]
 - [NFS server (non-GCP managed)][nfs-server]
@@ -18,6 +18,36 @@ with a network storage device that is already set up. The
 - daos
 - managed-lustre
 - gcsfuse
+
+## NetApp Volumes (Default mode)
+
+The [netapp-storage-pool][netapp-storage-pool] and [netapp-volume][netapp-volumes] modules provision NetApp Volumes in Default mode with NFSv3 and NFSv4.1 only. If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and use [pre-existing-network-storage] to mount the NFS export in your blueprint.
+
+### Service levels
+
+1. **STANDARD, PREMIUM, EXTREME** — Regional pools. Set `region` only.
+2. **Flex Unified** — Zonal or regional pools. Set `region` and `zone`; add `replica_zone` for regional pools. Optionally set `total_throughput_mibps` and `total_iops` for custom performance.
+
+### Capacity minimums
+
+Storage pools:
+
+1. STANDARD, PREMIUM, EXTREME — 2048 GiB
+2. Flex Unified — 1024 GiB
+3. Flex Unified large capacity (`SCALE_TYPE_SCALEOUT`) — 6144 GiB
+
+Volumes:
+
+1. STANDARD, PREMIUM, EXTREME (regular) — 100 GiB
+2. STANDARD, PREMIUM, EXTREME (large capacity) — 15 TiB (15360 GiB); set `large_capacity: true`
+3. Flex Unified — 1 GiB
+4. Flex Unified large capacity — 4800 GiB; set `large_capacity_config.constituent_count`
+
+### Not supported by these modules
+
+1. Flex File
+2. ONTAP mode (use [pre-existing-network-storage])
+3. SMB and iSCSI
 
 ## Connecting to Network Storage
 
@@ -128,3 +158,4 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE
 [managed-lustre]: ../modules/file-system/managed-lustre/README.md
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md
 [netapp-volumes]: ../modules/file-system/netapp-volume/README.md
+[netapp-storage-pool]: ../modules/file-system/netapp-storage-pool/README.md

--- a/docs/network_storage.md
+++ b/docs/network_storage.md
@@ -43,6 +43,13 @@ Volumes:
 3. Flex Unified — 1 GiB
 4. Flex Unified large capacity — 4800 GiB; set `large_capacity_config.constituent_count`
 
+### Mounting large-capacity volumes and FlexCache
+
+Large-capacity volumes and FlexCache caches expose the same NFS export on multiple IP addresses. For best performance, clients should resolve a DNS name that contains every endpoint IP rather than mounting a single address.
+
+1. **Volumes created by `netapp-volume`** — Provision a private [`dns-managed-zone`][dns-managed-zone] and set `dns_config.managed_zone_name` on the volume. The module creates a round-robin A record and sets `network_storage.server_ip` to the FQDN. Slurm and VM `use:` wiring then mount by hostname.
+2. **Pre-existing volumes and FlexCache** — Create the private zone yourself (the zone module accepts `recordsets`) and set `server_ip` on [`pre-existing-network-storage`][pre-existing-network-storage] to the FQDN. See [`examples/netapp-volumes-slurm.yaml`](../examples/netapp-volumes-slurm.yaml) and the [EDA hybrid blueprint](../community/examples/eda/eda-hybrid-cloud.yaml).
+
 ### Not supported by these modules
 
 1. Flex File
@@ -159,3 +166,4 @@ GCS FUSE (pre-existing) | via USE | via USE | via USE | via STARTUP | via USE
 [nfs-server]: ../community/modules/file-system/nfs-server/README.md
 [netapp-volumes]: ../modules/file-system/netapp-volume/README.md
 [netapp-storage-pool]: ../modules/file-system/netapp-storage-pool/README.md
+[dns-managed-zone]: ../modules/network/dns-managed-zone/README.md

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,7 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [gke-a4x](#gke-a4x-) ![core-badge]
   * [gke-a4x-max-bm](#gke-a4x-max-bm-) ![core-badge]
   * [netapp-volumes.yaml](#netapp-volumesyaml-) ![core-badge]
+  * [netapp-volumes-slurm.yaml](#netapp-volumes-slurmyaml-) ![core-badge]
   * [gke-tpu-7x](#gke-tpu-7x-) ![core-badge]
   * [gcloud-example.yaml](#gcloud-exampleyaml--) ![community-badge] ![experimental-badge]
   * [eda-all-on-cloud.yaml](#eda-all-on-cloudyaml-) ![community-badge]
@@ -1807,6 +1808,27 @@ To destroy all resources associated with creating the GKE cluster, run the follo
 [auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
 [netapp-volumes.yaml]: ../examples/netapp-volumes.yaml
 
+### [netapp-volumes-slurm.yaml] ![core-badge]
+
+This blueprint creates a basic Slurm cluster that mounts a Flex Unified large-capacity NetApp volume at `/home`. A private Cloud DNS zone publishes all NFS endpoint IPs under one FQDN so Slurm clients are distributed across endpoints. Auto-tiering is enabled on the storage pool and volume.
+
+#### Steps to deploy the blueprint
+
+```shell
+./gcluster create examples/netapp-volumes-slurm.yaml --vars "project_id=${GOOGLE_CLOUD_PROJECT}" --vars region=us-central1 --vars zone=us-central1-a
+./gcluster deploy netapp-volumes-slurm
+```
+
+After the cluster is deployed, SSH to the Slurm login node and confirm `/home` is mounted over NFS by FQDN.
+
+#### Clean Up
+
+```sh
+./gcluster destroy netapp-volumes-slurm
+```
+
+[netapp-volumes-slurm.yaml]: ../examples/netapp-volumes-slurm.yaml
+
 ### [gke-tpu-7x] ![core-badge]
 
 This example shows how TPU 7x cluster can be created and be used to run a job that requires TPU capacity on GKE. Additional information on TPU blueprint and associated changes are in this [README](/examples/gke-tpu-7x/README.md).
@@ -1823,7 +1845,7 @@ of creating and deleting a network, subnet, and VM instance.
 
 ### [eda-all-on-cloud.yaml] ![community-badge]
 
-Creates a basic auto-scaling Slurm cluster intended for EDA use cases. The blueprint also creates two new VPC networks, a network called `eda-net` which connects VMs, Slurm and storage and a RDMA network called `eda-rdma-net` between the H4D nodes, along with four [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) mounted to `/home`, `/tools`, `/library` and `/scratch`. There is an `h4d` partition that uses compute-optimized `h4d-highmem-192-lssd` machine type.
+Creates a basic auto-scaling Slurm cluster intended for EDA use cases. The blueprint also creates two new VPC networks, a network called `eda-net` which connects VMs, Slurm and storage and a RDMA network called `eda-rdma-net` between the H4D nodes, along with four [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) mounted to `/home`, `/tools`, `/library` and `/scratch`. Each volume is published in a private Cloud DNS zone so Slurm clients mount by FQDN and use every NFS endpoint IP. There is an `h4d` partition that uses compute-optimized `h4d-highmem-192-lssd` machine type.
 
 The deployment instructions can be found in the [README](../community/examples/eda/README.md).
 
@@ -1833,7 +1855,7 @@ The deployment instructions can be found in the [README](../community/examples/e
 
 Creates a basic auto-scaling Slurm cluster intended for EDA use cases. The blueprint also connects to one existing user network which connects VMs, Slurm and storage and creates a RDMA network called `eda-rdma-net` for low latency communication between the compute nodes. There is an `h4d` partition that uses compute-optimized `h4d-highmem-192-lssd` machine type.
 
-Four pre-existing NFS volumes are mounted to `/home`, `/tools`, `/library` and `/scratch`. Using [FlexCache](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview) volumes allows to bring on-premises data to Google Cloud compute, without having to manually copy the data. This enables "burst to the cloud" use cases.
+Four pre-existing NFS volumes are mounted to `/home`, `/tools`, `/library` and `/scratch`. Set each `*_server_ips` variable to the complete list of endpoint IPs; the blueprint creates private Cloud DNS records and mounts the volumes by FQDN. Using [FlexCache](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview) volumes allows to bring on-premises data to Google Cloud compute, without having to manually copy the data. This enables "burst to the cloud" use cases.
 
 The deployment instructions can be found in the [README](../community/examples/eda/README.md).
 

--- a/examples/gke-a3-highgpu-inference-gateway.yaml
+++ b/examples/gke-a3-highgpu-inference-gateway.yaml
@@ -23,7 +23,7 @@ vars:
   zone: us-central1-c
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
   gcp_public_cidrs_access_enabled: false
   gpu_static_node_count: 2
 

--- a/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
+++ b/examples/gke-a3-highgpu/gke-a3-highgpu.yaml
@@ -33,7 +33,7 @@ vars:
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr: # <your-ip-address>/32
 
   gcp_public_cidrs_access_enabled: false
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))

--- a/examples/gke-managed-hyperdisk.yaml
+++ b/examples/gke-managed-hyperdisk.yaml
@@ -21,7 +21,7 @@ vars:
 
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
 
 deployment_groups:
 - group: primary

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -24,7 +24,7 @@ vars:
   zone: us-central1-a
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
   version_prefix: "1.35."
   base_network_name: $(vars.deployment_name)
   # Managed-Lustre instance name. This should be unique for each deployment.

--- a/examples/hpc-gke.yaml
+++ b/examples/hpc-gke.yaml
@@ -21,7 +21,7 @@ vars:
   deployment_name: cluster-01
   region: us-central1
   gcp_public_cidrs_access_enabled: false
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
 
 deployment_groups:
 - group: primary

--- a/examples/ml-gke.yaml
+++ b/examples/ml-gke.yaml
@@ -23,7 +23,7 @@ vars:
   - asia-southeast1-b  # g2 machine has better availability in this zone
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
   gcp_public_cidrs_access_enabled: false
 
 deployment_groups:

--- a/examples/netapp-volumes-slurm.yaml
+++ b/examples/netapp-volumes-slurm.yaml
@@ -1,0 +1,132 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+# This blueprint creates a basic Slurm cluster backed by a Google Cloud NetApp
+# Volumes Flex Unified large-capacity volume. Cloud DNS publishes all NFS
+# endpoint IPs under one private FQDN, which Slurm clients use to mount /home.
+# Auto-tiering is enabled on both the storage pool and volume.
+
+blueprint_name: netapp-volumes-slurm
+
+vars:
+  project_id: ## Set GCP Project ID Here ##
+  deployment_name: netapp-volumes-slurm
+  region:     ## Set GCP Region Here ##
+  zone:       ## Set GCP Zone Here ##
+
+# Documentation for each of the modules used below can be found at
+# https://github.com/GoogleCloudPlatform/cluster-toolkit
+
+deployment_groups:
+- group: primary
+  modules:
+  - id: network
+    source: modules/network/vpc
+
+  # Private Service Access (PSA) requires the compute.networkAdmin role, which
+  # is included in the Owner role but not the Editor role.
+  # https://cloud.google.com/vpc/docs/configure-private-services-access#permissions
+  - id: private_service_access
+    source: modules/network/private-service-access
+    use: [network]
+    settings:
+      prefix_length: 24
+      service_name: netapp.servicenetworking.goog
+      deletion_policy: ABANDON
+
+  # The private zone makes the volume's multiple NFS endpoint IPs available
+  # under a single FQDN to clients in this VPC.
+  - id: gcnv_dns_zone
+    source: modules/network/dns-managed-zone
+    settings:
+      zone_name: $(vars.deployment_name)-gcnv-dns
+      dns_name: gcnv.internal.
+      visibility: private
+      network_id: $(network.network_id)
+      description: Private DNS for NetApp volume NFS endpoints
+
+  - id: netapp_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: $(vars.deployment_name)-netapp-pool
+      service_level: FLEX
+      region: $(vars.region)
+      zone: $(vars.zone)
+      scale_type: SCALE_TYPE_SCALEOUT
+      capacity_gib: 12288
+      total_throughput_mibps: 256
+      total_iops: 4096
+      allow_auto_tiering: true
+      hot_tier_size_gib: 6144
+      enable_hot_tier_auto_resize: true
+
+  - id: homefs
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]
+    settings:
+      volume_name: homefs
+      # 4800 GiB is the minimum Flex Unified large-capacity volume size.
+      capacity_gib: 4800
+      large_capacity_config:
+        constituent_count: 48
+      local_mount: /home
+      protocols: [NFSV3]
+      unix_permissions: "0777"
+      tiering_policy:
+        tier_action: ENABLED
+        cooling_threshold_days: 31
+        hot_tier_bypass_mode_enabled: false
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
+
+  - id: compute_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network, homefs]
+    settings:
+      node_count_static: 2
+      node_count_dynamic_max: 10
+      machine_type: n2-standard-4
+      disk_type: pd-balanced
+      bandwidth_tier: gvnic_enabled
+      allow_automatic_updates: false
+
+  - id: compute_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute_nodeset]
+    settings:
+      partition_name: compute
+      is_default: true
+      exclusive: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network]
+    settings:
+      machine_type: n2-standard-4
+      enable_login_public_ips: true
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use:
+    - network
+    - compute_partition
+    - homefs
+    - slurm_login
+    settings:
+      machine_type: n2-standard-4
+      enable_controller_public_ips: true
+      enable_slurm_auth: true

--- a/examples/netapp-volumes.yaml
+++ b/examples/netapp-volumes.yaml
@@ -14,10 +14,9 @@
 
 ---
 
-# This blueprint show how to provision shared file systems with Google Cloud NetApp Volumes.
-# It creates a NetApp storage pool and a volume for use by VM instances.
-# It can be used to build compute clusters on top of it and as a drop-in replacement
-# for Filestore in existing blueprints.
+# This blueprint shows how to provision shared file systems with Google Cloud NetApp Volumes.
+# It creates a Flex Unified SCALEOUT storage pool and one large capacity volume at the
+# minimum supported size. Example VMs mount the volume through the USE directive.
 
 blueprint_name: netapp-volumes
 
@@ -26,7 +25,6 @@ vars:
   deployment_name: netapp-volumes
   region:     ## Set GCP Region Here ##
   zone:       ## Set GCP Zone Here ##
-  pool_service_level: "EXTREME"  # Options: "STANDARD", "PREMIUM", "EXTREME"
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/cluster-toolkit
@@ -53,47 +51,28 @@ deployment_groups:
     use: [network, private_service_access]
     settings:
       pool_name: $(vars.deployment_name)-netapp-pool
-      capacity_gib: 2048
-      service_level: $(vars.pool_service_level)
+      service_level: FLEX
       region: $(vars.region)
-      # allow_auto_tiering: true
+      zone: $(vars.zone)
+      scale_type: SCALE_TYPE_SCALEOUT
+      capacity_gib: 6144
+      total_throughput_mibps: 256
+      total_iops: 4096
 
   - id: homefs
     source: modules/file-system/netapp-volume
-    use: [netapp_pool]             # Create this pool using the netapp-storage-pool module
+    use: [netapp_pool]
     settings:
-      region: $(vars.region)
-      volume_name: $(vars.deployment_name)-homefs
-      capacity_gib: 2048           # Size up to available capacity in the pool
-      large_capacity: false
-      local_mount: "/home"         # Mount point at client when client uses USE directive
-      # mount_options: "..."       # Use custom mount_options for special use cases. Defaults are sane.
-      protocols: ["NFSV3"]         # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
-      unix_permissions: "0777"     # Specify default permissions for root inode owned by root:root
-      # If no export policy is specified, a permissive default policy will be applied, which is:
-      #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
-      #  has_root_access = true      # no_root_squash enabled
-      #  access_type = "READ_WRITE"
-      # export_policy_rules:
-      # - allowed_clients: "10.10.20.8,10.10.20.9"
-      #   has_root_access: true      # no_root_squash enabled
-      #   access_type: "READ_WRITE"
-      #   nfsv3: true
-      #   nfsv4: false
-      # - allowed_clients: "10.0.0.0/8"
-      #   has_root_access: false     # no_root_squash disabled
-      #   access_type: "READ_WRITE"
-      #   nfsv3: true
-      #   nfsv4: false
-      # tiering_policy:              # Enable auto-tiering. Requires auto-tiering enabled storage pool
-      #   tier_action: "ENABLED"
-      #   cooling_threshold_days: 31 # tier data blocks which have not been touched for 31 days
-      # description: "Shared volume for EDA job"
-      # labels:
-      #   department: eda
+      volume_name: homefs
+      capacity_gib: 4800
+      large_capacity_config:
+        constituent_count: 48
+      local_mount: /home
+      protocols: ["NFSV3"]
+      unix_permissions: "0777"
 
   # Example VMs which use homefs
-  - id: gcnv_ubuntu_instances
+  - id: gcnv_instances
     source: modules/compute/vm-instance
     use: [network, homefs]
     settings:
@@ -103,5 +82,5 @@ deployment_groups:
   - id: wait-for-vms
     source: community/modules/scripts/wait-for-startup
     settings:
-      instance_names: $(gcnv_ubuntu_instances.name)
+      instance_names: $(gcnv_instances.name)
       timeout: 7200

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -21,7 +21,7 @@ vars:
   zone: us-central1-b
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
-  authorized_cidr: <your-ip-address>/32
+  authorized_cidr:  # <your-ip-address>/32
   gcp_public_cidrs_access_enabled: false
   # To use Storage Pools, they must be pre-created before deployment.
   # Replace 'your-pool-balanced' and 'your-pool-throughput' with your storage pool names.

--- a/modules/file-system/netapp-storage-pool/README.md
+++ b/modules/file-system/netapp-storage-pool/README.md
@@ -1,34 +1,210 @@
 ## Description
 
-This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
-storage pool.
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview) storage pool.
 
-NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volumes is a first-party Google service that provides NFS shared file systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+
 NetApp Volume provides:
 
-- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
+- support for NFSv3 and NFSv4.1
 - a [rich feature set][service-levels]
 - scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
-- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
-- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+- [FlexCache](https://docs.cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview): Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimize cost
 
 Support for NetApp Volumes is split into two modules.
 
 - **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
-- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume is a file system container shared using NFSv3 or NFSv4.1.
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
 
 ### NetApp storage pool service levels
 
-The netapp-storage-pool module currently supports the following NetApp Volumes [service levels][service-levels]:
+The netapp-storage-pool module supports the following NetApp Volumes [service levels][service-levels]:
 
 - Standard: 16 KiBps throughput per provisioned KiB of volume capacity.
 - Premium: 64 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
 - Extreme: 128 KiBps throughput per provisioned KiB of volume capacity. Optional [auto-tiering].
+- Flex Unified: Next-generation Flex service level. Supports zonal and regional pools, auto-tiering, and large capacity pools. Flex File and ONTAP mode are not supported by this module.
 
-Check the [service level matrix][service-levels] for additional information on capability differences between service levels. Flex service levels are currently not supported, but you can connect to existing Flex volumes using the [pre-existing-network-storage module][pre-existing].
+Check the [service level matrix][service-levels] for additional information on capability differences between service levels.
+
+### Flex Unified defaults
+
+When `service_level` is `FLEX`, the module sets these values automatically:
+
+1. `mode` = `DEFAULT`
+2. `type` = `UNIFIED`
+
+You do not set `mode` or `type` in your blueprint. Flex File (`type: FILE`) and ONTAP mode are not supported. Use [pre-existing-network-storage][pre-existing] for ONTAP-mode pools.
+
+### Region and zone settings
+
+Always set `region` in your blueprint. Zone settings apply only to Flex Unified pools.
+
+1. **Standard, Premium, and Extreme** — Set `region` only. Blueprint-level `zone` variables used for VMs are ignored.
+2. **Zonal Flex Unified** — Set `region` and `zone`. The module verifies that `zone` is in `region`.
+3. **Regional Flex Unified** — Set `region`, `zone` (active zone), and `replica_zone`. The module verifies that both zones are in `region`.
+4. **Large capacity (SCALE_TYPE_SCALEOUT)** — Zonal Flex Unified only. Set `region` and `zone`. Do not set `replica_zone`.
+
+### Minimum pool capacity
+
+The module enforces these minimum `capacity_gib` values at plan time:
+
+1. **STANDARD, PREMIUM, and EXTREME** — 2048 GiB
+2. **Flex Unified** — 1024 GiB
+3. **Flex Unified large capacity (`scale_type: SCALE_TYPE_SCALEOUT`)** — 6144 GiB
+
+### Flex Unified auto-tiering
+
+When `allow_auto_tiering` is `true` on a Flex Unified pool:
+
+1. Set `hot_tier_size_gib` to the hot-tier capacity in GiB.
+2. Optionally set `enable_hot_tier_auto_resize` to allow the hot tier to grow when it reaches 100%.
+
+When `allow_auto_tiering` is `false` (the default), omit `hot_tier_size_gib` and
+`enable_hot_tier_auto_resize`. The module fails at plan time if either is set.
+
+Volumes in the pool can then enable auto-tiering with `tiering_policy` in the [netapp-volume](../netapp-volume/README.md) module.
+
+### Flex Unified large capacity pools
+
+To host Flex Unified large capacity volumes, create a zonal pool with:
+
+1. `service_level: FLEX`
+2. `region` and `zone` (omit `replica_zone`)
+3. `scale_type: SCALE_TYPE_SCALEOUT`
+4. `capacity_gib` of at least 6144
+
+Pair this pool with volumes that set `large_capacity_config` in the [netapp-volume](../netapp-volume/README.md) module.
+
+### Flex Unified custom performance
+
+Flex Unified pools use custom performance implicitly. You can scale capacity, throughput, and IOPS independently.
+
+1. Each pool includes 64 MiB/s throughput and 1,024 IOPS by default.
+2. Set `total_throughput_mibps` to provision additional throughput in 1 MiB/s increments, up to 5 GiB/s for standard Flex pools.
+3. Set `total_iops` to provision additional IOPS, up to 160,000 per pool. Omit `total_iops` to let Google Cloud calculate IOPS from `total_throughput_mibps` (16 IOPS per additional MiB/s).
+4. All volumes in the pool share the pool throughput and IOPS.
+5. Large capacity pools (`scale_type: SCALE_TYPE_SCALEOUT`) can reach higher throughput limits. See [Volume performance sizing](https://cloud.google.com/netapp/volumes/docs/plan-and-prepare/volume-performance-sizing).
+
+```yaml
+  - id: flex_pool_custom_perf
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool-perf"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      capacity_gib: 5120
+      total_throughput_mibps: 256
+      total_iops: 4096
+```
+
+### Flex Unified zonal and regional pools
+
+Flex Unified pools can be zonal or regional. The module selects the pool type from your zone settings.
+
+#### Zonal vs regional rules
+
+1. **Zonal pool** — Set `region` and `zone`. Omit `replica_zone`. Pool `location` is the zone name.
+2. **Regional pool** — Set `region`, `zone` (active zone), and `replica_zone` (standby zone). Pool `location` is the region name. Volume access is served from the active zone. If the active zone fails, `replica_zone` becomes active.
+3. **`zone` and `replica_zone` must be different** for regional pools.
+4. **`zone` and `replica_zone` must be within `region`.**
+5. **Large capacity pools (`scale_type: SCALE_TYPE_SCALEOUT`) must be zonal.** Set `zone` and omit `replica_zone`.
+6. **Standard, Premium, and Extreme pools use `region` only.** Blueprint-level `zone` values (for example, for VM placement) are ignored and do not block pool creation.
+
+#### Multiple pools in one blueprint
+
+To provision both a zonal and a regional Flex pool, add one `netapp-storage-pool` module per pool. Use a unique module `id` and `pool_name` for each pool. Configure zone settings per module. Attach volumes with `use: [<pool_module_id>]`.
+
+Example:
+
+```yaml
+vars:
+  region: us-east1
+  zone_a: us-east1-b
+  zone_b: us-east1-c
+
+deployment_groups:
+- group: netapp-pools
+  modules:
+  - id: network
+    source: modules/network/pre-existing-vpc
+    settings:
+      region: $(vars.region)
+      network_name: $(vars.network)
+
+  - id: flex_pool_zonal
+    source: modules/file-system/netapp-storage-pool
+    use: [network]
+    settings:
+      pool_name: $(vars.deployment_name)-flex-zonal
+      service_level: FLEX
+      region: $(vars.region)
+      zone: $(vars.zone_a)
+      capacity_gib: 4096
+      total_throughput_mibps: 128
+      total_iops: 2048
+
+  - id: flex_pool_regional
+    source: modules/file-system/netapp-storage-pool
+    use: [network]
+    settings:
+      pool_name: $(vars.deployment_name)-flex-regional
+      service_level: FLEX
+      region: $(vars.region)
+      zone: $(vars.zone_a)
+      replica_zone: $(vars.zone_b)
+      capacity_gib: 4096
+      total_throughput_mibps: 128
+      total_iops: 2048
+
+- group: netapp-volumes
+  modules:
+  - id: zonal_homefs
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_zonal]
+    settings:
+      volume_name: zonal_homefs
+      capacity_gib: 1024
+      local_mount: /zonal-home
+      protocols: ["NFSV3"]
+
+  - id: regional_homefs
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_regional]
+    settings:
+      volume_name: regional_homefs
+      capacity_gib: 1024
+      local_mount: /regional-home
+      protocols: ["NFSV3"]
+```
+
+#### Zone switch and Terraform state
+
+If a regional pool fails over outside Terraform, update `zone` and `replica_zone` in your blueprint to match the current active and replica zones before the next apply. Otherwise Terraform can initiate an unwanted zone switch.
+
+### ONTAP mode
+
+These modules provision and manage NetApp Volumes through Google Cloud APIs in Default mode only. They do not support Flex Unified pools in ONTAP mode.
+
+If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and integrate them with the [pre-existing-network-storage][pre-existing] module. In ONTAP mode, the pool is created through Google Cloud APIs, but volumes, snapshots, and policies inside the pool are managed with ONTAP tools. See [Manage ONTAP mode](https://cloud.google.com/netapp/volumes/docs/ontap/manage-ontap).
+
+### Outputs for netapp-volume
+
+When a volume module uses `use: [netapp_pool]`, Cluster Toolkit wires these pool outputs automatically:
+
+1. `netapp_storage_pool_id`
+2. `service_level`
+3. `type`
+4. `allow_auto_tiering`
+5. `scale_type`
+
+The volume module parses volume location from `netapp_storage_pool_id`. It does not inherit `region` or `zone`.
 
 ### On-boarding NetApp Volumes
 NetApp Volumes uses [Private Service Access](https://cloud.google.com/vpc/docs/private-services-access) (PSA) to connect volumes to your network. Before you create a storage pool, make sure to [connect NetApp Volumes to your network](https://cloud.google.com/netapp/volumes/docs/get-started/configure-access/networking).
@@ -85,9 +261,9 @@ deployment_groups:
       region: $(vars.region)
 ```
 
-### Storage pool example
+### Storage pool examples
 
-The following example shows all available parameters in use:
+#### Standard, Premium, or Extreme
 
 ```yaml
   - id: netapp_pool
@@ -98,11 +274,53 @@ The following example shows all available parameters in use:
       region: "us-west4"
       capacity_gib: 2048
       service_level: "EXTREME"
-      active_directory_policy: "projects/myproject/locations/us-east4/activeDirectories/my-ad"
-      cmek_policy: "projects/myproject/locations/us-east4/kmsConfigs/my-cmek-policy"
+      allow_auto_tiering: true
+      active_directory_policy: "projects/myproject/locations/us-west4/activeDirectories/my-ad"
+      cmek_policy: "projects/myproject/locations/us-west4/kmsConfigs/my-cmek-policy"
       ldap_enabled: false
-      allow_auto_tiering: false
       description: "Demo storage pool"
+      labels:
+        owner: bob
+```
+
+#### Flex Unified zonal with auto-tiering
+
+```yaml
+  - id: flex_pool
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      capacity_gib: 4096
+      total_throughput_mibps: 256
+      total_iops: 4096
+      allow_auto_tiering: true
+      hot_tier_size_gib: 1024
+      enable_hot_tier_auto_resize: true
+      labels:
+        owner: bob
+```
+
+#### Flex Unified large capacity (SCALEOUT)
+
+```yaml
+  - id: flex_pool_large
+    source: modules/file-system/netapp-storage-pool
+    use: [network, private_service_access]
+    settings:
+      pool_name: "flex-pool-large"
+      service_level: FLEX
+      region: us-east1
+      zone: us-east1-b
+      scale_type: SCALE_TYPE_SCALEOUT
+      capacity_gib: 12288
+      total_throughput_mibps: 1024
+      total_iops: 16384
+      allow_auto_tiering: true
+      hot_tier_size_gib: 2048
       labels:
         owner: bob
 ```
@@ -111,7 +329,7 @@ The following example shows all available parameters in use:
 
 Your project must have unused quota for NetApp Volumes in the region you will
 provision the storage pool. This can be found by browsing to the [Quota tab within IAM & Admin](https://console.cloud.google.com/iam-admin/quotas) in the Cloud Console.
-Please note that there are separate quota limits for Standard and Premium/Extreme service levels.
+Please note that there are separate quota limits for Standard, Premium/Extreme, and Flex Unified service levels.
 
 See also NetApp Volumes [default quotas](https://cloud.google.com/netapp/volumes/docs/quotas#netapp-volumes-default-quotas).
 
@@ -168,12 +386,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_active_directory_policy"></a> [active\_directory\_policy](#input\_active\_directory\_policy) | The ID of the Active Directory policy to apply to the storage pool in the format:<br/>`projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>` | `string` | `null` | no |
+| <a name="input_active_directory_policy"></a> [active\_directory\_policy](#input\_active\_directory\_policy) | The ID of the Active Directory policy to apply to the storage pool in the format:<br/>`projects/<project_id>/locations/<location>/activeDirectories/<name>` | `string` | `null` | no |
 | <a name="input_allow_auto_tiering"></a> [allow\_auto\_tiering](#input\_allow\_auto\_tiering) | Whether to allow automatic tiering for the storage pool. | `bool` | `false` | no |
-| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the storage pool in GiB. | `number` | `2048` | no |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the storage pool in GiB. Minimum is 2048 GiB for STANDARD, PREMIUM, and EXTREME; 1024 GiB for Flex Unified; 6144 GiB for large capacity (SCALE\_TYPE\_SCALEOUT) pools. | `number` | `2048` | no |
 | <a name="input_cmek_policy"></a> [cmek\_policy](#input\_cmek\_policy) | The ID of the Customer Managed Encryption Key (CMEK) policy to apply to the storage pool in the format:<br/>`projects/<project>/locations/<location>/kmsConfigs/<name>` | `string` | `null` | no |
 | <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | Name of the deployment, used as name of the NetApp storage pool if no name is specified. | `string` | n/a | yes |
 | <a name="input_description"></a> [description](#input\_description) | A description of the NetApp storage pool. | `string` | `""` | no |
+| <a name="input_enable_hot_tier_auto_resize"></a> [enable\_hot\_tier\_auto\_resize](#input\_enable\_hot\_tier\_auto\_resize) | Whether hot-tier threshold will auto-increase when it reaches 100%. Flex-only. Requires allow\_auto\_tiering to be true. | `bool` | `null` | no |
+| <a name="input_hot_tier_size_gib"></a> [hot\_tier\_size\_gib](#input\_hot\_tier\_size\_gib) | Total hot tier capacity for the storage pool in GiB. Flex-only. Requires allow\_auto\_tiering to be true. | `number` | `null` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp storage pool. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_ldap_enabled"></a> [ldap\_enabled](#input\_ldap\_enabled) | Whether to enable LDAP for the storage pool. | `bool` | `false` | no |
 | <a name="input_network_id"></a> [network\_id](#input\_network\_id) | The ID of the GCE VPC network to which the NetApp storage pool is connected given in the format:<br/>`projects/<project_id>/global/networks/<network_name>`" | `string` | n/a | yes |
@@ -181,13 +401,23 @@ No modules.
 | <a name="input_pool_name"></a> [pool\_name](#input\_pool\_name) | The name of the storage pool. Leave empty to generate name based on deployment name. | `string` | `null` | no |
 | <a name="input_private_vpc_connection_peering"></a> [private\_vpc\_connection\_peering](#input\_private\_vpc\_connection\_peering) | The name of the private VPC connection peering. | `string` | `"sn-netapp-prod"` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region for the storage pool. Required for all service levels. | `string` | n/a | yes |
+| <a name="input_replica_zone"></a> [replica\_zone](#input\_replica\_zone) | Replica zone for regional Flex Unified pools. Must be within region when service\_level is FLEX. Omit for zonal Flex Unified pools. Ignored for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_scale_type"></a> [scale\_type](#input\_scale\_type) | Scale type of the storage pool. Flex-only. Use SCALE\_TYPE\_SCALEOUT for large capacity pools. | `string` | `null` | no |
 | <a name="input_service_level"></a> [service\_level](#input\_service\_level) | The service level of the storage pool. | `string` | `"PREMIUM"` | no |
+| <a name="input_total_iops"></a> [total\_iops](#input\_total\_iops) | Total pool IOPS for Flex Unified custom performance. Omit to let Google Cloud calculate IOPS from total\_throughput\_mibps. | `number` | `null` | no |
+| <a name="input_total_throughput_mibps"></a> [total\_throughput\_mibps](#input\_total\_throughput\_mibps) | Total pool throughput in MiB/s for Flex Unified custom performance. Omit to use the default 64 MiB/s. | `number` | `null` | no |
+| <a name="input_zone"></a> [zone](#input\_zone) | Zone for zonal Flex Unified pools, or active zone for regional Flex Unified pools. Must be within region when service\_level is FLEX. Ignored for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_allow_auto_tiering"></a> [allow\_auto\_tiering](#output\_allow\_auto\_tiering) | Whether the storage pool supports auto-tiering enabled volumes. |
 | <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | Storage pool capacity in GiB. |
+| <a name="output_mode"></a> [mode](#output\_mode) | Storage pool mode. Flex-only. |
 | <a name="output_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#output\_netapp\_storage\_pool\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}` |
+| <a name="output_scale_type"></a> [scale\_type](#output\_scale\_type) | Scale type of the storage pool. Flex-only. |
+| <a name="output_service_level"></a> [service\_level](#output\_service\_level) | Storage pool service level. |
+| <a name="output_type"></a> [type](#output\_type) | Storage pool type. Flex Unified pools use UNIFIED. Omitted for STANDARD, PREMIUM, and EXTREME pools. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/file-system/netapp-storage-pool/main.tf
+++ b/modules/file-system/netapp-storage-pool/main.tf
@@ -19,6 +19,15 @@ locals {
   labels = merge(var.labels, { ghpc_module = "netapp-storage-pool", ghpc_role = "file-system" })
 }
 
+locals {
+  is_flex_zonal    = var.service_level == "FLEX" && var.zone != null && var.replica_zone == null
+  is_flex_regional = var.service_level == "FLEX" && var.zone != null && var.replica_zone != null
+  pool_location    = local.is_flex_zonal ? var.zone : var.region
+  min_capacity_gib = var.scale_type == "SCALE_TYPE_SCALEOUT" ? 6144 : (
+    var.service_level == "FLEX" ? 1024 : 2048
+  )
+}
+
 resource "random_id" "resource_name_suffix" {
   byte_length = 4
 }
@@ -32,7 +41,7 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   project = var.project_id
 
   name          = var.pool_name != null ? var.pool_name : "${var.deployment_name}-${random_id.resource_name_suffix.hex}"
-  location      = var.region
+  location      = local.pool_location
   network       = var.network_id
   service_level = var.service_level
   capacity_gib  = var.capacity_gib
@@ -41,6 +50,16 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   kms_config         = var.cmek_policy
   ldap_enabled       = var.ldap_enabled
   allow_auto_tiering = var.allow_auto_tiering
+  mode               = var.service_level == "FLEX" ? "DEFAULT" : null
+  type               = var.service_level == "FLEX" ? "UNIFIED" : null
+  # zone and replica_zone are Flex regional-only API fields. Omit for all other pool types.
+  zone                        = local.is_flex_regional ? var.zone : null
+  replica_zone                = local.is_flex_regional ? var.replica_zone : null
+  hot_tier_size_gib           = var.service_level == "FLEX" ? var.hot_tier_size_gib : null
+  enable_hot_tier_auto_resize = var.service_level == "FLEX" ? var.enable_hot_tier_auto_resize : null
+  scale_type                  = var.service_level == "FLEX" ? var.scale_type : null
+  total_throughput_mibps      = var.service_level == "FLEX" ? var.total_throughput_mibps : null
+  total_iops                  = var.service_level == "FLEX" ? var.total_iops : null
 
   description = var.description
   labels      = local.labels
@@ -48,9 +67,42 @@ resource "google_netapp_storage_pool" "netapp_storage_pool" {
   depends_on = [data.google_compute_network_peering.private_peering]
 
   lifecycle {
+    # API defaults for mode, type, and scale_type differ from omitted (null) config on
+    # STANDARD, PREMIUM, and EXTREME pools. Ignore drift so Terraform does not send them.
+    ignore_changes = [
+      mode,
+      type,
+      scale_type,
+    ]
     precondition {
       condition     = data.google_compute_network_peering.private_peering.state == "ACTIVE"
       error_message = "The network for the storage pool must have private service access."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || var.zone != null
+      error_message = "FLEX pools require zone. For zonal pools set zone only. For regional pools set zone and replica_zone."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || var.replica_zone == null || var.zone != var.replica_zone
+      error_message = "zone and replica_zone must be different for regional FLEX pools."
+    }
+    precondition {
+      condition     = var.scale_type != "SCALE_TYPE_SCALEOUT" || (var.service_level == "FLEX" && var.replica_zone == null)
+      error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) must be zonal Flex Unified pools. Set zone and omit replica_zone."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || var.scale_type == null
+      error_message = "scale_type is supported only for FLEX storage pools."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || (var.total_throughput_mibps == null && var.total_iops == null)
+      error_message = "total_throughput_mibps and total_iops are supported only for FLEX storage pools."
+    }
+    precondition {
+      condition = var.capacity_gib >= local.min_capacity_gib
+      error_message = var.scale_type == "SCALE_TYPE_SCALEOUT" ? "Large capacity pools (SCALE_TYPE_SCALEOUT) require at least 6144 GiB." : (
+        var.service_level == "FLEX" ? "Flex Unified pools require at least 1024 GiB." : "STANDARD, PREMIUM, and EXTREME pools require at least 2048 GiB."
+      )
     }
   }
 }

--- a/modules/file-system/netapp-storage-pool/outputs.tf
+++ b/modules/file-system/netapp-storage-pool/outputs.tf
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+output "allow_auto_tiering" {
+  description = "Whether the storage pool supports auto-tiering enabled volumes."
+  value       = google_netapp_storage_pool.netapp_storage_pool.allow_auto_tiering
+}
+
+output "scale_type" {
+  description = "Scale type of the storage pool. Flex-only."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.scale_type : null
+}
+
 output "netapp_storage_pool_id" {
   description = "An identifier for the resource with format `projects/{{project}}/locations/{{location}}/storagePools/{{name}}`"
   value       = google_netapp_storage_pool.netapp_storage_pool.id
@@ -20,4 +30,19 @@ output "netapp_storage_pool_id" {
 output "capacity_gb" {
   description = "Storage pool capacity in GiB."
   value       = google_netapp_storage_pool.netapp_storage_pool.capacity_gib
+}
+
+output "service_level" {
+  description = "Storage pool service level."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level
+}
+
+output "mode" {
+  description = "Storage pool mode. Flex-only."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.mode : null
+}
+
+output "type" {
+  description = "Storage pool type. Flex Unified pools use UNIFIED. Omitted for STANDARD, PREMIUM, and EXTREME pools."
+  value       = google_netapp_storage_pool.netapp_storage_pool.service_level == "FLEX" ? google_netapp_storage_pool.netapp_storage_pool.type : null
 }

--- a/modules/file-system/netapp-storage-pool/variables.tf
+++ b/modules/file-system/netapp-storage-pool/variables.tf
@@ -25,7 +25,7 @@ variable "deployment_name" {
 }
 
 variable "region" {
-  description = "Location for NetApp storage pool."
+  description = "Region for the storage pool. Required for all service levels."
   type        = string
 }
 
@@ -64,31 +64,49 @@ variable "service_level" {
   type        = string
   default     = "PREMIUM"
   validation {
-    condition     = contains(["STANDARD", "PREMIUM", "EXTREME"], var.service_level)
-    error_message = "Allowed values for service_level are 'STANDARD', 'PREMIUM', or 'EXTREME'."
+    condition     = contains(["STANDARD", "PREMIUM", "EXTREME", "FLEX"], var.service_level)
+    error_message = "Allowed values for service_level are 'STANDARD', 'PREMIUM', 'EXTREME', or 'FLEX'."
+  }
+}
+
+variable "zone" {
+  description = "Zone for zonal Flex Unified pools, or active zone for regional Flex Unified pools. Must be within region when service_level is FLEX. Ignored for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.service_level != "FLEX" || var.zone == null || startswith(var.zone, "${var.region}-")
+    error_message = "zone must be within the specified region."
+  }
+}
+
+variable "replica_zone" {
+  description = "Replica zone for regional Flex Unified pools. Must be within region when service_level is FLEX. Omit for zonal Flex Unified pools. Ignored for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.service_level != "FLEX" || var.replica_zone == null || startswith(var.replica_zone, "${var.region}-")
+    error_message = "replica_zone must be within the specified region."
   }
 }
 
 variable "capacity_gib" {
-  description = "The capacity of the storage pool in GiB."
+  description = "The capacity of the storage pool in GiB. Minimum is 2048 GiB for STANDARD, PREMIUM, and EXTREME; 1024 GiB for Flex Unified; 6144 GiB for large capacity (SCALE_TYPE_SCALEOUT) pools."
   type        = number
   default     = 2048
-  validation {
-    condition     = var.capacity_gib >= 2048
-    error_message = "The minimum capacity for the storage pool is 2048 GiB."
-  }
 }
 
 variable "active_directory_policy" {
   description = <<-EOT
     The ID of the Active Directory policy to apply to the storage pool in the format:
-    `projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>`
+    `projects/<project_id>/locations/<location>/activeDirectories/<name>`
     EOT
   type        = string
   default     = null
   validation {
-    condition     = var.active_directory_policy == null ? true : length(split("/", var.active_directory_policy)) == 6
-    error_message = "The active directory policy must be provided in the following format: projects/<project_id>/locations/<location>/activeDirectoryPolicies/<policy_id>."
+    condition = var.active_directory_policy == null ? true : can(
+      regex("^projects/[^/]+/locations/[^/]+/activeDirectories/[^/]+$", var.active_directory_policy)
+    )
+    error_message = "The Active Directory policy must use the format projects/<project_id>/locations/<location>/activeDirectories/<name>."
   }
 }
 
@@ -115,6 +133,76 @@ variable "allow_auto_tiering" {
   description = "Whether to allow automatic tiering for the storage pool."
   type        = bool
   default     = false
+
+  validation {
+    condition     = var.service_level != "FLEX" || !var.allow_auto_tiering || var.hot_tier_size_gib != null
+    error_message = "hot_tier_size_gib is required when allow_auto_tiering is true for FLEX pools."
+  }
+
+  validation {
+    condition     = var.allow_auto_tiering || (var.hot_tier_size_gib == null && var.enable_hot_tier_auto_resize == null)
+    error_message = "hot_tier_size_gib and enable_hot_tier_auto_resize require allow_auto_tiering to be true."
+  }
+}
+
+variable "hot_tier_size_gib" {
+  description = "Total hot tier capacity for the storage pool in GiB. Flex-only. Requires allow_auto_tiering to be true."
+  type        = number
+  default     = null
+
+  validation {
+    condition     = var.service_level == "FLEX" || var.hot_tier_size_gib == null
+    error_message = "hot_tier_size_gib is supported only for FLEX storage pools."
+  }
+}
+
+variable "enable_hot_tier_auto_resize" {
+  description = "Whether hot-tier threshold will auto-increase when it reaches 100%. Flex-only. Requires allow_auto_tiering to be true."
+  type        = bool
+  default     = null
+
+  validation {
+    condition     = var.service_level == "FLEX" || var.enable_hot_tier_auto_resize == null
+    error_message = "enable_hot_tier_auto_resize is supported only for FLEX storage pools."
+  }
+}
+
+variable "scale_type" {
+  description = "Scale type of the storage pool. Flex-only. Use SCALE_TYPE_SCALEOUT for large capacity pools."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.scale_type == null ? true : contains(["SCALE_TYPE_DEFAULT", "SCALE_TYPE_SCALEOUT"], var.scale_type)
+    error_message = "Allowed values for scale_type are SCALE_TYPE_DEFAULT or SCALE_TYPE_SCALEOUT."
+  }
+  validation {
+    condition     = var.scale_type != "SCALE_TYPE_SCALEOUT" || var.replica_zone == null
+    error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) must be zonal Flex Unified pools. Set zone and omit replica_zone."
+  }
+}
+
+variable "total_throughput_mibps" {
+  description = <<-EOT
+    Total pool throughput in MiB/s for Flex Unified custom performance. Omit to use the default 64 MiB/s.
+  EOT
+  type        = number
+  default     = null
+  validation {
+    condition     = var.total_throughput_mibps == null || var.total_throughput_mibps > 0
+    error_message = "total_throughput_mibps must be greater than 0."
+  }
+}
+
+variable "total_iops" {
+  description = <<-EOT
+    Total pool IOPS for Flex Unified custom performance. Omit to let Google Cloud calculate IOPS from total_throughput_mibps.
+  EOT
+  type        = number
+  default     = null
+  validation {
+    condition     = var.total_iops == null || var.total_iops > 0
+    error_message = "total_iops must be greater than 0."
+  }
 }
 
 variable "description" {

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -1,39 +1,81 @@
 ## Description
 
-This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview)
-volume.
+This module creates a [Google Cloud NetApp Volumes](https://cloud.google.com/netapp/volumes/docs/discover/overview) volume.
 
-NetApp Volumes is a first-party Google service that provides NFS and/or SMB shared file-systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
+NetApp Volumes is a first-party Google service that provides NFS shared file systems to VMs. It offers advanced data management capabilities and highly scalable capacity and performance.
 NetApp Volume provides:
 
-- robust support for NFSv3, NFSv4.x and SMB 2.1 and 3.x
-- a [rich feature set][service-levels]
+- support for NFSv3 and NFSv4.1
+- a [rich feature set](https://cloud.google.com/netapp/volumes/docs/discover/service-levels)
 - scalable [performance](https://cloud.google.com/netapp/volumes/docs/performance/performance-benchmarks)
-- FlexCache: Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
-- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimse cost
+- [FlexCache](https://docs.cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/cache-ontap-volumes/overview): Caching of ONTAP-based volumes to provide high-throughput and low latency read access to compute clusters of on-premises data
+- [Auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering) of unused data to optimize cost
 
 Support for NetApp Volumes is split into two modules.
 
-- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level][service-levels], CMEK encryption, Active Directory and LDAP settings.
-- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume file-system container which is shared using NFS or SMB. It provides advanced data management capabilities.
+- **netapp-storage-pool** provisions a [storage pool](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview). Storage pools are pre-provisioned storage capacity containers which host volumes. A pool also defines fundamental properties of all the volumes within, like the region, the attached network, the [service level](https://cloud.google.com/netapp/volumes/docs/discover/service-levels), CMEK encryption, Active Directory and LDAP settings.
+- **netapp-volume** provisions a [volume](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview) inside an existing storage pool. A volume is a file system container shared using NFSv3 or NFSv4.1.
 
 For more information on this and other network storage options in the Cluster
 Toolkit, see the extended [Network Storage documentation](../../../docs/network_storage.md).
 
-## Deletion protection
-The netapp-volume module currently doesn't implement volume deletion protection. If you create a volume with Cluster Toolkit by using this module, Cluster Toolkit will also delete it when you run `gcluster destroy`. All the data in the volume will be gone. If you want to retain the volume instead, it is advised to [use existing volumes not created by Cluster Toolkit](#using-existing-volumes-not-created-by-cluster-toolkit).
+## Deletion policy
+
+By default, `gcluster destroy` deletes volumes created by this module and all data is lost. Set `deletion_policy` in your blueprint to control destroy behavior:
+
+1. **Omit or `null`** — Provider default. Terraform deletes the volume in Google Cloud.
+2. **`DEFAULT` or `DELETE`** — Delete the volume in Google Cloud.
+3. **`FORCE`** — Delete the volume even when nested snapshot resources exist.
+4. **`PREVENT`** — Block Terraform from deleting the volume. Use this to protect production data from accidental `gcluster destroy`.
+5. **`ABANDON`** — Remove the volume from Terraform state without deleting it in Google Cloud. The volume remains available for manual management or mounting through [pre-existing-network-storage](../pre-existing-network-storage/README.md).
+
+Example:
+
+```yaml
+  - id: homefs
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]
+    settings:
+      volume_name: "homefs"
+      capacity_gib: 1024
+      local_mount: "/home"
+      protocols: ["NFSV3"]
+      deletion_policy: "PREVENT"
+```
+
+Storage pools can only be deleted when empty. This module does not expose `deletion_policy` for pools.
 
 ## Volumes overview
-Volumes are filesystem containers which can be shared using NFS or SMB filesharing protocols. Volumes *live* inside of [storage pools](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview), which can be provisioned using the [netapp-storage-pool] module. Volumes inherit fundamental settings from the pool. They *consume* capacity provided by the pool. You can create one or multiple volumes *inside* a pool.
 
-[netapp-storage-pool]: ../netapp-storage-pool/README.md
-[service-levels]: https://cloud.google.com/netapp/volumes/docs/discover/service-levels
-[auto-tiering]: https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering
-[pre-existing]: ../pre-existing-network-storage/README.md
-[matrix]: ../../../docs/network_storage.md#compatibility-matrix
+Volumes are file system containers shared using NFSv3 or NFSv4.1. Volumes live inside [storage pools](https://cloud.google.com/netapp/volumes/docs/configure-and-use/storage-pools/overview), which can be provisioned using the [netapp-storage-pool](../netapp-storage-pool/README.md) module. Volumes inherit settings from the pool and consume capacity from the pool.
+
+### Inherited settings
+
+When you use `use: [netapp_pool]`, the volume module inherits:
+
+1. `netapp_storage_pool_id`
+2. `service_level`
+3. `type`
+4. `allow_auto_tiering`
+5. `scale_type`
+
+### Volume location
+
+The module sets volume location from the `locations/<location>` segment of `netapp_storage_pool_id`. When you use `use: [netapp_pool]`, Cluster Toolkit wires `netapp_storage_pool_id` from the pool automatically. Do not set location, region, or zone in the volume blueprint.
+
+1. Zonal pool — location is the zone (for example, `us-east1-b`).
+2. Regional pool — location is the region (for example, `us-east1`).
+
+### Volume naming
+
+Volume name rules depend on the storage pool service level. The module validates names at plan time.
+
+1. **FLEX pools** — Use lowercase letters, numbers, and underscores only. The name must start with a lowercase letter and cannot end with an underscore. Hyphens are not allowed.
+2. **STANDARD, PREMIUM, and EXTREME pools** — Hyphens are allowed. Underscores are not allowed.
 
 ## Volume examples
-The following examples show the use of netapp-volume. They builds on top of an storage pool which can be provisioned using the [netapp-storage-pool][netapp-storage-pool] module.
+
+The following examples show the use of netapp-volume. They build on top of a storage pool which can be provisioned using the [netapp-storage-pool](../netapp-storage-pool/README.md) module.
 
 ### Example with minimal parameters
 
@@ -46,8 +88,8 @@ The following examples show the use of netapp-volume. They builds on top of an s
       capacity_gib: 1024               # Size up to available capacity in the pool
       local_mount: "/eda-home"         # Mount point at client when client uses USE directive
       protocols: ["NFSV3"]
-      region: $(vars.region)
     # Default export policy exports to "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" and no_root_squash
+    # netapp_storage_pool_id and service_level are inherited from netapp_pool
 ```
 
 ### Example with all parameters
@@ -58,18 +100,17 @@ The following examples show the use of netapp-volume. They builds on top of an s
     use: [netapp_pool]              # Create this pool using the netapp-storage-pool module
     settings:
       volume_name: "eda-shared"
-      capacity_gib: 25000           # Size up to available capacity in the pool
+      capacity_gib: 25000           # At least 15360 GiB (15 TiB) when large_capacity is true
       large_capacity: true
       local_mount: "/shared"        # Mount point at client when client uses USE directive
       mount_options: "rw"           # Allows customizing mount options for special workloads
-      protocols: ["NFSV3","NFSV4"]  # List of protocols. ["NFSV3], ["NFSv4] or ["NFSV3, "NFSV4"]
-      region: $(vars.region)
-      unix_permissions: "0777"      # Specify default permissions for roo inode owned by root:root
+      protocols: ["NFSV3","NFSV4"]  # List of protocols. ["NFSV3"], ["NFSV4"], or ["NFSV3", "NFSV4"]
+      unix_permissions: "0770"      # Default permissions for root inode; supported on Flex Unified volumes
       # If no export policy is specified, a permissive default policy will be applied, which is:
       #  allowed_clients = "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16" # RFC1918
       #  has_root_access = true      # no_root_squash enabled
       #  access_type = "READ_WRITE"
-      export_policy:
+      export_policy_rules:
       - allowed_clients: "10.10.20.8,10.10.20.9"
         has_root_access: true       # no_root_squash enabled
         access_type: "READ_WRITE"
@@ -83,25 +124,104 @@ The following examples show the use of netapp-volume. They builds on top of an s
       tiering_policy:               # Enable auto-tiering. Requires auto-tiering enabled storage pool
         tier_action: "ENABLED"
         cooling_threshold_days: 31  # tier data blocks which have not been touched for 31 days
+      deletion_policy: "DEFAULT"
 
       description: "Shared volume for EDA job"
       labels:
         owner: bob
 ```
 
+### Example: Flex Unified large capacity volume
+
+Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`. Do not set `large_capacity` on Flex Unified volumes.
+
+```yaml
+  - id: flex_large_volume
+    source: modules/file-system/netapp-volume
+    use: [flex_pool_large]
+    settings:
+      volume_name: "flex_large_home"
+      capacity_gib: 12288          # Minimum 4800 GiB for Flex large capacity
+      local_mount: "/home"
+      protocols: ["NFSV3"]
+      large_capacity_config:
+        constituent_count: 48      # Typical value for SCALE_TYPE_SCALEOUT pools
+      tiering_policy:              # Requires allow_auto_tiering on the pool
+        tier_action: "ENABLED"
+        cooling_threshold_days: 31
+        hot_tier_bypass_mode_enabled: false  # Set true only during data migration; disable after
+```
+
 ## Protocol support
-Since Cluster Toolkit is currently built to provision Linux-based compute clusters, this module supports NFSv3 and NFSv4.1 only. SMB is blocked.
+
+This module supports NFSv3 and NFSv4.1 only. SMB and iSCSI are not supported.
+
+## ONTAP mode
+
+This module provisions and manages volumes through Google Cloud APIs in Default mode only. It does not support volumes in ONTAP-mode pools.
+
+If you need ONTAP-mode pools or volumes, provision them outside Cluster Toolkit and integrate them with the [pre-existing-network-storage](../pre-existing-network-storage/README.md) module. In ONTAP mode, volumes, snapshots, and policies are managed with ONTAP tools after the pool is created. See [Manage ONTAP mode](https://cloud.google.com/netapp/volumes/docs/ontap/manage-ontap).
 
 ## Large volumes
-Volumes larger than 15 TiB can be created as [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes). Such volumes can grow up to 3 PiB and can scale read performance up to 29 GiBps. They provide six IP addresses to the volume. They are exported via the `server_ips` output. When connecting a large volume to a client using the USE directive, cluster toolkit currently uses the first IP only. This will be improved in the future.
 
-This feature is allow-listed GA. To request allow-listing, see [Large Volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes).
+Standard, Premium, and Extreme service levels support [large capacity volumes](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/overview#large-capacity-volumes) of 15 TiB or larger. Flex Unified large capacity volumes use a separate configuration model.
+
+### Minimum volume capacity
+
+The module enforces these minimum `capacity_gib` values at plan time:
+
+1. **STANDARD, PREMIUM, and EXTREME (regular volumes)** — 100 GiB
+2. **STANDARD, PREMIUM, and EXTREME (large capacity volumes)** — 15 TiB (15360 GiB)
+3. **Flex Unified** — 1 GiB
+4. **Flex Unified large capacity (**`large_capacity_config`**)** — 4800 GiB
+
+To create a large capacity volume:
+
+1. **Standard, Premium, and Extreme** — Set `large_capacity: true` and `capacity_gib` to at least 15360.
+2. **Flex Unified** — Use the `large_capacity_config` block with `constituent_count` in the blueprint. Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`. Large capacity pools cannot be regional. The typical value is 48. Do not set `large_capacity` on Flex Unified volumes.
+
+### Large capacity rules by service level
+
+1. **Standard, Premium, and Extreme** — Set `large_capacity: true`. Set `capacity_gib` to at least 15360 (15 TiB). The module configures multiple NFS endpoints internally. Do not set `large_capacity_config`.
+2. **Flex Unified** — Set `large_capacity_config` with `constituent_count`. Set `capacity_gib` to at least 4800. Do not set `large_capacity`. Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`.
+3. `large_capacity` **and** `large_capacity_config` **cannot be used together.**
+
+### Mounting large capacity volumes
+
+Large capacity volumes expose the same NFS export through multiple IP addresses . For best performance, spread clients evenly across all available IPs so load is distributed and aggregated throughput is higher. See [Connect large capacity volumes with multiple storage endpoints](https://cloud.google.com/netapp/volumes/docs/connect-clients/connect-large-capacity-volumes).
+
+When you attach a volume with the `use:` directive, the module mount runner passes all `server_ips` to the mount script. Each client selects one endpoint from that list at mount time, which spreads clients across the available IPs.
+
+Slurm integrations do not distribute clients across endpoints today. Slurm mounts use the first IP address only, so large capacity volumes do not get the full multi-endpoint performance benefit in Slurm clusters.
+
+For volumes mounted through [pre-existing-network-storage](../pre-existing-network-storage/README.md), you must configure endpoints yourself (for example, round-robin DNS or manual client grouping per the Google Cloud documentation).
+
+### Plan-time validation
+
+The module enforces these rules at plan time:
+
+1. Flex File pools (`service_level: FLEX` with `type: FILE`) are rejected.
+2. `large_capacity` is rejected on Flex Unified pools; use `large_capacity_config` instead.
+3. `large_capacity_config` requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`.
+4. `tiering_policy` requires a pool with `allow_auto_tiering: true`.
+5. `hot_tier_bypass_mode_enabled` is supported only when `service_level` is `FLEX`.
 
 ## Auto-tiering support
-For auto-tiering enabled storage pools you can enable auto-tiering on the volume. For more information, see [manage auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering).
+
+For storage pools with `allow_auto_tiering` enabled, you can enable auto-tiering on the volume using `tiering_policy`. For more information, see [Manage auto-tiering](https://cloud.google.com/netapp/volumes/docs/configure-and-use/volumes/manage-auto-tiering).
+
+### Hot tier bypass mode
+
+Set `hot_tier_bypass_mode_enabled` only for FLEX service levels. Use it when you are migrating data into a new volume.
+
+When hot tier bypass mode is enabled, writes go directly to the cold tier instead of filling the hot tier. Frequently accessed data is promoted back to the hot tier based on client read activity.
+
+1. Enable `hot_tier_bypass_mode_enabled` before you migrate data into the volume.
+2. Disable `hot_tier_bypass_mode_enabled` after migration completes so normal tiering behavior resumes for ongoing workloads.
 
 ## Using existing volumes not created by Cluster Toolkit
-NetApp Volumes volumes are regular NFS exports. You can use the [pre-existing-network-storage] module to integrate them into Cluster Toolkit.
+
+NetApp Volumes volumes are regular NFS exports. Use the [pre-existing-network-storage](../pre-existing-network-storage/README.md) module to integrate volumes that Cluster Toolkit does not provision. This includes ONTAP-mode pools and volumes, FlexCache volumes, and any other NetApp export created outside these modules.
 
 Example code:
 
@@ -111,18 +231,16 @@ Example code:
   settings:
     server_ip: ## Set server IP here ##
     remote_mount: nfsshare
-    local_mount: /home
+    local_mount: /shared
     fs_type: nfs
 ```
 
-This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/home` by clients which mount if via USE directive.
+This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/shared` by clients which mount if via USE directive.
 
-Note that the `server_ip` must be known before deployment and this module does not allow
-to specify a list of IPs for large volumes.
-
-[pre-existing-network-storage]: ../pre-existing-network-storage/README.md
+Note that the `server_ip` must be known before deployment and this module does not allow to specify a list of IPs for large volumes. For large volumes it is recommended to use a DNS FQDN which hands out the volume IPs in round-robin fashion.
 
 ## FlexCache support
+
 NetApp FlexCache technology accelerates data access, reduces WAN latency and lowers WAN bandwidth costs for read-intensive workloads, especially where clients need to access the same data repeatedly. When you create a FlexCache volume, you create a remote cache of an already existing (origin) volume that contains only the actively accessed data (hot data) of the origin volume.
 
 The FlexCache support in Google Cloud NetApp Volumes allows you to provision a cache volume in your Google network to improve performance for hybrid cloud environments. A FlexCache volume can help you transition workloads to the hybrid cloud by caching data from an on-premises data center to cloud.
@@ -130,6 +248,7 @@ The FlexCache support in Google Cloud NetApp Volumes allows you to provision a c
 Deploying FlexCache volumes requires manual steps on the ONTAP origin side, which are not automated. Therefore this module has no support to deploy FlexCache volumes today. Deploy them manually and use the [pre-existing-network-storage](#using-existing-volumes-not-created-by-cluster-toolkit) instead.
 
 ## License
+
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 Copyright 2026 Google LLC
 
@@ -150,13 +269,13 @@ limitations under the License.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.45.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.34.0 |
 
 ## Providers
 
 | Name | Version |
 | ---- | ------- |
-| <a name="provider_google"></a> [google](#provider\_google) | >= 6.45.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 7.34.0 |
 
 ## Modules
 
@@ -172,20 +291,25 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. | `number` | `1024` | no |
+| <a name="input_allow_auto_tiering"></a> [allow\_auto\_tiering](#input\_allow\_auto\_tiering) | Whether the storage pool supports auto-tiering. Inherited from the pool when using use: [netapp\_pool]. | `bool` | `null` | no |
+| <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. Minimum is 100 GiB for STANDARD, PREMIUM, and EXTREME; 15 TiB (15360 GiB) for STANDARD, PREMIUM, and EXTREME large capacity volumes; 1 GiB for Flex Unified; 4800 GiB for Flex Unified large capacity volumes. | `number` | `1024` | no |
+| <a name="input_deletion_policy"></a> [deletion\_policy](#input\_deletion\_policy) | Controls Terraform destroy behavior. Omit to use the provider default (delete the volume in Google Cloud).<br/>DEFAULT or DELETE: delete the volume in Google Cloud.<br/>FORCE: delete the volume even when nested snapshot resources exist.<br/>PREVENT: block Terraform from deleting the volume.<br/>ABANDON: remove the volume from Terraform state without deleting it in Google Cloud. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the NetApp volume. | `string` | `""` | no |
 | <a name="input_export_policy_rules"></a> [export\_policy\_rules](#input\_export\_policy\_rules) | Define NFS export policy. | <pre>list(object({<br/>    allowed_clients = optional(string)<br/>    has_root_access = optional(bool, false)<br/>    access_type     = optional(string, "READ_WRITE")<br/>    nfsv3           = optional(bool)<br/>    nfsv4           = optional(bool)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "access_type": "READ_WRITE",<br/>    "allowed_clients": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",<br/>    "has_root_access": true<br/>  }<br/>]</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp volume. Key-value pairs. | `map(string)` | n/a | yes |
-| <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity.<br/>Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB. | `bool` | `false` | no |
+| <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity for STANDARD/PREMIUM/EXTREME service levels.<br/>For FLEX service level, use large\_capacity\_config instead. | `bool` | `false` | no |
+| <a name="input_large_capacity_config"></a> [large\_capacity\_config](#input\_large\_capacity\_config) | Configuration for a Flex Unified large capacity volume. Supported only for Flex Unified pools.<br/>Set constituent\_count in the blueprint. The typical value for current SCALE\_TYPE\_SCALEOUT pools is 48. | <pre>object({<br/>    constituent_count = number<br/>  })</pre> | `null` | no |
 | <a name="input_local_mount"></a> [local\_mount](#input\_local\_mount) | Mountpoint for this volume. | `string` | `"/shared"` | no |
-| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"rw,hard,rsize=65536,wsize=65536,tcp"` | no |
-| <a name="input_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#input\_netapp\_storage\_pool\_id) | The ID of the NetApp storage pool to use for the volume. | `string` | n/a | yes |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp storage pool will be created. | `string` | n/a | yes |
-| <a name="input_protocols"></a> [protocols](#input\_protocols) | The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported. | `list(string)` | <pre>[<br/>  "NFSV3"<br/>]</pre> | no |
-| <a name="input_region"></a> [region](#input\_region) | Location for NetApp storage pool. | `string` | n/a | yes |
-| <a name="input_tiering_policy"></a> [tiering\_policy](#input\_tiering\_policy) | Define the tiering policy for the NetApp volume. | <pre>object({<br/>    tier_action            = optional(string)<br/>    cooling_threshold_days = optional(number)<br/>  })</pre> | `null` | no |
-| <a name="input_unix_permissions"></a> [unix\_permissions](#input\_unix\_permissions) | UNIX permissions for root inode in the volume. | `string` | `"0777"` | no |
-| <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | The name of the volume. Needs to be unique within the storage pool. | `string` | `null` | no |
+| <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | NFS mount options to mount file system. | `string` | `"rw,hard,rsize=262144,wsize=262144,tcp"` | no |
+| <a name="input_netapp_storage_pool_id"></a> [netapp\_storage\_pool\_id](#input\_netapp\_storage\_pool\_id) | The ID of the NetApp storage pool to use for the volume. Volume location (region or zone) is parsed from this value.<br/>Inherited from the pool when using use: [netapp\_pool]. | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | ID of project in which the NetApp volume will be created. | `string` | n/a | yes |
+| <a name="input_protocols"></a> [protocols](#input\_protocols) | Access protocols for the volume. Only NFSv3 and NFSv4.1 (NFSV4) are supported. | `list(string)` | <pre>[<br/>  "NFSV3"<br/>]</pre> | no |
+| <a name="input_scale_type"></a> [scale\_type](#input\_scale\_type) | Scale type of the storage pool. Inherited from the pool when using use: [netapp\_pool]. Flex-only; null for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_service_level"></a> [service\_level](#input\_service\_level) | Service level of the storage pool used by this volume. Inherited from the pool when using use: [netapp\_pool]. | `string` | `null` | no |
+| <a name="input_tiering_policy"></a> [tiering\_policy](#input\_tiering\_policy) | Define the tiering policy for the NetApp volume. Requires a pool with allow\_auto\_tiering enabled.<br/>hot\_tier\_bypass\_mode\_enabled (FLEX only): use during data migration so writes go to the cold tier instead of filling the hot tier; disable after migration completes. | <pre>object({<br/>    tier_action                  = optional(string)<br/>    cooling_threshold_days       = optional(number)<br/>    hot_tier_bypass_mode_enabled = optional(bool)<br/>  })</pre> | `null` | no |
+| <a name="input_type"></a> [type](#input\_type) | Type of the storage pool used by this volume. Inherited from the pool when using use: [netapp\_pool]. Flex Unified pools use UNIFIED. Null for STANDARD, PREMIUM, and EXTREME pools. | `string` | `null` | no |
+| <a name="input_unix_permissions"></a> [unix\_permissions](#input\_unix\_permissions) | UNIX permissions for root inode in the volume. | `string` | `"0770"` | no |
+| <a name="input_volume_name"></a> [volume\_name](#input\_volume\_name) | The name of the volume. Needs to be unique within the storage pool.<br/>FLEX pools: lowercase letters, numbers, and underscores only; must start with a lowercase letter and cannot end with an underscore.<br/>STANDARD, PREMIUM, and EXTREME pools: hyphens are allowed; underscores are not allowed. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/modules/file-system/netapp-volume/README.md
+++ b/modules/file-system/netapp-volume/README.md
@@ -152,6 +152,40 @@ Requires a zonal pool with `scale_type: SCALE_TYPE_SCALEOUT`. Do not set `large_
         hot_tier_bypass_mode_enabled: false  # Set true only during data migration; disable after
 ```
 
+### Example: large capacity volume with DNS for Slurm
+
+Requires a private Cloud DNS zone in the same deployment group. The zone `dns_name` suffix is derived automatically; do not set `dns_suffix` on the volume.
+
+```yaml
+  - id: gcnv_dns_zone
+    source: modules/network/dns-managed-zone
+    settings:
+      project_id: $(vars.project_id)
+      zone_name: $(vars.deployment_name)-gcnv-dns
+      dns_name: gcnv.internal.
+      visibility: private
+      network_id: $(network.network_id)
+
+  - id: home_volume
+    source: modules/file-system/netapp-volume
+    use: [netapp_pool]
+    settings:
+      volume_name: homefs
+      capacity_gib: 16000
+      large_capacity: true
+      local_mount: /home
+      protocols: ["NFSV3"]
+      dns_config:
+        managed_zone_name: $(gcnv_dns_zone.zone_name)
+        record_name: my-dns-name
+```
+
+#### DNS configuration tips and requirements
+
+1. If you do not specify `dns_config.record_name`, the module uses `volume_name` as the DNS record name. `volume_name` must not contain underscores (`_`); use hyphens (`-`) instead. Terraform fails at plan time if this rule is violated.
+2. For Flex Unified volumes, dashes (`-`) are not allowed in volume names; use underscores (`_`) instead. DNS names cannot contain underscores, so set `dns_config.record_name` to a DNS-safe name (letters, digits, and hyphens only).
+3. The internal Cloud DNS zone is project-wide. Every NetApp volume using DNS in a project must have a unique DNS name. If multiple volumes share the same name, set unique values for `dns_config.record_name` to avoid conflicts.
+
 ## Protocol support
 
 This module supports NFSv3 and NFSv4.1 only. SMB and iSCSI are not supported.
@@ -192,7 +226,9 @@ Large capacity volumes expose the same NFS export through multiple IP addresses 
 
 When you attach a volume with the `use:` directive, the module mount runner passes all `server_ips` to the mount script. Each client selects one endpoint from that list at mount time, which spreads clients across the available IPs.
 
-Slurm integrations do not distribute clients across endpoints today. Slurm mounts use the first IP address only, so large capacity volumes do not get the full multi-endpoint performance benefit in Slurm clusters.
+Slurm integrations do not distribute clients across endpoints when `dns_config` is omitted. Slurm mounts use the first IP address only, so large capacity volumes do not get the full multi-endpoint performance benefit in Slurm clusters.
+
+To spread Slurm (and other) clients across all endpoints, set `dns_config` on the volume. The module creates a round-robin Cloud DNS A record and sets `network_storage.server_ip` to the volume FQDN. Provision a private `dns-managed-zone` in the same deployment group and pass `managed_zone_name: $(gcnv_dns_zone.zone_name)`.
 
 For volumes mounted through [pre-existing-network-storage](../pre-existing-network-storage/README.md), you must configure endpoints yourself (for example, round-robin DNS or manual client grouping per the Google Cloud documentation).
 
@@ -229,7 +265,7 @@ Example code:
 - id: homefs
   source: modules/file-system/pre-existing-network-storage
   settings:
-    server_ip: ## Set server IP here ##
+    server_ip: homefs.gcnv.internal.  # FQDN with all endpoint IPs; a single IP also works
     remote_mount: nfsshare
     local_mount: /shared
     fs_type: nfs
@@ -237,7 +273,7 @@ Example code:
 
 This creates a resource in Cluster Toolkit which references the specified NFS export, which will be mounted at `/shared` by clients which mount if via USE directive.
 
-Note that the `server_ip` must be known before deployment and this module does not allow to specify a list of IPs for large volumes. For large volumes it is recommended to use a DNS FQDN which hands out the volume IPs in round-robin fashion.
+`server_ip` must be known before deployment. The module accepts only one address string, not a list of IPs. For large-capacity volumes and FlexCache, publish every endpoint IP in a private Cloud DNS A record and set `server_ip` to that FQDN. The [EDA hybrid blueprint](../../../community/examples/eda/eda-hybrid-cloud.yaml) shows this pattern.
 
 ## FlexCache support
 
@@ -285,7 +321,10 @@ No modules.
 
 | Name | Type |
 | ---- | ---- |
+| [google_dns_record_set.volume](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dns_record_set) | resource |
 | [google_netapp_volume.netapp_volume](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/netapp_volume) | resource |
+| [google_project_service.dns_api](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_dns_managed_zone.mount](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
 
 ## Inputs
 
@@ -295,6 +334,7 @@ No modules.
 | <a name="input_capacity_gib"></a> [capacity\_gib](#input\_capacity\_gib) | The capacity of the volume in GiB. Minimum is 100 GiB for STANDARD, PREMIUM, and EXTREME; 15 TiB (15360 GiB) for STANDARD, PREMIUM, and EXTREME large capacity volumes; 1 GiB for Flex Unified; 4800 GiB for Flex Unified large capacity volumes. | `number` | `1024` | no |
 | <a name="input_deletion_policy"></a> [deletion\_policy](#input\_deletion\_policy) | Controls Terraform destroy behavior. Omit to use the provider default (delete the volume in Google Cloud).<br/>DEFAULT or DELETE: delete the volume in Google Cloud.<br/>FORCE: delete the volume even when nested snapshot resources exist.<br/>PREVENT: block Terraform from deleting the volume.<br/>ABANDON: remove the volume from Terraform state without deleting it in Google Cloud. | `string` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | A description of the NetApp volume. | `string` | `""` | no |
+| <a name="input_dns_config"></a> [dns\_config](#input\_dns\_config) | Optional Cloud DNS configuration for this volume. When set, the module creates an A record<br/>with all volume endpoint IPs (round-robin) and uses the resulting FQDN as network\_storage.server\_ip.<br/>managed\_zone\_name must reference an existing private Cloud DNS zone visible to clients.<br/>The zone dns\_name suffix is read from the managed zone; record\_name defaults to volume\_name.<br/>record\_name and the default volume\_name must not contain underscores; use hyphens (-) instead.<br/>For Flex Unified volumes, set record\_name explicitly when the volume name contains underscores. | <pre>object({<br/>    managed_zone_name = string<br/>    record_name       = optional(string)<br/>    ttl               = optional(number)<br/>  })</pre> | `null` | no |
 | <a name="input_export_policy_rules"></a> [export\_policy\_rules](#input\_export\_policy\_rules) | Define NFS export policy. | <pre>list(object({<br/>    allowed_clients = optional(string)<br/>    has_root_access = optional(bool, false)<br/>    access_type     = optional(string, "READ_WRITE")<br/>    nfsv3           = optional(bool)<br/>    nfsv4           = optional(bool)<br/>  }))</pre> | <pre>[<br/>  {<br/>    "access_type": "READ_WRITE",<br/>    "allowed_clients": "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",<br/>    "has_root_access": true<br/>  }<br/>]</pre> | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | Labels to add to the NetApp volume. Key-value pairs. | `map(string)` | n/a | yes |
 | <a name="input_large_capacity"></a> [large\_capacity](#input\_large\_capacity) | If true, the volume will be created with large capacity for STANDARD/PREMIUM/EXTREME service levels.<br/>For FLEX service level, use large\_capacity\_config instead. | `bool` | `false` | no |
@@ -318,6 +358,7 @@ No modules.
 | <a name="output_capacity_gb"></a> [capacity\_gb](#output\_capacity\_gb) | Volume capacity in GiB. |
 | <a name="output_install_nfs_client"></a> [install\_nfs\_client](#output\_install\_nfs\_client) | Script for installing NFS client |
 | <a name="output_install_nfs_client_runner"></a> [install\_nfs\_client\_runner](#output\_install\_nfs\_client\_runner) | Runner to install NFS client using the startup-script module |
+| <a name="output_mount_fqdn"></a> [mount\_fqdn](#output\_mount\_fqdn) | FQDN for NFS mount when dns\_config is set; null otherwise. |
 | <a name="output_mount_runner"></a> [mount\_runner](#output\_mount\_runner) | Runner to mount the file-system using an ansible playbook. The startup-script<br/>module will automatically handle installation of ansible.<br/>- id: example-startup-script<br/>  source: modules/scripts/startup-script<br/>  settings:<br/>    runners:<br/>    - $(your-fs-id.mount\_runner)<br/>... |
 | <a name="output_netapp_volume_id"></a> [netapp\_volume\_id](#output\_netapp\_volume\_id) | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/volumes/{{name}}` |
 | <a name="output_network_storage"></a> [network\_storage](#output\_network\_storage) | Describes a NetApp Volumes volume. |

--- a/modules/file-system/netapp-volume/dns.tf
+++ b/modules/file-system/netapp-volume/dns.tf
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_project_service" "dns_api" {
+  count = var.dns_config != null ? 1 : 0
+
+  project            = var.project_id
+  service            = "dns.googleapis.com"
+  disable_on_destroy = false
+}
+
+data "google_dns_managed_zone" "mount" {
+  count = var.dns_config != null ? 1 : 0
+
+  project = var.project_id
+  name    = var.dns_config.managed_zone_name
+
+  depends_on = [google_project_service.dns_api]
+}
+
+locals {
+  dns_record_name = var.dns_config != null ? coalesce(var.dns_config.record_name, var.volume_name) : null
+  mount_fqdn = var.dns_config != null ? (
+    endswith(local.dns_record_name, ".") ?
+    local.dns_record_name :
+    "${local.dns_record_name}.${data.google_dns_managed_zone.mount[0].dns_name}"
+  ) : null
+  mount_server        = local.mount_fqdn != null ? local.mount_fqdn : local.server_ip
+  mount_runner_server = local.mount_fqdn != null ? local.mount_fqdn : join(",", local.server_ips)
+}
+
+resource "google_dns_record_set" "volume" {
+  count = var.dns_config != null ? 1 : 0
+
+  project      = var.project_id
+  managed_zone = var.dns_config.managed_zone_name
+  name         = local.mount_fqdn
+  type         = "A"
+  ttl          = coalesce(var.dns_config.ttl, 60)
+  rrdatas      = local.server_ips
+
+  depends_on = [
+    google_netapp_volume.netapp_volume,
+    data.google_dns_managed_zone.mount,
+  ]
+}

--- a/modules/file-system/netapp-volume/main.tf
+++ b/modules/file-system/netapp-volume/main.tf
@@ -19,11 +19,24 @@ locals {
   labels = merge(var.labels, { ghpc_module = "netapp-volume", ghpc_role = "file-system" })
 }
 
-# resource "random_id" "resource_name_suffix" {
-#   byte_length = 4
-# }
-
 locals {
+  split_pool_id = split("/", var.netapp_storage_pool_id)
+  pool_name     = local.split_pool_id[5]
+  pool_location = local.split_pool_id[3]
+
+  # Inherited pool attributes are Flex-only; ignore API defaults on STANDARD/PREMIUM/EXTREME pools.
+  pool_type       = var.service_level == "FLEX" ? var.type : null
+  pool_scale_type = var.service_level == "FLEX" ? var.scale_type : null
+
+  # Flex Unified when service level is FLEX and pool type is UNIFIED or unset (inherited from pool).
+  is_flex_unified                 = var.service_level == "FLEX" && (local.pool_type == null || local.pool_type == "UNIFIED")
+  non_flex_large_min_capacity_gib = 15360 # 15 TiB
+  min_capacity_gib = var.large_capacity_config != null ? 4800 : (
+    local.is_flex_unified ? 1 : (
+      var.large_capacity ? local.non_flex_large_min_capacity_gib : 100
+    )
+  )
+
   full_path    = split(":", google_netapp_volume.netapp_volume.mount_options[0].export_full)
   server_ip    = local.full_path[0]
   remote_mount = local.full_path[1]
@@ -43,9 +56,6 @@ locals {
     "args"        = "\"${join(",", local.server_ips)}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
     "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
   }
-
-  split_pool_id = split("/", var.netapp_storage_pool_id)
-  pool_name     = local.split_pool_id[5]
 }
 
 resource "google_netapp_volume" "netapp_volume" {
@@ -53,19 +63,29 @@ resource "google_netapp_volume" "netapp_volume" {
 
   name               = var.volume_name
   share_name         = var.volume_name
-  location           = var.region
+  location           = local.pool_location
   protocols          = var.protocols
   capacity_gib       = var.capacity_gib
-  large_capacity     = var.large_capacity
-  multiple_endpoints = var.large_capacity == true ? true : null
+  large_capacity     = local.is_flex_unified ? null : var.large_capacity
+  multiple_endpoints = local.is_flex_unified ? null : (var.large_capacity ? true : null)
   storage_pool       = local.pool_name
   unix_permissions   = var.unix_permissions
+  security_style     = "UNIX"
+  deletion_policy    = var.deletion_policy
+
+  dynamic "large_capacity_config" {
+    for_each = var.large_capacity_config != null ? [1] : []
+    content {
+      constituent_count = var.large_capacity_config.constituent_count
+    }
+  }
 
   dynamic "tiering_policy" {
     for_each = var.tiering_policy == null ? [] : [0]
     content {
-      cooling_threshold_days = lookup(var.tiering_policy, "cooling_threshold_days", null)
-      tier_action            = lookup(var.tiering_policy, "tier_action", null)
+      cooling_threshold_days       = try(var.tiering_policy.cooling_threshold_days, null)
+      tier_action                  = try(var.tiering_policy.tier_action, null)
+      hot_tier_bypass_mode_enabled = try(var.tiering_policy.hot_tier_bypass_mode_enabled, null)
     }
   }
 
@@ -89,4 +109,55 @@ resource "google_netapp_volume" "netapp_volume" {
   }
 
   depends_on = [var.netapp_storage_pool_id]
+
+  lifecycle {
+    precondition {
+      condition     = local.pool_scale_type != "SCALE_TYPE_SCALEOUT" || var.large_capacity_config != null
+      error_message = "Large capacity pools (SCALE_TYPE_SCALEOUT) require large_capacity_config on the volume."
+    }
+    precondition {
+      condition     = var.large_capacity_config == null || local.is_flex_unified
+      error_message = "large_capacity_config is supported only with Flex Unified pools."
+    }
+    precondition {
+      condition     = !local.is_flex_unified || !var.large_capacity
+      error_message = "For Flex Unified pools, use large_capacity_config instead of large_capacity."
+    }
+    precondition {
+      condition     = !(var.large_capacity && var.large_capacity_config != null)
+      error_message = "large_capacity and large_capacity_config cannot be used together."
+    }
+    precondition {
+      condition     = local.pool_scale_type == null || var.large_capacity_config == null || local.pool_scale_type == "SCALE_TYPE_SCALEOUT"
+      error_message = "Flex Unified large capacity volumes require a storage pool with scale_type SCALE_TYPE_SCALEOUT."
+    }
+    precondition {
+      condition = var.capacity_gib >= local.min_capacity_gib
+      error_message = var.large_capacity_config != null ? "Flex Unified large capacity volumes require at least 4800 GiB." : (
+        local.is_flex_unified ? "Flex Unified volumes require at least 1 GiB." : (
+          var.large_capacity ? "STANDARD, PREMIUM, and EXTREME large capacity volumes require at least 15 TiB (15360 GiB)." : "STANDARD, PREMIUM, and EXTREME volumes require at least 100 GiB."
+        )
+      )
+    }
+    precondition {
+      condition     = var.tiering_policy == null || try(var.tiering_policy.hot_tier_bypass_mode_enabled, null) != true || var.service_level == "FLEX"
+      error_message = "hot_tier_bypass_mode_enabled is supported only for FLEX service level."
+    }
+    precondition {
+      condition     = var.tiering_policy == null || var.allow_auto_tiering == null || var.allow_auto_tiering
+      error_message = "tiering_policy requires a storage pool with allow_auto_tiering enabled."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || can(regex("^[a-z]([a-z0-9_]*[a-z0-9])?$", var.volume_name))
+      error_message = "Flex volume names must start with a lowercase letter, contain only lowercase letters, numbers, and underscores, and cannot end with an underscore."
+    }
+    precondition {
+      condition     = var.service_level == "FLEX" || var.service_level == null || can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.volume_name))
+      error_message = "STANDARD, PREMIUM, and EXTREME volume names must start with a lowercase letter, contain only lowercase letters, numbers, and hyphens, and cannot end with a hyphen."
+    }
+    precondition {
+      condition     = var.service_level != "FLEX" || local.pool_type != "FILE"
+      error_message = "Flex File pools (FLEX service level with type FILE) are not supported by this module."
+    }
+  }
 }

--- a/modules/file-system/netapp-volume/main.tf
+++ b/modules/file-system/netapp-volume/main.tf
@@ -40,7 +40,7 @@ locals {
   full_path    = split(":", google_netapp_volume.netapp_volume.mount_options[0].export_full)
   server_ip    = local.full_path[0]
   remote_mount = local.full_path[1]
-  # Large volumes will have 6 IPs
+  # Large volumes will have multiple IPs
   server_ips    = [for ip in google_netapp_volume.netapp_volume.mount_options[*].export_full : split(":", ip)[0]]
   fs_type       = "nfs"
   mount_options = var.mount_options
@@ -53,7 +53,7 @@ locals {
   mount_runner = {
     "type"        = "shell"
     "source"      = "${path.module}/scripts/mount.sh"
-    "args"        = "\"${join(",", local.server_ips)}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
+    "args"        = "\"${local.mount_runner_server}\" \"${local.remote_mount}\" \"${var.local_mount}\" \"${local.fs_type}\" \"${local.mount_options}\""
     "destination" = "mount${replace(var.local_mount, "/", "_")}.sh"
   }
 }

--- a/modules/file-system/netapp-volume/metadata.yaml
+++ b/modules/file-system/netapp-volume/metadata.yaml
@@ -17,3 +17,4 @@ spec:
   requirements:
     services:
     - netapp.googleapis.com
+    - dns.googleapis.com

--- a/modules/file-system/netapp-volume/outputs.tf
+++ b/modules/file-system/netapp-volume/outputs.tf
@@ -16,7 +16,7 @@
 output "network_storage" {
   description = "Describes a NetApp Volumes volume."
   value = {
-    server_ip             = local.server_ip
+    server_ip             = local.mount_server
     remote_mount          = local.remote_mount
     local_mount           = var.local_mount
     fs_type               = local.fs_type
@@ -63,4 +63,9 @@ output "capacity_gb" {
 output "server_ips" {
   description = "List of IP addresses of the volume."
   value       = local.server_ips
+}
+
+output "mount_fqdn" {
+  description = "FQDN for NFS mount when dns_config is set; null otherwise."
+  value       = local.mount_fqdn
 }

--- a/modules/file-system/netapp-volume/variables.tf
+++ b/modules/file-system/netapp-volume/variables.tf
@@ -15,12 +15,15 @@
  */
 
 variable "project_id" {
-  description = "ID of project in which the NetApp storage pool will be created."
+  description = "ID of project in which the NetApp volume will be created."
   type        = string
 }
 
 variable "netapp_storage_pool_id" {
-  description = "The ID of the NetApp storage pool to use for the volume."
+  description = <<-EOT
+    The ID of the NetApp storage pool to use for the volume. Volume location (region or zone) is parsed from this value.
+    Inherited from the pool when using use: [netapp_pool].
+    EOT
   type        = string
   validation {
     condition     = length(split("/", var.netapp_storage_pool_id)) == 6
@@ -28,29 +31,47 @@ variable "netapp_storage_pool_id" {
   }
 }
 
-variable "region" {
-  description = "Location for NetApp storage pool."
-  type        = string
-}
-
-variable "volume_name" {
-  description = "The name of the volume. Needs to be unique within the storage pool."
+variable "service_level" {
+  description = "Service level of the storage pool used by this volume. Inherited from the pool when using use: [netapp_pool]."
   type        = string
   default     = null
 }
 
+variable "type" {
+  description = "Type of the storage pool used by this volume. Inherited from the pool when using use: [netapp_pool]. Flex Unified pools use UNIFIED. Null for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+}
+
+variable "allow_auto_tiering" {
+  description = "Whether the storage pool supports auto-tiering. Inherited from the pool when using use: [netapp_pool]."
+  type        = bool
+  default     = null
+}
+
+variable "scale_type" {
+  description = "Scale type of the storage pool. Inherited from the pool when using use: [netapp_pool]. Flex-only; null for STANDARD, PREMIUM, and EXTREME pools."
+  type        = string
+  default     = null
+}
+
+variable "volume_name" {
+  description = <<-EOT
+    The name of the volume. Needs to be unique within the storage pool.
+    FLEX pools: lowercase letters, numbers, and underscores only; must start with a lowercase letter and cannot end with an underscore.
+    STANDARD, PREMIUM, and EXTREME pools: hyphens are allowed; underscores are not allowed.
+    EOT
+  type        = string
+}
+
 variable "capacity_gib" {
-  description = "The capacity of the volume in GiB."
+  description = "The capacity of the volume in GiB. Minimum is 100 GiB for STANDARD, PREMIUM, and EXTREME; 15 TiB (15360 GiB) for STANDARD, PREMIUM, and EXTREME large capacity volumes; 1 GiB for Flex Unified; 4800 GiB for Flex Unified large capacity volumes."
   type        = number
   default     = 1024
-  validation {
-    condition     = var.capacity_gib >= 100
-    error_message = "The minimum capacity for the volume is 100 GiB."
-  }
 }
 
 variable "protocols" {
-  description = "The protocols that the volume supports. Currently, only NFSv3 and NFSv4 is supported."
+  description = "Access protocols for the volume. Only NFSv3 and NFSv4.1 (NFSV4) are supported."
   type        = list(string)
   default     = ["NFSV3"]
   validation {
@@ -83,35 +104,84 @@ variable "local_mount" {
 variable "mount_options" {
   description = "NFS mount options to mount file system."
   type        = string
-  default     = "rw,hard,rsize=65536,wsize=65536,tcp"
+  default     = "rw,hard,rsize=262144,wsize=262144,tcp"
 }
 
 variable "large_capacity" {
   description = <<-EOT
-    If true, the volume will be created with large capacity.
-    Large capacity volumes have 6 IP addresses and a minimal size of 15 TiB.
+    If true, the volume will be created with large capacity for STANDARD/PREMIUM/EXTREME service levels.
+    For FLEX service level, use large_capacity_config instead.
     EOT
   type        = bool
   default     = false
 }
 
+variable "large_capacity_config" {
+  description = <<-EOT
+    Configuration for a Flex Unified large capacity volume. Supported only for Flex Unified pools.
+    Set constituent_count in the blueprint. The typical value for current SCALE_TYPE_SCALEOUT pools is 48.
+    EOT
+  type = object({
+    constituent_count = number
+  })
+  default = null
+  validation {
+    condition     = var.large_capacity_config == null || var.large_capacity_config.constituent_count >= 2
+    error_message = "constituent_count must be at least 2 for Flex Unified large capacity volumes."
+  }
+}
+
 variable "unix_permissions" {
   description = "UNIX permissions for root inode in the volume."
   type        = string
-  default     = "0777"
+  default     = "0770"
   validation {
-    condition     = length(var.unix_permissions) <= 4
-    error_message = "UNIX permissions must be a 4-digit octal number."
+    condition     = can(regex("^[0-7]{3,4}$", var.unix_permissions))
+    error_message = "UNIX permissions must be a 3 or 4-digit octal number (digits 0-7)."
   }
 }
 
 variable "tiering_policy" {
-  description = "Define the tiering policy for the NetApp volume."
+  description = <<-EOT
+    Define the tiering policy for the NetApp volume. Requires a pool with allow_auto_tiering enabled.
+    hot_tier_bypass_mode_enabled (FLEX only): use during data migration so writes go to the cold tier instead of filling the hot tier; disable after migration completes.
+    EOT
   type = object({
-    tier_action            = optional(string)
-    cooling_threshold_days = optional(number)
+    tier_action                  = optional(string)
+    cooling_threshold_days       = optional(number)
+    hot_tier_bypass_mode_enabled = optional(bool)
   })
   default = null
+  validation {
+    condition = var.tiering_policy == null || contains(
+      ["ENABLED", "PAUSED"],
+      coalesce(var.tiering_policy.tier_action, "PAUSED")
+    )
+    error_message = "tier_action must be ENABLED or PAUSED."
+  }
+  validation {
+    condition = var.tiering_policy == null || var.tiering_policy.cooling_threshold_days == null || (
+      coalesce(var.tiering_policy.cooling_threshold_days, 0) >= 2 &&
+      coalesce(var.tiering_policy.cooling_threshold_days, 0) <= 183
+    )
+    error_message = "cooling_threshold_days must be between 2 and 183."
+  }
+}
+
+variable "deletion_policy" {
+  description = <<-EOT
+    Controls Terraform destroy behavior. Omit to use the provider default (delete the volume in Google Cloud).
+    DEFAULT or DELETE: delete the volume in Google Cloud.
+    FORCE: delete the volume even when nested snapshot resources exist.
+    PREVENT: block Terraform from deleting the volume.
+    ABANDON: remove the volume from Terraform state without deleting it in Google Cloud.
+    EOT
+  type        = string
+  default     = null
+  validation {
+    condition     = var.deletion_policy == null ? true : contains(["DEFAULT", "FORCE", "PREVENT", "ABANDON", "DELETE"], var.deletion_policy)
+    error_message = "Allowed values for deletion_policy are DEFAULT, FORCE, PREVENT, ABANDON, or DELETE."
+  }
 }
 
 variable "export_policy_rules" {
@@ -130,4 +200,10 @@ variable "export_policy_rules" {
     access_type     = "READ_WRITE",
   }]
   nullable = true
+  validation {
+    condition = var.export_policy_rules == null ? true : alltrue([
+      for rule in var.export_policy_rules : contains(["READ_ONLY", "READ_WRITE", "READ_NONE"], rule.access_type)
+    ])
+    error_message = "access_type must be READ_ONLY, READ_WRITE, or READ_NONE."
+  }
 }

--- a/modules/file-system/netapp-volume/variables.tf
+++ b/modules/file-system/netapp-volume/variables.tf
@@ -184,6 +184,39 @@ variable "deletion_policy" {
   }
 }
 
+variable "dns_config" {
+  description = <<-EOT
+    Optional Cloud DNS configuration for this volume. When set, the module creates an A record
+    with all volume endpoint IPs (round-robin) and uses the resulting FQDN as network_storage.server_ip.
+    managed_zone_name must reference an existing private Cloud DNS zone visible to clients.
+    The zone dns_name suffix is read from the managed zone; record_name defaults to volume_name.
+    record_name and the default volume_name must not contain underscores; use hyphens (-) instead.
+    For Flex Unified volumes, set record_name explicitly when the volume name contains underscores.
+    EOT
+  type = object({
+    managed_zone_name = string
+    record_name       = optional(string)
+    ttl               = optional(number)
+  })
+  default = null
+  validation {
+    condition     = var.dns_config == null || var.dns_config.managed_zone_name != ""
+    error_message = "dns_config.managed_zone_name must be non-empty when dns_config is set."
+  }
+  validation {
+    condition     = var.dns_config == null || var.dns_config.ttl == null || var.dns_config.ttl > 0
+    error_message = "dns_config.ttl must be greater than 0 when set."
+  }
+  validation {
+    condition     = var.dns_config == null || var.dns_config.record_name != null || !strcontains(var.volume_name, "_")
+    error_message = "When dns_config is set and record_name is omitted, volume_name cannot contain underscores. Use hyphens (-) instead. For Flex Unified volumes, set dns_config.record_name to a DNS-safe name."
+  }
+  validation {
+    condition     = var.dns_config == null || var.dns_config.record_name == null || !strcontains(var.dns_config.record_name, "_")
+    error_message = "dns_config.record_name cannot contain underscores. DNS hostnames allow only letters, digits, and hyphens. Use hyphens (-) instead."
+  }
+}
+
 variable "export_policy_rules" {
   description = "Define NFS export policy."
   type = list(object({

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.45.0"
+      version = ">= 7.34.0"
     }
   }
   provider_meta "google" {

--- a/modules/file-system/pre-existing-network-storage/README.md
+++ b/modules/file-system/pre-existing-network-storage/README.md
@@ -25,7 +25,11 @@ the extended [Network Storage documentation](../../../docs/network_storage.md).
 
 This creates a pre-existing-network-storage module in terraform at the
 provided IP in `server_ip` of type nfs that will be mounted at `/home`. Note
-that the `server_ip` must be known before deployment.
+that the `server_ip` must be known before deployment. For large-capacity
+NetApp volumes and FlexCache caches, set `server_ip` to a DNS FQDN whose A
+record contains every NFS endpoint IP. See the
+[dns-managed-zone](../../network/dns-managed-zone/README.md) module and
+[network storage documentation](../../../docs/network_storage.md#mounting-large-capacity-volumes-and-flexcache).
 
 The following is an example of using `pre-existing-network-storage` with a GCS
 bucket:
@@ -181,7 +185,7 @@ No resources.
 | <a name="input_mount_options"></a> [mount\_options](#input\_mount\_options) | Options describing various aspects of the file system. Consider adding setting to 'defaults,\_netdev,implicit\_dirs' when using gcsfuse. | `string` | `"defaults,_netdev"` | no |
 | <a name="input_parallelstore_options"></a> [parallelstore\_options](#input\_parallelstore\_options) | Parallelstore specific options | <pre>object({<br/>    daos_agent_config = optional(string, "")<br/>    dfuse_environment = optional(map(string), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_remote_mount"></a> [remote\_mount](#input\_remote\_mount) | Remote FS name or export. This is the exported directory for nfs, fs name for lustre, and bucket name (without gs://) for gcsfuse. | `string` | n/a | yes |
-| <a name="input_server_ip"></a> [server\_ip](#input\_server\_ip) | The device name as supplied to fs-tab, excluding remote fs-name(for nfs, that is the server IP, for lustre <MGS NID>[:<MGS NID>]). This can be omitted for gcsfuse. | `string` | `""` | no |
+| <a name="input_server_ip"></a> [server\_ip](#input\_server\_ip) | The device name as supplied to fs-tab, excluding remote fs-name (for nfs, the server IP or DNS FQDN; for lustre <MGS NID>[:<MGS NID>]). This can be omitted for gcsfuse. For large-capacity NetApp volumes and FlexCache, use a DNS FQDN whose A record contains every NFS endpoint IP. | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/file-system/pre-existing-network-storage/variables.tf
+++ b/modules/file-system/pre-existing-network-storage/variables.tf
@@ -15,7 +15,7 @@
  */
 
 variable "server_ip" {
-  description = "The device name as supplied to fs-tab, excluding remote fs-name(for nfs, that is the server IP, for lustre <MGS NID>[:<MGS NID>]). This can be omitted for gcsfuse."
+  description = "The device name as supplied to fs-tab, excluding remote fs-name (for nfs, the server IP or DNS FQDN; for lustre <MGS NID>[:<MGS NID>]). This can be omitted for gcsfuse. For large-capacity NetApp volumes and FlexCache, use a DNS FQDN whose A record contains every NFS endpoint IP."
   type        = string
   default     = ""
 }

--- a/modules/network/dns-managed-zone/README.md
+++ b/modules/network/dns-managed-zone/README.md
@@ -22,6 +22,34 @@ This module creates a Google Cloud DNS Managed Zone.
       - "1.2.3.4"
 ```
 
+### Private zone for NetApp volume endpoints
+
+```yaml
+- id: gcnv_dns_zone
+  source: modules/network/dns-managed-zone
+  settings:
+    project_id: $(vars.project_id)
+    zone_name: $(vars.deployment_name)-gcnv-dns
+    dns_name: gcnv.internal.
+    visibility: private
+    network_id: $(network.network_id)
+```
+
+### Private zone visible to multiple VPCs
+
+```yaml
+- id: gcnv_dns_zone
+  source: modules/network/dns-managed-zone
+  settings:
+    project_id: $(vars.project_id)
+    zone_name: $(vars.deployment_name)-gcnv-dns
+    dns_name: gcnv.internal.
+    visibility: private
+    network_ids:
+    - $(frontend_network.network_id)
+    - $(backend_network.network_id)
+```
+
 ## License
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
@@ -71,14 +99,18 @@ No modules.
 | <a name="input_description"></a> [description](#input\_description) | A textual description of this managed zone | `string` | `"Managed by Cluster Toolkit"` | no |
 | <a name="input_dns_name"></a> [dns\_name](#input\_dns\_name) | The DNS name of this managed zone, e.g. 'example.com.' | `string` | n/a | yes |
 | <a name="input_labels"></a> [labels](#input\_labels) | A set of key/value label pairs to assign to this ManagedZone | `map(string)` | `{}` | no |
+| <a name="input_network_id"></a> [network\_id](#input\_network\_id) | VPC network ID for private zones (projects/PROJECT\_ID/global/networks/NETWORK\_NAME). Use network\_ids for multiple VPCs. | `string` | `null` | no |
+| <a name="input_network_ids"></a> [network\_ids](#input\_network\_ids) | VPC network IDs visible to a private zone. Combined with network\_id when both are set. | `list(string)` | `[]` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project ID | `string` | n/a | yes |
 | <a name="input_recordsets"></a> [recordsets](#input\_recordsets) | List of DNS record sets to create in the zone | <pre>list(object({<br/>    name    = string<br/>    type    = string<br/>    ttl     = number<br/>    rrdatas = list(string)<br/>  }))</pre> | `[]` | no |
+| <a name="input_visibility"></a> [visibility](#input\_visibility) | Visibility of the zone: public or private. Use private for NetApp volume endpoint DNS. | `string` | `"public"` | no |
 | <a name="input_zone_name"></a> [zone\_name](#input\_zone\_name) | The name of the DNS zone | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_dns_name"></a> [dns\_name](#output\_dns\_name) | The DNS suffix of the managed zone (for example, gcnv.internal.). |
 | <a name="output_managed_zone_id"></a> [managed\_zone\_id](#output\_managed\_zone\_id) | The fully qualified ID of the DNS Managed Zone. |
 | <a name="output_name_servers"></a> [name\_servers](#output\_name\_servers) | The delegated name servers for the zone. |
 | <a name="output_zone_name"></a> [zone\_name](#output\_zone\_name) | The name of the managed DNS zone. |

--- a/modules/network/dns-managed-zone/main.tf
+++ b/modules/network/dns-managed-zone/main.tf
@@ -27,12 +27,39 @@ locals {
   labels = merge(var.labels, { ghpc_module = "dns-managed-zone", ghpc_role = "network" })
 }
 
+locals {
+  private_network_urls = distinct(compact(concat(
+    var.network_ids,
+    var.network_id != null ? [var.network_id] : [],
+  )))
+}
+
 resource "google_dns_managed_zone" "zone" {
   project     = google_project_service.dns_api.project
   name        = var.zone_name
   dns_name    = var.dns_name
   description = var.description
   labels      = local.labels
+  visibility  = var.visibility
+
+  dynamic "private_visibility_config" {
+    for_each = var.visibility == "private" ? [1] : []
+    content {
+      dynamic "networks" {
+        for_each = local.private_network_urls
+        content {
+          network_url = networks.value
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.visibility != "private" || length(local.private_network_urls) > 0
+      error_message = "Private zones require at least one network. Set network_id or network_ids."
+    }
+  }
 }
 
 resource "google_dns_record_set" "record" {

--- a/modules/network/dns-managed-zone/outputs.tf
+++ b/modules/network/dns-managed-zone/outputs.tf
@@ -28,3 +28,8 @@ output "managed_zone_id" {
   description = "The fully qualified ID of the DNS Managed Zone."
   value       = google_dns_managed_zone.zone.id
 }
+
+output "dns_name" {
+  description = "The DNS suffix of the managed zone (for example, gcnv.internal.)."
+  value       = google_dns_managed_zone.zone.dns_name
+}

--- a/modules/network/dns-managed-zone/variables.tf
+++ b/modules/network/dns-managed-zone/variables.tf
@@ -52,3 +52,25 @@ variable "recordsets" {
   description = "List of DNS record sets to create in the zone"
   default     = []
 }
+
+variable "visibility" {
+  type        = string
+  description = "Visibility of the zone: public or private. Use private for NetApp volume endpoint DNS."
+  default     = "public"
+  validation {
+    condition     = contains(["public", "private"], var.visibility)
+    error_message = "visibility must be public or private."
+  }
+}
+
+variable "network_id" {
+  type        = string
+  description = "VPC network ID for private zones (projects/PROJECT_ID/global/networks/NETWORK_NAME). Use network_ids for multiple VPCs."
+  default     = null
+}
+
+variable "network_ids" {
+  type        = list(string)
+  description = "VPC network IDs visible to a private zone. Combined with network_id when both are set."
+  default     = []
+}

--- a/modules/scheduler/gke-cluster/metadata.yaml
+++ b/modules/scheduler/gke-cluster/metadata.yaml
@@ -33,3 +33,9 @@ ghpc:
       dependent: configure_workload_identity_sa
       dependent_value: true
     error_message: "The variable 'configure_workload_identity_sa' must be set to true when 'enable_ml_diagnostics' is enabled to correctly configure ML Diagnostics."
+
+  - validator: cidr
+    inputs:
+      vars: [master_authorized_networks]
+      object_key: cidr_block
+    error_message: "Validation failed due to invalid CIDR IP address in 'master_authorized_networks.cidr_block'. All values must be in CIDR format (e.g. 1.2.3.4/32)."

--- a/modules/scheduler/gke-cluster/variables.tf
+++ b/modules/scheduler/gke-cluster/variables.tf
@@ -383,6 +383,13 @@ variable "master_authorized_networks" {
     display_name = string
   }))
   default = []
+
+  validation {
+    condition     = var.master_authorized_networks == null ? true : can([for net in var.master_authorized_networks : cidrhost(net.cidr_block, 0)])
+    error_message = "Validation failed due to invalid CIDR IP address in 'master_authorized_networks.cidr_block'. All values must be in CIDR format (e.g. 1.2.3.4/32)."
+  }
+
+
 }
 
 variable "service_account_email" {

--- a/pkg/validators/metadata_validators.go
+++ b/pkg/validators/metadata_validators.go
@@ -13,6 +13,7 @@ package validators
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -21,6 +22,108 @@ import (
 
 	"github.com/zclconf/go-cty/cty"
 )
+
+// CIDRValidator implements the RuleValidator interface for the 'cidr' type.
+// It verifies that a given string is a valid IP CIDR block.
+// Used in a module's metadata.yaml via `- validator: cidr`.
+type CIDRValidator struct{}
+
+func extractCIDRValue(val cty.Value, objectKey string, allowNull bool, path config.Path) (cty.Value, error) {
+	if val.IsNull() {
+		return cty.NullVal(cty.String), nil
+	}
+	if val.Type() == cty.String {
+		return val, nil
+	}
+	if val.Type().IsObjectType() {
+		if objectKey == "" {
+			return cty.NilVal, config.BpError{Err: fmt.Errorf("object_key is required when validating an object"), Path: path}
+		}
+		if !val.Type().HasAttribute(objectKey) {
+			if !allowNull {
+				return cty.NilVal, config.BpError{Err: fmt.Errorf("missing key %q in object", objectKey), Path: path}
+			}
+			return cty.NilVal, nil
+		}
+		return val.GetAttr(objectKey), nil
+	}
+	if val.Type().IsMapType() {
+		if objectKey == "" {
+			return cty.NilVal, config.BpError{Err: fmt.Errorf("object_key is required when validating a map"), Path: path}
+		}
+		if !val.HasIndex(cty.StringVal(objectKey)).True() {
+			if !allowNull {
+				return cty.NilVal, config.BpError{Err: fmt.Errorf("missing key %q in map", objectKey), Path: path}
+			}
+			return cty.NilVal, nil
+		}
+		return val.Index(cty.StringVal(objectKey)), nil
+	}
+	return cty.NilVal, config.BpError{Err: fmt.Errorf("unsupported type %s for CIDR validation", val.Type().FriendlyName()), Path: path}
+}
+
+func validateCIDRValue(cidrVal cty.Value, rule modulereader.ValidationRule, allowNull bool, path config.Path) error {
+	if cidrVal == cty.NilVal {
+		return nil
+	}
+	if cidrVal.IsNull() {
+		if allowNull {
+			return nil
+		}
+		msg := rule.ErrorMessage
+		if msg == "" {
+			msg = "CIDR block cannot be null or empty"
+		}
+		return config.BpError{Err: fmt.Errorf("%s", msg), Path: path}
+	}
+	if cidrVal.Type() != cty.String {
+		return config.BpError{Err: fmt.Errorf("CIDR block must be a string, got %s", cidrVal.Type().FriendlyName()), Path: path}
+	}
+	if !cidrVal.IsKnown() {
+		return nil
+	}
+	str := cidrVal.AsString()
+	if _, _, err := net.ParseCIDR(str); err != nil {
+		msg := rule.ErrorMessage
+		if msg == "" {
+			msg = fmt.Sprintf("invalid CIDR address: %s", str)
+		}
+		return config.BpError{Err: fmt.Errorf("%s", msg), Path: path}
+	}
+	return nil
+}
+
+// Validate checks if the variables specified in the rule are valid CIDR addresses.
+func (c *CIDRValidator) Validate(
+	bp config.Blueprint,
+	mod config.Module,
+	rule modulereader.ValidationRule,
+	group config.Group,
+	modIdx int) error {
+
+	allowNull, err := parseBoolInput(rule.Inputs, "allow_null", false)
+	if err != nil {
+		modPath := config.Root.Groups.At(bp.GroupIndex(group.Name)).Modules.At(modIdx).Source
+		return config.BpError{Err: fmt.Errorf("validation rule for module %q: %v", mod.ID, err), Path: modPath}
+	}
+	objectKey, _ := parseString(rule.Inputs["object_key"])
+
+	return IterateRuleTargets(bp, mod, rule, group, modIdx, func(t Target) error {
+		for _, val := range t.Values {
+			if !val.IsKnown() {
+				continue
+			}
+			cidrVal, err := extractCIDRValue(val, objectKey, allowNull, t.Path)
+			if err != nil {
+				return err
+			}
+			if err := validateCIDRValue(cidrVal, rule, allowNull, t.Path); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
 
 // RegexValidator implements the Validator interface for 'regex' type.
 type RegexValidator struct{}

--- a/pkg/validators/metadata_validators_test.go
+++ b/pkg/validators/metadata_validators_test.go
@@ -1145,3 +1145,64 @@ func TestConditionalRegexValidator(t *testing.T) {
 		}
 	})
 }
+
+func createBaseTestBlueprint() config.Blueprint {
+	return config.Blueprint{
+		BlueprintName: "test-bp",
+		Groups: []config.Group{
+			{
+				Name: "primary",
+				Modules: []config.Module{
+					{
+						ID:     "test-module",
+						Source: "test/module",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestCIDRValidator(t *testing.T) {
+	validator := &CIDRValidator{}
+
+	rule := modulereader.ValidationRule{
+		Validator: "cidr",
+		Inputs: map[string]interface{}{
+			"vars":       []interface{}{"master_authorized_networks"},
+			"object_key": "cidr_block",
+		},
+	}
+
+	t.Run("fails_on_placeholder_cidr", func(t *testing.T) {
+		bp := createBaseTestBlueprint()
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"master_authorized_networks": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"display_name": cty.StringVal("test"),
+					"cidr_block":   cty.StringVal("<your-ip-address>/32"),
+				}),
+			}),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("passes_on_valid_cidr", func(t *testing.T) {
+		bp := createBaseTestBlueprint()
+		bp.Groups[0].Modules[0].Settings = config.NewDict(map[string]cty.Value{
+			"master_authorized_networks": cty.TupleVal([]cty.Value{
+				cty.ObjectVal(map[string]cty.Value{
+					"display_name": cty.StringVal("test"),
+					"cidr_block":   cty.StringVal("1.2.3.4/32"),
+				}),
+			}),
+		})
+		err := validator.Validate(bp, bp.Groups[0].Modules[0], rule, bp.Groups[0], 0)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/pkg/validators/registry.go
+++ b/pkg/validators/registry.go
@@ -16,6 +16,7 @@ package validators
 
 // Registry maps validation type strings to their corresponding validator implementation.
 var Registry = map[string]RuleValidator{
+	"cidr":              &CIDRValidator{},
 	"regex":             &RegexValidator{},
 	"allowed_enum":      &AllowedEnumValidator{},
 	"range":             &RangeValidator{},

--- a/tools/cloud-build/check_retriable_error.sh
+++ b/tools/cloud-build/check_retriable_error.sh
@@ -29,7 +29,7 @@ fi
 # Define all retriable errors here.
 # Note: "Couldn't find a zone to deploy" and "ERROR: ZONE not found" are not included here
 # because find_available_zone.sh now internally loops and waits for zone capacity to maintain Kueue locks.
-RETRIABLE_ERRORS="ZONE_RESOURCE_POOL_EXHAUSTED|does not have enough resources available|not enough resources available|stockout|os-login.*ssh-keys.*add|resourceInUseByAnotherResource|Error acquiring the state lock|412 Precondition Failed|conditionNotMet|RATE_LIMIT_EXCEEDED|Mutate requests per minute|Error 429|HTTP 429|429 Too Many Requests|Error 50[0-9]|Internal error|backendError|Service Unavailable|connection reset by peer|TLS handshake timeout|overlaps with the existing allocated IP range|Connection refused|Connection timed out|Failed to connect to the host via ssh"
+RETRIABLE_ERRORS="ZONE_RESOURCE_POOL_EXHAUSTED|does not have enough resources available|not enough resources available|stockout|was created in the error state.*ERROR.*|srun: error: Node failure on|srun: error: Nodes .* are still not ready|os-login.*ssh-keys.*add|resourceInUseByAnotherResource|Error acquiring the state lock|412 Precondition Failed|conditionNotMet|RATE_LIMIT_EXCEEDED|Mutate requests per minute|Error 429|HTTP 429|429 Too Many Requests|Error 50[0-9]|Internal error|backendError|Service Unavailable|connection reset by peer|TLS handshake timeout|overlaps with the existing allocated IP range|Connection refused|Connection timed out|Failed to connect to the host via ssh"
 
 if grep -q -i -E "$RETRIABLE_ERRORS" "$LOG_FILE"; then
 	exit 0

--- a/tools/python-integration-tests/ssh.py
+++ b/tools/python-integration-tests/ssh.py
@@ -52,9 +52,16 @@ class SSHManager:
         ]
 
         self.tunnel = subprocess.Popen(iap_tunnel_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        
-        # Sleep to give the tunnel a few seconds to set up
-        time.sleep(3)
+        # Wait for the tunnel to be established by polling the local port
+        start_time = time.time()
+        while time.time() - start_time < 15:
+            if self.tunnel.poll() is not None:
+                break
+            try:
+                with socket.create_connection(("localhost", self.local_port), timeout=1):
+                    break
+            except Exception:
+                time.sleep(0.5)
 
     def get_keypath(self):
         key_path = os.path.expanduser("~/.ssh/slurm_tests")

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -43,9 +43,13 @@ run_test() {
 	else
 		cd "${tmpdir}"
 	fi
+	ADDITIONAL_VARS=""
+	if grep -q "^[[:space:]]*authorized_cidr:" "${BP_PATH}"; then
+		ADDITIONAL_VARS=",authorized_cidr=1.2.3.4/32"
+	fi
 	${GHPC_PATH} create "${BP_PATH}" -l ERROR \
 		--skip-validators="${VALIDATORS_TO_SKIP}" "${deployment_args[@]}" \
-		--vars="project_id=${PROJECT},deployment_name=${DEPLOYMENT}" >/dev/null ||
+		--vars="project_id=${PROJECT},deployment_name=${DEPLOYMENT}${ADDITIONAL_VARS}" >/dev/null ||
 		{
 			echo "*** ERROR: error creating deployment with gcluster for ${exampleFile}"
 			exit 1


### PR DESCRIPTION
Large-capacity volumes and FlexCache expose multiple NFS endpoint IPs. Add volume dns_config and private-zone support so clients, including Slurm, mount by FQDN and use every endpoint. Update EDA and Slurm examples plus docs.