### PR TITLE
OS support workflow: pin actions SHAs and add explicit permissions

### DIFF
--- a/.github/workflows/os-support-validation.yml
+++ b/.github/workflows/os-support-validation.yml
@@ -14,6 +14,9 @@
 
 name: OS Support Validation
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [develop]
@@ -45,9 +48,9 @@ jobs:
           image: "rockylinux:9"
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 #v4.4.0
     - name: Set up Go 1.26
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff #v5.6.0
       with:
         go-version: '1.26'
     - name: Build Binary


### PR DESCRIPTION
### Summary
Updated the OS support workflow to address workflow security findings.

### Changes
Pinned GitHub Actions to specific commit SHAs.
Added explicit workflow permissions to avoid relying on default permissions.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
