### PR TITLE
Update Slurm blueprints to use Image Family

### DIFF
--- a/examples/hpc-enterprise-slurm.yaml
+++ b/examples/hpc-enterprise-slurm.yaml
@@ -28,8 +28,7 @@ vars:
     # for a list of valid family options with Slurm
     # Rocky 8: slurm-gcp-6-12-hpc-rocky-linux-8
     # Rocky 9: slurm-gcp-6-12-hpc-rocky-linux-9
-    # Pinned to working version prior to July 10, 2026 due to Lustre client incompatibility on Rocky 9.8
-    name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519
+    family: slurm-gcp-6-12-hpc-rocky-linux-9
     project: schedmd-slurm-public
   # If image above is changed to use custom image, then setting below must be set to true
   instance_image_custom: false

--- a/examples/pfs-managed-lustre-slurm.yaml
+++ b/examples/pfs-managed-lustre-slurm.yaml
@@ -33,8 +33,7 @@ vars:
   per_unit_storage_throughput: 500
   kms_key: ""
   slurm_image:
-    # Pinned to working version prior to July 10, 2026 due to Lustre client incompatibility on Rocky 9.8
-    name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519
+    family: slurm-gcp-6-12-hpc-rocky-linux-9
     project: schedmd-slurm-public
 
 # Documentation for each of the modules used below can be found at


### PR DESCRIPTION
## Summary

This PR updates the Slurm example blueprints (hpc-enterprise-slurm.yaml and pfs-managed-lustre-slurm.yaml) from the pinned legacy image (slurm-gcp-6-12-hpc-rocky-linux-9-20260519) to the standard slurm-gcp-6-12-hpc-rocky-linux-9 image family hosted in schedmd-slurm-public. This aligns these blueprints with the rest of Cluster Toolkit's Slurm examples and underlying Terraform modules.


## Changes

- Enterprise Slurm Blueprint: examples/hpc-enterprise-slurm.yaml updated slurm_image from pinned name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519 to family: slurm-gcp-6-12-hpc-rocky-linux-9.
- Parallelstore Managed Lustre Blueprint: examples/pfs-managed-lustre-slurm.yaml updated slurm_image from pinned name: slurm-gcp-6-12-hpc-rocky-linux-9-20260519 to family: slurm-gcp-6-12-hpc-rocky-linux-9.

## Testing
- Unit tests: go test ./cmd/... ./pkg/... (100% passed across all Go packages).
- Golden copy validation: make validate_golden_copy (Passed).
- Blueprint expansion: ./gcluster create examples/hpc-enterprise-slurm.yaml and ./gcluster create examples/pfs-managed-lustre-slurm.yaml (Validated successful parsing and Terraform expansion).