### PR TITLE
feat(destroy): default to robust destroy for all `gcluster destroy` operations

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -135,6 +135,6 @@ gcluster destroy DEPLOYMENT_DIRECTORY [flags]
 
 * `--only <strings>`: Only destroy groups with the given names (comma-separated).
 * `--skip <strings>`: Skip destroying groups with the given names (comma-separated).
-* `--robust`: Perform a robust destroy, including firewall rule cleanup.
+* `--robust`: Perform a robust destroy, including firewall rule cleanup (default: true, pass `--robust=false` to disable).
 
 Refer to the [Selective Deployment and Exclusion Guide](https://github.com/GoogleCloudPlatform/cluster-toolkit/blob/main/examples/machine-learning/README.md#selective-deployment-and-destruction-using---only-and---skip-flags) for more information on managing or skipping specific group destruction.

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -44,7 +44,7 @@ func init() {
 		addGroupSelectionFlags(
 			addAutoApproveFlag(
 				addArtifactsDirFlag(destroyCmd))))
-	destroyCmd.Flags().BoolVar(&robustDestroy, "robust", false, "Perform a robust destroy, including firewall rule cleanup.")
+	destroyCmd.Flags().BoolVar(&robustDestroy, "robust", true, "Perform a robust destroy, including firewall rule cleanup.")
 }
 
 var (


### PR DESCRIPTION
This PR makes robust as the default for destroy.
### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
