### PR TITLE
chore: bump golangci-lint for go 1.26 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
 #   hooks:
 #   - id: go-critic
 - repo: https://github.com/golangci/golangci-lint
-  rev: v2.4.0
+  rev: v2.13.1
   hooks:
   - id: golangci-lint
 - repo: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
This PR bumps golangci-lint to v2.13.1 to fix pre-commit failures with Go 1.26.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
