### PR TITLE
Adding assignees to PR reviews

### DIFF
--- a/.github/workflows/sync-assignees.yml
+++ b/.github/workflows/sync-assignees.yml
@@ -1,0 +1,76 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Sync Reviewers to Assignees'
+
+on:
+  # zizmor: ignore[dangerous-triggers] - We handle inputs safely via env vars and do not checkout code.
+  pull_request_target:
+    types: [opened, ready_for_review, review_requested, review_request_removed]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+  issues: write # Required for managing assignees
+
+jobs:
+  sync-assignees:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Sync Assignees with Ball-in-Court Status
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_URL: ${{ github.event.pull_request.html_url || github.event.review.pull_request_url }}
+        EVENT_NAME: ${{ github.event_name }}
+        EVENT_ACTION: ${{ github.event.action }}
+        REVIEW_STATE: ${{ github.event.review.state }}
+        APPROVER: ${{ github.event.review.user.login }}
+        REMOVED_USER: ${{ github.event.requested_reviewer.login }}
+      run: |
+        set -euo pipefail
+
+        # 1. When a reviewer approves, check if other reviewers are still waiting
+        if [ "$EVENT_NAME" = "pull_request_review" ]; then
+          if [ "$(echo "$REVIEW_STATE" | tr '[:upper:]' '[:lower:]')" = "approved" ]; then
+            # Robust query handling potential nested structures
+            REMAINING=$(gh pr view "$PR_URL" --json reviewRequests -q '[.reviewRequests[]? | (.login // .requestedReviewer?.login // empty)] | length' || echo "0")
+
+            if [ "$REMAINING" -gt 0 ]; then
+              echo "Other reviewers still requested ($REMAINING remaining). Removing $APPROVER from assignees."
+              gh pr edit "$PR_URL" --remove-assignee "$APPROVER" || true
+            else
+              echo "All reviews complete! Leaving final approver ($APPROVER) assigned to merge."
+            fi
+            exit 0
+          fi
+        fi
+
+        # 2. When a review request is removed, remove that user from Assignees
+        if [ "$EVENT_NAME" = "pull_request_target" ] && [ "$EVENT_ACTION" = "review_request_removed" ]; then
+          if [ -n "$REMOVED_USER" ]; then
+            echo "Review request removed for $REMOVED_USER. Removing from assignees."
+            gh pr edit "$PR_URL" --remove-assignee "$REMOVED_USER" || true
+            exit 0
+          fi
+        fi
+
+        # 3. Add currently requested individual reviewers to Assignees
+        # Robust query handling potential nested structures
+        REVIEWERS=$(gh pr view "$PR_URL" --json reviewRequests -q '[.reviewRequests[]? | (.login // .requestedReviewer?.login // empty)] | join(",")')
+
+        if [ -n "$REVIEWERS" ]; then
+          echo "Adding assignees: $REVIEWERS"
+          gh pr edit "$PR_URL" --add-assignee "$REVIEWERS"
+        fi

--- a/tools/github/inactive-pr-reminder.sh
+++ b/tools/github/inactive-pr-reminder.sh
@@ -99,7 +99,7 @@ get_latest_activity_timestamp() {
 		# Check latest non-bot comment activity
 		local latest_comment_updated_at
 		latest_comment_updated_at=$(echo "$comments_json" | jq -r '
-			map(select((.author.login // "" | test("github-actions|bot"; "i") | not) or (.body | contains("<!-- PR_INACTIVITY_REMINDER -->") | not))) |
+			map(select(.author.login // "" | test("github-actions|bot"; "i") | not)) |
 			map(select(.createdAt | type == "string")) |
 			map(.createdAt) |
 			max // null
@@ -200,8 +200,8 @@ process_pr() {
 
 	local target_tag
 	target_tag=$(echo "$pr_json" | jq -r '
-		([.reviewRequests[]? | select(.login != null) | "@" + .login] +
-		 [.assignees[]? | select(.login != null) | "@" + .login]) | unique | join(", ")
+		([.reviewRequests[]?.requestedReviewer.login // empty | "@" + .] +
+		 [.assignees[]?.login // empty | "@" + .]) | unique | join(", ")
 	')
 	if [[ -z "$target_tag" ]]; then
 		target_tag="$TEAM_TO_TAG"

--- a/tools/github/inactive-pr-reminder.sh
+++ b/tools/github/inactive-pr-reminder.sh
@@ -20,8 +20,8 @@ set -euo pipefail
 
 # --- Constants ---
 REMINDER_MARKER="<!-- PR_INACTIVITY_REMINDER -->"
-DAYS_INTERVAL=7
-DAYS_TO_CLOSE=21
+DAYS_INTERVAL=2
+DAYS_TO_CLOSE=14
 TEAM_TO_TAG="@GoogleCloudPlatform/hpc-toolkit"
 
 # --- Functions ---
@@ -67,7 +67,7 @@ get_latest_activity_timestamp() {
 	# Check if there are any bot reminders
 	local latest_bot_reminder_timestamp
 	latest_bot_reminder_timestamp=$(echo "$comments_json" | jq -r '
-		map(select(.body | contains("<!-- PR_INACTIVITY_REMINDER -->"))) |
+		map(select((.author.login // "" | test("github-actions|bot"; "i")) and (.body | contains("<!-- PR_INACTIVITY_REMINDER -->")))) |
 		map(select(.createdAt | type == "string")) |
 		map(.createdAt) |
 		max // null
@@ -99,7 +99,7 @@ get_latest_activity_timestamp() {
 		# Check latest non-bot comment activity
 		local latest_comment_updated_at
 		latest_comment_updated_at=$(echo "$comments_json" | jq -r '
-			map(select(.body | contains("<!-- PR_INACTIVITY_REMINDER -->") | not)) |
+			map(select((.author.login // "" | test("github-actions|bot"; "i") | not) or (.body | contains("<!-- PR_INACTIVITY_REMINDER -->") | not))) |
 			map(select(.createdAt | type == "string")) |
 			map(.createdAt) |
 			max // null
@@ -156,6 +156,7 @@ send_reminder() {
 	local approval_status_code=$4
 	local changes_requested=$5
 	local reminder_type=$6
+	local target_tag=$7
 
 	local prefix=""
 	if [[ "$reminder_type" == "second" ]]; then
@@ -168,7 +169,7 @@ send_reminder() {
 		if [[ "$changes_requested" == "CHANGES_REQUESTED" ]]; then
 			gh pr comment "$pr_number" --body "${prefix}this PR has been inactive for ${inactive_days} days and has changes requested. @${pr_author}, please address the requested changes or close the PR if it's no longer needed. ${REMINDER_MARKER}"
 		else
-			gh pr comment "$pr_number" --body "${prefix}this PR has been inactive for ${inactive_days} days and has no unresolved comments. ${TEAM_TO_TAG}, please review. ${REMINDER_MARKER}"
+			gh pr comment "$pr_number" --body "${prefix}this PR has been inactive for ${inactive_days} days and has no unresolved comments. ${target_tag}, please review. ${REMINDER_MARKER}"
 		fi
 	fi
 }
@@ -197,6 +198,15 @@ process_pr() {
 	local approval_status_code
 	approval_status_code=$(get_approval_status "$pr_number" "$pr_json")
 
+	local target_tag
+	target_tag=$(echo "$pr_json" | jq -r '
+		([.reviewRequests[]? | select(.login != null) | "@" + .login] +
+		 [.assignees[]? | select(.login != null) | "@" + .login]) | unique | join(", ")
+	')
+	if [[ -z "$target_tag" ]]; then
+		target_tag="$TEAM_TO_TAG"
+	fi
+
 	local latest_activity_timestamp
 	latest_activity_timestamp=$(get_latest_activity_timestamp "$pr_number" "$comments_json" "$created_at" "$latest_reviews_json" "$updated_at")
 
@@ -209,17 +219,17 @@ process_pr() {
 
 	local reminder_count
 	reminder_count=$(echo "$comments_json" | jq -r --arg since "$latest_activity_timestamp" '
-		map(select(.body | contains("<!-- PR_INACTIVITY_REMINDER -->"))) |
+		map(select((.author.login // "" | test("github-actions|bot"; "i")) and (.body | contains("<!-- PR_INACTIVITY_REMINDER -->")))) |
 		map(select(.createdAt > $since)) |
 		length
 	')
 	echo "Found ${reminder_count} reminder(s) since last human activity for PR #${pr_number}."
 
 	# Logic:
-	# Day 7 -> Reminder 1
-	# Day 14 -> Reminder 2
-	# Day 21 -> Close PR (only if unapproved)
-	if ((inactive_days >= DAYS_TO_CLOSE)) && [[ "$reminder_count" -eq 2 ]]; then
+	# Day DAYS_INTERVAL -> Reminder 1
+	# Day DAYS_INTERVAL * 2 -> Reminder 2
+	# Day DAYS_TO_CLOSE -> Close PR (only if unapproved)
+	if ((inactive_days >= DAYS_TO_CLOSE)) && [[ "$reminder_count" -ge 2 ]]; then
 		if [[ "$approval_status_code" -eq 1 ]]; then
 			echo "PR #${pr_number} is unapproved and has been inactive for ${inactive_days} days. Closing."
 			gh pr comment "$pr_number" --body "@${pr_author} This PR was automatically closed after being inactive for more than ${DAYS_TO_CLOSE} days. ${REMINDER_MARKER}"
@@ -227,12 +237,12 @@ process_pr() {
 		else
 			echo "PR #${pr_number} is approved but has been inactive for ${inactive_days} days. It should be merged or closed."
 		fi
-	elif ((inactive_days >= 14)) && [[ "$reminder_count" -eq 1 ]]; then
+	elif ((inactive_days >= (DAYS_INTERVAL * 2))) && [[ "$reminder_count" -eq 1 ]]; then
 		echo "Expected 2 reminders, found 1. Sending a second reminder."
-		send_reminder "$pr_number" "$pr_author" "$inactive_days" "$approval_status_code" "$review_decision" "second"
+		send_reminder "$pr_number" "$pr_author" "$inactive_days" "$approval_status_code" "$review_decision" "second" "$target_tag"
 	elif ((inactive_days >= DAYS_INTERVAL)) && [[ "$reminder_count" -eq 0 ]]; then
 		echo "Expected 1 reminder, found 0. Sending a first reminder."
-		send_reminder "$pr_number" "$pr_author" "$inactive_days" "$approval_status_code" "$review_decision" "first"
+		send_reminder "$pr_number" "$pr_author" "$inactive_days" "$approval_status_code" "$review_decision" "first" "$target_tag"
 	else
 		echo "No new action needed for PR #${pr_number}."
 	fi
@@ -247,7 +257,7 @@ main() {
 
 	while [ "$attempt_num" -le "$MAX_ATTEMPTS" ]; do
 		echo "Attempt $attempt_num of $MAX_ATTEMPTS to fetch PRs..."
-		if pr_list_output=$(gh pr list --limit 100 --label "external" --draft=false --json number,createdAt,comments,author,reviewDecision,statusCheckRollup,latestReviews,updatedAt); then
+		if pr_list_output=$(gh pr list --limit 100 --label "external" --draft=false --json number,createdAt,comments,author,reviewDecision,statusCheckRollup,latestReviews,updatedAt,reviewRequests,assignees); then
 			break
 		fi
 


### PR DESCRIPTION
This Pull Request introduces a ball-in-courtAssignee system and improves Inactive PR tracking mechanisms.

## Summary of Changes

### Reviewer-Assignee Sync Workflow
- Added `.github/workflows/sync-assignees.yml` to automatically manage Assignee queues.
- Dynamically moves requested reviewers into Assignees block.
- Removes individuals upon standard PR review Approvals pipelines if other reviewers are pending.

### Inactive PR Reminders Hardening
- **Targeted Custom Pings:** Upgraded standard `tools/github/inactive-pr-reminder.sh` fetching pending Reviewers/Users directly rather than spamming team handles globally.
- **Adjusted Trigger Hold Thresholds:** Lowered Inactive thresholds (2 days standard for Reminders, 14 days for Closures Candidate).

## Security Fixes & Zizmor Compliance

This PR explicitly addresses potential security block indicators **including Zizmor Diagnostic compliance findings**:
- **Zero Command Injection risks:** Decoupled direct Shell substitutions `${{ github.event }}` yielding safe Environment variables pipeline integration `[CodeQL/Zizmor Scan Compliance]`.
- Implemented **Inline Suppression bypasses** with strict safe-justification metrics without Code Checkout leaks.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
