### PR TITLE
feat(examples): enable DRANET for A4 examples

### DIFF
--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -110,37 +110,6 @@ deployment_groups:
           ports: ["0-65535"]
         - protocol: icmp
 
-  - id: gke-a4-net-1
-    source: modules/network/vpc
-    settings:
-      network_name: $(vars.deployment_name)-net-1
-      ips_per_nat: 6
-      subnetworks:
-      - subnet_name: $(vars.deployment_name)-sub-1
-        subnet_region: $(vars.region)
-        subnet_ip: 192.168.64.0/18
-      firewall_rules:
-      - name: $(vars.deployment_name)-internal-1
-        ranges: [192.168.0.0/16]
-        allow:
-        - protocol: tcp
-          ports: ["0-65535"]
-        - protocol: udp
-          ports: ["0-65535"]
-        - protocol: icmp
-
-  - id: gke-a4-rdma-net
-    source: modules/network/gpu-rdma-vpc
-    settings:
-      network_name: $(vars.deployment_name)-rdma-net
-      network_profile: https://www.googleapis.com/compute/beta/projects/$(vars.project_id)/global/networkProfiles/$(vars.zone)-vpc-roce
-      network_routing_mode: REGIONAL
-      subnetworks_template:
-        name_prefix: $(vars.deployment_name)-rdma-sub
-        count: 8
-        ip_range: 192.168.128.0/18
-        region: $(vars.region)
-
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -195,16 +164,13 @@ deployment_groups:
       enable_dcgm_monitoring: true
       enable_gcsfuse_csi: true
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
+      enable_dataplane_v2: true
       enable_private_endpoint: false # Allows access from authorized public IPs
       configure_workload_identity_sa: true
       enable_inference_gateway: $(vars.enable_inference_gateway)
       master_authorized_networks:
       - cidr_block: $(vars.authorized_cidr) # Allows your machine to run the kubectl command. Required for multi network setup.
         display_name: "kubectl-access-network"
-      additional_networks:
-        $(concat(gke-a4-net-1.instance_additional_networks,
-         gke-a4-rdma-net.subnetwork_interfaces_gke
-        ))
       # Cluster versions cannot be updated through the toolkit after creation
       # Please manage cluster version from the Google Cloud Console directly
       version_prefix: $(vars.version_prefix)
@@ -263,6 +229,7 @@ deployment_groups:
     settings:
       machine_type: a4-highgpu-8g
       auto_upgrade: true
+      enable_dranet: true
       zones: [$(vars.zone)]
       disk_size_gb: $(vars.a4_node_pool_disk_size_gb)
       static_node_count: $(vars.static_node_count)
@@ -273,10 +240,6 @@ deployment_groups:
         consume_reservation_type: SPECIFIC_RESERVATION
         specific_reservations:
         - name: $(vars.reservation)
-      additional_networks:
-        $(concat(gke-a4-net-1.instance_additional_networks,
-         gke-a4-rdma-net.subnetwork_interfaces_gke
-        ))
     outputs: [instructions]
 
   # Install Kueue, Jobset, and NCCL installer

--- a/examples/gke-a4/nccl-jobset-example.yaml
+++ b/examples/gke-a4/nccl-jobset-example.yaml
@@ -36,18 +36,6 @@ spec:
             annotations:
               kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
               networking.gke.io/default-interface: 'eth0'
-              networking.gke.io/interfaces: |
-                [
-                  {"interfaceName":"eth0","network":"default"},
-                  {"interfaceName":"eth2","network":"rdma-0"},
-                  {"interfaceName":"eth3","network":"rdma-1"},
-                  {"interfaceName":"eth4","network":"rdma-2"},
-                  {"interfaceName":"eth5","network":"rdma-3"},
-                  {"interfaceName":"eth6","network":"rdma-4"},
-                  {"interfaceName":"eth7","network":"rdma-5"},
-                  {"interfaceName":"eth8","network":"rdma-6"},
-                  {"interfaceName":"eth9","network":"rdma-7"}
-                ]
           spec:
             # Limit benchmark run duration
             activeDeadlineSeconds: 3600
@@ -84,6 +72,9 @@ spec:
             - name: proc-sys
               hostPath:
                 path: /proc/sys
+            resourceClaims:
+            - name: rdma
+              resourceClaimTemplateName: default-rdma
 
             initContainers:
             - name: gpu-healthcheck
@@ -218,3 +209,5 @@ spec:
                   nvidia.com/gpu: 8
                 requests:
                   nvidia.com/gpu: 8
+                claims:
+                - name: rdma

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -19,7 +19,6 @@ tags:
 - m.gke-cluster
 - m.gke-node-pool
 - m.service-account
-- m.gpu-rdma-vpc
 - m.kubectl-apply
 - m.vpc
 - m.cloud-storage-bucket


### PR DESCRIPTION
Updated A4 example blueprint, JobSet sample, and daily test builds to use DRANET (Dynamic Resource Allocation for Networking) instead of multi-network VPCs.

- Enabled Dataplane V2 on the GKE cluster (enable_dataplane_v2: true).
- Enabled DRANET on the A4 node pool (enable_dranet: true).
- Removed secondary VPCs (gke-a4-net-1, gke-a4-rdma-net) and additional_networks references.
- Updated nccl-jobset-example.yaml to request default-rdma via Kubernetes DRA resourceClaims and container claims.
- Removed - m.gpu-rdma-vpc tag from gke-a4-onspot.yaml daily test build.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
