### PR TITLE
Replace deprecated apt-key with gpg keyring in terraform/packer Dockerfiles

### DIFF
--- a/tools/cloud-build/dependency-checks/Dockerfile.packer
+++ b/tools/cloud-build/dependency-checks/Dockerfile.packer
@@ -14,7 +14,10 @@
 
 FROM us-central1-docker.pkg.dev/hpc-toolkit-dev/hpc-toolkit-repo/hpc-toolkit-partial-build:precommit
 
-RUN apt-get -y update && apt-get install -y curl gnupg && \
+RUN apt-get -y update && apt-get -y install gnupg && \
+    mkdir -p /usr/share/keyrings && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt-get -y update && apt-get -y install packer
+    . /etc/os-release && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $VERSION_CODENAME main" > /etc/apt/sources.list.d/hashicorp.list && \
+    apt-get -y update && apt-get -y install packer && \
+    rm -rf /var/lib/apt/lists/*

--- a/tools/cloud-build/dependency-checks/Dockerfile.packer
+++ b/tools/cloud-build/dependency-checks/Dockerfile.packer
@@ -14,7 +14,7 @@
 
 FROM us-central1-docker.pkg.dev/hpc-toolkit-dev/hpc-toolkit-repo/hpc-toolkit-partial-build:precommit
 
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-get -y update && apt-get -y install software-properties-common && \
-    apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main" && \
+RUN apt-get -y update && apt-get install -y curl gnupg && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/hashicorp.list && \
     apt-get -y update && apt-get -y install packer

--- a/tools/cloud-build/dependency-checks/Dockerfile.terraform
+++ b/tools/cloud-build/dependency-checks/Dockerfile.terraform
@@ -22,4 +22,14 @@ RUN apt-get -y update && apt-get -y install gnupg && \
     apt-get -y update && apt-get -y install terraform unzip && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+# --- Install TFLint Securely ---
+ARG TFLINT_VERSION=v0.62.1
+ARG TFLINT_ZIP_HASH="c004ec45ade3caf87cd4089feb1d2af9f7df57b13140a36df8a63c0a8cc69f14"
+
+RUN curl -fsSLo /tmp/tflint_linux_amd64.zip \
+      https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_linux_amd64.zip && \
+    echo "${TFLINT_ZIP_HASH}  /tmp/tflint_linux_amd64.zip" | sha256sum -c - && \
+    unzip -o /tmp/tflint_linux_amd64.zip -d /usr/local/bin && \
+    chmod +x /usr/local/bin/tflint && \
+    rm -f /tmp/tflint_linux_amd64.zip

--- a/tools/cloud-build/dependency-checks/Dockerfile.terraform
+++ b/tools/cloud-build/dependency-checks/Dockerfile.terraform
@@ -14,9 +14,12 @@
 
 FROM us-central1-docker.pkg.dev/hpc-toolkit-dev/hpc-toolkit-repo/hpc-toolkit-partial-build:precommit
 
-RUN apt-get -y update && apt-get install -y curl gnupg && \
+RUN apt-get -y update && apt-get -y install gnupg && \
+    mkdir -p /usr/share/keyrings && \
     curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
-    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/hashicorp.list && \
-    apt-get -y update && apt-get -y install terraform unzip
+    . /etc/os-release && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $VERSION_CODENAME main" > /etc/apt/sources.list.d/hashicorp.list && \
+    apt-get -y update && apt-get -y install terraform unzip && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/tools/cloud-build/dependency-checks/Dockerfile.terraform
+++ b/tools/cloud-build/dependency-checks/Dockerfile.terraform
@@ -14,9 +14,9 @@
 
 FROM us-central1-docker.pkg.dev/hpc-toolkit-dev/hpc-toolkit-repo/hpc-toolkit-partial-build:precommit
 
-RUN curl -fsSL https://apt.releases.hashicorp.com/gpg | apt-key add - && \
-    apt-get -y update && apt-get -y install software-properties-common && \
-    apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com bullseye main" && \
+RUN apt-get -y update && apt-get install -y curl gnupg && \
+    curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(. /etc/os-release && echo "$VERSION_CODENAME") main" | tee /etc/apt/sources.list.d/hashicorp.list && \
     apt-get -y update && apt-get -y install terraform unzip
 
 RUN curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash

--- a/tools/cloud-build/images/ghpc-docker/Dockerfile
+++ b/tools/cloud-build/images/ghpc-docker/Dockerfile
@@ -23,7 +23,7 @@ RUN git clone https://github.com/GoogleCloudPlatform/hpc-toolkit.git &&\
  /go/bin/go-licenses check "./..." &&\
  /go/bin/go-licenses save "./..." --save_path="THIRD_PARTY_NOTICES"
 
-FROM debian:bullseye-slim
+FROM debian:trixie-slim
 COPY --from=build /ghpc-build/hpc-toolkit/ghpc /usr/bin/ghpc
 COPY --from=build /ghpc-build/hpc-toolkit/THIRD_PARTY_NOTICES /THIRD_PARTY_NOTICES
 


### PR DESCRIPTION
Replace deprecated apt-key with gpg keyring in terraform/packer Dockerfiles

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
