### PR TITLE
add _PROVISIONING_MODEL substitution to daily test builds

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -23,6 +23,7 @@ tags:
 - gke
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -23,6 +23,7 @@ tags:
 - gke
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -23,6 +23,7 @@ tags:
 - gke
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -26,6 +26,7 @@ tags:
 - m.gke-persistent-volume
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -26,6 +26,7 @@ tags:
 - m.gke-persistent-volume
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -23,6 +23,7 @@ tags:
 - m.gke-job-template
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -26,6 +26,7 @@ tags:
 - m.gke-persistent-volume
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -22,6 +22,7 @@ tags:
 - gke
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -22,6 +22,7 @@ tags:
 - m.wait-for-startup
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -27,6 +27,7 @@ tags:
 - m.custom-image
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -29,6 +29,7 @@ tags:
 - m.private-service-access
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -23,6 +23,7 @@ tags:
 - m.wait-for-startup
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -28,6 +28,7 @@ tags:
 - slurm6
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -27,6 +27,7 @@ tags:
 - slurm6
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -25,6 +25,7 @@ tags:
 - slurm6
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -24,6 +24,7 @@ tags:
 - m.vpc
 
 substitutions:
+  _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
 
 timeout: 86400s


### PR DESCRIPTION
Adds _PROVISIONING_MODEL: "" to the substitutions block of daily test builds to provide a default fallback. This resolves strict validation errors when running tests locally via gcloud builds submit, while seamlessly allowing CI triggers to override it as intended.