### PR TITLE
Fix Spot Zones Filter Job

### DIFF
--- a/tools/cloud-build/filter-zone-options.yaml
+++ b/tools/cloud-build/filter-zone-options.yaml
@@ -60,11 +60,9 @@ steps:
         # Extract the GCS options file path using the standard Kueue format
         GCS_PATH=$$(grep -A 1 'name: OPTIONS_GCS_PATH' "$$yaml" | grep -o 'value: "gs://[^"]*' | cut -d'"' -f2 || true)
 
-        # Fallback to the legacy if Kueue format is missing
+        # If build file doesn't use spot options, silently skip it.
         if [[ -z "$$GCS_PATH" ]]; then
-          GCS_PATH=$$(grep -o 'OPTIONS_GCS_PATH=gs://[^"]*' "$$yaml" | cut -d= -f2 || true)
-          # If build file doesn't use spot options, silently skip it.
-          [[ -z "$$GCS_PATH" ]] && continue
+          continue
         fi
 
         FILE_NAME=$$(basename "$$GCS_PATH")

--- a/tools/cloud-build/filter-zone-options.yaml
+++ b/tools/cloud-build/filter-zone-options.yaml
@@ -60,6 +60,10 @@ steps:
         # Extract the GCS options file path
         GCS_PATH=$$(grep -o 'OPTIONS_GCS_PATH=gs://[^"]*' "$$yaml" | cut -d= -f2 || true)
         if [[ -z "$$GCS_PATH" ]]; then
+          # Fallback for Kueue job style env vars
+          GCS_PATH=$$(grep -A 1 'name: OPTIONS_GCS_PATH' "$$yaml" | grep -o 'value: "gs://[^"]*' | cut -d'"' -f2 || true)
+        fi
+        if [[ -z "$$GCS_PATH" ]]; then
           continue
         fi
 

--- a/tools/cloud-build/filter-zone-options.yaml
+++ b/tools/cloud-build/filter-zone-options.yaml
@@ -57,14 +57,14 @@ steps:
         [[ -f "$$yaml" ]] || continue
         [[ "$$yaml" != *"filter-zone-options.yaml"* ]] || continue
 
-        # Extract the GCS options file path
-        GCS_PATH=$$(grep -o 'OPTIONS_GCS_PATH=gs://[^"]*' "$$yaml" | cut -d= -f2 || true)
+        # Extract the GCS options file path using the standard Kueue format
+        GCS_PATH=$$(grep -A 1 'name: OPTIONS_GCS_PATH' "$$yaml" | grep -o 'value: "gs://[^"]*' | cut -d'"' -f2 || true)
+
+        # Fallback to the legacy if Kueue format is missing
         if [[ -z "$$GCS_PATH" ]]; then
-          # Fallback for Kueue job style env vars
-          GCS_PATH=$$(grep -A 1 'name: OPTIONS_GCS_PATH' "$$yaml" | grep -o 'value: "gs://[^"]*' | cut -d'"' -f2 || true)
-        fi
-        if [[ -z "$$GCS_PATH" ]]; then
-          continue
+          GCS_PATH=$$(grep -o 'OPTIONS_GCS_PATH=gs://[^"]*' "$$yaml" | cut -d= -f2 || true)
+          # If build file doesn't use spot options, silently skip it.
+          [[ -z "$$GCS_PATH" ]] && continue
         fi
 
         FILE_NAME=$$(basename "$$GCS_PATH")


### PR DESCRIPTION
The declaration for `OPTIONS_GCS_PATH` has been updated for tests migrated to Kueue, causing the dynamic `filter-zone-options` job to silently miss them. The filter job skipped pruning unwanted zones that lack support or capacity for secondary machine types or auxiliary resources (like Filestore), causing `zone is not supported` or `zone doesn't have capacity` failures in Tests.