### PR TITLE
fix(kubectl-apply): use dynamic namespace for Kueue LocalQueue in embedded templates

### DIFF
--- a/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing-pathways.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing-pathways.yaml.tftpl
@@ -71,7 +71,7 @@ spec:
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
-  namespace: default
+  namespace: ${namespace}
   name: user-queue
 spec:
   clusterQueue: cluster-queue

--- a/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/kueue-configuration-dynamic-slicing.yaml.tftpl
@@ -50,7 +50,7 @@ spec:
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
-  namespace: default
+  namespace: ${namespace}
   name: user-queue
 spec:
   clusterQueue: cluster-queue

--- a/modules/management/kubectl-apply/kueue/kueue-configuration-pathways.yaml.tftpl
+++ b/modules/management/kubectl-apply/kueue/kueue-configuration-pathways.yaml.tftpl
@@ -51,7 +51,7 @@ spec:
 apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
-  namespace: default
+  namespace: ${namespace}
   name: user-queue
 spec:
   clusterQueue: cluster-queue

--- a/modules/management/kubectl-apply/main.tf
+++ b/modules/management/kubectl-apply/main.tf
@@ -31,6 +31,7 @@ locals {
 
   kueue_config_template_vars = merge(
     {
+      namespace               = "default"
       pathways_cpu_quota      = 480
       pathways_memory_quota   = "2000G"
       tpu_flavor_cpu_quota    = "999999" # High default to avoid limiting TPU pods by CPU


### PR DESCRIPTION
### Description

Fixes an issue where embedded Kueue configuration templates in `modules/management/kubectl-apply/kueue/` hardcoded `namespace: default` for the `LocalQueue` (`user-queue`), ignoring `config_template_vars.namespace` when configured in blueprints.

### Changes Made
- Added `namespace = "default"` to `kueue_config_template_vars` default map in `modules/management/kubectl-apply/main.tf`.
- Replaced hardcoded `namespace: default` with `namespace: ${namespace}` across all embedded Kueue templates:
  - `kueue-configuration-pathways.yaml.tftpl`
  - `kueue-configuration-dynamic-slicing.yaml.tftpl`
  - `kueue-configuration-dynamic-slicing-pathways.yaml.tftpl`