### PR TITLE
Add Filestore and Lustre availability and quota checks for zone selection

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -95,6 +95,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -91,6 +91,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -96,6 +96,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -99,6 +99,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_LUSTRE
+              value: "true"
+            - name: REQUIRED_LUSTRE_GB
+              value: "36000"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -92,6 +92,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -97,6 +97,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_LUSTRE
+              value: "true"
+            - name: REQUIRED_LUSTRE_GB
+              value: "36000"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -96,6 +96,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "HIGH_SCALE_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "10240"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -94,6 +94,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -93,6 +93,12 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: CHECK_FILESTORE
+              value: "true"
+            - name: REQUIRED_FILESTORE_TIER
+              value: "BASIC_SSD"
+            - name: REQUIRED_FILESTORE_GB
+              value: "2560"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -181,6 +181,91 @@ check_vm_capacity() {
 	[[ "${success}" == "true" ]]
 }
 
+check_filestore_quota() {
+	local region=$1
+	local required_capacity=${REQUIRED_FILESTORE_GB:-0}
+	local tier=${REQUIRED_FILESTORE_TIER:-"BASIC_SSD"} # Default to BASIC_SSD if not specified
+
+	if [[ "$required_capacity" -le 0 ]]; then
+		return 0
+	fi
+
+	local quota_id
+	case "${tier}" in
+		"BASIC_HDD"|"STANDARD")
+			quota_id="StandardStorageGbPerRegion"
+			tier="BASIC_HDD"
+			;;
+		"BASIC_SSD"|"PREMIUM")
+			quota_id="PremiumStorageGbPerRegion"
+			tier="BASIC_SSD"
+			;;
+		"HIGH_SCALE_SSD")
+			quota_id="HighScaleSSDStorageGibPerRegion"
+			;;
+		"ENTERPRISE")
+			quota_id="EnterpriseStorageGibPerRegion"
+			;;
+		*)
+			echo "WARN: Unknown Filestore tier '${tier}'. Falling back to PremiumStorageGbPerRegion."
+			quota_id="PremiumStorageGbPerRegion"
+			tier="BASIC_SSD"
+			;;
+	esac
+
+	local limit
+	limit=$(gcloud beta quotas info list --service=file.googleapis.com --project="${PROJECT_ID}" \
+		--filter="quotaId=${quota_id}" --format="json" 2>/dev/null | \
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+
+	if [[ -z "$limit" || "$limit" == "0" ]]; then
+		echo "WARN: Could not fetch Filestore quota limit (${quota_id}) for $region or limit is 0. Assuming no capacity."
+		return 1
+	fi
+
+	local usage
+	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
+		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select(.name | contains($region)) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
+
+	local remaining=$(( limit - usage ))
+	if [[ "$remaining" -ge "$required_capacity" ]]; then
+		return 0
+	else
+		echo "INFO: Insufficient Filestore quota (${tier}/${quota_id}) in $region (Limit: $limit, Usage: $usage, Required: $required_capacity)."
+		return 1
+	fi
+}
+
+check_lustre_quota() {
+	local region=$1
+	local required_capacity=${REQUIRED_LUSTRE_GB:-0}
+	if [[ "$required_capacity" -le 0 ]]; then
+		return 0
+	fi
+
+	local limit
+	limit=$(gcloud beta quotas info list --service=parallelstore.googleapis.com --project="${PROJECT_ID}" \
+		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null | \
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+
+	if [[ -z "$limit" || "$limit" == "0" ]]; then
+		echo "WARN: Could not fetch Lustre quota limit for $region or limit is 0. Assuming no capacity."
+		return 1
+	fi
+
+	local usage
+	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
+		jq -r --arg region "$region" '[.[]? | select(.name | contains($region)) | .capacityGib | tonumber] | add // 0')
+
+	local remaining=$(( limit - usage ))
+	if [[ "$remaining" -ge "$required_capacity" ]]; then
+		return 0
+	else
+		echo "INFO: Insufficient Lustre quota in $region (Limit: $limit, Usage: $usage, Required: $required_capacity)."
+		return 1
+	fi
+}
+
 if ! GCS_CONTENT=$(gcloud storage cat "${OPTIONS_GCS_PATH}"); then
 	echo "ERROR: Failed to read ${OPTIONS_GCS_PATH}." >&2
 	exit 1
@@ -205,10 +290,46 @@ if [[ "${ENABLE_SPOT_FALLBACK:-false}" == "true" ]]; then
 	PROVISIONING_MODELS+=("STANDARD")
 fi
 
+FILESTORE_ZONES=""
+if [[ "${CHECK_FILESTORE}" == "true" ]]; then
+	echo "INFO: Fetching available Filestore zones..."
+	FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(name)" 2>/dev/null || true)
+fi
+
+LUSTRE_ZONES=""
+if [[ "${CHECK_LUSTRE}" == "true" ]]; then
+	echo "INFO: Fetching available Lustre (Parallelstore) zones..."
+	LUSTRE_ZONES=$(gcloud parallelstore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>/dev/null || true)
+fi
+
 for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 	echo "INFO: Trying provisioning model: ${PROVISIONING_MODEL}"
 
 	for ZONE in "${ZONES_ARRAY[@]}"; do
+		REGION=${ZONE%-*}
+
+		if [[ "${CHECK_FILESTORE}" == "true" ]]; then
+			if ! echo "${FILESTORE_ZONES}" | grep -q "${ZONE}"; then
+				echo "INFO: Skipping ${ZONE} - Filestore not available in this zone."
+				continue
+			fi
+			if ! check_filestore_quota "${REGION}"; then
+				echo "INFO: Skipping ${ZONE} - Filestore quota check failed in region ${REGION}."
+				continue
+			fi
+		fi
+
+		if [[ "${CHECK_LUSTRE}" == "true" ]]; then
+			if ! echo "${LUSTRE_ZONES}" | grep -q "${ZONE}"; then
+				echo "INFO: Skipping ${ZONE} - Lustre (Parallelstore) not available in this zone."
+				continue
+			fi
+			if ! check_lustre_quota "${REGION}"; then
+				echo "INFO: Skipping ${ZONE} - Lustre quota check failed in region ${REGION}."
+				continue
+			fi
+		fi
+
 		if [[ "${MACHINE_TYPE}" == "tpu" ]]; then
 			if check_tpu_capacity "${ZONE}" "${PROVISIONING_MODEL}"; then
 				SELECTED_ZONE="${ZONE}"

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -225,7 +225,7 @@ check_filestore_quota() {
 
 	local usage
 	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select(.name | contains($region)) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
+		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
 
 	local remaining=$(( limit - usage ))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
@@ -255,7 +255,7 @@ check_lustre_quota() {
 
 	local usage
 	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[]? | select(.name | contains($region)) | .capacityGib | tonumber] | add // 0')
+		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0')
 
 	local remaining=$(( limit - usage ))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
@@ -309,8 +309,8 @@ for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 		REGION=${ZONE%-*}
 
 		if [[ "${CHECK_FILESTORE}" == "true" ]]; then
-			if ! echo "${FILESTORE_ZONES}" | grep -q "${ZONE}"; then
-				echo "INFO: Skipping ${ZONE} - Filestore not available in this zone."
+			if ! echo "${FILESTORE_ZONES}" | grep -x -E -q "${ZONE}|${REGION}"; then
+				echo "INFO: Skipping ${ZONE} - Filestore not available in this zone or region."
 				continue
 			fi
 			if ! check_filestore_quota "${REGION}"; then
@@ -320,7 +320,7 @@ for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 		fi
 
 		if [[ "${CHECK_LUSTRE}" == "true" ]]; then
-			if ! echo "${LUSTRE_ZONES}" | grep -q "${ZONE}"; then
+			if ! echo "${LUSTRE_ZONES}" | grep -x -q "${ZONE}"; then
 				echo "INFO: Skipping ${ZONE} - Lustre (Parallelstore) not available in this zone."
 				continue
 			fi

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -186,6 +186,7 @@ check_filestore_quota() {
 	local region=$1
 	local required_capacity=${REQUIRED_FILESTORE_GB:-0}
 	local tier=${REQUIRED_FILESTORE_TIER:-"BASIC_SSD"} # Default to BASIC_SSD if not specified
+	tier="${tier^^}"
 
 	if [[ "$required_capacity" -le 0 ]]; then
 		return 0
@@ -222,6 +223,11 @@ check_filestore_quota() {
 	limit=$(gcloud beta quotas info list --service=file.googleapis.com --project="${PROJECT_ID}" \
 		--filter="quotaId=${quota_id}" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+
+	if [[ "${limit}" == "-1" ]]; then
+		FILESTORE_QUOTA_CACHE[$region]=0
+		return 0
+	fi
 
 	if [[ -z "$limit" || "$limit" == "0" ]]; then
 		echo "WARN: Could not fetch Filestore quota limit (${quota_id}) for $region or limit is 0. Assuming no capacity."
@@ -263,6 +269,11 @@ check_lustre_quota() {
 	limit=$(gcloud beta quotas info list --service=parallelstore.googleapis.com --project="${PROJECT_ID}" \
 		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+
+	if [[ "${limit}" == "-1" ]]; then
+		LUSTRE_QUOTA_CACHE[$region]=0
+		return 0
+	fi
 
 	if [[ -z "$limit" || "$limit" == "0" ]]; then
 		echo "WARN: Could not fetch Lustre quota limit for $region or limit is 0. Assuming no capacity."

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -198,31 +198,31 @@ check_filestore_quota() {
 
 	local quota_id
 	case "${tier}" in
-		"BASIC_HDD"|"STANDARD")
-			quota_id="StandardStorageGbPerRegion"
-			tier="BASIC_HDD"
-			;;
-		"BASIC_SSD"|"PREMIUM")
-			quota_id="PremiumStorageGbPerRegion"
-			tier="BASIC_SSD"
-			;;
-		"HIGH_SCALE_SSD")
-			quota_id="HighScaleSSDStorageGibPerRegion"
-			;;
-		"ENTERPRISE")
-			quota_id="EnterpriseStorageGibPerRegion"
-			;;
-		*)
-			echo "WARN: Unknown Filestore tier '${tier}'. Falling back to PremiumStorageGbPerRegion."
-			quota_id="PremiumStorageGbPerRegion"
-			tier="BASIC_SSD"
-			;;
+	"BASIC_HDD" | "STANDARD")
+		quota_id="StandardStorageGbPerRegion"
+		tier="BASIC_HDD"
+		;;
+	"BASIC_SSD" | "PREMIUM")
+		quota_id="PremiumStorageGbPerRegion"
+		tier="BASIC_SSD"
+		;;
+	"HIGH_SCALE_SSD")
+		quota_id="HighScaleSSDStorageGibPerRegion"
+		;;
+	"ENTERPRISE")
+		quota_id="EnterpriseStorageGibPerRegion"
+		;;
+	*)
+		echo "WARN: Unknown Filestore tier '${tier}'. Falling back to PremiumStorageGbPerRegion."
+		quota_id="PremiumStorageGbPerRegion"
+		tier="BASIC_SSD"
+		;;
 	esac
 
 	local limit
 	limit=$(gcloud beta quotas info list --service=file.googleapis.com --project="${PROJECT_ID}" \
-		--filter="quotaId=${quota_id}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max')
+		--filter="quotaId=${quota_id}" --format="json" 2>/dev/null |
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max' 2>/dev/null)
 
 	if [[ "${limit}" == "-1" ]]; then
 		FILESTORE_QUOTA_CACHE[$region]=0
@@ -242,15 +242,16 @@ check_filestore_quota() {
 	fi
 
 	local usage
-	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
+	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null |
+		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0' 2>/dev/null)
 
-	limit=${limit%.*}
-	usage=${usage%.*}
+	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
+	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
+
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
 
-	local remaining=$(( limit - usage ))
+	local remaining=$((limit - usage))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
 		FILESTORE_QUOTA_CACHE[$region]=0
 		return 0
@@ -275,8 +276,8 @@ check_lustre_quota() {
 
 	local limit
 	limit=$(gcloud beta quotas info list --service=parallelstore.googleapis.com --project="${PROJECT_ID}" \
-		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max')
+		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null |
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max' 2>/dev/null)
 
 	if [[ "${limit}" == "-1" ]]; then
 		LUSTRE_QUOTA_CACHE[$region]=0
@@ -296,15 +297,16 @@ check_lustre_quota() {
 	fi
 
 	local usage
-	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0')
+	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
+		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0' 2>/dev/null)
 
-	limit=${limit%.*}
-	usage=${usage%.*}
+	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
+	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
+
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
 
-	local remaining=$(( limit - usage ))
+	local remaining=$((limit - usage))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
 		LUSTRE_QUOTA_CACHE[$region]=0
 		return 0

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -264,41 +264,41 @@ check_filestore_quota() {
 
 declare -A LUSTRE_QUOTA_CACHE
 check_lustre_quota() {
-	local region=$1
+	local zone=$1
 	local required_capacity=${REQUIRED_LUSTRE_GB:-0}
 	if [[ "$required_capacity" -le 0 ]]; then
 		return 0
 	fi
 
-	if [[ -n "${LUSTRE_QUOTA_CACHE[$region]:-}" ]]; then
-		return "${LUSTRE_QUOTA_CACHE[$region]}"
+	if [[ -n "${LUSTRE_QUOTA_CACHE[$zone]:-}" ]]; then
+		return "${LUSTRE_QUOTA_CACHE[$zone]}"
 	fi
 
 	local limit
-	limit=$(gcloud beta quotas info list --service=parallelstore.googleapis.com --project="${PROJECT_ID}" \
-		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null |
-		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max' 2>/dev/null)
+	limit=$(gcloud beta quotas info list --service=lustre.googleapis.com --project="${PROJECT_ID}" \
+		--filter="quotaId=Capacity" --format="json" 2>/dev/null |
+		jq -r --arg zone "$zone" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($zone) or (.dimensions?.zone? // "") == $zone) | .details?.value? | select(. != null) | tonumber] | max' 2>/dev/null)
 
 	if [[ "${limit}" == "-1" ]]; then
-		LUSTRE_QUOTA_CACHE[$region]=0
+		LUSTRE_QUOTA_CACHE[$zone]=0
 		return 0
 	fi
 
 	if [[ -z "$limit" || "$limit" == "null" ]]; then
-		echo "WARN: Could not fetch Lustre quota limit for $region. Failing-open and assuming capacity exists."
-		LUSTRE_QUOTA_CACHE[$region]=0
+		echo "WARN: Could not fetch Lustre quota limit for $zone. Failing-open and assuming capacity exists."
+		LUSTRE_QUOTA_CACHE[$zone]=0
 		return 0
 	fi
 
 	if [[ "$limit" == "0" ]]; then
-		echo "INFO: Lustre quota limit for $region is explicitly 0. Skipping zone."
-		LUSTRE_QUOTA_CACHE[$region]=1
+		echo "INFO: Lustre quota limit for $zone is explicitly 0. Skipping zone."
+		LUSTRE_QUOTA_CACHE[$zone]=1
 		return 1
 	fi
 
 	local usage
-	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
-		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
+	usage=$(gcloud lustre instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
+		jq -r --arg zone "$zone" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $zone or ($loc | startswith($zone + "-"))) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
 	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
 	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
@@ -308,11 +308,11 @@ check_lustre_quota() {
 
 	local remaining=$((limit - usage))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
-		LUSTRE_QUOTA_CACHE[$region]=0
+		LUSTRE_QUOTA_CACHE[$zone]=0
 		return 0
 	else
-		echo "INFO: Insufficient Lustre quota in $region (Limit: $limit, Usage: $usage, Required: $required_capacity)."
-		LUSTRE_QUOTA_CACHE[$region]=1
+		echo "INFO: Insufficient Lustre quota in $zone (Limit: $limit, Usage: $usage, Required: $required_capacity)."
+		LUSTRE_QUOTA_CACHE[$zone]=1
 		return 1
 	fi
 }
@@ -352,8 +352,8 @@ fi
 
 LUSTRE_ZONES=""
 if [[ "${CHECK_LUSTRE:-false}" == "true" ]]; then
-	echo "INFO: Fetching available Lustre (Parallelstore) zones..."
-	if ! LUSTRE_ZONES=$(gcloud parallelstore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
+	echo "INFO: Fetching available Managed Lustre zones..."
+	if ! LUSTRE_ZONES=$(gcloud lustre locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
 		echo "ERROR: Failed to fetch available Lustre locations: ${LUSTRE_ZONES}" >&2
 		exit 1
 	fi
@@ -378,11 +378,11 @@ for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 
 		if [[ "${CHECK_LUSTRE:-false}" == "true" ]]; then
 			if ! echo "${LUSTRE_ZONES}" | grep -x -q "${ZONE}"; then
-				echo "INFO: Skipping ${ZONE} - Lustre (Parallelstore) not available in this zone."
+				echo "INFO: Skipping ${ZONE} - Managed Lustre not available in this zone."
 				continue
 			fi
-			if ! check_lustre_quota "${REGION}"; then
-				echo "INFO: Skipping ${ZONE} - Lustre quota check failed in region ${REGION}."
+			if ! check_lustre_quota "${ZONE}"; then
+				echo "INFO: Skipping ${ZONE} - Lustre quota check failed in zone ${ZONE}."
 				continue
 			fi
 		fi

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -342,7 +342,7 @@ if [[ "${ENABLE_SPOT_FALLBACK:-false}" == "true" ]]; then
 fi
 
 FILESTORE_ZONES=""
-if [[ "${CHECK_FILESTORE}" == "true" ]]; then
+if [[ "${CHECK_FILESTORE:-false}" == "true" ]]; then
 	echo "INFO: Fetching available Filestore zones..."
 	if ! FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
 		echo "ERROR: Failed to fetch available Filestore locations: ${FILESTORE_ZONES}" >&2
@@ -351,7 +351,7 @@ if [[ "${CHECK_FILESTORE}" == "true" ]]; then
 fi
 
 LUSTRE_ZONES=""
-if [[ "${CHECK_LUSTRE}" == "true" ]]; then
+if [[ "${CHECK_LUSTRE:-false}" == "true" ]]; then
 	echo "INFO: Fetching available Lustre (Parallelstore) zones..."
 	if ! LUSTRE_ZONES=$(gcloud parallelstore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
 		echo "ERROR: Failed to fetch available Lustre locations: ${LUSTRE_ZONES}" >&2
@@ -365,7 +365,7 @@ for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 	for ZONE in "${ZONES_ARRAY[@]}"; do
 		REGION=${ZONE%-*}
 
-		if [[ "${CHECK_FILESTORE}" == "true" ]]; then
+		if [[ "${CHECK_FILESTORE:-false}" == "true" ]]; then
 			if ! echo "${FILESTORE_ZONES}" | grep -x -E -q "${ZONE}|${REGION}"; then
 				echo "INFO: Skipping ${ZONE} - Filestore not available in this zone or region."
 				continue
@@ -376,7 +376,7 @@ for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do
 			fi
 		fi
 
-		if [[ "${CHECK_LUSTRE}" == "true" ]]; then
+		if [[ "${CHECK_LUSTRE:-false}" == "true" ]]; then
 			if ! echo "${LUSTRE_ZONES}" | grep -x -q "${ZONE}"; then
 				echo "INFO: Skipping ${ZONE} - Lustre (Parallelstore) not available in this zone."
 				continue

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -222,15 +222,21 @@ check_filestore_quota() {
 	local limit
 	limit=$(gcloud beta quotas info list --service=file.googleapis.com --project="${PROJECT_ID}" \
 		--filter="quotaId=${quota_id}" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max')
 
 	if [[ "${limit}" == "-1" ]]; then
 		FILESTORE_QUOTA_CACHE[$region]=0
 		return 0
 	fi
 
-	if [[ -z "$limit" || "$limit" == "0" ]]; then
-		echo "WARN: Could not fetch Filestore quota limit (${quota_id}) for $region or limit is 0. Assuming no capacity."
+	if [[ -z "$limit" || "$limit" == "null" ]]; then
+		echo "WARN: Could not fetch Filestore quota limit (${quota_id}) for $region. Failing-open and assuming capacity exists."
+		FILESTORE_QUOTA_CACHE[$region]=0
+		return 0
+	fi
+
+	if [[ "$limit" == "0" ]]; then
+		echo "INFO: Filestore quota limit (${quota_id}) for $region is explicitly 0. Skipping zone."
 		FILESTORE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
@@ -270,15 +276,21 @@ check_lustre_quota() {
 	local limit
 	limit=$(gcloud beta quotas info list --service=parallelstore.googleapis.com --project="${PROJECT_ID}" \
 		--filter="quotaId=StorageGiBPerRegion" --format="json" 2>/dev/null | \
-		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max // 0')
+		jq -r --arg region "$region" '[.[].dimensionsInfos[]? | select((.applicableLocations? // []) | index($region) or (.dimensions?.region? // "") == $region) | .details?.value? | select(. != null) | tonumber] | max')
 
 	if [[ "${limit}" == "-1" ]]; then
 		LUSTRE_QUOTA_CACHE[$region]=0
 		return 0
 	fi
 
-	if [[ -z "$limit" || "$limit" == "0" ]]; then
-		echo "WARN: Could not fetch Lustre quota limit for $region or limit is 0. Assuming no capacity."
+	if [[ -z "$limit" || "$limit" == "null" ]]; then
+		echo "WARN: Could not fetch Lustre quota limit for $region. Failing-open and assuming capacity exists."
+		LUSTRE_QUOTA_CACHE[$region]=0
+		return 0
+	fi
+
+	if [[ "$limit" == "0" ]]; then
+		echo "INFO: Lustre quota limit for $region is explicitly 0. Skipping zone."
 		LUSTRE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
@@ -330,7 +342,7 @@ fi
 FILESTORE_ZONES=""
 if [[ "${CHECK_FILESTORE}" == "true" ]]; then
 	echo "INFO: Fetching available Filestore zones..."
-	if ! FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(name)" 2>&1); then
+	if ! FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
 		echo "ERROR: Failed to fetch available Filestore locations: ${FILESTORE_ZONES}" >&2
 		exit 1
 	fi

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -239,6 +239,8 @@ check_filestore_quota() {
 	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
 
+	limit=${limit%.*}
+	usage=${usage%.*}
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
 
@@ -285,6 +287,8 @@ check_lustre_quota() {
 	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0')
 
+	limit=${limit%.*}
+	usage=${usage%.*}
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
 
@@ -326,13 +330,19 @@ fi
 FILESTORE_ZONES=""
 if [[ "${CHECK_FILESTORE}" == "true" ]]; then
 	echo "INFO: Fetching available Filestore zones..."
-	FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(name)" 2>/dev/null || true)
+	if ! FILESTORE_ZONES=$(gcloud filestore locations list --project="${PROJECT_ID}" --format="value(name)" 2>&1); then
+		echo "ERROR: Failed to fetch available Filestore locations: ${FILESTORE_ZONES}" >&2
+		exit 1
+	fi
 fi
 
 LUSTRE_ZONES=""
 if [[ "${CHECK_LUSTRE}" == "true" ]]; then
 	echo "INFO: Fetching available Lustre (Parallelstore) zones..."
-	LUSTRE_ZONES=$(gcloud parallelstore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>/dev/null || true)
+	if ! LUSTRE_ZONES=$(gcloud parallelstore locations list --project="${PROJECT_ID}" --format="value(locationId)" 2>&1); then
+		echo "ERROR: Failed to fetch available Lustre locations: ${LUSTRE_ZONES}" >&2
+		exit 1
+	fi
 fi
 
 for PROVISIONING_MODEL in "${PROVISIONING_MODELS[@]}"; do

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -181,6 +181,7 @@ check_vm_capacity() {
 	[[ "${success}" == "true" ]]
 }
 
+declare -A FILESTORE_QUOTA_CACHE
 check_filestore_quota() {
 	local region=$1
 	local required_capacity=${REQUIRED_FILESTORE_GB:-0}
@@ -188,6 +189,10 @@ check_filestore_quota() {
 
 	if [[ "$required_capacity" -le 0 ]]; then
 		return 0
+	fi
+
+	if [[ -n "${FILESTORE_QUOTA_CACHE[$region]:-}" ]]; then
+		return "${FILESTORE_QUOTA_CACHE[$region]}"
 	fi
 
 	local quota_id
@@ -220,6 +225,7 @@ check_filestore_quota() {
 
 	if [[ -z "$limit" || "$limit" == "0" ]]; then
 		echo "WARN: Could not fetch Filestore quota limit (${quota_id}) for $region or limit is 0. Assuming no capacity."
+		FILESTORE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
 
@@ -227,20 +233,30 @@ check_filestore_quota() {
 	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0')
 
+	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
+	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
+
 	local remaining=$(( limit - usage ))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
+		FILESTORE_QUOTA_CACHE[$region]=0
 		return 0
 	else
 		echo "INFO: Insufficient Filestore quota (${tier}/${quota_id}) in $region (Limit: $limit, Usage: $usage, Required: $required_capacity)."
+		FILESTORE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
 }
 
+declare -A LUSTRE_QUOTA_CACHE
 check_lustre_quota() {
 	local region=$1
 	local required_capacity=${REQUIRED_LUSTRE_GB:-0}
 	if [[ "$required_capacity" -le 0 ]]; then
 		return 0
+	fi
+
+	if [[ -n "${LUSTRE_QUOTA_CACHE[$region]:-}" ]]; then
+		return "${LUSTRE_QUOTA_CACHE[$region]}"
 	fi
 
 	local limit
@@ -250,6 +266,7 @@ check_lustre_quota() {
 
 	if [[ -z "$limit" || "$limit" == "0" ]]; then
 		echo "WARN: Could not fetch Lustre quota limit for $region or limit is 0. Assuming no capacity."
+		LUSTRE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
 
@@ -257,11 +274,16 @@ check_lustre_quota() {
 	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null | \
 		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0')
 
+	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
+	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
+
 	local remaining=$(( limit - usage ))
 	if [[ "$remaining" -ge "$required_capacity" ]]; then
+		LUSTRE_QUOTA_CACHE[$region]=0
 		return 0
 	else
 		echo "INFO: Insufficient Lustre quota in $region (Limit: $limit, Usage: $usage, Required: $required_capacity)."
+		LUSTRE_QUOTA_CACHE[$region]=1
 		return 1
 	fi
 }

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -298,7 +298,7 @@ check_lustre_quota() {
 
 	local usage
 	usage=$(gcloud lustre instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
-		jq -r --arg zone "$zone" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $zone or ($loc | startswith($zone + "-"))) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
+		jq -r --arg zone "$zone" '[.[]? | select((.name | split("/")[3]) == $zone) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
 	if ! limit=$(printf "%.0f" "${limit}" 2>/dev/null); then limit=0; fi
 	if ! usage=$(printf "%.0f" "${usage}" 2>/dev/null); then usage=0; fi

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -245,8 +245,8 @@ check_filestore_quota() {
 	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null |
 		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
-	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
-	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
+	if ! limit=$(printf "%.0f" "${limit}" 2>/dev/null); then limit=0; fi
+	if ! usage=$(printf "%.0f" "${usage}" 2>/dev/null); then usage=0; fi
 
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi
@@ -300,8 +300,8 @@ check_lustre_quota() {
 	usage=$(gcloud lustre instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
 		jq -r --arg zone "$zone" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $zone or ($loc | startswith($zone + "-"))) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
-	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
-	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
+	if ! limit=$(printf "%.0f" "${limit}" 2>/dev/null); then limit=0; fi
+	if ! usage=$(printf "%.0f" "${usage}" 2>/dev/null); then usage=0; fi
 
 	if [[ ! "${limit}" =~ ^[0-9]+$ ]]; then limit=0; fi
 	if [[ ! "${usage}" =~ ^[0-9]+$ ]]; then usage=0; fi

--- a/tools/cloud-build/find_available_zone.sh
+++ b/tools/cloud-build/find_available_zone.sh
@@ -243,7 +243,7 @@ check_filestore_quota() {
 
 	local usage
 	usage=$(gcloud filestore instances list --project="${PROJECT_ID}" --format="json" 2>/dev/null |
-		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | tonumber] | add // 0' 2>/dev/null)
+		jq -r --arg region "$region" --arg tier "$tier" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | select(.tier == $tier) | .fileShares[]?.capacityGb | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
 	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
 	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)
@@ -298,7 +298,7 @@ check_lustre_quota() {
 
 	local usage
 	usage=$(gcloud parallelstore instances list --location="-" --project="${PROJECT_ID}" --format="json" 2>/dev/null |
-		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | tonumber] | add // 0' 2>/dev/null)
+		jq -r --arg region "$region" '[.[]? | select((.name | split("/")[3]) as $loc | $loc == $region or ($loc | startswith($region + "-"))) | .capacityGib | select(. != null) | tonumber] | add // 0' 2>/dev/null)
 
 	limit=$(printf "%.0f" "${limit}" 2>/dev/null || echo 0)
 	usage=$(printf "%.0f" "${usage}" 2>/dev/null || echo 0)


### PR DESCRIPTION
This PR enhances the `find_available_zone.sh` script to verify Filestore and Managed Lustre (`lustre.googleapis.com`) service availability and quota limits before falling back to expensive VM or TPU capacity checks.

By pre-verifying storage requirements, the script can prune candidate zones early, significantly speeding up the provisioning process and avoiding resource creation attempts in zones that don't meet storage requirements.

### Key Changes

*   **Location Verification:** Pre-fetches supported zones for Filestore and Managed Lustre before evaluating candidates.
*   **Quota Verification:**
    *   Added `check_filestore_quota` to dynamically query the **regional** quota limit, calculate current usage, and ensure `limit - usage >= required_capacity`. Supports multiple Filestore tiers (`BASIC_HDD`, `BASIC_SSD`, `HIGH_SCALE_SSD`, `ENTERPRISE`).
    *   Added `check_lustre_quota` to perform the same calculations for Managed Lustre (`lustre.googleapis.com`). This correctly evaluates the **zonal** `Capacity` quota rather than regional.
*   **Fail-Open Safety:** Automatically bypasses quota blocking (assumes capacity exists) if the quotas API returns missing values, explicit 0 limits, or API errors, preventing CI/CD pipelines from hanging on transient backend hiccups.
*   **Early Pruning:** Integrated these checks into the main loop to skip incompatible zones before attempting to bulk create VMs or TPUs.

### New Opt-in Environment Variables

*   `CHECK_FILESTORE` / `CHECK_LUSTRE`: Set to `true` to enable the respective storage checks.
*   `REQUIRED_FILESTORE_GB` / `REQUIRED_LUSTRE_GB`: The amount of free quota required (defaults to `0`).
*   `REQUIRED_FILESTORE_TIER`: The desired Filestore performance tier (defaults to `BASIC_SSD`).