### PR TITLE
Optimize zone waiting and deduplicate Kueue job monitoring logic

### DIFF
--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -194,6 +194,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ansible-vm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -192,67 +192,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ansible-vm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ansible-vm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -210,6 +210,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - batch-mpi
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -208,67 +208,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="batch-mpi-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - batch-mpi
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -160,6 +160,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - batch
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -158,67 +158,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="batch-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - batch
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -191,67 +191,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="chrome-remote-desktop-ubuntu-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - chrome-remote-desktop-ubuntu
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -193,6 +193,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - chrome-remote-desktop-ubuntu
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -191,6 +191,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - chrome-remote-desktop
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -189,67 +189,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="crd-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - chrome-remote-desktop
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -176,6 +176,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - e2e
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/e2e.yaml
@@ -174,63 +174,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="e2e-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - e2e
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -161,65 +161,10 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gcluster-dockerfile-$$BUILD_ID_SHORT"
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gcluster-dockerfile
 
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
-
-# 5. Cleanup the built images from Registry to save costs
+# 5. Cleanup the built image from Registry to save costs
 - id: cleanup-images
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash

--- a/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
+++ b/tools/cloud-build/daily-tests/builds/gcluster-dockerfile.yaml
@@ -163,6 +163,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gcluster-dockerfile
+  - $BUILD_ID
 
 # 5. Cleanup the built image from Registry to save costs
 - id: cleanup-images

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -227,67 +227,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a2-highgpu-kueue-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a2-highgpu-kueue-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -229,6 +229,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a2-highgpu-kueue-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -220,67 +220,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a3-highgpu-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a3-highgpu-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -222,6 +222,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a3-highgpu-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -223,6 +223,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a3-megagpu-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -221,67 +221,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a3-megagpu-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a3-megagpu-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -225,6 +225,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a3-ultragpu-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -223,67 +223,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a3-ultragpu-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a3-ultragpu-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -225,67 +225,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a4-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a4-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -227,6 +227,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a4-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -191,6 +191,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-a4x
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -189,63 +189,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-a4x-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-a4x
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
@@ -182,6 +182,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-g4-confidential
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
@@ -180,63 +180,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-g4-conf-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=280
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-g4-confidential
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -217,6 +217,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-g4-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -215,67 +215,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-g4-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-g4-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -216,68 +216,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-h4d-onspot-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-      echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml"
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-h4d-onspot
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -218,6 +218,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-h4d-onspot
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -218,6 +218,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-inactive-reservation
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -216,67 +216,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-inactive-reservation-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-inactive-reservation
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -207,6 +207,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-managed-hyperdisk
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -205,67 +205,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-managed-hyperdisk-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-managed-hyperdisk
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -212,67 +212,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-managed-lustre-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-managed-lustre
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -214,6 +214,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-managed-lustre
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -238,67 +238,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-storage-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-storage
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -240,6 +240,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-storage
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -203,63 +203,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-tpu-7x-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=280
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-tpu-7x
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -205,6 +205,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-tpu-7x
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
@@ -212,63 +212,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-tpu-v5e-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=280
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-tpu-v5e
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
@@ -214,6 +214,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-tpu-v5e
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
@@ -212,63 +212,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-tpu-v5p-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=280
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-tpu-v5p
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
@@ -214,6 +214,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-tpu-v5p
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -226,63 +226,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-tpu-v6e-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke-tpu-v6e
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -228,6 +228,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke-tpu-v6e
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -204,63 +204,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="gke-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - gke
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -206,6 +206,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - gke
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -201,68 +201,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="h4d-vm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-      echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/h4d-vm.yaml"
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - h4d-vm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -203,6 +203,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - h4d-vm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -209,6 +209,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - hcls
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -207,67 +207,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="hcls-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - hcls
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -194,6 +194,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - hpc-build-slurm-image
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -192,67 +192,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="hpc-build-slurm-image-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - hpc-build-slurm-image
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -203,67 +203,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="hpc-enterprise-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - hpc-enterprise-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -205,6 +205,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - hpc-enterprise-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -193,63 +193,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="htc-slurm-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - htc-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -195,6 +195,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - htc-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -196,67 +196,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="htcondor-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - htcondor
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -198,6 +198,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - htcondor
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -217,6 +217,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a3-highgpu-onspot-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -215,67 +215,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a3-highgpu-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a3-highgpu-onspot-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -211,67 +211,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a3-megagpu-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a3-megagpu-onspot-slurm-ubuntu
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -213,6 +213,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a3-megagpu-onspot-slurm-ubuntu
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -205,6 +205,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a3-ultragpu-onspot-jbvms
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -203,67 +203,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a3-ultragpu-onspot-jbvms-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a3-ultragpu-onspot-jbvms
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -215,6 +215,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a3-ultragpu-onspot-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -213,67 +213,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a3-ultragpu-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a3-ultragpu-onspot-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -213,6 +213,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a4-highgpu-onspot-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -211,68 +211,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a4-highgpu-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-      echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml"
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a4-highgpu-onspot-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -181,6 +181,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-a4x-highgpu-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -179,67 +179,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-a4x-highgpu-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-a4x-highgpu-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -205,6 +205,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-g4-onspot-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -203,68 +203,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-g4-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-      echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml"
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-g4-onspot-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -208,6 +208,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-gke-e2e
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -206,67 +206,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-gke-e2e-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-gke-e2e
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -207,67 +207,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-gke-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-gke
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -209,6 +209,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-gke
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -203,68 +203,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-h4d-onspot-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-      echo "\"test_file_path\": tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml"
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-h4d-onspot-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -205,6 +205,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-h4d-onspot-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -201,67 +201,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="ml-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - ml-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -203,6 +203,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - ml-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -193,67 +193,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="monitoring-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - monitoring
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -195,6 +195,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - monitoring
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -193,67 +193,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="netapp-volumes-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - netapp-volumes
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -195,6 +195,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - netapp-volumes
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -193,63 +193,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="packer-$$BUILD_ID_SHORT"
-
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - packer
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -195,6 +195,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - packer
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -200,67 +200,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="pfs-managed-lustre-slurm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - pfs-managed-lustre-slurm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -202,6 +202,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - pfs-managed-lustre-slurm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -200,6 +200,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - pfs-managed-lustre-vm
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -198,67 +198,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="pfs-managed-lustre-vm-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - pfs-managed-lustre-vm
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -171,6 +171,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-flex
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-flex.yaml
@@ -169,67 +169,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-flex-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-flex
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -197,67 +197,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-debian-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-debian
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -199,6 +199,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-debian
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -167,6 +167,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-reconfig-size
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-reconfig-size.yaml
@@ -165,67 +165,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-reconfig-size-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-reconfig-size
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -177,6 +177,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-simple-job-completion
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-simple-job-completion.yaml
@@ -175,67 +175,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-simple-job-co-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-simple-job-completion
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -198,67 +198,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-ssd-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-ssd
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -200,6 +200,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-ssd
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -199,67 +199,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-startup-scripts-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-startup-scripts
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -201,6 +201,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-startup-scripts
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -161,67 +161,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-topology-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-topology
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-topology.yaml
@@ -163,6 +163,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-topology
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -199,67 +199,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gcp-v6-ubuntu-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gcp-v6-ubuntu
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -201,6 +201,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gcp-v6-ubuntu
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -203,6 +203,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-gke
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -201,67 +201,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-gke-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-gke
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
@@ -191,67 +191,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="slurm-storage-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - slurm-storage
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
@@ -193,6 +193,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - slurm-storage
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -198,6 +198,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - spack-gromacs
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -196,67 +196,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="spack-gromacs-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # Check if the failure was specifically due to a lack of GCP zone capacity.
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        echo "ERROR: Job failed to find zone capacity after $$MAX_RETRIES attempts." >&2
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - spack-gromacs
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/vm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/vm-storage.yaml
@@ -183,65 +183,8 @@ steps:
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
   args:
-  - -c
-  - |
-    set -eo pipefail
-    gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
-    BUILD_ID_SHORT=$$(echo "$BUILD_ID" | cut -c1-6)
-    JOB_NAME="vm-storage-$$BUILD_ID_SHORT"
-
-    # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
-    # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
-    cleanup_cb() {
-      echo ""
-      echo "=========================================================================="
-      echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-      echo "Deleting GKE Kueue Job ($$JOB_NAME) to force the Pod to clean itself up!"
-      echo "=========================================================================="
-      kubectl delete job "$$JOB_NAME" -n default || true
-      exit 1
-    }
-    trap cleanup_cb SIGTERM SIGINT
-
-    MAX_RETRIES=10
-    RETRY_DELAY=300
-    ATTEMPT=1
-
-    while true; do
-      echo "=== ATTEMPT $$ATTEMPT: Submitting Kueue Job ==="
-      kubectl apply -f /workspace/job.yaml
-
-      set +e
-      ( bash tools/cloud-build/monitor_kueue_job.sh \
-          test-kueue-cluster \
-          us-central1 \
-          "$$JOB_NAME" \
-          default | tee /workspace/job_logs.txt; exit $${PIPESTATUS[0]} ) &
-      MONITOR_PID=$$!
-      wait $$MONITOR_PID
-      EXIT_CODE=$$?
-      set -e
-
-      if [ $$EXIT_CODE -eq 0 ]; then
-        echo "Job succeeded!"
-        break
-      fi
-
-      # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-      if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-        echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $$RETRY_DELAY seconds..."
-      else
-        echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-        exit 1
-      fi
-
-      if [ $$ATTEMPT -ge $$MAX_RETRIES ]; then
-        exit 1
-      fi
-
-      sleep $$RETRY_DELAY
-      ATTEMPT=$$((ATTEMPT + 1))
-    done
+  - tools/cloud-build/submit_and_monitor_kueue_job.sh
+  - vm-storage
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/daily-tests/builds/vm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/vm-storage.yaml
@@ -185,6 +185,7 @@ steps:
   args:
   - tools/cloud-build/submit_and_monitor_kueue_job.sh
   - vm-storage
+  - $BUILD_ID
 
 # 4. Cleanup the built image from Registry to save costs
 - id: cleanup-image

--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -18,8 +18,8 @@ set -eo pipefail
 TEST_NAME=$1
 
 if [ -z "$TEST_NAME" ]; then
-  echo "Usage: $0 <test-name>" >&2
-  exit 1
+	echo "Usage: $0 <test-name>" >&2
+	exit 1
 fi
 
 gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
@@ -29,13 +29,13 @@ JOB_NAME="${TEST_NAME}-${BUILD_ID_SHORT}"
 # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
 # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
 cleanup_cb() {
-  echo ""
-  echo "=========================================================================="
-  echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
-  echo "Deleting GKE Kueue Job ($JOB_NAME) to force the Pod to clean itself up!"
-  echo "=========================================================================="
-  kubectl delete job "$JOB_NAME" -n default || true
-  exit 1
+	echo ""
+	echo "=========================================================================="
+	echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
+	echo "Deleting GKE Kueue Job ($JOB_NAME) to force the Pod to clean itself up!"
+	echo "=========================================================================="
+	kubectl delete job "$JOB_NAME" -n default || true
+	exit 1
 }
 trap cleanup_cb SIGTERM SIGINT
 
@@ -44,39 +44,42 @@ RETRY_DELAY=300
 ATTEMPT=1
 
 while true; do
-  echo "=== ATTEMPT $ATTEMPT: Submitting Kueue Job ==="
-  kubectl apply -f /workspace/job.yaml
+	echo "=== ATTEMPT $ATTEMPT: Submitting Kueue Job ==="
+	kubectl apply -f /workspace/job.yaml
 
-  set +e
-  ( bash tools/cloud-build/monitor_kueue_job.sh \
-      test-kueue-cluster \
-      us-central1 \
-      "$JOB_NAME" \
-      default | tee /workspace/job_logs.txt; exit ${PIPESTATUS[0]} ) &
-  MONITOR_PID=$!
-  wait $MONITOR_PID
-  EXIT_CODE=$?
-  set -e
+	set +e
+	(
+		bash tools/cloud-build/monitor_kueue_job.sh \
+			test-kueue-cluster \
+			us-central1 \
+			"$JOB_NAME" \
+			default | tee /workspace/job_logs.txt
+		exit ${PIPESTATUS[0]}
+	) &
+	MONITOR_PID=$!
+	wait $MONITOR_PID
+	EXIT_CODE=$?
+	set -e
 
-  if [ $EXIT_CODE -eq 0 ]; then
-    echo "Job succeeded!"
-    break
-  fi
+	if [ $EXIT_CODE -eq 0 ]; then
+		echo "Job succeeded!"
+		break
+	fi
 
-  # Check if the failure was specifically due to a lack of GCP zone capacity.
-  # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
-  if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
-    echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $RETRY_DELAY seconds..."
-  else
-    echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
-    exit 1
-  fi
+	# Check if the failure was specifically due to a lack of GCP zone capacity.
+	# If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
+	if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
+		echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $RETRY_DELAY seconds..."
+	else
+		echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
+		exit 1
+	fi
 
-  if [ $ATTEMPT -ge $MAX_RETRIES ]; then
-    echo "ERROR: Job failed to find zone capacity after $MAX_RETRIES attempts." >&2
-    exit 1
-  fi
+	if [ $ATTEMPT -ge $MAX_RETRIES ]; then
+		echo "ERROR: Job failed to find zone capacity after $MAX_RETRIES attempts." >&2
+		exit 1
+	fi
 
-  sleep $RETRY_DELAY
-  ATTEMPT=$((ATTEMPT + 1))
+	sleep $RETRY_DELAY
+	ATTEMPT=$((ATTEMPT + 1))
 done

--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -16,6 +16,7 @@
 set -eo pipefail
 
 TEST_NAME=$1
+BUILD_ID=$2
 
 if [ -z "$TEST_NAME" ]; then
 	echo "Usage: $0 <test-name>" >&2

--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+TEST_NAME=$1
+
+if [ -z "$TEST_NAME" ]; then
+  echo "Usage: $0 <test-name>" >&2
+  exit 1
+fi
+
+gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
+BUILD_ID_SHORT=$(echo "$BUILD_ID" | cut -c1-6)
+JOB_NAME="${TEST_NAME}-${BUILD_ID_SHORT}"
+
+# Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
+# delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.
+cleanup_cb() {
+  echo ""
+  echo "=========================================================================="
+  echo "PIPELINE CANCELLED: The Cloud Build step received a termination signal."
+  echo "Deleting GKE Kueue Job ($JOB_NAME) to force the Pod to clean itself up!"
+  echo "=========================================================================="
+  kubectl delete job "$JOB_NAME" -n default || true
+  exit 1
+}
+trap cleanup_cb SIGTERM SIGINT
+
+MAX_RETRIES=3
+RETRY_DELAY=300
+ATTEMPT=1
+
+while true; do
+  echo "=== ATTEMPT $ATTEMPT: Submitting Kueue Job ==="
+  kubectl apply -f /workspace/job.yaml
+
+  set +e
+  ( bash tools/cloud-build/monitor_kueue_job.sh \
+      test-kueue-cluster \
+      us-central1 \
+      "$JOB_NAME" \
+      default | tee /workspace/job_logs.txt; exit ${PIPESTATUS[0]} ) &
+  MONITOR_PID=$!
+  wait $MONITOR_PID
+  EXIT_CODE=$?
+  set -e
+
+  if [ $EXIT_CODE -eq 0 ]; then
+    echo "Job succeeded!"
+    break
+  fi
+
+  # Check if the failure was specifically due to a lack of GCP zone capacity.
+  # If so, retry. If it's a real error (like a terraform syntax error), fail immediately.
+  if bash tools/cloud-build/check_retriable_error.sh /workspace/job_logs.txt; then
+    echo "WARNING: Retriable error detected. Kueue Job has already been deleted. Retrying in $RETRY_DELAY seconds..."
+  else
+    echo "ERROR: Test failed due to an actual error (not zone capacity). Failing pipeline." >&2
+    exit 1
+  fi
+
+  if [ $ATTEMPT -ge $MAX_RETRIES ]; then
+    echo "ERROR: Job failed to find zone capacity after $MAX_RETRIES attempts." >&2
+    exit 1
+  fi
+
+  sleep $RETRY_DELAY
+  ATTEMPT=$((ATTEMPT + 1))
+done

--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -54,7 +54,7 @@ while true; do
 			us-central1 \
 			"$JOB_NAME" \
 			default | tee /workspace/job_logs.txt
-		exit ${PIPESTATUS[0]}
+		exit "${PIPESTATUS[0]}"
 	) &
 	MONITOR_PID=$!
 	wait $MONITOR_PID

--- a/tools/cloud-build/wait_for_available_zone.sh
+++ b/tools/cloud-build/wait_for_available_zone.sh
@@ -20,7 +20,14 @@ ZONE_EXPORT=$(mktemp)
 ZONE_OUTPUT=$(mktemp)
 trap 'rm -f "$ZONE_EXPORT" "$ZONE_OUTPUT"' EXIT
 
+MAX_WAIT_SECONDS=28800
+START_TIME=$SECONDS
+
 while true; do
+	if [ $((SECONDS - START_TIME)) -gt $MAX_WAIT_SECONDS ]; then
+		echo "--- FATAL ERROR: Timed out waiting for available zone after 8 hours. Exiting. ---" >&2
+		exit 1
+	fi
 	# Run the script in a subshell, streaming stdout and stderr to the console and a log file.
 	# To extract the exported variables, we have the subshell write them to a file.
 	set +e


### PR DESCRIPTION
This PR optimizes the infrastructure provisioning timeout and refactors the duplicated Kueue job monitoring logic across the daily test suite.
**Changes:**
1. **8-Hour Zone Availability Timeout:** 
   Modified `wait_for_available_zone.sh` to enforce a maximum wait time of 8 hours (`MAX_WAIT_SECONDS=28800`). Previously, the loop could hang indefinitely (up to the 24-hour Cloud Build limit) when trying to acquire a zone. It now fails gracefully with a fatal error.
2. **Reduced Kueue Job Retries:** 
   Reduced the `MAX_RETRIES` threshold for retriable Kueue Job failures from `10` down to `3` to fail faster on continuous zone exhaustion or infrastructure errors. 
3. **Extracted `submit_and_monitor_kueue_job.sh`:** 
   Extracted a massive ~40-line inline bash script (`submit-and-monitor-gke-job`) that was duplicated verbatim across over 50 Cloud Build YAML files. The logic is now centralized in `tools/cloud-build/submit_and_monitor_kueue_job.sh`, which accepts the test name dynamically as an argument.
