### PR TITLE
fix(workflow): prevent crashes in Assignee Sync pipeline due to varied event payloads

### DIFF
--- a/.github/workflows/sync-assignees.yml
+++ b/.github/workflows/sync-assignees.yml
@@ -35,9 +35,9 @@ jobs:
         PR_URL: ${{ github.event.pull_request.html_url || github.event.review.pull_request_url }}
         EVENT_NAME: ${{ github.event_name }}
         EVENT_ACTION: ${{ github.event.action }}
-        REVIEW_STATE: ${{ github.event.review.state }}
-        APPROVER: ${{ github.event.review.user.login }}
-        REMOVED_USER: ${{ github.event.requested_reviewer.login }}
+        REVIEW_STATE: ${{ github.event.review && github.event.review.state || '' }}
+        APPROVER: ${{ github.event.review && github.event.review.user && github.event.review.user.login || '' }}
+        REMOVED_USER: ${{ github.event.requested_reviewer && github.event.requested_reviewer.login || '' }}
       run: |
         set -euo pipefail
 
@@ -47,7 +47,7 @@ jobs:
             # Robust query handling potential nested structures
             REMAINING=$(gh pr view "$PR_URL" --json reviewRequests -q '[.reviewRequests[]? | (.login // .requestedReviewer?.login // empty)] | length' || echo "0")
 
-            if [ "$REMAINING" -gt 0 ]; then
+            if [ "$REMAINING" -gt 0 ] && [ -n "$APPROVER" ]; then
               echo "Other reviewers still requested ($REMAINING remaining). Removing $APPROVER from assignees."
               gh pr edit "$PR_URL" --remove-assignee "$APPROVER" || true
             else


### PR DESCRIPTION
This PR fixes a critical failure in the Sync Reviewers to Assignees workflow where standard triggering events (like opening a PR or requesting a review) would cause the Action runner to crash before executing logic.
Key changes : 
- Safe Property Guards: Added logical conditions to environment variable extraction (e.g., github.event.review && ... || ''). If parent objects are absent on specific standard triggers, pipeline gracefully defaults to blank strings instead of aborting initialization.
- Guarded CLI execution: Secured gh pr edit calls (like removing approvers) behind strict Variable checks, suppressing rare potential failures down the pipeline stack silently.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
