### PR TITLE
test: allow teardown of training and checkpoint daily test buckets

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -190,6 +190,10 @@ steps:
               # Setting placement policy as compact for nccl test to run on spot VMs, adding spot variable and removing reservation from blueprint.
               sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: '"\$$ENABLE_SPOT"'' \$$EXAMPLE_BP
               sed -i '/reservation/d' \$$EXAMPLE_BP
+
+              # Override force_destroy from false to true for training and checkpoint storage buckets
+              sed -i -E 's/force_destroy:\s*false/force_destroy: true/g' \$$EXAMPLE_BP
+
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -191,6 +191,10 @@ steps:
               # Setting placement policy as compact for nccl test to run on spot VMs, adding spot variable and removing reservation from blueprint.
               sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: '"\$$ENABLE_SPOT"'' \$$EXAMPLE_BP
               sed -i '/reservation/d' \$$EXAMPLE_BP
+
+              # Override force_destroy from false to true for training and checkpoint storage buckets
+              sed -i -E 's/force_destroy:\s*false/force_destroy: true/g' \$$EXAMPLE_BP
+
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -159,6 +159,9 @@ steps:
               echo '        effect: NoSchedule'                          >> \$$EXAMPLE_BP
               echo '    outputs: [instructions]'                         >> \$$EXAMPLE_BP
 
+              # Override force_destroy from false to true for training and checkpoint storage buckets
+              sed -i -E 's/force_destroy:\s*false/force_destroy: true/g' \$$EXAMPLE_BP
+
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \


### PR DESCRIPTION
This PR enforces force_destroy: true during the creation of the training and checkpoint buckets to streamline resource cleanup across daily integration tests. This ensures the buckets are successfully cleaned up during cluster teardown, regardless of objects stored within.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
