### PR TITLE
fix(testing): resolve gke-storage integration test validation and teardown failures

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/fio-test-job.yaml.j2
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/fio-test-job.yaml.j2
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: fio
+  # Note: The blueprint (storage-gke.yaml) creates the Workload Identity SA in 'default'.
   namespace: default
   annotations:
     gke-gcsfuse/volumes: "true"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-storage-pool.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-gke-storage-pool.yml
@@ -15,9 +15,12 @@
 ---
 - name: Verify GKE Node Pool Storage Pool
   delegate_to: localhost
-  ansible.builtin.shell: |
-    # The cluster name defaults to deployment_name in our GKE module
-    gcloud container node-pools describe hp-pool --cluster {{ deployment_name }} --region {{ region }} --project {{ project }} --format="value(config.storagePools)"
+  ansible.builtin.command: >-
+    gcloud container node-pools describe hp-pool
+    --cluster {{ deployment_name }}
+    --region {{ region }}
+    --project {{ (custom_vars | default({})).project | default(project) }}
+    --format="value(config.storagePools)"
   register: gke_node_pool
   changed_when: false
   # Ignore errors in case the cluster is zonal instead of regional, and try zonal
@@ -25,8 +28,12 @@
 
 - name: Verify GKE Node Pool Storage Pool (Zonal Fallback)
   delegate_to: localhost
-  ansible.builtin.shell: |
-    gcloud container node-pools describe hp-pool --cluster {{ deployment_name }} --zone {{ zone }} --project {{ project }} --format="value(config.storagePools)"
+  ansible.builtin.command: >-
+    gcloud container node-pools describe hp-pool
+    --cluster {{ deployment_name }}
+    --zone {{ zone }}
+    --project {{ (custom_vars | default({})).project | default(project) }}
+    --format="value(config.storagePools)"
   register: gke_node_pool_zonal
   changed_when: false
   when: gke_node_pool.failed
@@ -45,23 +52,26 @@
 
 - name: Authenticate to GKE Cluster (Regional)
   delegate_to: localhost
-  ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ project }}
+  ansible.builtin.command: >-
+    gcloud container clusters get-credentials {{ deployment_name }}
+    --region {{ region }}
+    --project {{ (custom_vars | default({})).project | default(project) }}
   register: gke_auth
   changed_when: false
   ignore_errors: true
 
 - name: Authenticate to GKE Cluster (Zonal Fallback)
   delegate_to: localhost
-  ansible.builtin.shell: |
-    gcloud container clusters get-credentials {{ deployment_name }} --zone {{ zone }} --project {{ project }}
+  ansible.builtin.command: >-
+    gcloud container clusters get-credentials {{ deployment_name }}
+    --zone {{ zone }}
+    --project {{ (custom_vars | default({})).project | default(project) }}
   changed_when: false
   when: gke_auth.failed
 
 - name: Verify StorageClass contains storage-pools (Balanced)
   delegate_to: localhost
-  ansible.builtin.shell: |
-    kubectl get sc hyperdisk-balanced-sc -o yaml
+  ansible.builtin.command: kubectl get sc hyperdisk-balanced-sc -o yaml
   register: sc_balanced
   changed_when: false
 
@@ -69,13 +79,12 @@
   delegate_to: localhost
   ansible.builtin.assert:
     that:
-    - "'storage-pools: projects/{{ project }}' in sc_balanced.stdout"
+    - "'storage-pools: projects/' ~ ((custom_vars | default({})).project | default(project)) in sc_balanced.stdout"
     - hyperdisk_balanced_pool in sc_balanced.stdout
 
 - name: Verify StorageClass contains storage-pools (Throughput)
   delegate_to: localhost
-  ansible.builtin.shell: |
-    kubectl get sc hyperdisk-throughput-sc -o yaml
+  ansible.builtin.command: kubectl get sc hyperdisk-throughput-sc -o yaml
   register: sc_throughput
   changed_when: false
 
@@ -83,81 +92,96 @@
   delegate_to: localhost
   ansible.builtin.assert:
     that:
-    - "'storage-pools: projects/{{ project }}' in sc_throughput.stdout"
+    - "'storage-pools: projects/' ~ ((custom_vars | default({})).project | default(project)) in sc_throughput.stdout"
     - hyperdisk_throughput_pool in sc_throughput.stdout
 
-- name: Deploy Test Pod to trigger PVC binding
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    cat <<'POD' | kubectl apply -f -
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: test-hd-pod
-    spec:
-      containers:
-      - name: test
-        image: busybox
-        command: ["sleep", "3600"]
-        volumeMounts:
-        - mountPath: "/data-balanced"
-          name: vol-balanced
-        - mountPath: "/data-throughput"
-          name: vol-throughput
-      nodeSelector:
-        cloud.google.com/gke-nodepool: hp-pool
-      volumes:
-      - name: vol-balanced
-        persistentVolumeClaim:
-          claimName: hyperdisk-balanced-pvc-0
-      - name: vol-throughput
-        persistentVolumeClaim:
-          claimName: hyperdisk-throughput-pvc-0
-    POD
-  changed_when: true
+# Note: The test pod and kubectl commands explicitly use the 'default' namespace
+# because the blueprint (examples/storage-gke.yaml) provisions its PVCs in 'default'.
+# Kubernetes does not support cross-namespace PVC binding.
+- name: Test Pod PVC binding and verification
+  block:
+  - name: Deploy Test Pod to trigger PVC binding
+    delegate_to: localhost
+    ansible.builtin.command: kubectl apply -f -
+    args:
+      stdin: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: test-hd-pod
+          namespace: default
+        spec:
+          containers:
+          - name: test
+            image: busybox
+            command: ["sleep", "3600"]
+            volumeMounts:
+            - mountPath: "/data-balanced"
+              name: vol-balanced
+            - mountPath: "/data-throughput"
+              name: vol-throughput
+          nodeSelector:
+            cloud.google.com/gke-nodepool: hp-pool
+          volumes:
+          - name: vol-balanced
+            persistentVolumeClaim:
+              claimName: hyperdisk-balanced-pvc-0
+          - name: vol-throughput
+            persistentVolumeClaim:
+              claimName: hyperdisk-throughput-pvc-0
+    changed_when: true
 
-- name: Wait for Test Pod to be Running (Binding PVCs)
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    kubectl wait --for=condition=Ready pod/test-hd-pod --timeout=600s
-  changed_when: false
+  - name: Wait for Test Pod to be Running (Binding PVCs)
+    delegate_to: localhost
+    ansible.builtin.command: kubectl wait --for=condition=Ready pod/test-hd-pod -n default --timeout=600s
+    changed_when: false
 
-- name: Get Persistent Volume names (Balanced)
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    kubectl get pvc hyperdisk-balanced-pvc-0 -o jsonpath='{.spec.volumeName}'
-  register: pv_balanced_name
-  changed_when: false
+  - name: Get Persistent Volume names (Balanced)
+    delegate_to: localhost
+    ansible.builtin.command: kubectl get pvc hyperdisk-balanced-pvc-0 -n default -o jsonpath='{.spec.volumeName}'
+    register: pv_balanced_name
+    changed_when: false
 
-- name: Get Persistent Volume names (Throughput)
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    kubectl get pvc hyperdisk-throughput-pvc-0 -o jsonpath='{.spec.volumeName}'
-  register: pv_throughput_name
-  changed_when: false
+  - name: Get Persistent Volume names (Throughput)
+    delegate_to: localhost
+    ansible.builtin.command: kubectl get pvc hyperdisk-throughput-pvc-0 -n default -o jsonpath='{.spec.volumeName}'
+    register: pv_throughput_name
+    changed_when: false
 
-- name: Verify GCP Persistent Disk Placement (Balanced)
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    gcloud compute disks describe {{ pv_balanced_name.stdout }} --zone {{ zone }} --project {{ project }} --format="value(storagePool)"
-  register: disk_pool_balanced
-  changed_when: false
+  - name: Verify GCP Persistent Disk Placement (Balanced)
+    delegate_to: localhost
+    ansible.builtin.command: >-
+      gcloud compute disks describe {{ pv_balanced_name.stdout }}
+      --zone {{ zone }}
+      --project {{ (custom_vars | default({})).project | default(project) }}
+      --format="value(storagePool)"
+    register: disk_pool_balanced
+    changed_when: false
 
-- name: Assert Balanced Disk is in Storage Pool
-  delegate_to: localhost
-  ansible.builtin.assert:
-    that:
-    - hyperdisk_balanced_pool in disk_pool_balanced.stdout
+  - name: Assert Balanced Disk is in Storage Pool
+    delegate_to: localhost
+    ansible.builtin.assert:
+      that:
+      - hyperdisk_balanced_pool in disk_pool_balanced.stdout
 
-- name: Verify GCP Persistent Disk Placement (Throughput)
-  delegate_to: localhost
-  ansible.builtin.shell: |
-    gcloud compute disks describe {{ pv_throughput_name.stdout }} --zone {{ zone }} --project {{ project }} --format="value(storagePool)"
-  register: disk_pool_throughput
-  changed_when: false
+  - name: Verify GCP Persistent Disk Placement (Throughput)
+    delegate_to: localhost
+    ansible.builtin.command: >-
+      gcloud compute disks describe {{ pv_throughput_name.stdout }}
+      --zone {{ zone }}
+      --project {{ (custom_vars | default({})).project | default(project) }}
+      --format="value(storagePool)"
+    register: disk_pool_throughput
+    changed_when: false
 
-- name: Assert Throughput Disk is in Storage Pool
-  delegate_to: localhost
-  ansible.builtin.assert:
-    that:
-    - hyperdisk_throughput_pool in disk_pool_throughput.stdout
+  - name: Assert Throughput Disk is in Storage Pool
+    delegate_to: localhost
+    ansible.builtin.assert:
+      that:
+      - hyperdisk_throughput_pool in disk_pool_throughput.stdout
+  always:
+  - name: Clean up Test Pod
+    delegate_to: localhost
+    ansible.builtin.command: kubectl delete pod test-hd-pod -n default --ignore-not-found
+    changed_when: false
+    ignore_errors: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-zonal-bucket.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-zonal-bucket.yml
@@ -47,46 +47,67 @@
 
 - name: Get cluster credentials for kubectl
   delegate_to: localhost
-  ansible.builtin.command: gcloud container clusters get-credentials {{ deployment_name }} --region {{ region }} --project {{ custom_vars.project }}
+  ansible.builtin.command: >-
+    gcloud container clusters get-credentials {{ deployment_name }}
+    --region {{ region }}
+    --project {{ (custom_vars | default({})).project | default(project) }}
+  changed_when: false
 
-- name: Deploy FIO Kubernetes Pod using kubectl apply
-  ansible.builtin.command: kubectl apply -f {{ workspace }}/fio-test-job.yaml
+- name: Wait for GCS FUSE CSI driver daemonset to be ready
+  ansible.builtin.command: kubectl rollout status daemonset gcsfusecsi-node -n kube-system --timeout=300s
   delegate_to: localhost
+  changed_when: false
 
-- name: Wait for FIO Pod to complete
-  ansible.builtin.command: kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/fio --namespace default --timeout=900s
-  delegate_to: localhost
-  ignore_errors: true # Even if we timeout, continue to next steps
+# Note: The test pod and kubectl commands explicitly use the 'default' namespace
+# because the blueprint (examples/storage-gke.yaml) provisions its Workload
+# Identity Kubernetes Service Account in 'default'. Kubernetes does not
+# support cross-namespace ServiceAccount usage.
+- name: Run FIO benchmark and verify results
+  block:
+  - name: Deploy FIO Kubernetes Pod using kubectl apply
+    ansible.builtin.command: kubectl apply -f {{ workspace }}/fio-test-job.yaml
+    delegate_to: localhost
 
-- name: Fetch FIO logs
-  ansible.builtin.command: kubectl logs pod/fio --namespace default
-  register: fio_pod_logs
-  delegate_to: localhost
+  - name: Wait for FIO Pod to complete
+    ansible.builtin.command: kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/fio --namespace default --timeout=900s
+    delegate_to: localhost
+    ignore_errors: true
 
-- name: Delete FIO Pod
-  ansible.builtin.command: kubectl delete pod/fio --namespace default
-  delegate_to: localhost
-  ignore_errors: true
+  - name: Fetch FIO logs
+    ansible.builtin.command: kubectl logs pod/fio -c fio --namespace default
+    register: fio_pod_logs
+    delegate_to: localhost
 
-- name: Parse FIO results
-  delegate_to: localhost
-  ansible.builtin.set_fact:
-    fio_results: "{{ fio_pod_logs.stdout | from_json }}"
+  - name: Print raw FIO logs
+    ansible.builtin.debug:
+      var: fio_pod_logs.stdout_lines
+    delegate_to: localhost
 
-- name: Print FIO results
-  delegate_to: localhost
-  ansible.builtin.debug:
-    msg:
-    - "fio_results.jobs[0].read.bw_mean: {{ fio_results.jobs[0].read.bw_mean }}"
-    - "Type of bw: {{ fio_results.jobs[0].read.bw_mean | type_debug }}"
-    - "fio_results.jobs[0].read.iops_mean: {{ fio_results.jobs[0].read.iops_mean }}"
-    - "Type of iops: {{ fio_results.jobs[0].read.iops_mean | type_debug }}"
+  - name: Parse FIO results
+    delegate_to: localhost
+    ansible.builtin.set_fact:
+      fio_results: "{{ fio_pod_logs.stdout | from_json }}"
 
-- name: Assert FIO results
-  delegate_to: localhost
-  ansible.builtin.assert:
-    that:
-    - fio_results.jobs[0].read.bw_mean >= 1000
-    - fio_results.jobs[0].read.iops_mean >= 300
-    fail_msg: "FIO read performance thresholds not met. Bandwidth: {{ fio_results.jobs[0].read.bw_mean }} KB/s (expected >= 1000 KB/s), IOPS: {{ fio_results.jobs[0].read.iops_mean }} (expected >= 300)."
-    success_msg: "FIO read performance thresholds met. Bandwidth: {{ fio_results.jobs[0].read.bw_mean }} KB/s, IOPS: {{ fio_results.jobs[0].read.iops_mean }}."
+  - name: Print FIO results
+    delegate_to: localhost
+    ansible.builtin.debug:
+      msg:
+      - "fio_results.jobs[0].read.bw_mean: {{ fio_results.jobs[0].read.bw_mean }}"
+      - "Type of bw: {{ fio_results.jobs[0].read.bw_mean | type_debug }}"
+      - "fio_results.jobs[0].read.iops_mean: {{ fio_results.jobs[0].read.iops_mean }}"
+      - "Type of iops: {{ fio_results.jobs[0].read.iops_mean | type_debug }}"
+
+  - name: Assert FIO results
+    delegate_to: localhost
+    ansible.builtin.assert:
+      that:
+      - fio_results.jobs[0].read.bw_mean >= 1000
+      - fio_results.jobs[0].read.iops_mean >= 300
+      fail_msg: "FIO read performance thresholds not met. Bandwidth: {{ fio_results.jobs[0].read.bw_mean }} KB/s (expected >= 1000 KB/s), IOPS: {{ fio_results.jobs[0].read.iops_mean }} (expected >= 300)."
+      success_msg: "FIO read performance thresholds met. Bandwidth: {{ fio_results.jobs[0].read.bw_mean }} KB/s, IOPS: {{ fio_results.jobs[0].read.iops_mean }}."
+  always:
+  - name: Delete FIO Pod
+    ansible.builtin.command: kubectl delete pod/fio --namespace default --ignore-not-found
+    delegate_to: localhost
+    changed_when: false
+    ignore_errors: true


### PR DESCRIPTION
### Summary of Changes

1. **GCS FUSE CSI DaemonSet Readiness**:
   - Added `kubectl rollout status daemonset gcsfusecsi-node -n kube-system` wait step in `test-zonal-bucket.yml` to ensure the CSI driver is registered and ready before running FIO benchmarks.

2. **Storage Pool Test Pod Cleanup**:
   - Wrapped the PVC binding pod and assertions in `test-gke-storage-pool.yml` within a `block ... always` to ensure `test-hd-pod` is always deleted, preventing Kubernetes `pvc-protection` finalizers from blocking subsequent `terraform destroy` operations.