### PR TITLE
Triage Agent: Use firestore DB instead of GCS bucket

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -42,7 +42,7 @@
   ignore_errors: true
 
 - name: Bind Secrets to Ansible Facts
-  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not triage_secrets.failed"
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
   ansible.builtin.set_fact:
     triage_project_number: "{{ triage_secrets.results[0].stdout }}"
     triage_invoker_sa: "{{ triage_secrets.results[1].stdout }}"
@@ -51,85 +51,29 @@
     triage_ui_url: "{{ triage_secrets.results[4].stdout }}"
 
 - name: Execute Triage Agent Pipeline
-  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not triage_secrets.failed"
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
   vars:
     triage_build_id: "{{ full_build_id | default('') }}"
   block:
   - name: Trigger Failure Triage Agent
     delegate_to: localhost
     changed_when: false
-    args:
-      executable: /bin/bash
     environment:
       TRIAGE_BUILD_ID: "{{ triage_build_id }}"
       TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
       TRIAGE_CLOUD_RUN_URL: "{{ triage_cloud_run_url }}"
       TRIAGE_PROJECT_NUMBER: "{{ triage_project_number }}"
-    ansible.builtin.shell: |
-      TOKEN=$(gcloud auth print-identity-token --impersonate-service-account="$TRIAGE_INVOKER_SA" --audiences="$TRIAGE_CLOUD_RUN_URL")
-      if [ -z "$TOKEN" ]; then
-        echo "Failed to get identity token." >&2
-        exit 1
-      fi
-
-      RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "${TRIAGE_CLOUD_RUN_URL%/}/trigger" \
-        -H "Authorization: Bearer $TOKEN" \
-        -H "Content-Type: application/json" \
-        -d "{\"build_id\": \"$TRIAGE_BUILD_ID\", \"project_number\": \"$TRIAGE_PROJECT_NUMBER\"}")
-
-      HTTP_STATUS=$(echo "$RESPONSE" | tail -n1)
-      BODY=$(echo "$RESPONSE" | sed '$d')
-
-      if [ "$HTTP_STATUS" != "202" ]; then
-        echo "Failed to trigger agent. HTTP Status: $HTTP_STATUS" >&2
-        echo "Response Body: $BODY" >&2
-        exit 1
-      fi
+    ansible.builtin.command: "{{ playbook_dir }}/../../trigger_triage_agent.py"
     ignore_errors: true
 
   - name: Wait for Analysis to Complete
     delegate_to: localhost
     changed_when: false
-    args:
-      executable: /bin/bash
     environment:
       TRIAGE_BUILD_ID: "{{ triage_build_id }}"
       TRIAGE_FIRESTORE_URL: "{{ triage_firestore_url }}"
       TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
-    ansible.builtin.shell: |
-      TOKEN=$(gcloud auth print-access-token --impersonate-service-account="$TRIAGE_INVOKER_SA")
-      if [ -z "$TOKEN" ]; then
-        echo "Failed to get access token." >&2
-        exit 1
-      fi
-
-      URL="${TRIAGE_FIRESTORE_URL%/}/${TRIAGE_BUILD_ID}"
-
-      # Wait for Cloud Run to dynamically hydrate the Document
-      for i in {1..12}; do
-        DOC=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL")
-        if echo "$DOC" | grep -q '"name":'; then
-          break
-        fi
-        sleep 5
-      done
-
-      if ! echo "$DOC" | grep -q '"name":'; then
-        echo "Agent failed to start: Database document was not created within 60 seconds." >&2
-        exit 1
-      fi
-
-      for i in {1..30}; do
-        DOC=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL")
-        STATUS=$(echo "$DOC" | python3 -c "import sys, json; doc=json.load(sys.stdin); print(doc.get('fields', {}).get('status', {}).get('stringValue', ''))" 2>/dev/null)
-        if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
-          echo "$DOC" | python3 -c "import sys, json; doc=json.load(sys.stdin); exec_sum=doc.get('fields', {}).get('report', {}).get('mapValue', {}).get('fields', {}).get('executive_summary', {}).get('stringValue', ''); print(json.dumps({'status': '$STATUS', 'executive_summary': exec_sum}))"
-          exit 0
-        fi
-        # Time delay between polling attempts
-        sleep 30
-      done
-      exit 1
+    ansible.builtin.command: "{{ playbook_dir }}/../../wait_for_triage_agent.py"
     register: agent_state
     ignore_errors: true
 
@@ -146,4 +90,4 @@
         {% endif %}
 
         View the comprehensive diagnostic report for this build at:
-        {{ triage_ui_url | regex_replace('/$', '') }}/?build_id={{ triage_build_id }}
+        {{ triage_ui_url | regex_replace('/$', '') }}/?build_id={{ triage_build_id }}&project={{ project }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -12,52 +12,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-- name: Set Triage Agent Configuration
-  ansible.builtin.set_fact:
-    triage_gcs_bucket: "{{ triage_gcs_bucket_override | default('') }}"
-    triage_project_number: "{{ triage_project_number_override | default('') }}"
-    triage_invoker_sa: "{{ triage_invoker_sa_override | default('') }}"
-    triage_cloud_run_url: "{{ triage_cloud_run_url_override | default('') }}"
-
-- name: Check Triage Agent Prerequisites
+- name: Determine Triage Agent Pre-requisites
   delegate_to: localhost
   changed_when: false
-  args:
-    executable: /bin/bash
   environment:
-    TRIAGE_BUILD_ID: "{{ full_build_id | default('') }}"
-    TRIAGE_GCS_BUCKET: "{{ triage_gcs_bucket }}"
-    TRIAGE_PROJECT_NUMBER: "{{ triage_project_number }}"
-    TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
-    TRIAGE_CLOUD_RUN_URL: "{{ triage_cloud_run_url }}"
+    PROJECT_ID: "{{ project }}"
   ansible.builtin.shell: |
-    if [ -z "$TRIAGE_GCS_BUCKET" ] || [ -z "$TRIAGE_PROJECT_NUMBER" ] || [ -z "$TRIAGE_INVOKER_SA" ] || [ -z "$TRIAGE_CLOUD_RUN_URL" ]; then
-      echo "SKIPPED: One or more Triage Agent configuration variables are missing." >&2
-      exit 0
-    fi
-
-    if [ -z "$TRIAGE_BUILD_ID" ]; then
-      echo "SKIPPED: The 'full_build_id' variable is missing." >&2
-      exit 0
-    fi
-
-    if ! gcloud storage buckets describe "gs://$TRIAGE_GCS_BUCKET" >/dev/null 2>&1; then
-      echo "SKIPPED: Triage Agent bucket '$TRIAGE_GCS_BUCKET' does not exist." >&2
-      exit 0
-    fi
-
-    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$TRIAGE_PROJECT_NUMBER" || echo "false")
+    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$PROJECT_ID" 2>/dev/null || echo "false")
     if [ "$ENABLE_AGENT" != "true" ]; then
-      echo "SKIPPED: Failure Triage Agent is currently disabled in Secret Manager, or the secret could not be accessed." >&2
+      echo "DISABLED"
       exit 0
     fi
-
-    echo "PROCEED: Agent is enabled and build ID is present."
+    echo "PROCEED"
   register: triage_init
   ignore_errors: true
 
+- name: Retrieve Core Architecture Secrets natively via gcloud
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default(''))"
+  delegate_to: localhost
+  changed_when: false
+  ansible.builtin.command: "gcloud secrets versions access latest --secret={{ item }} --project={{ project }}"
+  loop:
+  - triage-project-number
+  - triage-invoker-sa
+  - triage-cloud-run-url
+  - triage_firestore_url
+  - triage_ui_url
+  register: triage_secrets
+  ignore_errors: true
+
+- name: Bind Secrets to Ansible Facts
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not triage_secrets.failed"
+  ansible.builtin.set_fact:
+    triage_project_number: "{{ triage_secrets.results[0].stdout }}"
+    triage_invoker_sa: "{{ triage_secrets.results[1].stdout }}"
+    triage_cloud_run_url: "{{ triage_secrets.results[2].stdout }}"
+    triage_firestore_url: "{{ triage_secrets.results[3].stdout }}"
+    triage_ui_url: "{{ triage_secrets.results[4].stdout }}"
+
 - name: Execute Triage Agent Pipeline
-  when: "'PROCEED' in triage_init.stdout"
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not triage_secrets.failed"
   vars:
     triage_build_id: "{{ full_build_id | default('') }}"
   block:
@@ -78,7 +72,7 @@
         exit 1
       fi
 
-      RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "$TRIAGE_CLOUD_RUN_URL/trigger" \
+      RESPONSE=$(curl -sS -w "\n%{http_code}" -X POST "${TRIAGE_CLOUD_RUN_URL%/}/trigger" \
         -H "Authorization: Bearer $TOKEN" \
         -H "Content-Type: application/json" \
         -d "{\"build_id\": \"$TRIAGE_BUILD_ID\", \"project_number\": \"$TRIAGE_PROJECT_NUMBER\"}")
@@ -100,26 +94,36 @@
       executable: /bin/bash
     environment:
       TRIAGE_BUILD_ID: "{{ triage_build_id }}"
-      TRIAGE_GCS_BUCKET: "{{ triage_gcs_bucket }}"
+      TRIAGE_FIRESTORE_URL: "{{ triage_firestore_url }}"
+      TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
     ansible.builtin.shell: |
-      # Wait for Cloud Run to start and for the initial state file to be copied
+      TOKEN=$(gcloud auth print-access-token --impersonate-service-account="$TRIAGE_INVOKER_SA")
+      if [ -z "$TOKEN" ]; then
+        echo "Failed to get access token." >&2
+        exit 1
+      fi
+
+      URL="${TRIAGE_FIRESTORE_URL%/}/${TRIAGE_BUILD_ID}"
+
+      # Wait for Cloud Run to dynamically hydrate the Document
       for i in {1..12}; do
-        if gcloud storage ls "gs://$TRIAGE_GCS_BUCKET/$TRIAGE_BUILD_ID/state.json" >/dev/null 2>&1; then
+        DOC=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL")
+        if echo "$DOC" | grep -q '"name":'; then
           break
         fi
         sleep 5
       done
 
-      if ! gcloud storage ls "gs://$TRIAGE_GCS_BUCKET/$TRIAGE_BUILD_ID/state.json" >/dev/null 2>&1; then
-        echo "Agent failed to start: state.json was not created within 60 seconds." >&2
+      if ! echo "$DOC" | grep -q '"name":'; then
+        echo "Agent failed to start: Database document was not created within 60 seconds." >&2
         exit 1
       fi
 
       for i in {1..30}; do
-        STATE_JSON=$(gcloud storage cat "gs://$TRIAGE_GCS_BUCKET/$TRIAGE_BUILD_ID/state.json" 2>/dev/null || echo '{}')
-        STATUS=$(echo "$STATE_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('status', ''))" 2>/dev/null)
+        DOC=$(curl -s -H "Authorization: Bearer $TOKEN" "$URL")
+        STATUS=$(echo "$DOC" | python3 -c "import sys, json; doc=json.load(sys.stdin); print(doc.get('fields', {}).get('status', {}).get('stringValue', ''))" 2>/dev/null)
         if [ "$STATUS" = "completed" ] || [ "$STATUS" = "failed" ]; then
-          echo "$STATE_JSON"
+          echo "$DOC" | python3 -c "import sys, json; doc=json.load(sys.stdin); exec_sum=doc.get('fields', {}).get('report', {}).get('mapValue', {}).get('fields', {}).get('executive_summary', {}).get('stringValue', ''); print(json.dumps({'status': '$STATUS', 'executive_summary': exec_sum}))"
           exit 0
         fi
         # Time delay between polling attempts
@@ -139,9 +143,7 @@
         TRIAGE AGENT SUMMARY:
         {{ (agent_state.stdout | default('{}', true) | from_json).executive_summary | default('No summary available.') | wordwrap(100) }}
 
-        Full diagnostic report available at:
-        https://storage.mtls.cloud.google.com/{{ triage_gcs_bucket }}/{{ triage_build_id }}/report.txt
         {% endif %}
 
-        For detailed intermediate state information, please review the diagnostic state file:
-        https://storage.mtls.cloud.google.com/{{ triage_gcs_bucket }}/{{ triage_build_id }}/state.json
+        View the comprehensive diagnostic report for this build at:
+        {{ triage_ui_url | regex_replace('/$', '') }}/?build_id={{ triage_build_id }}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -48,11 +48,11 @@
 - name: Bind Secrets to Ansible Facts
   when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
   ansible.builtin.set_fact:
-    triage_project_number: "{{ triage_secrets.results[0].stdout }}"
-    triage_invoker_sa: "{{ triage_secrets.results[1].stdout }}"
-    triage_cloud_run_url: "{{ triage_secrets.results[2].stdout }}"
-    triage_firestore_url: "{{ triage_secrets.results[3].stdout }}"
-    triage_ui_url: "{{ triage_secrets.results[4].stdout }}"
+    triage_project_number: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-project-number') | first).stdout | default('') }}"
+    triage_invoker_sa: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-invoker-sa') | first).stdout | default('') }}"
+    triage_cloud_run_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-cloud-run-url') | first).stdout | default('') }}"
+    triage_firestore_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage_firestore_url') | first).stdout | default('') }}"
+    triage_ui_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage_ui_url') | first).stdout | default('') }}"
 
 - name: Execute Triage Agent Pipeline
   when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
@@ -67,7 +67,7 @@
       TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
       TRIAGE_CLOUD_RUN_URL: "{{ triage_cloud_run_url }}"
       TRIAGE_PROJECT_NUMBER: "{{ triage_project_number }}"
-    ansible.builtin.command: "{{ playbook_dir }}/../../trigger_triage_agent.py"
+    ansible.builtin.command: "python3 {{ playbook_dir }}/../../trigger_triage_agent.py"
     ignore_errors: true
 
   - name: Wait for Analysis to Complete
@@ -77,7 +77,7 @@
       TRIAGE_BUILD_ID: "{{ triage_build_id }}"
       TRIAGE_FIRESTORE_URL: "{{ triage_firestore_url }}"
       TRIAGE_INVOKER_SA: "{{ triage_invoker_sa }}"
-    ansible.builtin.command: "{{ playbook_dir }}/../../wait_for_triage_agent.py"
+    ansible.builtin.command: "python3 {{ playbook_dir }}/../../wait_for_triage_agent.py"
     register: agent_state
     ignore_errors: true
 
@@ -91,7 +91,6 @@
         TRIAGE AGENT SUMMARY:
         {{ (agent_state.stdout | default('{}', true) | from_json).executive_summary | default('No summary available.') | wordwrap(100) }}
 
-        {% endif %}
-
         View the comprehensive diagnostic report for this build at:
         {{ triage_ui_url | regex_replace('/$', '') }}/?build_id={{ triage_build_id }}&project={{ project }}
+        {% endif %}

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -22,7 +22,7 @@
       echo "ERROR: PROJECT_ID is empty or undefined." >&2
       exit 1
     fi
-    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$PROJECT_ID" 2>/dev/null || echo "false")
+    ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage-agent-enabled" --project="$PROJECT_ID" 2>/dev/null || echo "false")
     if [ "$ENABLE_AGENT" != "true" ]; then
       echo "DISABLED"
       exit 0
@@ -40,22 +40,22 @@
   - triage-project-number
   - triage-invoker-sa
   - triage-cloud-run-url
-  - triage_firestore_url
-  - triage_ui_url
+  - triage-firestore-url
+  - triage-ui-url
   register: triage_secrets
   ignore_errors: true
 
 - name: Bind Secrets to Ansible Facts
-  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and (triage_secrets.results | default([]) | selectattr('failed') | list | length) == 0"
   ansible.builtin.set_fact:
     triage_project_number: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-project-number') | first).stdout | default('') }}"
     triage_invoker_sa: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-invoker-sa') | first).stdout | default('') }}"
     triage_cloud_run_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-cloud-run-url') | first).stdout | default('') }}"
-    triage_firestore_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage_firestore_url') | first).stdout | default('') }}"
-    triage_ui_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage_ui_url') | first).stdout | default('') }}"
+    triage_firestore_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-firestore-url') | first).stdout | default('') }}"
+    triage_ui_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-ui-url') | first).stdout | default('') }}"
 
 - name: Execute Triage Agent Pipeline
-  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and not (triage_secrets.failed | default(false))"
+  when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and (triage_secrets.results | default([]) | selectattr('failed') | list | length) == 0"
   vars:
     triage_build_id: "{{ full_build_id | default('') }}"
   block:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -48,11 +48,11 @@
 - name: Bind Secrets to Ansible Facts
   when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and (triage_secrets.results | default([]) | selectattr('failed') | list | length) == 0"
   ansible.builtin.set_fact:
-    triage_project_number: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-project-number') | first).stdout | default('') }}"
-    triage_invoker_sa: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-invoker-sa') | first).stdout | default('') }}"
-    triage_cloud_run_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-cloud-run-url') | first).stdout | default('') }}"
-    triage_firestore_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-firestore-url') | first).stdout | default('') }}"
-    triage_ui_url: "{{ (triage_secrets.results | selectattr('item', 'equalto', 'triage-ui-url') | first).stdout | default('') }}"
+    triage_project_number: "{{ triage_project_number_override | default((triage_secrets.results | selectattr('item', 'equalto', 'triage-project-number') | first).stdout | default(''), true) }}"
+    triage_invoker_sa: "{{ triage_invoker_sa_override | default((triage_secrets.results | selectattr('item', 'equalto', 'triage-invoker-sa') | first).stdout | default(''), true) }}"
+    triage_cloud_run_url: "{{ triage_cloud_run_url_override | default((triage_secrets.results | selectattr('item', 'equalto', 'triage-cloud-run-url') | first).stdout | default(''), true) }}"
+    triage_firestore_url: "{{ triage_firestore_url_override | default((triage_secrets.results | selectattr('item', 'equalto', 'triage-firestore-url') | first).stdout | default(''), true) }}"
+    triage_ui_url: "{{ triage_ui_url_override | default((triage_secrets.results | selectattr('item', 'equalto', 'triage-ui-url') | first).stdout | default(''), true) }}"
 
 - name: Execute Triage Agent Pipeline
   when: "not triage_init.failed and 'PROCEED' in (triage_init.stdout | default('')) and (triage_secrets.results | default([]) | selectattr('failed') | list | length) == 0"

--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/trigger_failure_triage_agent.yml
@@ -18,6 +18,10 @@
   environment:
     PROJECT_ID: "{{ project }}"
   ansible.builtin.shell: |
+    if [ -z "$PROJECT_ID" ]; then
+      echo "ERROR: PROJECT_ID is empty or undefined." >&2
+      exit 1
+    fi
     ENABLE_AGENT=$(gcloud secrets versions access latest --secret="triage_agent_enabled" --project="$PROJECT_ID" 2>/dev/null || echo "false")
     if [ "$ENABLE_AGENT" != "true" ]; then
       echo "DISABLED"

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -124,11 +124,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/ansible-vm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/ansible-vm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID

--- a/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ansible-vm.yaml
@@ -47,7 +47,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,14 +101,6 @@ steps:
               value: "$PROJECT_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -203,11 +195,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -94,6 +94,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch-mpi.yaml
@@ -52,7 +52,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'SPACK_CACHE_WRF', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'SPACK_CACHE_WRF', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -106,14 +106,6 @@ steps:
               value: "$$SPACK_CACHE_WRF"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -148,11 +140,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=\$$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/batch-mpi.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -221,11 +209,3 @@ availableSecrets:
     env: SPACK_CACHE_WRF
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/batch.yaml
+++ b/tools/cloud-build/daily-tests/builds/batch.yaml
@@ -46,7 +46,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,14 +101,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -133,11 +125,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/batch.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/batch.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -203,11 +191,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop-ubuntu.yaml
@@ -46,7 +46,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -100,14 +100,6 @@ steps:
               value: "$PROJECT_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -131,11 +123,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID os=ubuntu" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -201,11 +189,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -88,6 +88,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
+++ b/tools/cloud-build/daily-tests/builds/chrome-remote-desktop.yaml
@@ -46,7 +46,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -98,14 +98,6 @@ steps:
               value: "$BUILD_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -129,11 +121,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID os=default" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/chrome-remote-desktop.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -199,11 +187,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -119,14 +119,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
             command: ["/bin/bash", "-c"]
@@ -200,11 +192,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -273,11 +261,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -93,6 +93,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -117,14 +117,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -193,11 +185,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -265,11 +253,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -118,14 +118,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -193,11 +185,7 @@ steps:
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$GKE_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -265,11 +253,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -51,7 +51,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -119,14 +119,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: CHS_REPO
               value: "$$CHS_REPO"
             command: ["/bin/bash", "-c"]
@@ -196,11 +188,7 @@ steps:
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=$$CHS_REPO" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -268,13 +256,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -51,7 +51,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -119,14 +119,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: CHS_REPO
               value: "$$CHS_REPO"
             command: ["/bin/bash", "-c"]
@@ -198,11 +190,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -270,13 +258,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
@@ -40,6 +40,7 @@ steps:
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
+  - "PROJECT_ID=$PROJECT_ID"
   - "BUILD_ID=$BUILD_ID"
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"

--- a/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
@@ -82,20 +82,9 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} full_build_id=$BUILD_ID" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x-max-bm.yml" \
-        --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-        --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-        --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-        --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL"
-  secretEnv: ['GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+
+  secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -52,7 +52,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -107,14 +107,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -162,11 +154,7 @@ steps:
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                  --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x.yml" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@tools/cloud-build/daily-tests/tests/gke-a4x.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -235,11 +223,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,16 +101,8 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -153,11 +145,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                  --extra-vars="@tools/cloud-build/daily-tests/tests/gke-g4-confidential.yml" \
-                  --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@tools/cloud-build/daily-tests/tests/gke-g4-confidential.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -225,11 +213,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -93,6 +93,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -117,14 +117,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
             command: ["/bin/bash", "-c"]
@@ -187,11 +179,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -259,11 +247,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -52,7 +52,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -126,14 +126,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -195,11 +187,7 @@ steps:
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -267,11 +255,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -103,14 +103,6 @@ steps:
               value: "$BUILD_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -156,11 +148,7 @@ steps:
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -226,11 +214,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "$BUILD_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -145,11 +137,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-hyperdisk.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -216,11 +204,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -105,14 +105,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -152,11 +144,7 @@ steps:
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="test_prefix=${_TEST_PREFIX}" \
                 --extra-vars="use_fixed_vpc=true" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -222,11 +210,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -55,7 +55,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -106,14 +106,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: PROJECT_ID
               value: "$PROJECT_ID"
             - name: BUILD_ID
@@ -178,11 +170,7 @@ steps:
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --extra-vars="hyperdisk_balanced_pool=test-pool-balanced hyperdisk_throughput_pool=test-pool-throughput" --extra-vars="test_prefix=${_TEST_PREFIX}" --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/gke-storage.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -248,11 +236,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-7x.yaml
@@ -48,7 +48,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -115,14 +115,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: CHS_REPO
               value: "$$CHS_REPO"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -176,11 +168,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                   --extra-vars="region=us-central1 zone=us-central1-c" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -248,13 +236,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5e.yaml
@@ -47,7 +47,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -120,14 +120,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: CHS_REPO
               value: "$$CHS_REPO"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -185,11 +177,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -257,13 +245,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v5p.yaml
@@ -47,7 +47,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -120,14 +120,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: CHS_REPO
               value: "$$CHS_REPO"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -185,11 +177,7 @@ steps:
                   --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -257,13 +245,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e-flex.yaml
@@ -75,20 +75,9 @@ steps:
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} full_build_id=$BUILD_ID" \
         --extra-vars="region=$${REGION} zone=$${ZONE}" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/gke-tpu-v6e-flex.yml" \
-        --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-        --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-        --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-        --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL"
-  secretEnv: ['GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+
+  secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -93,6 +93,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-tpu-v6e.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -123,14 +123,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: CHS_REPO
               value: "$$CHS_REPO"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -199,11 +191,7 @@ steps:
                   --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                   --extra-vars="region=\$$REGION zone=\$$ZONE" \
                   --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                  --extra-vars="@\$$GKE_VARS_FILE" \
-                  --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                  --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                  --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                  --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                  --extra-vars="@\$$GKE_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -271,13 +259,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -99,14 +99,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -144,11 +136,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/gke.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -215,11 +203,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -98,6 +98,10 @@ steps:
               value: "BASIC_SSD"
             - name: REQUIRED_FILESTORE_GB
               value: "2560"
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/h4d-vm.yaml
@@ -48,7 +48,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -122,14 +122,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -180,11 +172,7 @@ steps:
                 --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$H4D_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$H4D_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -253,11 +241,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -60,7 +60,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -112,14 +112,6 @@ steps:
               value: "$BUILD_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -145,11 +137,7 @@ steps:
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --extra-vars="test_prefix=${_TEST_PREFIX}" --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/hcls.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -217,11 +205,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/hcls.yaml
+++ b/tools/cloud-build/daily-tests/builds/hcls.yaml
@@ -102,6 +102,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -91,6 +91,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-build-slurm-image.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,14 +101,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -132,11 +124,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-build-slurm-image.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-build-slurm-image.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -203,11 +191,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -95,6 +95,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/hpc-enterprise-slurm.yaml
@@ -53,7 +53,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -105,14 +105,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -141,11 +133,7 @@ steps:
                 --extra-vars="test_prefix=${_TEST_PREFIX}" \
                 --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/hpc-enterprise-slurm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -213,11 +201,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/htc-slurm.yaml
@@ -52,7 +52,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -102,14 +102,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -133,11 +125,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/htc-slurm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/htc-slurm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -204,11 +192,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -96,6 +96,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/htcondor.yaml
+++ b/tools/cloud-build/daily-tests/builds/htcondor.yaml
@@ -54,7 +54,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -106,14 +106,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -136,11 +128,7 @@ steps:
               bash tools/add_ttl_label.sh \$$BLUEPRINT
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/htcondor-integration-test.yml \
-                --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=\$$BUILD_ID" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=\$$BUILD_ID" --extra-vars="@tools/cloud-build/daily-tests/tests/htcondor.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -206,11 +194,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-highgpu-onspot-slurm.yaml
@@ -53,7 +53,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TCPX_KERNEL_LOGIN', 'TCPX_KERNEL_PASSWORD', 'KEYSERVER_UBUNTU_KEY', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TCPX_KERNEL_LOGIN', 'TCPX_KERNEL_PASSWORD', 'KEYSERVER_UBUNTU_KEY']
   args:
   - -c
   - |
@@ -133,14 +133,6 @@ steps:
               value: "$$TCPX_KERNEL_PASSWORD"
             - name: KEYSERVER_UBUNTU_KEY
               value: "$$KEYSERVER_UBUNTU_KEY"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -192,11 +184,7 @@ steps:
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
                 --extra-vars="tcpx_kernel_login=\$$TCPX_KERNEL_LOGIN tcpx_kernel_password=\$$TCPX_KERNEL_PASSWORD keyserver_ubuntu_key=\$$KEYSERVER_UBUNTU_KEY" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -267,14 +255,6 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/tcpx-kernel-ppa-login/versions/latest
     env: 'TCPX_KERNEL_LOGIN'
   - versionName: projects/${PROJECT_ID}/secrets/tcpx-kernel-ppa-password/versions/latest

--- a/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-megagpu-onspot-slurm-ubuntu.yaml
@@ -56,7 +56,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -128,14 +128,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -188,11 +180,7 @@ steps:
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -261,11 +249,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-jbvms.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -123,14 +123,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -182,11 +174,7 @@ steps:
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$JBVM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$JBVM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -254,11 +242,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a3-ultragpu-onspot-slurm.yaml
@@ -54,7 +54,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -126,14 +126,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: CHS_REPO
               value: "$$CHS_REPO"
             command: ["/bin/bash", "-c"]
@@ -190,11 +182,7 @@ steps:
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=$$CHS_REPO" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -262,13 +250,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -53,7 +53,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'CHS_REPO']
   args:
   - -c
   - |
@@ -129,14 +129,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: CHS_REPO
               value: "$$CHS_REPO"
             command: ["/bin/bash", "-c"]
@@ -190,11 +182,7 @@ steps:
                 --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID chs_repo=\$$CHS_REPO" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -263,13 +251,5 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/cluster-health-scanner/versions/latest
     env: 'CHS_REPO'

--- a/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4x-highgpu-slurm.yaml
@@ -53,7 +53,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -108,14 +108,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -150,11 +142,7 @@ steps:
                 --user="$$OSLOGIN_USER" \
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-a4x-highgpu-slurm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -225,11 +213,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-g4-onspot-slurm.yaml
@@ -51,7 +51,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -125,14 +125,6 @@ steps:
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -182,11 +174,7 @@ steps:
                 --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -254,11 +242,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -99,14 +99,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -146,11 +138,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke-e2e.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -216,11 +204,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -91,6 +91,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -48,7 +48,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -100,14 +100,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -147,11 +139,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-gke.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -218,11 +206,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -90,6 +90,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -122,14 +122,6 @@ steps:
               value: "true"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
             command: ["/bin/bash", "-c"]
@@ -181,11 +173,7 @@ steps:
                 --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="enable_spot=\$$ENABLE_SPOT" \
-                --extra-vars="@\$$SLURM_VARS_FILE" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@\$$SLURM_VARS_FILE" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -253,11 +241,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-h4d-onspot-slurm.yaml
@@ -100,6 +100,10 @@ steps:
               value: "BASIC_SSD"
             - name: REQUIRED_FILESTORE_GB
               value: "2560"
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -52,7 +52,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -137,11 +129,7 @@ steps:
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
                 --extra-vars="test_prefix=${_TEST_PREFIX}" --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/ml-slurm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -212,11 +200,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-slurm.yaml
@@ -94,6 +94,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -92,6 +92,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/monitoring.yaml
+++ b/tools/cloud-build/daily-tests/builds/monitoring.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -102,14 +102,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -133,11 +125,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=\$$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/monitoring.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -203,11 +191,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
+++ b/tools/cloud-build/daily-tests/builds/netapp-volumes.yaml
@@ -48,7 +48,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -103,14 +103,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -133,11 +125,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/netapp-volumes.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -204,11 +192,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -46,20 +46,9 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/ofe-deployment-integration-test.yml \
       --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} full_build_id=$BUILD_ID" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/ofe-deployment.yml" \
-        --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-        --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-        --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-        --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL"
-  secretEnv: ['GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+
+  secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
+++ b/tools/cloud-build/daily-tests/builds/ofe-deployment.yaml
@@ -29,6 +29,7 @@ steps:
   name: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner
   entrypoint: /bin/bash
   env:
+  - "PROJECT_ID=$PROJECT_ID"
   - "BUILD_ID=$BUILD_ID"
   - "ANSIBLE_HOST_KEY_CHECKING=false"
   - "ANSIBLE_CONFIG=/workspace/tools/cloud-build/ansible.cfg"

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -92,6 +92,8 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING

--- a/tools/cloud-build/daily-tests/builds/packer.yaml
+++ b/tools/cloud-build/daily-tests/builds/packer.yaml
@@ -51,7 +51,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -102,14 +102,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -135,11 +127,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/multigroup-integration-test.yml \
                 --user="$$OSLOGIN_USER"  --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=\$$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/packer.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -206,11 +194,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-slurm.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -138,11 +130,7 @@ steps:
                 --extra-vars="test_prefix=${_TEST_PREFIX}" \
                 --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER"  --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-slurm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -210,11 +198,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
+++ b/tools/cloud-build/daily-tests/builds/pfs-managed-lustre-vm.yaml
@@ -46,7 +46,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,14 +101,6 @@ steps:
               value: "$BUILD_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -138,11 +130,7 @@ steps:
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="test_prefix=${_TEST_PREFIX}" \
                 --extra-vars="use_fixed_vpc=true" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/pfs-managed-lustre-vm.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -209,11 +197,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -62,20 +62,9 @@ steps:
     ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \
         --user=sa_106486320838376751393 --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} full_build_id=$BUILD_ID" \
         --extra-vars="@tools/cloud-build/daily-tests/tests/slinky.yml" \
-        --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-        --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-        --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-        --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL"
-  secretEnv: ['GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+
+  secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-debian.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -135,11 +127,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-debian.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -207,11 +195,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-rocky8.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['GCLUSTER_GCS_PATH', 'SA_EMAIL', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['GCLUSTER_GCS_PATH', 'SA_EMAIL']
   args:
   - -c
   - |
@@ -103,14 +103,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -136,11 +128,7 @@ steps:
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --extra-vars="test_prefix=${_TEST_PREFIX}" --extra-vars="use_fixed_vpc=true" \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml" \
-                --extra-vars="triage_gcs_bucket_override=\$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=\$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=\$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=\$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-rocky8.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -262,13 +250,5 @@ availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'
   - versionName: projects/${PROJECT_ID}/secrets/sa-email/versions/latest
     env: 'SA_EMAIL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ssd.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -105,14 +105,6 @@ steps:
               value: "/workspace/tools/cloud-build/ansible.cfg"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -136,11 +128,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ssd.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -208,11 +196,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-startup-scripts.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -101,14 +101,6 @@ steps:
               value: "${_TEST_PREFIX}"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             - name: BUILD_ID
               value: "$BUILD_ID"
             - name: PROJECT_ID
@@ -137,11 +129,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-startup-scripts.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -209,11 +197,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-tpu.yaml
@@ -70,20 +70,9 @@ steps:
       --extra-vars="project=${PROJECT_ID} build=$${BUILD_ID_SHORT} full_build_id=$BUILD_ID" \
       --extra-vars="region=$${REGION} zone=$${ZONE}" \
       --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-tpu.yml" \
-        --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-        --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-        --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-        --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL"
-  secretEnv: ['GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+
+  secretEnv: ['GCLUSTER_GCS_PATH']
 availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gcp-v6-ubuntu.yaml
@@ -49,7 +49,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -137,11 +129,7 @@ steps:
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" \
                 --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-v6-ubuntu.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -209,11 +197,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -100,6 +100,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-gke.yaml
@@ -57,7 +57,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -108,14 +108,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -139,11 +131,7 @@ steps:
 
               ansible-playbook -v tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_3CHAR full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gke.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-gke.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -211,11 +199,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/slurm-storage.yaml
@@ -50,7 +50,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -105,14 +105,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -166,11 +158,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID hyperdisk_balanced_pool=test-pool-balanced hyperdisk_throughput_pool=test-pool-throughput" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-storage.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/slurm-storage.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -236,11 +224,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -54,7 +54,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -104,14 +104,6 @@ steps:
               value: "$$GCLUSTER_GCS_PATH"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -136,11 +128,7 @@ steps:
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/slurm-integration-test.yml \
                 --user="$$OSLOGIN_USER" --extra-vars="project=$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/spack-gromacs.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -206,11 +194,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
+++ b/tools/cloud-build/daily-tests/builds/spack-gromacs.yaml
@@ -96,6 +96,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
+            - name: PROJECT_ID
+              value: "$PROJECT_ID"
+            - name: BUILD_ID
+              value: "$BUILD_ID"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG

--- a/tools/cloud-build/daily-tests/builds/vm-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/vm-storage.yaml
@@ -44,7 +44,7 @@ steps:
 - id: generate-job-manifest
   name: gcr.io/cloud-builders/gcloud
   entrypoint: /bin/bash
-  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH', 'TRIAGE_GCS_BUCKET', 'TRIAGE_PROJECT_NUMBER', 'TRIAGE_INVOKER_SA', 'TRIAGE_CLOUD_RUN_URL']
+  secretEnv: ['SA_EMAIL', 'GCLUSTER_GCS_PATH']
   args:
   - -c
   - |
@@ -99,14 +99,6 @@ steps:
               value: "$PROJECT_ID"
             - name: GCLUSTER_GCS_PATH
               value: "$$GCLUSTER_GCS_PATH"
-            - name: TRIAGE_GCS_BUCKET
-              value: "$$TRIAGE_GCS_BUCKET"
-            - name: TRIAGE_PROJECT_NUMBER
-              value: "$$TRIAGE_PROJECT_NUMBER"
-            - name: TRIAGE_INVOKER_SA
-              value: "$$TRIAGE_INVOKER_SA"
-            - name: TRIAGE_CLOUD_RUN_URL
-              value: "$$TRIAGE_CLOUD_RUN_URL"
             command: ["/bin/bash", "-c"]
             args:
             - |
@@ -157,11 +149,7 @@ steps:
                 --user="$$OSLOGIN_USER" --extra-vars="project=\$$PROJECT_ID build=$$BUILD_ID_SHORT full_build_id=$BUILD_ID" \
                 --extra-vars="region=\$$REGION zone=\$$ZONE" \
                 --extra-vars="hyperdisk_balanced_pool=test-pool-balanced hyperdisk_throughput_pool=test-pool-throughput" \
-                --extra-vars="@tools/cloud-build/daily-tests/tests/vm-storage.yml" \
-                --extra-vars="triage_gcs_bucket_override=$$TRIAGE_GCS_BUCKET" \
-                --extra-vars="triage_project_number_override=$$TRIAGE_PROJECT_NUMBER" \
-                --extra-vars="triage_invoker_sa_override=$$TRIAGE_INVOKER_SA" \
-                --extra-vars="triage_cloud_run_url_override=$$TRIAGE_CLOUD_RUN_URL" &
+                --extra-vars="@tools/cloud-build/daily-tests/tests/vm-storage.yml" &
               ANSIBLE_PID=\$$!
 
               wait \$$ANSIBLE_PID
@@ -229,11 +217,3 @@ availableSecrets:
     env: 'SA_EMAIL'
   - versionName: projects/${PROJECT_ID}/secrets/gcluster-develop-release-bucket/versions/latest
     env: 'GCLUSTER_GCS_PATH'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-gcs-bucket/versions/latest
-    env: 'TRIAGE_GCS_BUCKET'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-project-number/versions/latest
-    env: 'TRIAGE_PROJECT_NUMBER'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-invoker-sa/versions/latest
-    env: 'TRIAGE_INVOKER_SA'
-  - versionName: projects/${PROJECT_ID}/secrets/triage-cloud-run-url/versions/latest
-    env: 'TRIAGE_CLOUD_RUN_URL'

--- a/tools/cloud-build/kueue_cleanup_pod.sh
+++ b/tools/cloud-build/kueue_cleanup_pod.sh
@@ -49,7 +49,7 @@ cleanup_pod() {
 		echo "      file: tools/cloud-build/daily-tests/ansible_playbooks/tasks/rescue_gcluster_failure.yml"
 	} >/workspace/cleanup-playbook.yml
 
-	ansible-playbook /workspace/cleanup-playbook.yml -e deployment_name="$DEPLOYMENT_NAME" -e workspace="/workspace" || true
+	ansible-playbook /workspace/cleanup-playbook.yml -e deployment_name="$DEPLOYMENT_NAME" -e workspace="/workspace" -e project="$PROJECT_ID" -e full_build_id="$BUILD_ID" || true
 
 	echo "Graceful cleanup finished."
 	exit $exit_code

--- a/tools/cloud-build/trigger_triage_agent.py
+++ b/tools/cloud-build/trigger_triage_agent.py
@@ -51,7 +51,7 @@ def main():
     })
 
     try:
-        with urllib.request.urlopen(req) as response:
+        with urllib.request.urlopen(req, timeout=30) as response:
             if response.status != 202:
                 print(f"Failed to trigger agent. HTTP Status: {response.status}", file=sys.stderr)
                 print(f"Response Body: {response.read().decode()}", file=sys.stderr)
@@ -59,6 +59,9 @@ def main():
     except urllib.error.HTTPError as e:
         print(f"Failed to trigger agent. HTTP Status: {e.code}", file=sys.stderr)
         print(f"Response Body: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+    except urllib.error.URLError as e:
+        print(f"Failed to trigger agent. Network error: {e.reason}", file=sys.stderr)
         sys.exit(1)
 
 if __name__ == "__main__":

--- a/tools/cloud-build/trigger_triage_agent.py
+++ b/tools/cloud-build/trigger_triage_agent.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import json
+import subprocess
+import urllib.request
+import urllib.error
+
+def main():
+    build_id = os.environ.get("TRIAGE_BUILD_ID")
+    project_number = os.environ.get("TRIAGE_PROJECT_NUMBER")
+    cloud_run_url = os.environ.get("TRIAGE_CLOUD_RUN_URL")
+    invoker_sa = os.environ.get("TRIAGE_INVOKER_SA")
+
+    if not all([build_id, project_number, cloud_run_url, invoker_sa]):
+        print("Missing required environment variables for Triage Agent Trigger.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        proc = subprocess.run(
+            ["gcloud", "auth", "print-identity-token", 
+             "--impersonate-service-account", invoker_sa,
+             "--audiences", cloud_run_url],
+            capture_output=True, text=True, check=True
+        )
+        token = proc.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to get identity token: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    url = f"{cloud_run_url.rstrip('/')}/trigger"
+    data = json.dumps({"build_id": build_id, "project_number": project_number}).encode("utf-8")
+    
+    req = urllib.request.Request(url, data=data, headers={
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json"
+    })
+
+    try:
+        with urllib.request.urlopen(req) as response:
+            if response.status != 202:
+                print(f"Failed to trigger agent. HTTP Status: {response.status}", file=sys.stderr)
+                print(f"Response Body: {response.read().decode()}", file=sys.stderr)
+                sys.exit(1)
+    except urllib.error.HTTPError as e:
+        print(f"Failed to trigger agent. HTTP Status: {e.code}", file=sys.stderr)
+        print(f"Response Body: {e.read().decode()}", file=sys.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cloud-build/trigger_triage_agent.py
+++ b/tools/cloud-build/trigger_triage_agent.py
@@ -21,6 +21,15 @@ import urllib.request
 import urllib.error
 
 def main():
+    """
+    Triggers the asynchronous Cloud Run Triage Agent via an authenticated REST POST request.
+    
+    Required Environment Variables:
+    - TRIAGE_BUILD_ID: Unique string identifying the active build execution.
+    - TRIAGE_INVOKER_SA: Service Account email to safely impersonate for authorization.
+    - TRIAGE_CLOUD_RUN_URL: Target endpoint URL for the backend Triage service.
+    - TRIAGE_PROJECT_NUMBER: GCP project number associated with the active pipeline.
+    """
     build_id = os.environ.get("TRIAGE_BUILD_ID")
     project_number = os.environ.get("TRIAGE_PROJECT_NUMBER")
     cloud_run_url = os.environ.get("TRIAGE_CLOUD_RUN_URL")

--- a/tools/cloud-build/wait_for_triage_agent.py
+++ b/tools/cloud-build/wait_for_triage_agent.py
@@ -22,6 +22,14 @@ import urllib.request
 import urllib.error
 
 def main():
+    """
+    Polls the Firestore database REST API to determine when the async Triage Agent completes.
+    
+    Required Environment Variables:
+    - TRIAGE_BUILD_ID: Unique string identifying the active build document.
+    - TRIAGE_INVOKER_SA: Service Account email to safely impersonate for authorization.
+    - TRIAGE_FIRESTORE_URL: The Firestore REST API base endpoint for the diagnostics DB.
+    """
     build_id = os.environ.get("TRIAGE_BUILD_ID")
     firestore_url = os.environ.get("TRIAGE_FIRESTORE_URL")
     invoker_sa = os.environ.get("TRIAGE_INVOKER_SA")
@@ -32,7 +40,7 @@ def main():
 
     try:
         proc = subprocess.run(
-            ["gcloud", "auth", "print-access-token", f"--impersonate-service-account={invoker_sa}"],
+            ["gcloud", "auth", "print-access-token", "--impersonate-service-account", invoker_sa],
             capture_output=True, text=True, check=True
         )
         token = proc.stdout.strip()
@@ -52,6 +60,10 @@ def main():
             if "name" in doc:
                 doc_hydrated = True
                 break
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                print(f"Auth error ({e.code}): Permission denied when accessing Firestore.", file=sys.stderr)
+                sys.exit(1)
         except (urllib.error.URLError, json.JSONDecodeError):
             pass
         time.sleep(5)
@@ -68,15 +80,22 @@ def main():
                 
             status = doc.get("fields", {}).get("status", {}).get("stringValue", "")
             if status in ["completed", "failed"]:
-                exec_sum = (doc.get("fields", {})
-                              .get("report", {})
-                              .get("mapValue", {})
-                              .get("fields", {})
-                              .get("executive_summary", {})
-                              .get("stringValue", ""))
+                try:
+                    exec_sum = (doc.get("fields", {})
+                                  .get("report", {})
+                                  .get("mapValue", {})
+                                  .get("fields", {})
+                                  .get("executive_summary", {})
+                                  .get("stringValue", ""))
+                except (AttributeError, TypeError):
+                    exec_sum = ""
                 
                 print(json.dumps({"status": status, "executive_summary": exec_sum}))
                 sys.exit(0)
+        except urllib.error.HTTPError as e:
+            if e.code in (401, 403):
+                print(f"Auth error ({e.code}): Permission denied when accessing Firestore.", file=sys.stderr)
+                sys.exit(1)
         except (urllib.error.URLError, json.JSONDecodeError):
             pass
         

--- a/tools/cloud-build/wait_for_triage_agent.py
+++ b/tools/cloud-build/wait_for_triage_agent.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import time
+import json
+import subprocess
+import urllib.request
+import urllib.error
+
+def main():
+    build_id = os.environ.get("TRIAGE_BUILD_ID")
+    firestore_url = os.environ.get("TRIAGE_FIRESTORE_URL")
+    invoker_sa = os.environ.get("TRIAGE_INVOKER_SA")
+
+    if not all([build_id, firestore_url, invoker_sa]):
+        print("Missing required environment variables for Triage Agent verification.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        proc = subprocess.run(
+            ["gcloud", "auth", "print-access-token", f"--impersonate-service-account={invoker_sa}"],
+            capture_output=True, text=True, check=True
+        )
+        token = proc.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to get access token: {e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    url = f"{firestore_url.rstrip('/')}/{build_id}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+
+    # Wait for Cloud Run to dynamically hydrate the Document
+    doc_hydrated = False
+    for _ in range(12):
+        try:
+            with urllib.request.urlopen(req) as response:
+                doc = json.loads(response.read().decode())
+            if "name" in doc:
+                doc_hydrated = True
+                break
+        except urllib.error.HTTPError:
+            pass
+        time.sleep(5)
+
+    if not doc_hydrated:
+        print("Agent failed to start: Database document was not created within 60 seconds.", file=sys.stderr)
+        sys.exit(1)
+
+    # Poll for completion status
+    for _ in range(30):
+        try:
+            with urllib.request.urlopen(req) as response:
+                doc = json.loads(response.read().decode())
+                
+            status = doc.get("fields", {}).get("status", {}).get("stringValue", "")
+            if status in ["completed", "failed"]:
+                exec_sum = (doc.get("fields", {})
+                              .get("report", {})
+                              .get("mapValue", {})
+                              .get("fields", {})
+                              .get("executive_summary", {})
+                              .get("stringValue", ""))
+                
+                print(json.dumps({"status": status, "executive_summary": exec_sum}))
+                sys.exit(0)
+        except urllib.error.HTTPError:
+            pass
+        
+        time.sleep(30)
+        
+    print("Agent failed to complete analysis within the time limit.", file=sys.stderr)
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cloud-build/wait_for_triage_agent.py
+++ b/tools/cloud-build/wait_for_triage_agent.py
@@ -47,12 +47,12 @@ def main():
     doc_hydrated = False
     for _ in range(12):
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=10) as response:
                 doc = json.loads(response.read().decode())
             if "name" in doc:
                 doc_hydrated = True
                 break
-        except urllib.error.HTTPError:
+        except (urllib.error.URLError, json.JSONDecodeError):
             pass
         time.sleep(5)
 
@@ -63,7 +63,7 @@ def main():
     # Poll for completion status
     for _ in range(30):
         try:
-            with urllib.request.urlopen(req) as response:
+            with urllib.request.urlopen(req, timeout=10) as response:
                 doc = json.loads(response.read().decode())
                 
             status = doc.get("fields", {}).get("status", {}).get("stringValue", "")
@@ -77,7 +77,7 @@ def main():
                 
                 print(json.dumps({"status": status, "executive_summary": exec_sum}))
                 sys.exit(0)
-        except urllib.error.HTTPError:
+        except (urllib.error.URLError, json.JSONDecodeError):
             pass
         
         time.sleep(30)


### PR DESCRIPTION
## Summary
This PR updates the test files to support the newly migrated Failure Triage Agent architecture.

The agent backend has been updated to use a Firestore DB instead of GCS buckets to support RAG, vector search, and human feedback. The resulting diagnostic report has also been moved from an GCS bucket text file to a dedicated Dashboard page.

To support this, updated `trigger_failure_triage_agent.yml` to inject the new database URL variables, and centralized all the triage agent secrets.