### PR TITLE
Replace obsoleted google-cloud-sdk with google-cloud-cli

### DIFF
--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -48,6 +48,7 @@ sed -i -e 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config
 printf "####################\n#### Installing required packages\n####################\n"
 dnf install -y epel-release
 dnf update -y --security
+dnf update -y expat
 dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
 
 dnf install -y terraform

--- a/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
+++ b/community/front-end/ofe/infrastructure_files/gcs_bucket/webserver/startup.sh
@@ -51,7 +51,7 @@ dnf update -y --security
 dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo
 
 dnf install -y terraform
-dnf install --best -y google-cloud-sdk nano make gcc python3.12-devel unzip git \
+dnf install --best -y google-cloud-cli nano make gcc python3.12-devel unzip git \
 	rsync wget nginx bind-utils policycoreutils-python-utils \
 	packer supervisor python3-certbot-nginx jq
 curl --silent --show-error --location https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64 --output /usr/local/bin/yq

--- a/tools/cloud-build/images/test-runner/Dockerfile
+++ b/tools/cloud-build/images/test-runner/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get -y update && apt-get -y install \
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
       | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    apt-get -y update && apt-get -y install google-cloud-sdk && \
+    apt-get -y update && apt-get -y install google-cloud-cli && \
     apt-get -y install kubectl && \
     # following is required to execute kubectl commands
     apt-get -y install google-cloud-cli-gke-gcloud-auth-plugin && \


### PR DESCRIPTION
Replace obsoleted google-cloud-sdk with google-cloud-cli


###  Bug Fix: Resolve 502 Bad Gateway Error

**The Problem:**
 OFE test were failing with a [502 Bad Gateway](https://pantheon.corp.google.com/cloud-build/builds;region=global/65d22908-4343-4bad-ab58-3dace4d2b787?project=hpc-toolkit-dev) error. This means the "front door" of our website was working, but the backend was completely dead.

**Why it happened (in simple terms):**
Our backend website runs on Python. However, when Python tried to turn on, it noticed that the server was using an outdated "XML translator" tool (a background library called `expat`).
Logs:https://paste.googleplex.com/5511692038045696#l=16 

Python requires a newer version of this tool that has a specific security shield built-in to protect against a known trick called the "Billion Laughs" XML attack. Because this XML safety shield was missing, Python refused to start and crashed immediately. Since Python crashed, our backend website was never built!

**The Fix:**
I added one line of code (`dnf update -y expat`) to our startup script. This tells the server to update the XML safety tool *before* installing Python. Now, Python sees the shield is there, the backend starts successfully, and the 502 error is gone!


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
