### PR TITLE
Resolve Kueue monitor timeouts for tests with abbreviated job names

### DIFF
--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -26,10 +26,15 @@ fi
 gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
 BUILD_ID_SHORT=$(echo "$BUILD_ID" | cut -c1-6)
 
-# Read the actual job name from the manifest to handle cases where tests use abbreviated names (e.g. crd)
-JOB_NAME=$(grep -m 1 -E '^ *name:' /workspace/job.yaml | awk '{print $2}')
+# Read the actual job name from the manifest to handle cases where tests use abbreviated names.
+# Strip any YAML quotes and suppress errors if the file doesn't exist yet.
+JOB_NAME=""
+if [ -f "/workspace/job.yaml" ]; then
+	JOB_NAME=$(grep -m 1 -E '^ *name:' /workspace/job.yaml | awk '{print $2}' | tr -d '"' | tr -d "'")
+fi
+
 if [ -z "$JOB_NAME" ]; then
-	# Fallback if grep fails
+	# Fallback if grep fails or file is missing
 	JOB_NAME="${TEST_NAME}-${BUILD_ID_SHORT}"
 fi
 

--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -25,7 +25,13 @@ fi
 
 gcloud container clusters get-credentials test-kueue-cluster --region=us-central1
 BUILD_ID_SHORT=$(echo "$BUILD_ID" | cut -c1-6)
-JOB_NAME="${TEST_NAME}-${BUILD_ID_SHORT}"
+
+# Read the actual job name from the manifest to handle cases where tests use abbreviated names (e.g. crd)
+JOB_NAME=$(grep -m 1 -E '^ *name:' /workspace/job.yaml | awk '{print $2}')
+if [ -z "$JOB_NAME" ]; then
+	# Fallback if grep fails
+	JOB_NAME="${TEST_NAME}-${BUILD_ID_SHORT}"
+fi
 
 # Cloud Build trap: If the Cloud Build step itself receives a cancellation signal,
 # delete the GKE job so the pod receives a SIGTERM and performs infrastructure cleanup.


### PR DESCRIPTION
This PR fixes a bug in the Kueue job monitoring script where tests with long names (e.g., `chrome-remote-desktop`, `gke-g4-confidential`, `slurm-gcp-v6-simple-job-completion`) would infinitely loop and time out during the pipeline.