### PR TITLE
test(ci): replace deprecated e2 instances with n2d across daily tests and test configs

### DIFF
--- a/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a2-highgpu-kueue-onspot.yaml
@@ -173,7 +173,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [network1]'                           >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
 

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -159,7 +159,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [network1]'                           >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
               echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu.yaml
@@ -54,7 +54,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [network1]'                           >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu-onspot.yaml
@@ -161,7 +161,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [network1]'                           >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
               echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-megagpu.yaml
@@ -54,7 +54,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [network1]'                           >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu-onspot.yaml
@@ -163,7 +163,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [gke-a3-ultra-net-0]'                 >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
               echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-ultragpu.yaml
@@ -56,7 +56,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [gke-a3-ultra-net-0]'                 >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -164,7 +164,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [gke-a4-net-0]'                       >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
               echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x-max-bm.yaml
@@ -58,7 +58,7 @@ steps:
     echo '    source: modules/compute/vm-instance'             >> $${EXAMPLE_BP}
     echo '    use: [gke-a4x-max-net-0]'                        >> $${EXAMPLE_BP}
     echo '    settings:'                                       >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'                   >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'                  >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                      >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true'       >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4x.yaml
@@ -140,7 +140,7 @@ steps:
               echo '    source: modules/compute/vm-instance'             >> \$$EXAMPLE_BP
               echo '    use: [gke-a4x-net-0]'                            >> \$$EXAMPLE_BP
               echo '    settings:'                                       >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'                   >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'                   >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                      >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true'       >> \$$EXAMPLE_BP
               echo ''                                                    >> \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-confidential.yaml
@@ -133,7 +133,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [gke-g4-net-0]'                       >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
               echo ''                                              >> \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4-onspot.yaml
@@ -160,7 +160,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [gke-g4-net-0]'                        >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
 

--- a/tools/cloud-build/daily-tests/builds/gke-g4.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-g4.yaml
@@ -53,7 +53,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [gke-g4-net-0]'                       >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d-onspot.yaml
@@ -169,7 +169,7 @@ steps:
               echo '    source: modules/compute/vm-instance'       >> \$$EXAMPLE_BP
               echo '    use: [gke-h4d-net]'                        >> \$$EXAMPLE_BP
               echo '    settings:'                                 >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'             >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
 

--- a/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-h4d.yaml
@@ -57,7 +57,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [gke-h4d-net]'                        >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
     echo ''

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -136,7 +136,7 @@ steps:
               echo '    source: modules/compute/vm-instance'                >> \$$EXAMPLE_BP
               echo '    use: [network1]'                                    >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'                      >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
               echo '      zone: us-central1-a'                              >> \$$EXAMPLE_BP
 
               # Adding node pool with reservation defined
@@ -144,7 +144,7 @@ steps:
               echo '    source: modules/compute/gke-node-pool'              >> \$$EXAMPLE_BP
               echo '    use: [gke_cluster, node_pool_service_account]'      >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'                      >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
               echo '      zones: [us-central1-a]'                           >> \$$EXAMPLE_BP
               echo '      static_node_count: 0'                             >> \$$EXAMPLE_BP
               echo '      is_reservation_active: false'                     >> \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-hyperdisk.yaml
@@ -136,7 +136,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$SG_EXAMPLE
               echo '    use: [network]'                      >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
-              echo '      machine_type: e2-standard-2'       >> \$$SG_EXAMPLE
+              echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
               echo '      zone: europe-west1-b'              >> \$$SG_EXAMPLE
 
               IP=\$(curl ifconfig.me)

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -137,7 +137,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$EXAMPLE_BP
               echo '    use: [network]'                      >> \$$EXAMPLE_BP
               echo '    settings:'                           >> \$$EXAMPLE_BP
-              echo '      machine_type: e2-standard-2'       >> \$$EXAMPLE_BP
+              echo '      machine_type: n2d-standard-2'       >> \$$EXAMPLE_BP
               echo '      zone: us-central1-a'               >> \$$EXAMPLE_BP
 
               IP=\$(curl ifconfig.me)

--- a/tools/cloud-build/daily-tests/builds/gke-storage.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-storage.yaml
@@ -144,7 +144,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$SG_EXAMPLE
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
-              echo '      machine_type: e2-standard-2'       >> \$$SG_EXAMPLE
+              echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
               echo '      zone: us-central1-b'               >> \$$SG_EXAMPLE
 
               echo "Checking if required storage pools exist..."

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -132,7 +132,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$SG_EXAMPLE
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
-              echo '      machine_type: e2-standard-2'       >> \$$SG_EXAMPLE
+              echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
               echo '      zone: us-central1-a'               >> \$$SG_EXAMPLE
 
               echo '  - id: ubuntu_pool'                                         >> \$$SG_EXAMPLE

--- a/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke-e2e.yaml
@@ -132,7 +132,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$SG_EXAMPLE
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
-              echo '      machine_type: e2-standard-2'       >> \$$SG_EXAMPLE
+              echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
               echo '      zone: asia-southeast1-b'           >> \$$SG_EXAMPLE
 
               echo '  - id: ubuntu_pool'                                         >> \$$SG_EXAMPLE

--- a/tools/cloud-build/daily-tests/builds/ml-gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-gke.yaml
@@ -133,7 +133,7 @@ steps:
               echo '    source: modules/compute/vm-instance' >> \$$SG_EXAMPLE
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
-              echo '      machine_type: e2-standard-2'       >> \$$SG_EXAMPLE
+              echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
               echo '      zone: asia-southeast1-b'           >> \$$SG_EXAMPLE
 
               echo '  - id: ubuntu_pool'                               >> \$$SG_EXAMPLE

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -55,7 +55,7 @@ steps:
     echo '    use: [network]'                            >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
     echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
-    echo '      zone: us-central1-a'                     >> $${SG_EXAMPLE}
+    echo '      zone: us-central1-a'                     >> $${EXAMPLE_BP}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}
 

--- a/tools/cloud-build/daily-tests/builds/slinky.yml
+++ b/tools/cloud-build/daily-tests/builds/slinky.yml
@@ -54,7 +54,7 @@ steps:
     echo '    source: modules/compute/vm-instance'       >> $${EXAMPLE_BP}
     echo '    use: [network]'                            >> $${EXAMPLE_BP}
     echo '    settings:'                                 >> $${EXAMPLE_BP}
-    echo '      machine_type: e2-standard-2'             >> $${EXAMPLE_BP}
+    echo '      machine_type: n2d-standard-2'            >> $${EXAMPLE_BP}
     echo '      zone: us-central1-a'                     >> $${SG_EXAMPLE}
     echo '      name_prefix: remote-node'                >> $${EXAMPLE_BP}
     echo '      add_deployment_name_before_prefix: true' >> $${EXAMPLE_BP}

--- a/tools/validate_configs/test_configs/2filestore-4instances.yaml
+++ b/tools/validate_configs/test_configs/2filestore-4instances.yaml
@@ -51,7 +51,7 @@ deployment_groups:
     use: [network, homefs]
     settings:
       name_prefix: ls1
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       labels:
         ghpc_role: license
 
@@ -60,7 +60,7 @@ deployment_groups:
     use: [network, homefs]
     settings:
       name_prefix: ls2
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       labels:
         ghpc_role: license
 

--- a/tools/validate_configs/test_configs/centos8-ss.yaml
+++ b/tools/validate_configs/test_configs/centos8-ss.yaml
@@ -75,7 +75,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       instance_image:
         family: centos-stream-8
         project: centos-cloud

--- a/tools/validate_configs/test_configs/complex-data.yaml
+++ b/tools/validate_configs/test_configs/complex-data.yaml
@@ -67,7 +67,7 @@ deployment_groups:
     use: [network, homefs]
     settings:
       name_prefix: ls1
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       labels:
         ghpc_role: license
       disable_public_ips: true

--- a/tools/validate_configs/test_configs/debian-ss.yaml
+++ b/tools/validate_configs/test_configs/debian-ss.yaml
@@ -75,7 +75,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       instance_image:
         family: debian-10
         project: debian-cloud

--- a/tools/validate_configs/test_configs/hpc-centos-ss.yaml
+++ b/tools/validate_configs/test_configs/hpc-centos-ss.yaml
@@ -75,4 +75,4 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4

--- a/tools/validate_configs/test_configs/hpc-cluster-simple.yaml
+++ b/tools/validate_configs/test_configs/hpc-cluster-simple.yaml
@@ -52,6 +52,6 @@ deployment_groups:
     - startup
     settings:
       name_prefix: workstation
-      machine_type: e2-standard-8
+      machine_type: n2d-standard-8
       labels:
         ghpc_role: workstation

--- a/tools/validate_configs/test_configs/instance-with-startup.yaml
+++ b/tools/validate_configs/test_configs/instance-with-startup.yaml
@@ -40,7 +40,7 @@ deployment_groups:
     - network1
     - homefs
     settings:
-      machine_type: e2-standard-8
+      machine_type: n2d-standard-8
 
   - id: wait
     source: community/modules/scripts/wait-for-startup

--- a/tools/validate_configs/test_configs/rocky-ss.yaml
+++ b/tools/validate_configs/test_configs/rocky-ss.yaml
@@ -79,7 +79,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       instance_image:
         family: rocky-linux-8
         project: rocky-linux-cloud

--- a/tools/validate_configs/test_configs/simple-startup.yaml
+++ b/tools/validate_configs/test_configs/simple-startup.yaml
@@ -47,7 +47,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
 
   - id: waiter
     source: community/modules/scripts/wait-for-startup

--- a/tools/validate_configs/test_configs/startup-options.yaml
+++ b/tools/validate_configs/test_configs/startup-options.yaml
@@ -52,7 +52,7 @@ deployment_groups:
     use: [network1]
     settings:
       name_prefix: explicit
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       startup_script: $(startup.startup_script)
 
   - id: instance-no-startup
@@ -60,20 +60,20 @@ deployment_groups:
     use: [network1]
     settings:
       name_prefix: no-startup
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
 
   - id: instance-use-startup
     source: modules/compute/vm-instance
     use: [network1, startup]
     settings:
       name_prefix: use-startup
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
 
   - id: instance-metadata-startup
     source: modules/compute/vm-instance
     use: [network1]
     settings:
       name_prefix: metadata-startup
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       metadata:
         startup-script: $(startup.startup_script)

--- a/tools/validate_configs/test_configs/ubuntu-ss.yaml
+++ b/tools/validate_configs/test_configs/ubuntu-ss.yaml
@@ -79,7 +79,7 @@ deployment_groups:
     source: modules/compute/vm-instance
     use: [network1, startup, nfs, appsfs]
     settings:
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       instance_image:
         family: ubuntu-2204-lts
         project: ubuntu-os-cloud


### PR DESCRIPTION
- Replaced dynamic e2-standard-2 remote-node injections with n2d-standard-2 across 23 daily test build manifests
- Updated static test configurations in tools/validate_configs/test_configs/ to use n2d-standard-4 and n2d-standard-8