### PR TITLE
Make GetUniqueGcsBuckets fail-fast on invalid bucket configs

### DIFF
--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -210,12 +210,12 @@ func (s *MySuite) TestVerifyGcsBucketsEmptyBucket(c *C) {
 
 	err := verifyGcsBuckets(context.Background(), bp)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "GCS backend bucket name cannot be empty or unknown")
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group1\" cannot be empty or unknown")
 
 	bp.Groups[0].TerraformBackend.Configuration = config.NewDict(map[string]cty.Value{
 		"bucket": cty.StringVal(""),
 	})
 	err = verifyGcsBuckets(context.Background(), bp)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "GCS backend bucket name cannot be empty")
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group1\" cannot be empty")
 }

--- a/cmd/deploy_test.go
+++ b/cmd/deploy_test.go
@@ -60,12 +60,12 @@ func (s *MySuite) TestCreateGcsBucketsIfMissingEmptyBucket(c *C) {
 
 	err := createGcsBucketsIfMissing(context.Background(), bp)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "GCS backend bucket name cannot be empty or unknown")
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group1\" cannot be empty or unknown")
 
 	bp.Groups[0].TerraformBackend.Configuration = config.NewDict(map[string]cty.Value{
 		"bucket": cty.StringVal(""),
 	})
 	err = createGcsBucketsIfMissing(context.Background(), bp)
 	c.Assert(err, NotNil)
-	c.Check(err.Error(), Equals, "GCS backend bucket name cannot be empty")
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group1\" cannot be empty")
 }

--- a/pkg/modulewriter/modulewriter.go
+++ b/pkg/modulewriter/modulewriter.go
@@ -503,7 +503,6 @@ func WriteGcsDestroyInstructions(w io.Writer, buckets []string) {
 func GetUniqueGcsBuckets(bp config.Blueprint) ([]string, error) {
 	seenBuckets := make(map[string]bool)
 	var buckets []string
-	var retErr error
 
 	for _, g := range bp.Groups {
 		if g.TerraformBackend.Type != "gcs" || !g.TerraformBackend.Configuration.Has("bucket") {
@@ -511,17 +510,15 @@ func GetUniqueGcsBuckets(bp config.Blueprint) ([]string, error) {
 		}
 		evaluatedConfig, err := bp.EvalDict(g.TerraformBackend.Configuration)
 		if err != nil {
-			return buckets, fmt.Errorf("failed to evaluate terraform backend configuration: %w", err)
+			return nil, fmt.Errorf("failed to evaluate terraform backend configuration for group %q: %w", g.Name, err)
 		}
 		bucketVal := evaluatedConfig.Get("bucket")
 		if bucketVal.IsNull() || !bucketVal.IsKnown() || bucketVal.Type() != cty.String {
-			retErr = fmt.Errorf("GCS backend bucket name cannot be empty or unknown")
-			continue
+			return nil, fmt.Errorf("GCS backend bucket name for group %q cannot be empty or unknown", g.Name)
 		}
 		bucketName := bucketVal.AsString()
 		if bucketName == "" {
-			retErr = fmt.Errorf("GCS backend bucket name cannot be empty")
-			continue
+			return nil, fmt.Errorf("GCS backend bucket name for group %q cannot be empty", g.Name)
 		}
 		if seenBuckets[bucketName] {
 			continue
@@ -530,5 +527,5 @@ func GetUniqueGcsBuckets(bp config.Blueprint) ([]string, error) {
 		buckets = append(buckets, bucketName)
 	}
 
-	return buckets, retErr
+	return buckets, nil
 }

--- a/pkg/modulewriter/modulewriter_test.go
+++ b/pkg/modulewriter/modulewriter_test.go
@@ -684,24 +684,6 @@ func (s *zeroSuite) TestWriteGcsDestroyInstructions(c *C) {
 					}),
 				},
 			},
-			{
-				Name: "group_empty_bucket",
-				TerraformBackend: config.TerraformBackend{
-					Type: "gcs",
-					Configuration: config.NewDict(map[string]cty.Value{
-						"bucket": cty.StringVal(""),
-					}),
-				},
-			},
-			{
-				Name: "group_null_bucket",
-				TerraformBackend: config.TerraformBackend{
-					Type: "gcs",
-					Configuration: config.NewDict(map[string]cty.Value{
-						"bucket": cty.NullVal(cty.String),
-					}),
-				},
-			},
 		},
 	}
 
@@ -710,4 +692,31 @@ func (s *zeroSuite) TestWriteGcsDestroyInstructions(c *C) {
 	out := buf.String()
 
 	c.Check(strings.Contains(out, "my-bucket-name"), Equals, true)
+}
+
+func (s *zeroSuite) TestGetUniqueGcsBuckets_Errors(c *C) {
+	bp := config.Blueprint{
+		Groups: []config.Group{
+			{
+				Name: "group_empty",
+				TerraformBackend: config.TerraformBackend{
+					Type: "gcs",
+					Configuration: config.NewDict(map[string]cty.Value{
+						"bucket": cty.StringVal(""),
+					}),
+				},
+			},
+		},
+	}
+	_, err := GetUniqueGcsBuckets(bp)
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group_empty\" cannot be empty")
+
+	bp.Groups[0].Name = "group_null"
+	bp.Groups[0].TerraformBackend.Configuration = config.NewDict(map[string]cty.Value{
+		"bucket": cty.NullVal(cty.String),
+	})
+	_, err = GetUniqueGcsBuckets(bp)
+	c.Assert(err, NotNil)
+	c.Check(err.Error(), Equals, "GCS backend bucket name for group \"group_null\" cannot be empty or unknown")
 }


### PR DESCRIPTION
Refactors GetUniqueGcsBuckets to immediately fail on invalid configurations and includes the exact group name in the error message for easier debugging. Also updates related CLI tests and adds a dedicated unit test for these specific error conditions.



### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
