### PR TITLE
fix(slurm): don't restart slurmctld on a topology-only reconfigure

### DIFF
--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/slurmsync.py
@@ -515,7 +515,9 @@ def update_topology(lkp: util.Lookup) -> None:
 
     if updated:
         log.info("Topology configuration updated. Reconfiguring Slurm.")
-        util.scontrol_reconfigure(lkp)
+        # Topology is reloaded by `scontrol reconfigure`; restarting slurmctld
+        # here would flap nodes that register during the restart window.
+        util.scontrol_reconfigure(lkp, restart=False)
         # Safe summary only after Slurm got reconfigured, so summary reflects Slurm POV
         summary.dump(lkp)
 

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/tests/test_util.py
@@ -1112,3 +1112,26 @@ def test_slurmsync_mig_auto_repair(mock_lookup, mock_compute_prop, mock_inst):
                 action_recovered_fqdn = slurmsync.get_node_action("testcl-ns-2.c.testproj.internal")
                 assert isinstance(action_recovered_fqdn, slurmsync.NodeActionIdle)
                 mock_get_reason.assert_called_with("testcl-ns-2")
+
+
+@pytest.mark.parametrize(
+    "restart,expect_restart",
+    [
+        (True, True),
+        (False, False),
+    ],
+)
+def test_scontrol_reconfigure(restart, expect_restart, mocker):
+    """`scontrol reconfigure` always runs; the slurmctld restart is opt-out.
+
+    `update_topology` runs on every node power-up, so restarting slurmctld there
+    put a controller restart on the autoscaling hot path.
+    """
+    mock_run = mocker.patch("util.run")
+    lkp = mocker.Mock(scontrol="scontrol")
+
+    util.scontrol_reconfigure(lkp, restart=restart)
+
+    commands = [c.args[0] for c in mock_run.call_args_list]
+    assert "scontrol reconfigure" in commands
+    assert ("sudo systemctl restart slurmctld.service" in commands) == expect_restart

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/modules/slurm_files/scripts/util.py
@@ -2488,9 +2488,18 @@ def update_config(cfg: NSDict) -> None:
     global _lkp
     _lkp = Lookup(cfg)
 
-def scontrol_reconfigure(lkp: Lookup) -> None:
-    log.info("Running systemctl restart slurmctld.service")
-    run("sudo systemctl restart slurmctld.service", timeout=30)
+def scontrol_reconfigure(lkp: Lookup, restart: bool = True) -> None:
+    """Make Slurm pick up regenerated configuration.
+
+    Args:
+        restart: also restart slurmctld. Needed when slurm.conf/cloud.conf
+            content changed. A topology-only change is picked up by `scontrol
+            reconfigure` alone, and restarting for it makes slurmctld falsely
+            flag nodes that register during the restart as not responding.
+    """
+    if restart:
+        log.info("Running systemctl restart slurmctld.service")
+        run("sudo systemctl restart slurmctld.service", timeout=30)
     log.info("Running scontrol reconfigure")
     run(f"{lkp.scontrol} reconfigure")
 


### PR DESCRIPTION
## Problem

`util.scontrol_reconfigure()` has two callers in `slurmsync.py`:

| caller | fires when | frequency |
|---|---|---|
| `reconfigure_slurm()` | the config bucket changed (regenerates `cloud.conf`) | rare |
| `update_topology()` | the topology changed — i.e. **a node powered up** | every autoscale event |

[#4609](https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/4609) moved an unconditional
`systemctl restart slurmctld.service` into that shared helper. It is reasonable for the first caller
(which already restarted explicitly on the line above). But it also applied to the second, which had
been doing a plain `scontrol reconfigure` — so since then **an autoscaling cluster restarts its
controller once per scale event.** On our cluster that is ~25 slurmctld restarts/day.

The restart is not harmless. A node that registers within 300 s of a slurmctld restart is
subsequently flagged `not responding`, and jobs running on it are requeued.

## Evidence

Reproduced on demand on a live cluster, 4/4, on idle and busy nodes:

- The flag fires at **exactly restart + 300 s** on a node that registers in the seconds *after* the
  restart. A node that was already steady before the restart is unaffected.
- A plain `scontrol reconfigure` (no restart) does **not** reproduce it.
- It is immune to every relevant configured timeout — each varied to a distinct value and confirmed
  live via `scontrol show config` across the restart:

  | varied | result |
  |---|--:|
  | `SlurmdTimeout` = 150 / 200 / 450 | +300 |
  | `ResumeTimeout` = 600 (global and partition) | +300 |
  | `SuspendTimeout` = 500 | +300 |
  | `BatchStartTimeout` = 500 | +300 |

  300 s is Slurm's *default* `SlurmdTimeout`, which suggests a node registering just after a restart
  is health-checked against the default rather than the configured value. That part may well be a
  Slurm-side issue — but it is only reachable because we restart slurmctld on the hot path.

This is most visible on slow-provisioning machine types. Ours (`h4d-standard-192` with Cloud RDMA)
takes 563–576 s to provision and register, so during a batch bring-up node N's power-up restarts the
controller while node N+1 is still registering. Faster types tend to register *before* the restart
their own power-up triggers, so they never land in the window — which is likely why this has not been
widely reported.

## Fix

Make the restart opt-out on the helper, and have the topology path skip it. A topology change takes
effect on `scontrol reconfigure` (per the `topology.conf` man page), so the restart is not needed
there. **The config-change path in `reconfigure_slurm()` is deliberately left untouched** — node-set
reconciliation may genuinely require the restart, and this change is scoped not to alter it. In effect
this restores the pre-#4609 behaviour for the topology path only.

## Testing

- Added a parametrized unit test in `tests/test_util.py` asserting `scontrol reconfigure` always runs
  and the restart is opt-out.
- Full script suite passes locally: `173 passed`.
- Happy to add an integration-level test if you would like one.