### PR TITLE
fix(iam): resolve service account eventual consistency propagation & cold start failures in GKE blueprints

### DIFF
--- a/examples/ml-gke.yaml
+++ b/examples/ml-gke.yaml
@@ -83,6 +83,7 @@ deployment_groups:
     settings:
       disk_type: pd-balanced
       machine_type: g2-standard-4
+      static_node_count: 1
 
   - id: nvidia_smi_job_template
     source: modules/compute/gke-job-template

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -43,6 +43,7 @@ deployment_groups:
         - range_name: services
           ip_cidr_range: 10.0.32.0/20
 
+  # Service account used by GKE node pool VMs (Compute/Node level permissions)
   - id: node_pool_service_account
     source: modules/project/service-account
     settings:
@@ -55,9 +56,22 @@ deployment_groups:
       - storage.objectViewer
       - artifactregistry.reader
 
+  # Service account used by GKE Workload Identity for pod-level storage access
+  - id: workload_service_account
+    source: modules/project/service-account
+    settings:
+      name: gke-wl-sa
+      project_roles:
+      - logging.logWriter
+      - monitoring.metricWriter
+      - monitoring.viewer
+      - stackdriver.resourceMetadata.writer
+      - storage.objectAdmin
+      - artifactregistry.reader
+
   - id: gke_cluster
     source: modules/scheduler/gke-cluster
-    use: [network1, node_pool_service_account]
+    use: [network1, workload_service_account]
     settings:
       enable_filestore_csi: true
       enable_gcsfuse_csi: true

--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -258,6 +258,7 @@ deployment_groups:
       machine_type: c3d-standard-4
       disk_type: hyperdisk-balanced
       disk_storage_pool: $(vars.hyperdisk_balanced_storage_pool)
+      static_node_count: 1
 
   - id: gke-storage-hp
     source: modules/file-system/gke-storage

--- a/modules/project/service-account/README.md
+++ b/modules/project/service-account/README.md
@@ -67,10 +67,13 @@ limitations under the License.
 | Name | Version |
 | ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.12.2 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
 
-No providers.
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules
 
@@ -80,7 +83,9 @@ No providers.
 
 ## Resources
 
-No resources.
+| Name | Type |
+| ---- | ---- |
+| [time_sleep.wait_for_service_account](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 
 ## Inputs
 

--- a/modules/project/service-account/main.tf
+++ b/modules/project/service-account/main.tf
@@ -35,3 +35,11 @@ module "service_account" {
   project_id         = var.project_id
   project_roles      = [for role in var.project_roles : "${var.project_id}=>roles/${role}"]
 }
+
+resource "time_sleep" "wait_for_service_account" {
+  create_duration = "30s"
+
+  depends_on = [
+    module.service_account
+  ]
+}

--- a/modules/project/service-account/outputs.tf
+++ b/modules/project/service-account/outputs.tf
@@ -18,7 +18,6 @@ output "key" {
   description = "Service account key (if creation was requested)"
   value       = module.service_account.key
   depends_on = [
-    module.service_account,
     time_sleep.wait_for_service_account,
   ]
 }
@@ -27,7 +26,6 @@ output "service_account_email" {
   description = "Service account e-mail address"
   value       = module.service_account.email
   depends_on = [
-    module.service_account,
     time_sleep.wait_for_service_account,
   ]
 }
@@ -36,7 +34,6 @@ output "service_account_iam_email" {
   description = "Service account IAM binding format (serviceAccount:name@example.com)"
   value       = module.service_account.iam_email
   depends_on = [
-    module.service_account,
     time_sleep.wait_for_service_account,
   ]
 }

--- a/modules/project/service-account/outputs.tf
+++ b/modules/project/service-account/outputs.tf
@@ -17,6 +17,10 @@
 output "key" {
   description = "Service account key (if creation was requested)"
   value       = module.service_account.key
+  depends_on = [
+    module.service_account,
+    time_sleep.wait_for_service_account,
+  ]
 }
 
 output "service_account_email" {
@@ -24,6 +28,7 @@ output "service_account_email" {
   value       = module.service_account.email
   depends_on = [
     module.service_account,
+    time_sleep.wait_for_service_account,
   ]
 }
 
@@ -32,5 +37,6 @@ output "service_account_iam_email" {
   value       = module.service_account.iam_email
   depends_on = [
     module.service_account,
+    time_sleep.wait_for_service_account,
   ]
 }

--- a/modules/project/service-account/versions.tf
+++ b/modules/project/service-account/versions.tf
@@ -16,6 +16,10 @@
 
 terraform {
   required_providers {
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.9"
+    }
   }
 
   required_version = ">= 1.12.2"

--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -768,4 +768,7 @@ resource "google_service_account_iam_member" "mtc_node_workload_identity" {
   service_account_id = "projects/${var.project_id}/serviceAccounts/${local.sa_email}"
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${replace(var.project_id, ":", "/")}.svc.id.goog[gke-managed-checkpointing/gke-checkpointing-multitier-node]"
+  depends_on = [
+    google_container_cluster.gke_cluster
+  ]
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -777,6 +777,7 @@ func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespa
 			pods = fallbackPods
 		}
 	}
+	podsDeleted := 0
 	for _, pod := range pods.Items {
 		if strings.HasPrefix(pod.GetName(), "multitier-driver") {
 			logging.Info("Restarting MTC driver pod: %s", pod.GetName())
@@ -786,8 +787,15 @@ func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespa
 					continue
 				}
 				logging.Warn("Failed to delete MTC driver pod %s: %v", pod.GetName(), err)
+			} else {
+				podsDeleted++
 			}
 		}
+	}
+	if podsDeleted > 0 {
+		// Brief pause to allow the DaemonSet controller to observe the pod deletions
+		// and decrement status.numberReady before we poll for readiness.
+		time.Sleep(daemonSetPollInterval)
 	}
 	waitForMTCDriverDaemonSetReady(ctx, client, namespace)
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -718,6 +718,8 @@ func checkDaemonSetReady(ctx context.Context, client dynamic.Interface, namespac
 	return isDaemonSetRolloutComplete(dsObj), nil
 }
 
+var daemonSetPollInterval = 2 * time.Second
+
 // waitForMTCDriverDaemonSetReady waits for the multitier-driver DaemonSet to finish rollout and become ready.
 func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interface, namespace string) {
 	logging.Info("Waiting for MTC multitier-driver DaemonSet in %s to be ready...", namespace)
@@ -728,7 +730,7 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 		return
 	}
 
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(daemonSetPollInterval)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -688,11 +688,70 @@ func (g *GKEOrchestrator) getNodeServiceAccount() string {
 	return ""
 }
 
+func isDaemonSetRolloutComplete(dsObj *unstructured.Unstructured) bool {
+	gen, _, _ := unstructured.NestedInt64(dsObj.Object, "metadata", "generation")
+	obsGen, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "observedGeneration")
+	desired, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "desiredNumberScheduled")
+	ready, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "numberReady")
+	updated, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "updatedNumberScheduled")
+
+	if obsGen >= gen && ready >= desired && updated >= desired {
+		logging.Info("MTC multitier-driver DaemonSet is ready (%d/%d nodes ready).", ready, desired)
+		return true
+	}
+	return false
+}
+
+func checkDaemonSetReady(ctx context.Context, client dynamic.Interface, namespace string) (bool, error) {
+	dsObj, err := client.Resource(daemonsetGVR).Namespace(namespace).Get(ctx, "multitier-driver", metav1.GetOptions{})
+	if err != nil {
+		if isForbiddenError(err) {
+			logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
+			return true, nil
+		}
+		if apierrors.IsNotFound(err) {
+			logging.Warn("MTC multitier-driver DaemonSet not found in %s. Proceeding with job submission.", namespace)
+			return true, nil
+		}
+		return false, err
+	}
+	return isDaemonSetRolloutComplete(dsObj), nil
+}
+
+// waitForMTCDriverDaemonSetReady waits for the multitier-driver DaemonSet to finish rollout and become ready.
+func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interface, namespace string) {
+	logging.Info("Waiting for MTC multitier-driver DaemonSet in %s to be ready...", namespace)
+	waitCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	if ready, err := checkDaemonSetReady(waitCtx, client, namespace); ready && err == nil {
+		return
+	}
+
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			logging.Warn("Timed out or context canceled waiting for MTC multitier-driver DaemonSet in %s to become ready. Proceeding with job submission.", namespace)
+			return
+		case <-ticker.C:
+			if ready, err := checkDaemonSetReady(waitCtx, client, namespace); ready && err == nil {
+				return
+			} else if err != nil {
+				logging.Warn("Retrying get of multitier-driver DaemonSet: %v", err)
+			}
+		}
+	}
+}
+
 // restartMTCDriverPods restarts the multitier-driver DaemonSet to pick up updated service account tokens.
 func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespace string) {
 	patchData := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, time.Now().UTC().Format(time.RFC3339))
 	if _, err := client.Resource(daemonsetGVR).Namespace(namespace).Patch(ctx, "multitier-driver", types.StrategicMergePatchType, patchData, metav1.PatchOptions{}); err == nil {
 		logging.Info("Triggered rolling restart of multitier-driver DaemonSet in %s", namespace)
+		waitForMTCDriverDaemonSetReady(ctx, client, namespace)
 		return
 	} else if isForbiddenError(err) {
 		logging.Warn("Insufficient RBAC permissions to restart multitier-driver DaemonSet in %s (403 Forbidden). Skipping driver restart.", namespace)
@@ -728,6 +787,7 @@ func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespa
 			}
 		}
 	}
+	waitForMTCDriverDaemonSetReady(ctx, client, namespace)
 }
 
 // updateMTCServiceAccountAnnotation updates the MTC KSA with the node GSA Workload Identity annotation and restarts driver pods.

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -4129,6 +4129,111 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 	})
 }
 
+func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
+	t.Run("DaemonSet ready immediately", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"generation": int64(2),
+						},
+						"status": map[string]interface{}{
+							"observedGeneration":     int64(2),
+							"desiredNumberScheduled": int64(3),
+							"numberReady":            int64(3),
+							"updatedNumberScheduled": int64(3),
+						},
+					},
+				}, nil
+			},
+		}
+		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+	})
+
+	t.Run("DaemonSet ready after polling", func(t *testing.T) {
+		calls := 0
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				calls++
+				if calls < 2 {
+					return &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"generation": int64(2),
+							},
+							"status": map[string]interface{}{
+								"observedGeneration":     int64(2),
+								"desiredNumberScheduled": int64(3),
+								"numberReady":            int64(1),
+								"updatedNumberScheduled": int64(1),
+							},
+						},
+					}, nil
+				}
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"generation": int64(2),
+						},
+						"status": map[string]interface{}{
+							"observedGeneration":     int64(2),
+							"desiredNumberScheduled": int64(3),
+							"numberReady":            int64(3),
+							"updatedNumberScheduled": int64(3),
+						},
+					},
+				}, nil
+			},
+		}
+		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+		if calls < 2 {
+			t.Errorf("expected at least 2 calls for polling, got %d", calls)
+		}
+	})
+
+	t.Run("403 Forbidden returns gracefully", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "daemonsets"}, "multitier-driver", fmt.Errorf("forbidden"))
+			},
+		}
+		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+	})
+
+	t.Run("DaemonSet NotFound returns gracefully", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "daemonsets"}, "multitier-driver")
+			},
+		}
+		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+	})
+
+	t.Run("Context canceled/timeout returns gracefully", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"generation": int64(2),
+						},
+						"status": map[string]interface{}{
+							"observedGeneration":     int64(2),
+							"desiredNumberScheduled": int64(3),
+							"numberReady":            int64(1),
+							"updatedNumberScheduled": int64(1),
+						},
+					},
+				}, nil
+			},
+		}
+		waitForMTCDriverDaemonSetReady(ctx, dynClient, "gke-managed-checkpointing")
+	})
+}
+
 func TestIsForbiddenError(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -4130,6 +4130,10 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 }
 
 func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
+	oldInterval := daemonSetPollInterval
+	daemonSetPollInterval = 1 * time.Millisecond
+	defer func() { daemonSetPollInterval = oldInterval }()
+
 	t.Run("DaemonSet ready immediately", func(t *testing.T) {
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -3931,6 +3931,10 @@ func TestEnsureMTCWorkloadIdentity_Restart(t *testing.T) {
 		},
 	}
 
+	oldInterval := daemonSetPollInterval
+	daemonSetPollInterval = 1 * time.Millisecond
+	defer func() { daemonSetPollInterval = oldInterval }()
+
 	t.Run("Annotation missing - Updates SA and restarts DaemonSet", func(t *testing.T) {
 		updated := false
 		patchedDS := false

--- a/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ml-gke-e2e.yaml
@@ -85,6 +85,7 @@ deployment_groups:
     settings:
       name: g2-latest-driver
       machine_type: g2-standard-4
+      static_node_count: 1
       guest_accelerator:
       - gpu_driver_installation_config:
           gpu_driver_version: "LATEST"
@@ -117,6 +118,7 @@ deployment_groups:
       name: n1-pool-default
       disk_type: pd-balanced
       machine_type: n1-standard-4
+      static_node_count: 1
       guest_accelerator:
       - type: nvidia-tesla-t4
         count: 2
@@ -145,6 +147,7 @@ deployment_groups:
       name: n1-pool-full-spec
       disk_type: pd-balanced
       machine_type: n1-standard-4
+      static_node_count: 1
       guest_accelerator:
       - type: nvidia-tesla-t4
         count: 2
@@ -177,6 +180,7 @@ deployment_groups:
     use: [gke_cluster, node_pool_service_account]
     settings:
       name: default-settings-pool
+      static_node_count: 1
 
   - id: job_default_settings_pool
     source: modules/compute/gke-job-template


### PR DESCRIPTION
## Description
Resolves IAM replication race conditions (b/553899936) that cause 403 / 404 / 400 errors during `terraform apply` when service accounts and GKE clusters/node pools are created simultaneously.

### Root Cause
When a GCP service account is created in `modules/project/service-account`, IAM replication across Google's internal APIs (IAM, GCS, GKE) takes 10–30 seconds. Upstream data sources (such as `data "google_service_account"` in GKE Workload Identity) and resources (`google_storage_bucket_iam_member`, `google_container_node_pool`, and `google_service_account_iam_member.mtc_node_workload_identity`) evaluated the SA reference immediately, resulting in `Error 403: Permission 'iam.serviceAccounts.get' denied on resource (or it may not exist)`.

### Key Changes
1. **`modules/project/service-account`**: Added `time_sleep` (30s) resource and wired all module outputs (`service_account_email`, `service_account_iam_email`, `key`) to depend on it.
2. **`modules/scheduler/gke-cluster`**: Added explicit `depends_on = [google_container_cluster.gke_cluster]` to `google_service_account_iam_member.mtc_node_workload_identity`.
3. **`examples/storage-gke.yaml`**: Configured dual service accounts (`node_pool_service_account` for VM nodes and `workload_service_account` for GKE Workload Identity) consistent with standard GKE blueprints.

Fixes b/553899936