### PR TITLE
feat(examples,docs): migrate e2 instances to n2d across blueprints and documentation

### DIFF
--- a/community/examples/client-google-cloud-storage.yaml
+++ b/community/examples/client-google-cloud-storage.yaml
@@ -56,7 +56,7 @@ deployment_groups:
     - existing-bucket
     settings:
       name_prefix: workstation
-      machine_type: e2-standard-2
+      machine_type: n2d-standard-2
       allow_automatic_updates: false
 
   - id: wait

--- a/community/examples/flux-framework/flux-cluster.yaml
+++ b/community/examples/flux-framework/flux-cluster.yaml
@@ -49,12 +49,12 @@ deployment_groups:
       login_node_specs:
       - name_prefix: gfluxfw-login
         machine_arch: x86-64
-        machine_type: e2-standard-4
+        machine_type: n2d-standard-4
         instances: 1
         properties: []
         boot_script: null
       manager_name_prefix: gfluxfw
-      manager_machine_type: e2-standard-8
+      manager_machine_type: n2d-standard-8
 
       subnetwork: $(flux-net.subnetwork_self_link)
 

--- a/community/examples/gcloud-example.yaml
+++ b/community/examples/gcloud-example.yaml
@@ -39,7 +39,7 @@ deployment_groups:
           --zone=$(vars.zone)
           --network=$(vars.deployment_name)-net
           --subnet=$(vars.deployment_name)-subnet
-          --machine-type=e2-micro
+          --machine-type=n2d-standard-2
           --image-family=debian-11
           --image-project=debian-cloud
         delete: "gcloud compute instances delete $(vars.deployment_name)-vm --project=$(vars.project_id) --zone=$(vars.zone) --quiet"

--- a/community/examples/hpc-slinky/hpc-slinky.yaml
+++ b/community/examples/hpc-slinky/hpc-slinky.yaml
@@ -24,7 +24,7 @@ vars:
   authorized_cidr:  # <your-ip-address>/32
   gcp_public_cidrs_access_enabled: false
   exporter_pod_monitoring_path: $(ghpc_stage("./exporter-pod-monitoring.yaml"))
-  base_pool_machine_type: e2-standard-8
+  base_pool_machine_type: n2d-standard-8
   base_pool_size: 2
   debug_nodeset_replicas: 2
   compute_pool_machine_type: h3-standard-88

--- a/community/examples/slurm-gke/slurm-gke.yaml
+++ b/community/examples/slurm-gke/slurm-gke.yaml
@@ -108,7 +108,7 @@ deployment_groups:
     settings:
       initial_node_count: 1
       disk_type: pd-balanced
-      machine_type: e2-standard-4
+      machine_type: n2d-standard-4
       zones: [$(vars.zone)]
 
   - id: gke_compute_pool

--- a/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
+++ b/community/examples/xpk-n2-filestore/xpk-n2-filestore.yaml
@@ -54,7 +54,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [network]
     settings:
-      system_node_pool_machine_type: "e2-standard-4"
+      system_node_pool_machine_type: "n2d-standard-4"
       system_node_pool_node_count:
         total_min_nodes: 1
         total_max_nodes: 1000

--- a/community/front-end/ofe/tf/README.md
+++ b/community/front-end/ofe/tf/README.md
@@ -66,7 +66,7 @@ limitations under the License.
 | <a name="input_region"></a> [region](#input\_region) | GCP Region for HPC Frontend deployment. | `string` | n/a | yes |
 | <a name="input_repo_branch"></a> [repo\_branch](#input\_repo\_branch) | git branch to checkout when deploying the HPC Frontend | `string` | `"main"` | no |
 | <a name="input_repo_fork"></a> [repo\_fork](#input\_repo\_fork) | GitHub repository name in which to find the cluster-toolkit repo | `string` | `"GoogleCloudPlatform"` | no |
-| <a name="input_server_instance_type"></a> [server\_instance\_type](#input\_server\_instance\_type) | Instance size to use from HPC Frontend webserver | `string` | `"e2-standard-2"` | no |
+| <a name="input_server_instance_type"></a> [server\_instance\_type](#input\_server\_instance\_type) | Instance size to use from HPC Frontend webserver | `string` | `"n2d-standard-2"` | no |
 | <a name="input_static_ip"></a> [static\_ip](#input\_static\_ip) | Optional pre-configured static IP for HPC Frontend. | `string` | `""` | no |
 | <a name="input_subnet"></a> [subnet](#input\_subnet) | Subnet in which to deploy HPC Frontend. | `string` | `""` | no |
 | <a name="input_webserver_hostname"></a> [webserver\_hostname](#input\_webserver\_hostname) | DNS Hostname for the webserver | `string` | `""` | no |

--- a/community/front-end/ofe/tf/variables.tf
+++ b/community/front-end/ofe/tf/variables.tf
@@ -70,7 +70,7 @@ variable "django_su_email" {
 }
 
 variable "server_instance_type" {
-  default     = "e2-standard-2"
+  default     = "n2d-standard-2"
   type        = string
   description = "Instance size to use from HPC Frontend webserver"
 }

--- a/community/modules/scheduler/slinky/README.md
+++ b/community/modules/scheduler/slinky/README.md
@@ -64,7 +64,7 @@ Through `cert_manager_values`, `prometheus_values`, `slurm_operator_values`, and
                 - key: "node.kubernetes.io/instance-type"
                   operator: In
                   values:
-                  - e2-standard-8 # base_pool's machine-type
+                  - n2d-standard-8 # base_pool's machine-type
 ```
 
 This creates a Slinky cluster with the following attributes:

--- a/community/modules/scripts/gcloud/README.md
+++ b/community/modules/scripts/gcloud/README.md
@@ -11,7 +11,7 @@ This module allows you to run a series of gcloud commands as part of a Cluster T
     commands:
       - gcloud compute networks create my-network --subnet-mode=custom
       - gcloud compute networks subnets create my-subnet --network=my-network --range=10.0.0.0/24 --region=us-central1
-      - gcloud compute instances create my-vm --zone=us-central1-a --network=my-network --subnet=my-subnet --machine-type=e2-medium
+      - gcloud compute instances create my-vm --zone=us-central1-a --network=my-network --subnet=my-subnet --machine-type=n2d-standard-2
 ## Dependency Management
 
 This module uses `local-exec` provisioners to run `gcloud` commands. As such, it does not expose any outputs that other Terraform modules can consume to establish dependencies.

--- a/examples/gke-a3-highgpu-inference-gateway.yaml
+++ b/examples/gke-a3-highgpu-inference-gateway.yaml
@@ -122,7 +122,7 @@ deployment_groups:
     use: [gke_cluster, node_pool_service_account]
     settings:
       name: "default"
-      machine_type: "e2-standard-2"
+      machine_type: "n2d-standard-2"
       autoscaling_total_min_nodes: 1
       autoscaling_total_max_nodes: 3
       zones: [$(vars.zone)]

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -128,7 +128,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -158,7 +158,7 @@ deployment_groups:
     use: [gke-a4-net-0, workload_service_account]
     settings:
       auto_monitoring_scope: $(vars.auto_monitoring_scope)
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -50,7 +50,7 @@ vars:
   reservation_project_id: $(vars.project_id)
 
   compute_nodepool_machine_type: a4x-maxgpu-4g-metal
-  system_nodepool_machine_type: e2-standard-16
+  system_nodepool_machine_type: n2d-standard-16
   system_node_pool_disk_size_gb: 200
   a4x_max_node_pool_disk_size_gb: 100
   k8s_service_account_name: workload-identity-k8s-sa

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -60,7 +60,7 @@ vars:
   a4x_node_pool_disk_size_gb: 100
   k8s_service_account_name: workload-identity-k8s-sa
   compute_nodepool_machine_type: a4x-highgpu-4g
-  system_nodepool_machine_type: e2-standard-16
+  system_nodepool_machine_type: n2d-standard-16
 
   # # To enable Managed-Lustre please uncomment this section and fill out the settings.
   # # Additionally, please uncomment the private_service_access, lustre_firewall_rule, managed-lustre and lustre-pv modules.

--- a/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-compact-placement/gke-h4d/gke-h4d.yaml
@@ -110,7 +110,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-h4d-net, gke-h4d-rdma-net, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_multi_networking: true

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-a3-ultragpu.yaml
@@ -124,7 +124,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-a3-ultragpu.yaml
@@ -116,7 +116,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-a3-ultra-net-0, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-g4/gke-g4.yaml
+++ b/examples/gke-g4/gke-g4.yaml
@@ -118,7 +118,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-g4-net-0, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-h4d/gke-h4d.yaml
+++ b/examples/gke-h4d/gke-h4d.yaml
@@ -117,7 +117,7 @@ deployment_groups:
     source: modules/scheduler/gke-cluster
     use: [gke-h4d-net, gke-h4d-rdma-net, workload_service_account]
     settings:
-      system_node_pool_machine_type: "e2-standard-16"
+      system_node_pool_machine_type: "n2d-standard-16"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_multi_networking: true

--- a/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-ultragpu-8g/a3ultra-slurm-blueprint.yaml
@@ -413,7 +413,7 @@ deployment_groups:
     settings:
       disk_size_gb: 300
       enable_login_public_ips: true
-      machine_type: e2-standard-16
+      machine_type: n2d-standard-16
 
   - id: controller_startup
     source: modules/scripts/startup-script
@@ -472,7 +472,7 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: 300
-      machine_type: e2-standard-16
+      machine_type: n2d-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
       compute_startup_scripts_timeout: 1800

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -438,7 +438,7 @@ deployment_groups:
     settings:
       disk_size_gb: $(vars.disk_size_gb)
       enable_login_public_ips: true
-      machine_type: e2-standard-16
+      machine_type: n2d-standard-16
       metadata:
         user-data: |
           #cloud-config
@@ -501,7 +501,7 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: $(vars.disk_size_gb)
-      machine_type: e2-standard-16
+      machine_type: n2d-standard-16
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
       compute_startup_scripts_timeout: 1800

--- a/examples/science/af3-slurm/README.md
+++ b/examples/science/af3-slurm/README.md
@@ -233,7 +233,7 @@ Build Pool. The `gcloud` command to create a custom build pool is shown below.
 
 ```bash
 gcloud builds worker-pools create mypool --region=<your region> --worker-disk-size=100 \
---worker-machine-type=e2-highmem-8
+--worker-machine-type=n2d-highmem-8
 ```
 
 With a custom build pool created, the Cloud Build command is as follows (use the [apptainer_cloudbuild.yaml](adm/apptainer_cloudbuild.yaml)):

--- a/modules/README.md
+++ b/modules/README.md
@@ -532,7 +532,7 @@ vm-instance module:
     use:
     - network1
     settings:
-      machine_type: e2-medium
+      machine_type: n2d-standard-2
     outputs:
     - internal_ip
     - name: external_ip

--- a/modules/compute/resource-policy/README.md
+++ b/modules/compute/resource-policy/README.md
@@ -19,7 +19,7 @@ The following example creates a group placement resource policy and applies it t
     source: modules/compute/gke-node-pool
     use: [group_placement_1]
     settings:
-      machine_type: e2-standard-8
+      machine_type: n2d-standard-8
     outputs: [instructions]
 ```
 

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -1120,14 +1120,14 @@ func TestGetMachineType(t *testing.T) {
 							{
 								ID: config.ModuleID("gke_cluster"),
 								Settings: config.NewDict(map[string]cty.Value{
-									"system_node_pool_machine_type": cty.StringVal("e2-standard-16"),
+									"system_node_pool_machine_type": cty.StringVal("n2d-standard-16"),
 								}),
 							},
 						},
 					},
 				},
 			},
-			want: "e2-standard-16",
+			want: "n2d-standard-16",
 		},
 		{
 			name: "Extracts default machine_type when omitted from blueprint",

--- a/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-lustre.yaml
@@ -21,7 +21,7 @@ vars:
   deployment_name: test
   region: us-central1
   zone: us-central1-a
-  machine_type: e2-small
+  machine_type: n2d-standard-2
 
 
 deployment_groups:


### PR DESCRIPTION
- Updated GKE example blueprints (A3 Ultra, A4, A4X, H4D, G4) to use n2d-standard-16 for system node pools
- Updated Slurm blueprints (A3 Ultra, A4) to use n2d-standard-16 for login and controller instances
- Updated community examples (Flux, Slinky, XPK, Slurm-GKE, GCS client) to use n2d instances
- Updated documentation and READMEs across modules and examples to reflect E2-less standards