### PR TITLE
UX(job): dynamically suggest Artifact Registry repositories on missing env var

### DIFF
--- a/cmd/job/artifact_registry.go
+++ b/cmd/job/artifact_registry.go
@@ -20,15 +20,13 @@ import (
 	"strings"
 	"time"
 
+	"hpc-toolkit/pkg/shell"
+
 	"google.golang.org/api/artifactregistry/v1"
 )
 
 func locationToRegion(location string) string {
-	parts := strings.Split(location, "-")
-	if len(parts) >= 3 {
-		return strings.Join(parts[:len(parts)-1], "-")
-	}
-	return location
+	return shell.ExtractRegion(location)
 }
 
 // lookupArtifactRegistryRepos queries Artifact Registry to find up to 5 Docker repositories
@@ -40,13 +38,14 @@ var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location 
 
 	region := locationToRegion(location)
 
-	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-	defer cancel()
-
 	service, err := artifactregistry.NewService(ctx)
 	if err != nil {
 		return nil
 	}
+
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
 
 	parent := fmt.Sprintf("projects/%s/locations/%s", projectID, region)
 	maxSuggestions := 5

--- a/cmd/job/artifact_registry.go
+++ b/cmd/job/artifact_registry.go
@@ -25,10 +25,6 @@ import (
 	"google.golang.org/api/artifactregistry/v1"
 )
 
-func locationToRegion(location string) string {
-	return shell.ExtractRegion(location)
-}
-
 // lookupArtifactRegistryRepos queries Artifact Registry to find up to 5 Docker repositories
 // in the specified project and region.
 var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) []string {
@@ -36,15 +32,14 @@ var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location 
 		return nil
 	}
 
-	region := locationToRegion(location)
+	region := shell.ExtractRegion(location)
 
 	service, err := artifactregistry.NewService(ctx)
 	if err != nil {
 		return nil
 	}
 
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, 3*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
 	parent := fmt.Sprintf("projects/%s/locations/%s", projectID, region)
@@ -59,7 +54,7 @@ var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location 
 			req.PageToken(nextPageToken)
 		}
 
-		resp, err := req.Context(ctx).Do()
+		resp, err := req.Context(timeoutCtx).Do()
 		if err != nil {
 			break
 		}

--- a/cmd/job/artifact_registry.go
+++ b/cmd/job/artifact_registry.go
@@ -17,6 +17,7 @@ package job
 import (
 	"context"
 	"fmt"
+	"path"
 	"strings"
 	"time"
 
@@ -25,18 +26,22 @@ import (
 	"google.golang.org/api/artifactregistry/v1"
 )
 
+var newArtifactRegistryService = func(ctx context.Context) (*artifactregistry.Service, error) {
+	return artifactregistry.NewService(ctx)
+}
+
 // lookupArtifactRegistryRepos queries Artifact Registry to find up to 5 Docker repositories
 // in the specified project and region.
-var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) []string {
+var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) ([]string, bool) {
 	if projectID == "" || location == "" {
-		return nil
+		return nil, false
 	}
 
 	region := shell.ExtractRegion(location)
 
-	service, err := artifactregistry.NewService(ctx)
+	service, err := newArtifactRegistryService(ctx)
 	if err != nil {
-		return nil
+		return nil, false
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -60,11 +65,10 @@ var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location 
 		}
 
 		for _, repo := range resp.Repositories {
-			if repo.Format != "DOCKER" {
+			if !strings.EqualFold(repo.Format, "DOCKER") {
 				continue
 			}
-			repoParts := strings.Split(repo.Name, "/")
-			repoID := repoParts[len(repoParts)-1]
+			repoID := path.Base(repo.Name)
 
 			if len(suggestions) < maxSuggestions {
 				suggestions = append(suggestions, repoID)
@@ -80,9 +84,5 @@ var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location 
 		nextPageToken = resp.NextPageToken
 	}
 
-	if hasMore {
-		suggestions = append(suggestions, "... (and more)")
-	}
-
-	return suggestions
+	return suggestions, hasMore
 }

--- a/cmd/job/artifact_registry.go
+++ b/cmd/job/artifact_registry.go
@@ -1,0 +1,94 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/api/artifactregistry/v1"
+)
+
+func locationToRegion(location string) string {
+	parts := strings.Split(location, "-")
+	if len(parts) >= 3 {
+		return strings.Join(parts[:len(parts)-1], "-")
+	}
+	return location
+}
+
+// lookupArtifactRegistryRepos queries Artifact Registry to find up to 5 Docker repositories
+// in the specified project and region.
+var lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) []string {
+	if projectID == "" || location == "" {
+		return nil
+	}
+
+	region := locationToRegion(location)
+
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	service, err := artifactregistry.NewService(ctx)
+	if err != nil {
+		return nil
+	}
+
+	parent := fmt.Sprintf("projects/%s/locations/%s", projectID, region)
+	maxSuggestions := 5
+	var suggestions []string
+	hasMore := false
+	nextPageToken := ""
+
+	for {
+		req := service.Projects.Locations.Repositories.List(parent)
+		if nextPageToken != "" {
+			req.PageToken(nextPageToken)
+		}
+
+		resp, err := req.Context(ctx).Do()
+		if err != nil {
+			break
+		}
+
+		for _, repo := range resp.Repositories {
+			if repo.Format != "DOCKER" {
+				continue
+			}
+			repoParts := strings.Split(repo.Name, "/")
+			repoID := repoParts[len(repoParts)-1]
+
+			if len(suggestions) < maxSuggestions {
+				suggestions = append(suggestions, repoID)
+			} else {
+				hasMore = true
+				break
+			}
+		}
+
+		if hasMore || resp.NextPageToken == "" {
+			break
+		}
+		nextPageToken = resp.NextPageToken
+	}
+
+	if hasMore {
+		suggestions = append(suggestions, "... (and more)")
+	}
+
+	return suggestions
+}

--- a/cmd/job/artifact_registry_test.go
+++ b/cmd/job/artifact_registry_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 "Google LLC"
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package job
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"google.golang.org/api/artifactregistry/v1"
+	"google.golang.org/api/option"
+)
+
+func TestLookupArtifactRegistryRepos(t *testing.T) {
+	// 1. Setup the httptest server with a handler to mock GCP API
+	mockHandler := func(w http.ResponseWriter, r *http.Request) {
+		// Verify URL matches the expected parent URL requested
+		if r.URL.Path != "/v1/projects/my-project/locations/us-central1/repositories" {
+			t.Errorf("Unexpected path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		pageToken := r.URL.Query().Get("pageToken")
+
+		var resp artifactregistry.ListRepositoriesResponse
+
+		switch pageToken {
+		case "":
+			// Page 1: 3 Docker repos + 1 Maven repo
+			resp.Repositories = []*artifactregistry.Repository{
+				{Name: "projects/my-project/locations/us-central1/repositories/repo1", Format: "DOCKER"},
+				{Name: "projects/my-project/locations/us-central1/repositories/repo2", Format: "docker"},     // Case testing
+				{Name: "projects/my-project/locations/us-central1/repositories/repo-maven", Format: "MAVEN"}, // Should filter out
+				{Name: "projects/my-project/locations/us-central1/repositories/repo3", Format: "DOCKER"},
+			}
+			resp.NextPageToken = "page2"
+		case "page2":
+			// Page 2: 3 more Docker repos (total 6 valid ones). It should stop at 5 and hasMore=true
+			resp.Repositories = []*artifactregistry.Repository{
+				{Name: "projects/my-project/locations/us-central1/repositories/repo4", Format: "DOCKER"},
+				{Name: "projects/my-project/locations/us-central1/repositories/repo5", Format: "DOCKER"},
+				{Name: "projects/my-project/locations/us-central1/repositories/repo6", Format: "DOCKER"},
+			}
+			resp.NextPageToken = ""
+		default:
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		bytes, _ := json.Marshal(resp)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(bytes)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(mockHandler))
+	defer ts.Close()
+
+	// 2. Override newArtifactRegistryService pointing it to local server
+	origNewService := newArtifactRegistryService
+	defer func() { newArtifactRegistryService = origNewService }()
+
+	newArtifactRegistryService = func(ctx context.Context) (*artifactregistry.Service, error) {
+		return artifactregistry.NewService(ctx, option.WithEndpoint(ts.URL), option.WithoutAuthentication())
+	}
+
+	// 3. Call the logic
+	// Testing with a zone (us-central1-c) ensures the shell.ExtractRegion resolves it to us-central1 for the URL above
+	suggestions, hasMore := lookupArtifactRegistryRepos(context.Background(), "my-project", "us-central1-c")
+
+	// 4. Assertions
+	expected := []string{"repo1", "repo2", "repo3", "repo4", "repo5"}
+	if !reflect.DeepEqual(suggestions, expected) {
+		t.Errorf("Expected suggestions %v, got %v", expected, suggestions)
+	}
+	if !hasMore {
+		t.Errorf("Expected hasMore to be true, got false")
+	}
+}

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -367,7 +367,7 @@ func validateBuildContext(ctx context.Context, projectID, location string) error
 		return nil
 	}
 	if os.Getenv("GCLUSTER_IMAGE_REPO") == "" {
-		suggestions := lookupArtifactRegistryRepos(ctx, projectID, location)
+		suggestions, hasMore := lookupArtifactRegistryRepos(ctx, projectID, location)
 
 		region := shell.ExtractRegion(location)
 
@@ -382,6 +382,9 @@ func validateBuildContext(ctx context.Context, projectID, location string) error
 
 		if len(suggestions) > 0 {
 			reposStr := "'" + strings.Join(suggestions, "', '") + "'"
+			if hasMore {
+				reposStr += " (and more)"
+			}
 			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\n"+
 				"Available Docker repositories in project '%s' and region '%s' are: %s.\n\n"+
 				"To view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\n"+

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -387,13 +387,13 @@ func validateBuildContext(ctx context.Context, projectID, location string) error
 			}
 			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\n"+
 				"Available Docker repositories in project '%s' and region '%s' are: %s.\n\n"+
-				"To view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\n"+
+				"To view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --filter=\"format=DOCKER\" --format=\"value(name.basename())\"\n\n"+
 				"Please set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)",
 				projPrint, regPrint, reposStr, projPrint, regPrint, suggestions[0])
 		}
 		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. "+
 			"Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\n"+
-			"To see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"",
+			"To see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --filter=\"format=DOCKER\" --format=\"value(name.basename())\"",
 			projPrint, regPrint)
 	}
 	if os.Getenv("USER") == "" && os.Getenv("USERNAME") == "" {

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -15,6 +15,7 @@
 package job
 
 import (
+	"context"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"os"
@@ -104,7 +105,7 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 			return fmt.Errorf("required flag \"command\" not set")
 		}
 
-		if err := validateImageFlags(); err != nil {
+		if err := validateImageFlags(projectID, location); err != nil {
 			return err
 		}
 
@@ -338,14 +339,14 @@ func validatePathwaysFlags() error {
 	return nil
 }
 
-func validateImageFlags() error {
+func validateImageFlags(projectID, location string) error {
 	if pathways.Headless {
 		return nil
 	}
 	if err := validateImageSources(); err != nil {
 		return err
 	}
-	return validateBuildContext()
+	return validateBuildContext(projectID, location)
 }
 
 func validateImageSources() error {
@@ -361,12 +362,25 @@ func validateImageSources() error {
 	return nil
 }
 
-func validateBuildContext() error {
+func validateBuildContext(projectID, location string) error {
 	if buildContext == "" {
 		return nil
 	}
 	if os.Getenv("GCLUSTER_IMAGE_REPO") == "" {
-		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo)")
+		ctx := context.Background()
+		suggestions := lookupArtifactRegistryRepos(ctx, projectID, location)
+
+		parts := strings.Split(location, "-")
+		region := location
+		if len(parts) >= 3 {
+			region = strings.Join(parts[:len(parts)-1], "-")
+		}
+
+		if len(suggestions) > 0 {
+			reposStr := "'" + strings.Join(suggestions, "', '") + "'"
+			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project '%s' and region '%s' are: %s.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)", projectID, region, reposStr, projectID, region, suggestions[0])
+		}
+		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\nTo see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"", projectID, region)
 	}
 	if os.Getenv("USER") == "" && os.Getenv("USERNAME") == "" {
 		return fmt.Errorf("failed to determine user identity from environment (tried USER and USERNAME). This is required to ensure unique image tagging when using --build-context")

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -105,7 +105,7 @@ and JobSet/Kueue specific configurations like workload name, queue, nodes, and r
 			return fmt.Errorf("required flag \"command\" not set")
 		}
 
-		if err := validateImageFlags(projectID, location); err != nil {
+		if err := validateImageFlags(cmd.Context(), projectID, location); err != nil {
 			return err
 		}
 
@@ -339,14 +339,14 @@ func validatePathwaysFlags() error {
 	return nil
 }
 
-func validateImageFlags(projectID, location string) error {
+func validateImageFlags(ctx context.Context, projectID, location string) error {
 	if pathways.Headless {
 		return nil
 	}
 	if err := validateImageSources(); err != nil {
 		return err
 	}
-	return validateBuildContext(projectID, location)
+	return validateBuildContext(ctx, projectID, location)
 }
 
 func validateImageSources() error {
@@ -362,15 +362,14 @@ func validateImageSources() error {
 	return nil
 }
 
-func validateBuildContext(projectID, location string) error {
+func validateBuildContext(ctx context.Context, projectID, location string) error {
 	if buildContext == "" {
 		return nil
 	}
 	if os.Getenv("GCLUSTER_IMAGE_REPO") == "" {
-		ctx := context.Background()
 		suggestions := lookupArtifactRegistryRepos(ctx, projectID, location)
 
-		region := locationToRegion(location)
+		region := shell.ExtractRegion(location)
 
 		projPrint := projectID
 		if projPrint == "" {
@@ -383,9 +382,16 @@ func validateBuildContext(projectID, location string) error {
 
 		if len(suggestions) > 0 {
 			reposStr := "'" + strings.Join(suggestions, "', '") + "'"
-			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project '%s' and region '%s' are: %s.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)", projPrint, regPrint, reposStr, projPrint, regPrint, suggestions[0])
+			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\n"+
+				"Available Docker repositories in project '%s' and region '%s' are: %s.\n\n"+
+				"To view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\n"+
+				"Please set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)",
+				projPrint, regPrint, reposStr, projPrint, regPrint, suggestions[0])
 		}
-		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\nTo see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"", projPrint, regPrint)
+		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. "+
+			"Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\n"+
+			"To see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"",
+			projPrint, regPrint)
 	}
 	if os.Getenv("USER") == "" && os.Getenv("USERNAME") == "" {
 		return fmt.Errorf("failed to determine user identity from environment (tried USER and USERNAME). This is required to ensure unique image tagging when using --build-context")

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -372,11 +372,20 @@ func validateBuildContext(projectID, location string) error {
 
 		region := locationToRegion(location)
 
+		projPrint := projectID
+		if projPrint == "" {
+			projPrint = "<PROJECT_ID>"
+		}
+		regPrint := region
+		if regPrint == "" {
+			regPrint = "<REGION>"
+		}
+
 		if len(suggestions) > 0 {
 			reposStr := "'" + strings.Join(suggestions, "', '") + "'"
-			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project '%s' and region '%s' are: %s.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)", projectID, region, reposStr, projectID, region, suggestions[0])
+			return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project '%s' and region '%s' are: %s.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=%s)", projPrint, regPrint, reposStr, projPrint, regPrint, suggestions[0])
 		}
-		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\nTo see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"", projectID, region)
+		return fmt.Errorf("GCLUSTER_IMAGE_REPO environment variable is required when using --build-context. Please set it in your environment with the repository name only (e.g., export GCLUSTER_IMAGE_REPO=gcluster-repo).\n\nTo see available repositories manually, you can run:\n\t> gcloud artifacts repositories list --project=%s --location=%s --format=\"value(name)\"", projPrint, regPrint)
 	}
 	if os.Getenv("USER") == "" && os.Getenv("USERNAME") == "" {
 		return fmt.Errorf("failed to determine user identity from environment (tried USER and USERNAME). This is required to ensure unique image tagging when using --build-context")

--- a/cmd/job/submit.go
+++ b/cmd/job/submit.go
@@ -370,11 +370,7 @@ func validateBuildContext(projectID, location string) error {
 		ctx := context.Background()
 		suggestions := lookupArtifactRegistryRepos(ctx, projectID, location)
 
-		parts := strings.Split(location, "-")
-		region := location
-		if len(parts) >= 3 {
-			region = strings.Join(parts[:len(parts)-1], "-")
-		}
+		region := locationToRegion(location)
 
 		if len(suggestions) > 0 {
 			reposStr := "'" + strings.Join(suggestions, "', '") + "'"

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -474,8 +474,8 @@ func TestSubmitCmd_MissingRepoEnvVar_DynamicSuggestions(t *testing.T) {
 
 	oldLookup := lookupArtifactRegistryRepos
 	defer func() { lookupArtifactRegistryRepos = oldLookup }()
-	lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) []string {
-		return []string{"repo1", "repo2", "repo3"}
+	lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) ([]string, bool) {
+		return []string{"repo1", "repo2", "repo3"}, false
 	}
 
 	_, err := executeCommand(JobCmd,

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -494,7 +494,7 @@ func TestSubmitCmd_MissingRepoEnvVar_DynamicSuggestions(t *testing.T) {
 		t.Fatal("expected error for missing GCLUSTER_IMAGE_REPO, got nil")
 	}
 
-	expectedMsg := "GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project 'test-project' and region 'us-central1' are: 'repo1', 'repo2', 'repo3'.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=test-project --location=us-central1 --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=repo1)"
+	expectedMsg := "GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project 'test-project' and region 'us-central1' are: 'repo1', 'repo2', 'repo3'.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=test-project --location=us-central1 --filter=\"format=DOCKER\" --format=\"value(name.basename())\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=repo1)"
 	if !strings.Contains(err.Error(), expectedMsg) {
 		t.Errorf("unexpected error: %v\nexpected contained: %v", err, expectedMsg)
 	}

--- a/cmd/job/submit_test.go
+++ b/cmd/job/submit_test.go
@@ -16,6 +16,7 @@ package job
 
 import (
 	"bytes"
+	"context"
 	"hpc-toolkit/pkg/orchestrator"
 	"hpc-toolkit/pkg/shell"
 	"os"
@@ -423,9 +424,7 @@ func TestParseDurationToSeconds(t *testing.T) {
 func TestSubmitCmd_MissingRepoEnvVar(t *testing.T) {
 	setupSubmitTestEnv(t)
 
-	origRepo := os.Getenv("GCLUSTER_IMAGE_REPO")
-	os.Setenv("GCLUSTER_IMAGE_REPO", "")
-	defer os.Setenv("GCLUSTER_IMAGE_REPO", origRepo)
+	t.Setenv("GCLUSTER_IMAGE_REPO", "")
 
 	oldStore := store
 	defer func() { store = oldStore }()
@@ -455,6 +454,49 @@ func TestSubmitCmd_MissingRepoEnvVar(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "GCLUSTER_IMAGE_REPO environment variable is required") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSubmitCmd_MissingRepoEnvVar_DynamicSuggestions(t *testing.T) {
+	setupSubmitTestEnv(t)
+
+	t.Setenv("GCLUSTER_IMAGE_REPO", "")
+
+	oldStore := store
+	defer func() { store = oldStore }()
+	store = &MockPrereqStore{State: PrereqState{LastCheckedTimestamp: time.Now()}}
+
+	oldFactory := gkeOrchestratorFactory
+	defer func() { gkeOrchestratorFactory = oldFactory }()
+	gkeOrchestratorFactory = func() orchestrator.JobOrchestrator {
+		return &mockOrchestrator{}
+	}
+
+	oldLookup := lookupArtifactRegistryRepos
+	defer func() { lookupArtifactRegistryRepos = oldLookup }()
+	lookupArtifactRegistryRepos = func(ctx context.Context, projectID, location string) []string {
+		return []string{"repo1", "repo2", "repo3"}
+	}
+
+	_, err := executeCommand(JobCmd,
+		"submit",
+		"--name", "fail-test",
+		"--base-image", "python:3.9-slim",
+		"--build-context", "job_details",
+		"--command", "echo hello",
+		"--compute-type", "n2-standard-4",
+		"--cluster", "test-cluster",
+		"--location", "us-central1-a",
+		"--project", "test-project",
+	)
+
+	if err == nil {
+		t.Fatal("expected error for missing GCLUSTER_IMAGE_REPO, got nil")
+	}
+
+	expectedMsg := "GCLUSTER_IMAGE_REPO environment variable is required when using --build-context.\n\nAvailable Docker repositories in project 'test-project' and region 'us-central1' are: 'repo1', 'repo2', 'repo3'.\n\nTo view all repositories, you can run:\n\t> gcloud artifacts repositories list --project=test-project --location=us-central1 --format=\"value(name)\"\n\nPlease set your environment variable to one of these (e.g., export GCLUSTER_IMAGE_REPO=repo1)"
+	if !strings.Contains(err.Error(), expectedMsg) {
+		t.Errorf("unexpected error: %v\nexpected contained: %v", err, expectedMsg)
 	}
 }
 


### PR DESCRIPTION
This pull request improves the user experience for the job submission command by providing dynamic suggestions for Artifact Registry repositories. When a user attempts to use a build context without specifying the required GCLUSTER_IMAGE_REPO environment variable, the tool now queries the project's Artifact Registry to list available Docker repositories, helping the user identify the correct configuration to use.

### Highlights

* **Artifact Registry Integration**: Added a new utility to dynamically query and suggest Docker repositories from Google Artifact Registry when the GCLUSTER_IMAGE_REPO environment variable is missing.
* **Improved Error Messaging**: Updated the validation logic for the --build-context flag to provide actionable error messages, including a list of available repositories in the target project and region.
* **Test Coverage**: Added a new unit test to verify that the CLI correctly suggests repositories when the required environment variable is not set.


### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
