### PR TITLE
Update Ramble repository cloning URL to https://github.com/Ramble-Project/ramble

### DIFF
--- a/community/h4d-hpc-benchmarks/install-hpl-dependencies.sh
+++ b/community/h4d-hpc-benchmarks/install-hpl-dependencies.sh
@@ -37,7 +37,7 @@ if [ ! -d "${INSTALL_DIR}/spack/.git" ]; then
     git clone -c feature.manyFiles=true https://github.com/spack/spack.git ${INSTALL_DIR}/spack
 fi
 if [ ! -d "${INSTALL_DIR}/ramble/.git" ]; then
-    git clone -b v0.6.0 https://github.com/GoogleCloudPlatform/ramble.git ${INSTALL_DIR}/ramble
+    git clone -b v0.6.0 https://github.com/Ramble-Project/ramble.git ${INSTALL_DIR}/ramble
 fi
 
 source ${INSTALL_DIR}/spack/share/spack/setup-env.sh

--- a/community/modules/scripts/ramble-execute/README.md
+++ b/community/modules/scripts/ramble-execute/README.md
@@ -5,7 +5,7 @@ This module will create a startup-script runner that will execute Ramble command
 Ramble is a multi-platform experimentation framework capable of driving
 software installation, acquiring input files, configuring experiments, and
 extracting results. For more information about Ramble, see:
-https://github.com/GoogleCloudPlatform/ramble
+https://github.com/Ramble-Project/ramble
 
 This module outputs a startup script runner, which can be combined with other
 startup script runners to execute a set of Ramble commands.

--- a/community/modules/scripts/ramble-setup/README.md
+++ b/community/modules/scripts/ramble-setup/README.md
@@ -6,7 +6,7 @@ and install Ramble’s dependencies.
 Ramble is a multi-platform experimentation framework capable of driving
 software installation, acquiring input files, configuring experiments, and
 extracting results. For more information about ramble, see:
-https://github.com/GoogleCloudPlatform/ramble
+https://github.com/Ramble-Project/ramble
 
 This module outputs two startup script runners, which can be added to startup
 scripts to setup, ramble and its dependencies.
@@ -36,7 +36,7 @@ This example simply installs ramble on a VM.
   source: community/modules/scripts/ramble-setup
   settings:
     install_dir: /ramble
-    ramble_url: https://github.com/GoogleCloudPlatform/ramble
+    ramble_url: https://github.com/Ramble-Project/ramble
     ramble_ref: v0.2.1
     log_file: /var/log/ramble.log
     chown_owner: “owner”
@@ -106,7 +106,7 @@ limitations under the License.
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project in which the HPC deployment will be created. | `string` | n/a | yes |
 | <a name="input_ramble_profile_script_path"></a> [ramble\_profile\_script\_path](#input\_ramble\_profile\_script\_path) | Path to the Ramble profile.d script. Created by this module | `string` | `"/etc/profile.d/ramble.sh"` | no |
 | <a name="input_ramble_ref"></a> [ramble\_ref](#input\_ramble\_ref) | Git ref to checkout for Ramble. | `string` | `"develop"` | no |
-| <a name="input_ramble_url"></a> [ramble\_url](#input\_ramble\_url) | URL for Ramble repository to clone. | `string` | `"https://github.com/GoogleCloudPlatform/ramble"` | no |
+| <a name="input_ramble_url"></a> [ramble\_url](#input\_ramble\_url) | URL for Ramble repository to clone. | `string` | `"https://github.com/Ramble-Project/ramble"` | no |
 | <a name="input_ramble_virtualenv_path"></a> [ramble\_virtualenv\_path](#input\_ramble\_virtualenv\_path) | Virtual environment path in which to install Ramble Python interpreter and other dependencies | `string` | `"/usr/local/ramble-python"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region to place bucket containing startup script. | `string` | n/a | yes |
 | <a name="input_system_user_gid"></a> [system\_user\_gid](#input\_system\_user\_gid) | GID used when creating system user group. Ignored if `system_user_name` already exists on system. Default of 1104762904 is arbitrary. | `number` | `1104762904` | no |

--- a/community/modules/scripts/ramble-setup/variables.tf
+++ b/community/modules/scripts/ramble-setup/variables.tf
@@ -27,7 +27,7 @@ variable "install_dir" {
 
 variable "ramble_url" {
   description = "URL for Ramble repository to clone."
-  default     = "https://github.com/GoogleCloudPlatform/ramble"
+  default     = "https://github.com/Ramble-Project/ramble"
   type        = string
 }
 

--- a/examples/gke-a3-ultragpu/system_benchmarks/README.md
+++ b/examples/gke-a3-ultragpu/system_benchmarks/README.md
@@ -1,7 +1,7 @@
 Running System Benchmarks with Ramble
 =====================================
 
-[Ramble](https://github.com/GoogleCloudPlatform/ramble) is an open source
+[Ramble](https://github.com/Ramble-Project/ramble) is an open source
 multi-platform experimentation framework written in python. It can be used
 to easily reproduce benchmark results across systems, and here
 we will use it to run a series of system benchmarks.

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-hpl.yaml
@@ -484,7 +484,7 @@ spec:
           mkdir -p ${SOFTWARE_INSTALL} ${TEST_DIR}
 
           printf "Cloning ramble and cluster-toolkit\n"
-          git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble
+          git clone --depth 1 -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble
 
           printf "Setting up ramble python environment, and installing requirements\n"
           python3 -m venv "${SOFTWARE_INSTALL}"/ramble/env || true

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nccl.yaml
@@ -456,7 +456,7 @@ spec:
           mkdir -p ${SOFTWARE_INSTALL} ${TEST_DIR}
 
           printf "Cloning ramble and cluster-toolkit\n"
-          git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble
+          git clone --depth 1 -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble
 
           printf "Setting up ramble python environment, and installing requirements\n"
           python3 -m venv "${SOFTWARE_INSTALL}"/ramble/env || true

--- a/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
+++ b/examples/gke-a3-ultragpu/system_benchmarks/ramble-nemo.yaml
@@ -538,7 +538,7 @@ spec:
           mkdir -p ${SOFTWARE_INSTALL} ${TEST_DIR}
 
           printf "Cloning ramble and cluster-toolkit\n"
-          git clone --depth 1 -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble
+          git clone --depth 1 -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble
 
           printf "Setting up ramble python environment, and installing requirements\n"
           python3 -m venv "${SOFTWARE_INSTALL}"/ramble/env || true

--- a/examples/machine-learning/a4-highgpu-8g/system_benchmarks/README.md
+++ b/examples/machine-learning/a4-highgpu-8g/system_benchmarks/README.md
@@ -1,7 +1,7 @@
 Running System Benchmarks with Ramble
 =====================================
 
-[Ramble](https://github.com/GoogleCloudPlatform/ramble) is an open source
+[Ramble](https://github.com/Ramble-Project/ramble) is an open source
 multi-platform experimentation framework written in python. It can be used
 to easily reproduce benchmark results across systems, and here
 we will use it to run a series of system benchmarks.

--- a/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4-highgpu-8g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -32,7 +32,7 @@ by adding the following to ${HOME}/.enroot/.credentials:
 
   machine us-docker.pkg.dev login oauth2accesstoken password \$(gcloud auth print-access-token)
 
-And will clone ramble (https://github.com/GoogleCloudPlatform/ramble.git)
+And will clone ramble (https://github.com/Ramble-Project/ramble.git)
 to "${SOFTWARE_INSTALL}"/, and it will create an enroot "sqsh" file located
 in your ${HOME}/.enroot/ folder. Afterwards it will create a ramble workspace
 to run a number of NCCL tests in $(readlink -f "${TEST_DIR}"/).
@@ -77,7 +77,7 @@ EOF
 fi
 
 # Install ramble and make world read/writeable.
-sudo git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git clone -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
 sudo git -C "${SOFTWARE_INSTALL}"/ramble checkout 2a020babedd68be15448f3893d2a245fcaa8bd73
 sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 

--- a/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/README.md
+++ b/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/README.md
@@ -1,7 +1,7 @@
 Running System Benchmarks with Ramble
 =====================================
 
-[Ramble](https://github.com/GoogleCloudPlatform/ramble) is an open source
+[Ramble](https://github.com/Ramble-Project/ramble) is an open source
 multi-platform experimentation framework written in python. It can be used
 to easily reproduce benchmark results across systems, and here
 we will use it to run a series of system benchmarks.

--- a/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-highgpu-4g/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -39,7 +39,7 @@ by adding the following to ${HOME}/.enroot/.credentials:
 
   machine us-docker.pkg.dev login oauth2accesstoken password \$(gcloud auth print-access-token)
 
-And will clone ramble (https://github.com/GoogleCloudPlatform/ramble.git)
+And will clone ramble (https://github.com/Ramble-Project/ramble.git)
 to "${SOFTWARE_INSTALL}"/, and it will create an enroot "sqsh" file located
 in your ${HOME}/.enroot/ folder. Afterwards it will create a ramble workspace
 to run a number of NCCL tests in $(readlink -f "${TEST_DIR}"/).
@@ -84,7 +84,7 @@ EOF
 fi
 
 # Install ramble and make world read/writeable.
-sudo git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git clone -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
 sudo git -C "${SOFTWARE_INSTALL}"/ramble checkout 2a020babedd68be15448f3893d2a245fcaa8bd73
 sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/README.md
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/README.md
@@ -1,7 +1,7 @@
 Running System Benchmarks with Ramble
 =====================================
 
-[Ramble](https://github.com/GoogleCloudPlatform/ramble) is an open source
+[Ramble](https://github.com/Ramble-Project/ramble) is an open source
 multi-platform experimentation framework written in python. It can be used
 to easily reproduce benchmark results across systems, and here
 we will use it to run a series of system benchmarks.

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/system_benchmarks/run-nccl-tests-via-ramble.sh
@@ -39,7 +39,7 @@ by adding the following to ${HOME}/.enroot/.credentials:
 
   machine us-docker.pkg.dev login oauth2accesstoken password \$(gcloud auth print-access-token)
 
-And will clone ramble (https://github.com/GoogleCloudPlatform/ramble.git)
+And will clone ramble (https://github.com/Ramble-Project/ramble.git)
 to "${SOFTWARE_INSTALL}"/, and it will create an enroot "sqsh" file located
 in your ${HOME}/.enroot/ folder. Afterwards it will create a ramble workspace
 to run a number of NCCL tests in $(readlink -f "${TEST_DIR}"/).
@@ -84,7 +84,7 @@ EOF
 fi
 
 # Install ramble and make world read/writeable.
-sudo git clone -c feature.manyFiles=true https://github.com/GoogleCloudPlatform/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
+sudo git clone -c feature.manyFiles=true https://github.com/Ramble-Project/ramble.git "${SOFTWARE_INSTALL}"/ramble || true
 sudo git -C "${SOFTWARE_INSTALL}"/ramble checkout 2a020babedd68be15448f3893d2a245fcaa8bd73
 sudo chmod -R a+w "${SOFTWARE_INSTALL}"/ramble
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -258,11 +258,11 @@ Pub/Sub subscription. Primarily used for [FSI - MonteCarlo Tutorial][fsi-monteca
   a startup script to install HTCondor and exports a list of required APIs
 * **[ramble-execute]** ![community-badge] ![experimental-badge] : Creates a
   startup script to execute
-  [Ramble](https://github.com/GoogleCloudPlatform/ramble) commands on a target
+  [Ramble](https://github.com/Ramble-Project/ramble) commands on a target
   VM
 * **[ramble-setup]** ![community-badge] ![experimental-badge] : Creates a
   startup script to install
-  [Ramble](https://github.com/GoogleCloudPlatform/ramble) on an instance or a
+  [Ramble](https://github.com/Ramble-Project/ramble) on an instance or a
   slurm login or controller.
 * **[spack-setup]** ![community-badge] ![experimental-badge] : Creates a startup
   script to install [Spack](https://github.com/spack/spack) on an instance or a


### PR DESCRIPTION
Updates the default Ramble repository cloning URL and all references across modules, benchmarks, examples, and documentation from `https://github.com/GoogleCloudPlatform/ramble` to `https://github.com/Ramble-Project/ramble`.