### PR TITLE
Fix transient webhook timeouts on kueue job submission

### DIFF
--- a/tools/cloud-build/submit_and_monitor_kueue_job.sh
+++ b/tools/cloud-build/submit_and_monitor_kueue_job.sh
@@ -57,7 +57,26 @@ ATTEMPT=1
 
 while true; do
 	echo "=== ATTEMPT $ATTEMPT: Submitting Kueue Job ==="
-	kubectl apply -f /workspace/job.yaml
+
+	SUBMIT_RETRIES=3
+	SUBMIT_ATTEMPT=1
+
+	while true; do
+		echo "Executing job submission (attempt ${SUBMIT_ATTEMPT}/${SUBMIT_RETRIES})..."
+
+		if kubectl apply -f /workspace/job.yaml; then
+			break
+		fi
+
+		if ((SUBMIT_ATTEMPT >= SUBMIT_RETRIES)); then
+			echo "ERROR: Failed to apply job manifest after ${SUBMIT_RETRIES} attempts." >&2
+			exit 1
+		fi
+
+		echo "WARNING: kubectl apply failed. Retrying in 5s..." >&2
+		sleep 5
+		SUBMIT_ATTEMPT=$((SUBMIT_ATTEMPT + 1))
+	done
 
 	set +e
 	(


### PR DESCRIPTION
This PR prevents the Cloud Build pipeline from terminating  immediately during kueue job submission due to `set -e` when the GKE control plane or Kueue mutating webhook (mjob.kb.io) experiences temporary latency.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
