### PR TITLE
fix(gke-cluster): emit confidential_nodes only when enabled

### DIFF
--- a/modules/scheduler/gke-cluster/main.tf
+++ b/modules/scheduler/gke-cluster/main.tf
@@ -402,9 +402,15 @@ resource "google_container_cluster" "gke_cluster" {
     }
   }
 
-  confidential_nodes {
-    enabled                    = var.enable_confidential_nodes
-    confidential_instance_type = var.confidential_instance_type
+  # Emit the block only when enabled. The provider marks confidential_nodes
+  # ForceNew, so sending `enabled = false` to a cluster created without the
+  # block plans a full cluster replacement on every pre-existing cluster.
+  dynamic "confidential_nodes" {
+    for_each = var.enable_confidential_nodes ? [1] : []
+    content {
+      enabled                    = true
+      confidential_instance_type = var.confidential_instance_type
+    }
   }
 
 


### PR DESCRIPTION
The `gke-cluster` module sends `confidential_nodes { enabled = var.enable_confidential_nodes }` unconditionally (since #5859). The google provider marks `confidential_nodes` ForceNew, so for any cluster created before that block existed, the diff `absent → { enabled = false }` plans a **full cluster replacement** — with every node pool replaced behind it — even though nothing changes semantically.

Observed on a 15-pool GKE cluster when moving from a pre-#5859 toolkit to v1.98.0+:

```
# module.a4x-cluster.google_container_cluster.gke_cluster must be replaced
      + confidential_nodes { # forces replacement
          + enabled = false # forces replacement
```

This change wraps the block in `dynamic "confidential_nodes"` so it is only emitted when `enable_confidential_nodes = true`. Clusters that enable confidential nodes are unaffected; clusters that do not no longer see a diff.

**Tested:** `terraform plan` against the live cluster above with this change shows no cluster or node-pool changes; without it, 36 to add / 16 to destroy. `terraform fmt -check` passes.