### PR TITLE
fix(blueprints): disable private IPv6 Google access in GKE TPU blueprints

### DIFF
--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -155,6 +155,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_private_ipv6_google_access: false
       enable_gcsfuse_csi: true # enable GCS Fuse for the cluster
       configure_workload_identity_sa: true
       master_authorized_networks:

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -160,6 +160,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       enable_gcsfuse_csi: true
       master_authorized_networks:

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -154,6 +154,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_private_ipv6_google_access: false
       enable_gcsfuse_csi: true # enable GCS Fuse for the cluster
       configure_workload_identity_sa: true
       master_authorized_networks:

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -159,6 +159,7 @@ deployment_groups:
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       enable_gcsfuse_csi: true
       master_authorized_networks:

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -159,6 +159,7 @@ deployment_groups:
       enable_managed_lustre_csi: true  # enable Managed Lustre for the cluster
       enable_filestore_csi: true # enable Filestore for the cluster
       enable_dataplane_v2: true
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)

--- a/examples/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x.yaml
@@ -121,6 +121,7 @@ deployment_groups:
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
       enable_dataplane_v2: true
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)

--- a/examples/gke-tpu-v4/gke-tpu-v4.yaml
+++ b/examples/gke-tpu-v4/gke-tpu-v4.yaml
@@ -122,6 +122,7 @@ deployment_groups:
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       namespace: $(vars.user_namespace)
       enable_ml_diagnostics: true

--- a/examples/gke-tpu-v5e/gke-tpu-v5e.yaml
+++ b/examples/gke-tpu-v5e/gke-tpu-v5e.yaml
@@ -121,6 +121,7 @@ deployment_groups:
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       namespace: $(vars.user_namespace)
       enable_ml_diagnostics: true

--- a/examples/gke-tpu-v5p/gke-tpu-v5p.yaml
+++ b/examples/gke-tpu-v5p/gke-tpu-v5p.yaml
@@ -122,6 +122,7 @@ deployment_groups:
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_private_endpoint: false # Allows access from authorized public IPs
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       namespace: $(vars.user_namespace)
       enable_ml_diagnostics: true

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -158,6 +158,7 @@ deployment_groups:
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
       enable_dataplane_v2: true
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       enable_ml_diagnostics: true
       namespace: $(vars.user_namespace)

--- a/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -123,6 +123,7 @@ deployment_groups:
       enable_private_endpoint: false # Allows access from authorized public IPs
       enable_pathways_for_tpus: $(vars.enable_pathways_for_tpus)
       enable_dataplane_v2: true
+      enable_private_ipv6_google_access: false
       configure_workload_identity_sa: true
       namespace: $(vars.user_namespace)
       enable_ml_diagnostics: true


### PR DESCRIPTION
## Description
Explicitly set `enable_private_ipv6_google_access: false` on the `modules/scheduler/gke-cluster` module across all GKE TPU blueprints.

### Context & Root Cause
On TPU workloads (such as Pathways, JAX, MaxText, and vLLM), C++ gRPC and standard Linux `getaddrinfo` resolve the internal IPv6 address (`2600:2d00::/32`) assigned to the node VM interface when private IPv6 Google access is enabled. Because IPv4-only subnetworks have no IPv6 default gateway in the kernel routing table, inter-node and runtime connections fail with:
```
Network is unreachable (errno 101)
```

PR #6199 enabled passing `PRIVATE_IPV6_GOOGLE_ACCESS_DISABLED` when `enable_private_ipv6_google_access: false`. Setting this explicitly in the TPU blueprints prevents GCE from assigning internal IPv6 addresses to node interfaces, allowing TPU distributed workloads to bind cleanly to IPv4 out of the box without requiring DaemonSet or host `sysctl` workarounds.

### Changes
Added `enable_private_ipv6_google_access: false` to `gke-cluster` settings in:
- `examples/gke-tpu-v6e/gke-tpu-v6e.yaml`
- `examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml`
- `examples/gke-tpu-v5e/gke-tpu-v5e.yaml`
- `examples/gke-tpu-v5p/gke-tpu-v5p.yaml`
- `examples/gke-tpu-v4/gke-tpu-v4.yaml`
- `examples/gke-tpu-7x/gke-tpu-7x.yaml`
- `examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml`
- `examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml`
- `examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml`
- `examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml`
- `examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml`

Context: https://github.com/GoogleCloudPlatform/cluster-toolkit/pull/6199