### PR TITLE
remove deprecated debian-11 image

### DIFF
--- a/community/examples/gcloud-example.yaml
+++ b/community/examples/gcloud-example.yaml
@@ -40,6 +40,6 @@ deployment_groups:
           --network=$(vars.deployment_name)-net
           --subnet=$(vars.deployment_name)-subnet
           --machine-type=n2d-standard-2
-          --image-family=debian-11
+          --image-family=debian-12
           --image-project=debian-cloud
         delete: "gcloud compute instances delete $(vars.deployment_name)-vm --project=$(vars.project_id) --zone=$(vars.zone) --quiet"

--- a/community/modules/compute/gke-nodeset/versions.tf
+++ b/community/modules/compute/gke-nodeset/versions.tf
@@ -22,6 +22,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-nodeset/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-nodeset/v1.103.0"
   }
 }

--- a/community/modules/compute/gke-partition/versions.tf
+++ b/community/modules/compute/gke-partition/versions.tf
@@ -22,6 +22,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-partition/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-partition/v1.103.0"
   }
 }

--- a/community/modules/compute/htcondor-execute-point/versions.tf
+++ b/community/modules/compute/htcondor-execute-point/versions.tf
@@ -29,6 +29,6 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-execute-point/v1.103.0"
   }
 }

--- a/community/modules/compute/mig/versions.tf
+++ b/community/modules/compute/mig/versions.tf
@@ -22,6 +22,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:mig/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:mig/v1.103.0"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-dynamic/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = ">= 1.12.2"
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-dynamic/v1.103.0"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset-tpu/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.12.2"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset-tpu/v1.103.0"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-nodeset/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-nodeset/v1.103.0"
   }
 }

--- a/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
+++ b/community/modules/compute/schedmd-slurm-gcp-v6-partition/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.12.2"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-partition/v1.103.0"
   }
 }

--- a/community/modules/database/slurm-cloudsql-federation/versions.tf
+++ b/community/modules/database/slurm-cloudsql-federation/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:slurm-cloudsql-federation/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/file-system/nfs-server/versions.tf
+++ b/community/modules/file-system/nfs-server/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:nfs-server/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/files/fsi-montecarlo-on-batch/versions.tf
+++ b/community/modules/files/fsi-montecarlo-on-batch/versions.tf
@@ -35,9 +35,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:fsi-montecarlo-on-batch/v1.103.0"
   }
 }

--- a/community/modules/internal/slurm-gcp/login/versions.tf
+++ b/community/modules/internal/slurm-gcp/login/versions.tf
@@ -24,6 +24,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.103.0"
   }
 }

--- a/community/modules/project/service-enablement/versions.tf
+++ b/community/modules/project/service-enablement/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:service-enablement/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/pubsub/bigquery-sub/versions.tf
+++ b/community/modules/pubsub/bigquery-sub/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:bigquery-sub/v1.103.0"
   }
   required_version = ">= 1.12.2"
 }

--- a/community/modules/pubsub/topic/versions.tf
+++ b/community/modules/pubsub/topic/versions.tf
@@ -27,6 +27,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:topic/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:topic/v1.103.0"
   }
 }

--- a/community/modules/scheduler/htcondor-access-point/versions.tf
+++ b/community/modules/scheduler/htcondor-access-point/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-access-point/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/scheduler/htcondor-central-manager/versions.tf
+++ b/community/modules/scheduler/htcondor-central-manager/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-central-manager/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/scheduler/htcondor-pool-secrets/versions.tf
+++ b/community/modules/scheduler/htcondor-pool-secrets/versions.tf
@@ -26,7 +26,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:htcondor-pool-secrets/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-controller/versions.tf
@@ -28,6 +28,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-controller/v1.103.0"
   }
 }

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/versions.tf
@@ -18,6 +18,6 @@ terraform {
   required_version = ">= 1.12.2"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:schedmd-slurm-gcp-v6-login/v1.103.0"
   }
 }

--- a/community/modules/scripts/wait-for-startup/versions.tf
+++ b/community/modules/scripts/wait-for-startup/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:wait-for-startup/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/community/modules/scripts/windows-startup-script/versions.tf
+++ b/community/modules/scripts/windows-startup-script/versions.tf
@@ -16,7 +16,7 @@
 
 terraform {
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:windows-startup-script/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -5,7 +5,7 @@
   * [Pinning Specific Images](#pinning-specifics-images)
 * [Cluster Toolkit Supported Images](#cluster-toolkit-supported-images)
   * [HPC Rocky Linux 9](#hpc-rocky-linux-9)
-  * [Debian 11](#debian-11)
+  * [Debian 12](#debian-12)
   * [Ubuntu 22.04 LTS](#ubuntu-2204-lts)
   * [Windows](#windows)
   * [Other Images](#other-images)
@@ -71,7 +71,7 @@ blueprint:
         project: cloud-hpc-image-public
 
       instance_image:
-        family: debian-11
+        family: debian-12
         project: debian-cloud
 
       instance_image:

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -158,7 +158,7 @@ deployment_groups:
     use: [gke-a4-net-0, workload_service_account]
     settings:
       auto_monitoring_scope: $(vars.auto_monitoring_scope)
-      system_node_pool_machine_type: "n2d-standard-16"
+      system_node_pool_machine_type: "n2d-standard-8"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -32,10 +32,11 @@ vars:
   # The values of size_gib and per_unit_storage_throughput are co-related
   # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
   # Storage capacity of the lustre instance in GiB
-  size_gib: 36000
+  size_gib: 18000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
   kms_key: ""
+  system_node_pool_machine_type: "n2d-standard-4"
 
 deployment_groups:
 - group: primary
@@ -118,6 +119,7 @@ deployment_groups:
     use: [network, workload_service_account]
     settings:
       version_prefix: $(vars.version_prefix)
+      system_node_pool_machine_type: $(vars.system_node_pool_machine_type)
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       configure_workload_identity_sa: true
       enable_private_endpoint: false  # Allows for access from authorized public IPs
@@ -143,5 +145,5 @@ deployment_groups:
     settings:
       name: gke-lustre-pool
       zones: [$(vars.zone)]
-      machine_type: n2-standard-16
+      machine_type: n2d-standard-4
       auto_upgrade: true

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -27,7 +27,7 @@ vars:
   custom_image:
     family: my-slurm-image
     project: $(vars.project_id)
-  disk_size: 32
+  disk_size: 50
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -438,7 +438,7 @@ deployment_groups:
     settings:
       disk_size_gb: $(vars.disk_size_gb)
       enable_login_public_ips: true
-      machine_type: n2d-standard-16
+      machine_type: n2d-standard-8
       metadata:
         user-data: |
           #cloud-config
@@ -501,7 +501,7 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: $(vars.disk_size_gb)
-      machine_type: n2d-standard-16
+      machine_type: n2d-standard-8
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
       compute_startup_scripts_timeout: 1800

--- a/modules/compute/gke-node-pool/versions.tf
+++ b/modules/compute/gke-node-pool/versions.tf
@@ -30,9 +30,9 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-node-pool/v1.103.0"
   }
 }

--- a/modules/compute/resource-policy/versions.tf
+++ b/modules/compute/resource-policy/versions.tf
@@ -27,7 +27,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:resource-policy/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:resource-policy/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/compute/vm-instance/versions.tf
+++ b/modules/compute/vm-instance/versions.tf
@@ -31,10 +31,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:vm-instance/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/file-system/cloud-storage-bucket/versions.tf
+++ b/modules/file-system/cloud-storage-bucket/versions.tf
@@ -30,10 +30,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:cloud-storage-bucket/v1.103.0"
   }
   required_version = ">= 1.12.2"
 }

--- a/modules/file-system/filestore/versions.tf
+++ b/modules/file-system/filestore/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:filestore/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/file-system/gke-persistent-volume/versions.tf
+++ b/modules/file-system/gke-persistent-volume/versions.tf
@@ -25,6 +25,6 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-persistent-volume/v1.103.0"
   }
 }

--- a/modules/file-system/gke-storage/versions.tf
+++ b/modules/file-system/gke-storage/versions.tf
@@ -16,6 +16,6 @@ terraform {
   required_version = ">= 1.12.2"
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-storage/v1.103.0"
   }
 }

--- a/modules/file-system/managed-lustre/versions.tf
+++ b/modules/file-system/managed-lustre/versions.tf
@@ -26,10 +26,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:managed-lustre/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/file-system/netapp-storage-pool/versions.tf
+++ b/modules/file-system/netapp-storage-pool/versions.tf
@@ -27,10 +27,10 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-storage-pool/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/file-system/netapp-volume/versions.tf
+++ b/modules/file-system/netapp-volume/versions.tf
@@ -22,10 +22,10 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.103.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:netapp-volume/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/management/kubectl-apply/versions.tf
+++ b/modules/management/kubectl-apply/versions.tf
@@ -39,7 +39,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:kubectl-apply/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:kubectl-apply/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/monitoring/dashboard/versions.tf
+++ b/modules/monitoring/dashboard/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:dashboard/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/network/firewall-rules/versions.tf
+++ b/modules/network/firewall-rules/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:firewall-rules/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/network/pre-existing-subnetwork/versions.tf
+++ b/modules/network/pre-existing-subnetwork/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-subnetwork/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/network/pre-existing-vpc/versions.tf
+++ b/modules/network/pre-existing-vpc/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-vpc/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/network/private-service-access/versions.tf
+++ b/modules/network/private-service-access/versions.tf
@@ -22,11 +22,11 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.103.0"
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:private-service-access/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/scheduler/batch-login-node/versions.tf
+++ b/modules/scheduler/batch-login-node/versions.tf
@@ -22,7 +22,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:batch-login-node/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/scheduler/gke-cluster/versions.tf
+++ b/modules/scheduler/gke-cluster/versions.tf
@@ -35,10 +35,10 @@ terraform {
 
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.103.0"
   }
 
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:gke-cluster/v1.103.0"
   }
 }

--- a/modules/scheduler/pre-existing-gke-cluster/versions.tf
+++ b/modules/scheduler/pre-existing-gke-cluster/versions.tf
@@ -23,7 +23,7 @@ terraform {
   }
 
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:pre-existing-gke-cluster/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/modules/scripts/startup-script/versions.tf
+++ b/modules/scripts/startup-script/versions.tf
@@ -30,7 +30,7 @@ terraform {
     }
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.102.0"
+    module_name = "blueprints/terraform/hpc-toolkit:startup-script/v1.103.0"
   }
 
   required_version = ">= 1.12.2"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	maxHintDist          int = 3 // Maximum Levenshtein distance where we suggest a hint
-	latestToolkitVersion     = "v1.102.0"
+	latestToolkitVersion     = "v1.103.0"
 	// SharedModulesDirName is the name of the shared directory for embedded modules
 	SharedModulesDirName = "_modules"
 )

--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -82,18 +82,6 @@ deployment_groups:
         family: ubuntu-2404-lts-arm64
         project: ubuntu-os-cloud
 
-  - id: workstation-debian-11
-    source: modules/compute/vm-instance
-    use:
-    - network1
-    - startup-script
-    settings:
-      name_prefix: deb11
-      add_deployment_name_before_prefix: true
-      instance_image:
-        family: debian-11
-        project: debian-cloud
-
   - id: workstation-debian-12
     source: modules/compute/vm-instance
     use:
@@ -104,6 +92,18 @@ deployment_groups:
       add_deployment_name_before_prefix: true
       instance_image:
         family: debian-12
+        project: debian-cloud
+
+  - id: workstation-debian-13
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - startup-script
+    settings:
+      name_prefix: deb13
+      add_deployment_name_before_prefix: true
+      instance_image:
+        family: debian-13
         project: debian-cloud
 
   - id: workstation-rocky-8
@@ -161,8 +161,8 @@ deployment_groups:
       - $(workstation-ubuntu-2204.name[0])
       - $(workstation-ubuntu-2404.name[0])
       - $(workstation-ubuntu-2404-arm.name[0])
-      - $(workstation-debian-11.name[0])
       - $(workstation-debian-12.name[0])
+      - $(workstation-debian-13.name[0])
       - $(workstation-rocky-8.name[0])
       - $(workstation-rocky-9.name[0])
       - $(workstation-rhel-8.name[0])

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -153,7 +153,7 @@ steps:
               echo '    use: [network1]'                                    >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
-              echo '      zone: us-central1-a'                              >> \$$EXAMPLE_BP
+              echo '      zone: us-east4-a'                              >> \$$EXAMPLE_BP
 
               # Adding node pool with reservation defined
               echo '  - id: compute-pool-reservation'                       >> \$$EXAMPLE_BP
@@ -161,7 +161,7 @@ steps:
               echo '    use: [gke_cluster, node_pool_service_account]'      >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
-              echo '      zones: [us-central1-a]'                           >> \$$EXAMPLE_BP
+              echo '      zones: [us-east4-a]'                           >> \$$EXAMPLE_BP
               echo '      static_node_count: 0'                             >> \$$EXAMPLE_BP
               echo '      is_reservation_active: false'                     >> \$$EXAMPLE_BP
               echo '      reservation_affinity:'                            >> \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -154,7 +154,7 @@ steps:
               echo '    use: [network]'                      >> \$$EXAMPLE_BP
               echo '    settings:'                           >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'       >> \$$EXAMPLE_BP
-              echo '      zone: us-central1-a'               >> \$$EXAMPLE_BP
+              echo '      zone: $(vars.zone)'                 >> \$$EXAMPLE_BP
 
               IP=\$(curl ifconfig.me)
               sed -i "s|.*authorized_cidr:.*|  authorized_cidr: \$$IP/32|" \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -149,7 +149,7 @@ steps:
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
               echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
-              echo '      zone: us-central1-a'               >> \$$SG_EXAMPLE
+              echo '      zone: us-east4-a'               >> \$$SG_EXAMPLE
 
               echo '  - id: ubuntu_pool'                                         >> \$$SG_EXAMPLE
               echo '    source: modules/compute/gke-node-pool'                   >> \$$SG_EXAMPLE

--- a/tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml
@@ -14,8 +14,8 @@
 ---
 test_name: gke-inactive-reservation
 deployment_name: gke-ir-{{ build }}
-region: us-central1
-zone: us-central1-a
+region: us-east4
+zone: us-east4-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-gke.yaml"
 network: "{{ deployment_name }}-net"

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -17,7 +17,7 @@ deployment_name: gke-ml-{{ build }}
 region: us-central1
 zone: us-central1-a
 lustre_instance_id: "{{ deployment_name }}-lstr"
-size_gib: 36000
+size_gib: 18000
 per_unit_storage_throughput: 500
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-managed-lustre.yaml"

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -14,7 +14,7 @@
 ---
 test_name: hpc-gke
 deployment_name: gke-{{ build }}
-zone: us-central1-a  # for remote node
+zone: us-east4-a  # for remote node
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-gke.yaml"
 network: "{{ deployment_name }}-net"
@@ -22,4 +22,6 @@ remote_node: "{{ deployment_name }}-0"
 cli_deployment_vars:
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
+  region: us-east4
+  zone: "{{ zone }}"
 post_deploy_tests: []

--- a/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
@@ -31,7 +31,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
@@ -31,7 +31,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
@@ -25,7 +25,7 @@ vars:
     family: ubuntu-2204-lts
     project: ubuntu-os-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -103,7 +103,7 @@ deployment_groups:
     - homefs
     settings:
       instance_image:
-        family: debian-11
+        family: debian-12
         project: debian-cloud
       name_prefix: workstation-debian
       instance_count: 1

--- a/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
@@ -32,7 +32,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:


### PR DESCRIPTION
This PR removes the deprecated debian-11 image family from ansible-vm blueprint. 

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
