### PR TITLE
fix(build): set CGO_ENABLED=0 in Makefile to produce static gcluster binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 
 gcluster: warn-go-version warn-terraform-version warn-packer-version $(shell find ./cmd ./pkg gcluster.go -type f)
 	$(info **************** building gcluster ************************)
-	@go build -ldflags="-X 'main.gitTagVersion=$(GIT_TAG_VERSION)' -X 'main.gitBranch=$(GIT_BRANCH)' -X 'main.gitCommitInfo=$(GIT_COMMIT_INFO)' -X 'main.gitCommitHash=$(GIT_COMMIT_HASH)' -X 'main.gitInitialHash=$(GIT_INITIAL_HASH)' -X 'main.gitIsOfficial=$(GIT_IS_OFFICIAL)' -X 'main.installationMode=$(INSTALLATION_MODE)'" gcluster.go
+	@CGO_ENABLED=0 go build -ldflags="-X 'main.gitTagVersion=$(GIT_TAG_VERSION)' -X 'main.gitBranch=$(GIT_BRANCH)' -X 'main.gitCommitInfo=$(GIT_COMMIT_INFO)' -X 'main.gitCommitHash=$(GIT_COMMIT_HASH)' -X 'main.gitInitialHash=$(GIT_INITIAL_HASH)' -X 'main.gitIsOfficial=$(GIT_IS_OFFICIAL)' -X 'main.installationMode=$(INSTALLATION_MODE)'" gcluster.go
 	@ln -sf gcluster ghpc
 
 ghpc: gcluster


### PR DESCRIPTION
## Description
The official `gcluster` Linux amd64 release binary (`v1.102.0`) fails on Debian 11 (Bullseye) due to missing GLIBC symbols:
```
/gcluster: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /gcluster)
/gcluster: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /gcluster)
```

### Root Cause
1. In PR #6173 and #6174 (Go 1.26 upgrade), build environments were updated to `golang:1.26-trixie` (Debian 13 Trixie, which has GLIBC 2.40+).
2. When building for `linux/amd64` on a `linux/amd64` builder host, Go defaults to `CGO_ENABLED=1`, dynamically linking `gcluster` against the builder's glibc (Debian Trixie) and embedding requirements for `GLIBC_2.32` and `GLIBC_2.34`. Debian 11 ships with GLIBC 2.31.
3. In contrast, `.github/workflows/os-support-validation.yml` explicitly builds with `CGO_ENABLED=0 go build -o gcluster .`, which is why PR CI passed on `debian:11-slim` while release binaries were dynamically linked.

### Solution
Explicitly set `CGO_ENABLED=0` in the `Makefile` for the `gcluster` target. This ensures that:
- All Linux amd64 binaries built via `make` (including Cloud Build release pipelines and local builds) are fully static ELF executables with zero GLIBC dependencies.
- Binaries run portably on older Linux distributions like Debian 11, CentOS, RHEL, and minimal container environments.

### Testing
- Verified `make gcluster` produces a statically linked ELF executable (`file gcluster`).
- Verified execution of `./gcluster --version` inside a clean `debian:11` container.
- Full test suite passed with `CGO_ENABLED=0 go test ./cmd/... ./pkg/...`.
- Pre-commit hooks passed cleanly.