### PR TITLE
feat(examples): add Slurm hybrid cloud burst blueprints and instructions for GCD

### DIFF
--- a/community/examples/hpc-slurm-google-cloud-dedicated/README.md
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/README.md
@@ -216,3 +216,9 @@ srun -N 2 hostname
 ```shell
 ./gcluster destroy <deployment_name> --auto-approve
 ```
+
+---
+
+## Multi-Cluster & Cloud Bursting
+
+For deploying Multi-Cluster Slurm with Elastic Cloud Bursting across two autonomous GCD projects, see [hybrid-slurm-cluster](./hybrid-slurm-cluster/README.md).

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml
@@ -14,6 +14,27 @@
 
 ---
 blueprint_name: hpc-c3-slurm-google-cloud-dedicated
+
+# These validators query public Google APIs that are unreachable from a GCD private
+# universe (apis-<location>.goog), so gcluster create would fail before generating
+# anything. On commercial GCP you can safely delete this block to restore the
+# pre-flight checks.
+validators:
+- validator: test_project_exists
+  skip: true
+- validator: test_apis_enabled
+  skip: true
+- validator: test_region_exists
+  skip: true
+- validator: test_zone_exists
+  skip: true
+- validator: test_zone_in_region
+  skip: true
+- validator: test_machine_type_in_zone
+  skip: true
+- validator: test_disk_type_in_zone
+  skip: true
+
 vars:
   project_id: # <project-id>
   deployment_name: hpc-slurm
@@ -23,12 +44,12 @@ vars:
   service_account_email: default # <account-id>-compute@developer.gserviceaccount.com
 
   # Image Build Settings
-  source_image_family: rocky-linux-8-optimized-gcp
-  source_image_project: rocky-linux-cloud
+  source_image_family: rocky-linux-9-optimized-gcp
+  source_image_project: rocky-linux-cloud # <partition>-system:rocky-linux-cloud
   image_build_machine_type: c3-standard-4
   build_slurm_from_git_ref: 6.12.3
   built_instance_image:
-    family: slurm-c3-rocky8
+    family: slurm-rocky9
     project: $(vars.project_id)
 
 terraform_providers:
@@ -166,6 +187,9 @@ deployment_groups:
             if ! id "$user" &>/dev/null; then
               UID_HASH=`printf "%s" "$user" | cksum | cut -d' ' -f1`
               USER_UID=`expr 2000 + $UID_HASH % 58000`
+              while getent passwd "$USER_UID" >/dev/null || getent group "$USER_UID" >/dev/null; do
+                USER_UID=`expr $USER_UID + 1`
+              done
               groupadd -g "$USER_UID" "$user" || true
               useradd -u "$USER_UID" -g "$USER_UID" -m -s /bin/bash "$user"
             fi
@@ -200,7 +224,7 @@ deployment_groups:
           # 3. Disable StrictHostKeyChecking safely for internal network jumps only
           if ! grep -q "Host 10.\*" /etc/ssh/ssh_config; then
             if ! grep -q "StrictHostKeyChecking no" /etc/ssh/ssh_config; then
-              echo -e "Host 10.* 172.16.* 192.168.* *.internal *\n    StrictHostKeyChecking no\n    UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+              echo -e "Host 10.* 172.16.* 192.168.* *.internal\n    StrictHostKeyChecking no\n    UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
             fi
           fi
 

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md
@@ -8,7 +8,7 @@ This directory contains the blueprints, playbooks, test scripts, and architectur
 
 The testbed simulates an enterprise customer's on-premises HPC cluster bursting into Google Cloud without requiring physical datacenter hardware. It deploys two independent Slurm clusters across two isolated GCD projects connected via high-performance VPC routing:
 
-* **Primary Cluster (`primary-cluster`)**: Simulates the **On-Premises / Primary Cluster** (persistent head node, static compute nodes, and a standalone NFS server).
+* **Primary Cluster (`primary-cluster`)**: Simulates the **On-Premises / Primary Cluster** (persistent head node, 1 static compute node that autoscales to `N` on demand, and a standalone NFS server).
 * **Burst Cluster (`burst-cluster`)**: Simulates the **Cloud Burst Target** in Google Cloud (lightweight head node, 0 static nodes, and dynamic compute nodes that autoscale from `0 -> N` on demand).
 
 ```text
@@ -24,8 +24,8 @@ The testbed simulates an enterprise customer's on-premises HPC cluster bursting 
                 :                                               |
                 : (mounts NFS)                                  v
                 :                               +---------------------------------+
-                :                               |  Static Compute Nodes           |
-                :                               |  (primary-cluster-compute-0, 1) |
+                :                               |  Compute Nodes (1 static, 0->N) |
+                :                               |  (primary-cluster-compute-0...) |
                 v                               +---------------------------------+
   +-------------------------------------------------------------+
   |  Shared Standalone NFS Storage Instance (10.128.0.2)
@@ -48,7 +48,7 @@ The testbed simulates an enterprise customer's on-premises HPC cluster bursting 
                                                                 v
                                                 +---------------------------------+
                                                 |  Dynamic Compute Nodes (0 -> N) |
-                                                |  (burst-cluster-burst-0, 1, ...) |
+                                                |  (burst-cluster-burst-0...)     |
                                                 +---------------------------------+
 
 ====================================================================================================
@@ -112,16 +112,45 @@ To ensure deterministic, conflict-free routing without requiring manual network 
 > In enterprise GCD environments where networking is managed centrally via Fabric FAST or CFT Shared VPCs, you can deploy into pre-existing networks instead. Simply replace `modules/network/vpc` with `modules/network/pre-existing-vpc` in the blueprints and configure your network and subnetwork names.
 
 ### C. Cross-Project Custom Slurm Image Sharing
-If reusing a pre-baked Slurm Rocky Linux image across projects:
+
+The Burst Cluster in Project B needs access to the Slurm image built by the Primary Cluster in Project A. There are two ways to arrange this.
+
+**Option 1 — Copy the image into Project B.** This is what the blueprint defaults assume:
 
 ```bash
-gcloud compute images copy rocky-linux-8-optimized-gcp-v20240129 \
-  --source-project=<PROJECT_B_ID> \
-  --destination-project=<PROJECT_A_ID> \
-  --destination-image=rocky-linux-8-optimized-gcp-v20240129
+# Resolve the current image name from the family (avoids hardcoding a dated build):
+IMAGE_NAME=$(gcloud compute images describe-from-family slurm-rocky9 \
+  --project=<PROJECT_A_ID> \
+  --format="value(name)")
+
+gcloud compute images create "${IMAGE_NAME}" \
+  --source-image="${IMAGE_NAME}" \
+  --source-image-project=<PROJECT_A_ID> \
+  --family=slurm-rocky9 \
+  --project=<PROJECT_B_ID>
 ```
 
-*(Or reference `source_image_project: <IMAGE_PROJECT>`, `source_image_family: rocky-linux-8-optimized-gcp`).*
+**Option 2 — Read the image in place from Project A.** Point `built_instance_image.project` in `burst-cluster.yaml` at Project A:
+
+```yaml
+vars:
+  built_instance_image:
+    family: slurm-rocky9
+    project: <PROJECT_A_ID>
+```
+
+Then grant Project B's service agent permission to read images from Project A:
+
+```bash
+gcloud projects add-iam-policy-binding <PROJECT_A_ID> \
+  --member="serviceAccount:<PROJECT_B_NUMBER>-compute@developer.gserviceaccount.com" \
+  --role="roles/compute.imageUser"
+```
+
+> [!IMPORTANT]
+> Option 2 requires both halves. Setting `built_instance_image.project` without the `roles/compute.imageUser` grant turns the `404: image not found` error into a `403: permission denied`.
+
+*(Alternatively, skip image sharing entirely and rebuild in Project B from the base OS image by setting `source_image_project` and `source_image_family`. In GCD these are `<partition>-system:rocky-linux-cloud` and `rocky-linux-9-optimized-gcp`; on commercial GCP the project is `rocky-linux-cloud`.)*
 
 ---
 
@@ -133,37 +162,7 @@ gcloud compute images copy rocky-linux-8-optimized-gcp-v20240129 \
 > Primary Cluster **must be deployed first and reach running state** before Burst Cluster is provisioned.
 > Primary Cluster provisions its VPC network (`primary-cluster-net`), the shared NFS server VM (`/home`), generates the master SAuth encryption key (`slurm.key`), and writes its internal IP (`primary_cluster_ctrl_ip`). Burst Cluster requires Primary Cluster's NFS Server IP (`NFS_IP`) to mount `/home` and bootstrap on boot.
 
-### One-Time Setup: Build Custom Slurm OS Image with Packer
-
-In Google Cloud Dedicated (GCD), public SchedMD marketplace images are not available. A custom Slurm VM image (Rocky Linux 8 with Slurm v6) must be built inside the project using the embedded `build-slurm` Packer deployment group in `primary-cluster.yaml`.
-
-> [!NOTE]
-> **This build step is only required ONCE per project/environment.**
->
-> Once the image is baked into family `slurm-c3-rocky8`:
->
-> * It is permanently saved in your project and can be reused indefinitely across Primary Cluster and Burst Cluster.
-> * Standard cluster deployments only need to deploy `--only setup,cluster`, skipping the ~20-minute Packer build.
-> * If you are reusing a pre-baked Slurm image or copied one from another project (see Section 3.C), you can skip this step entirely.
-
-To build the Slurm image:
-
-```bash
-# 1. Create deployment definition for Primary Cluster:
-./gcluster create community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
-
-# 2. Deploy VPC network and build scripts:
-./gcluster deploy primary-cluster --only setup --auto-approve
-
-# 3. Build the custom Slurm OS image with Packer (takes ~20-25 minutes):
-./gcluster deploy primary-cluster --only build-slurm --auto-approve
-```
-
-Once the Packer build completes, the image is registered under family `slurm-c3-rocky8` in your project and is ready for cluster provisioning.
-
----
-
-### Step 1: Deploy Primary Cluster (Project A)
+### Before You Begin: Configure and Create the Deployment
 
 Configure the `vars` block in `community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml` with your project parameters:
 
@@ -178,14 +177,48 @@ vars:
   authorized_ssh_ranges: ["<CLIENT_IP_OR_CIDR>"] # e.g. ["x.x.x.x/32"], or ["0.0.0.0/0"] for open access
 ```
 
-Navigate to your Cluster Toolkit directory:
+From your Cluster Toolkit directory, create the deployment definition:
 
 ```bash
-# 1. Create deployment definition for Primary Cluster:
 ./gcluster create community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
+```
 
-# 2. Deploy Primary Cluster infrastructure (VPC network, NFS, and Slurm nodes):
-#    Since the Slurm image was already built (or copied), deploy only setup and cluster:
+> [!NOTE]
+> Run `gcluster create` **once**. Every step below reuses the same `primary-cluster/` deployment
+> directory; re-running it fails with `deployment folder "primary-cluster" already exists`.
+> If you change `vars` later, re-create with `-w` to overwrite.
+
+---
+
+### One-Time Setup: Build Custom Slurm OS Image with Packer
+
+In Google Cloud Dedicated (GCD), public SchedMD marketplace images are not available. A custom Slurm VM image (Rocky Linux 9 with Slurm v6) must be built inside the project using the embedded `build-slurm` Packer deployment group in `primary-cluster.yaml`.
+
+> [!NOTE]
+> **This build step is only required ONCE per project/environment.**
+>
+> Once the image is baked into family `slurm-rocky9`:
+>
+> * It is permanently saved in your project and can be reused indefinitely across Primary Cluster and Burst Cluster.
+> * Standard cluster deployments only need to deploy `--only setup,cluster`, skipping the ~20-minute Packer build.
+> * If you are reusing a pre-baked Slurm image or copied one from another project (see Section 3.C), you can skip this step entirely.
+
+To build the Slurm image:
+
+```bash
+# Deploy the VPC network and build the custom Slurm OS image (takes ~20-25 minutes):
+./gcluster deploy primary-cluster --only setup,build-slurm --auto-approve
+```
+
+Once the Packer build completes, the image is registered under family `slurm-rocky9` in your project and is ready for cluster provisioning.
+
+---
+
+### Step 1: Deploy Primary Cluster (Project A)
+
+```bash
+# Deploy Primary Cluster infrastructure (VPC network, NFS, and Slurm nodes).
+# The `setup` group is idempotent, so this is safe whether or not you ran the Packer build above.
 ./gcluster deploy primary-cluster --auto-approve --only setup,cluster
 ```
 
@@ -198,7 +231,7 @@ Once Primary Cluster finishes deploying, retrieve the internal IP of the standal
 ```bash
 NFS_IP=$(gcloud compute instances list \
   --project=<PROJECT_A_ID> \
-  --filter="name ~ primary-cluster AND name ~ nfs" \
+  --filter="labels.ghpc_module:nfs-server AND labels.ghpc_deployment:primary-cluster" \
   --format="value(networkInterfaces[0].networkIP)")
 echo "Primary Cluster NFS Server IP: ${NFS_IP}"
 ```
@@ -222,6 +255,11 @@ vars:
   service_account_email: <PROJECT_B_NUMBER>-compute@developer.gserviceaccount.com
   authorized_ssh_ranges: ["<CLIENT_IP_OR_CIDR>"] # e.g. ["x.x.x.x/32"], or ["0.0.0.0/0"] for open access
   nfs_server_ip: <NFS_IP> # Set to Primary Cluster NFS Server IP
+
+  # Reuse the Slurm image built by the Primary Cluster (see Section 3.C).
+  built_instance_image:
+    family: slurm-rocky9
+    project: <PROJECT_B_ID> # Set to <PROJECT_A_ID> to read the image from Project A instead
 ```
 
 Create the deployment files and provision **only** Burst Cluster's VPC network and firewalls (`setup` group):

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md
@@ -1,0 +1,401 @@
+# Multi-Cluster Slurm with Cloud Bursting on Google Cloud Dedicated (GCD)
+
+This directory contains the blueprints, playbooks, test scripts, and architecture for demonstrating **Multi-Cluster Slurm with Elastic Cloud Bursting** between two autonomous projects in **Google Cloud Dedicated (GCD)** environments (e.g., `apis-<location>.goog`).
+
+---
+
+## 1. Experiment Setup & Architecture
+
+The testbed simulates an enterprise customer's on-premises HPC cluster bursting into Google Cloud without requiring physical datacenter hardware. It deploys two independent Slurm clusters across two isolated GCD projects connected via high-performance VPC routing:
+
+* **Primary Cluster (`primary-cluster`)**: Simulates the **On-Premises / Primary Cluster** (persistent head node, static compute nodes, and a standalone NFS server).
+* **Burst Cluster (`burst-cluster`)**: Simulates the **Cloud Burst Target** in Google Cloud (lightweight head node, 0 static nodes, and dynamic compute nodes that autoscale from `0 -> N` on demand).
+
+```text
+====================================================================================================
+                        PRIMARY CLUSTER: Primary / Simulated On-Premises (Project A)
+====================================================================================================
+  [<PROJECT_A_ID>] (VPC: primary-cluster-net, Subnet: 10.128.0.0/20)
+  +---------------------------+                 +---------------------------------+
+  |  Login Node               | --------------> |  Controller Node                |
+  |  (primary-cluster-login)  |                 |  (primary-cluster-controller)   |
+  |  User Submission Endpoint |                 |  slurmctld: 6817 | slurmdbd: 6819
+  +---------------------------+                 +---------------------------------+
+                :                                               |
+                : (mounts NFS)                                  v
+                :                               +---------------------------------+
+                :                               |  Static Compute Nodes           |
+                :                               |  (primary-cluster-compute-0, 1) |
+                v                               +---------------------------------+
+  +-------------------------------------------------------------+
+  |  Shared Standalone NFS Storage Instance (10.128.0.2)
+  |  Exports: /exports/home -> /home  &  /exports/opt/apps -> /opt/apps
+  +-------------------------------------------------------------+
+                ^
+                | (Cross-Project VPC Peering: peer-b-to-a <---> peer-a-to-b)
+================:===================================================================================
+                :
+                :       BURST CLUSTER: Elastic Cloud Burst Target (Project B)
+================:===================================================================================
+  [<PROJECT_B_ID>] (VPC: burst-cluster-net, Subnet: 10.130.0.0/20)
+  +---------------------------+                 +---------------------------------+
+  |  Login Node               | --------------> |  Controller Node                |
+  |  (burst-cluster-login)    |                 |  (burst-cluster-controller)     |
+  +---------------------------+                 |  slurmctld: 6817                |
+                                                +---------------------------------+
+                                                                |
+                                                                | (Dynamic bulkInsert on demand)
+                                                                v
+                                                +---------------------------------+
+                                                |  Dynamic Compute Nodes (0 -> N) |
+                                                |  (burst-cluster-burst-0, 1, ...) |
+                                                +---------------------------------+
+
+====================================================================================================
+                              CROSS-CLUSTER CONTROL & DATA LINK
+====================================================================================================
+  1. Mutual SAuth Trust  : Master /etc/slurm/slurm.key synchronized automatically via shared /home
+  2. SlurmDBD Routing    : Bidirectional TCP 6819 via AccountingStorageExternalHost on both controllers
+  3. Shared Home State   : Both clusters mount Primary Cluster's NFS for unified POSIX directories & logs
+  4. Remote Dispatch     : Jobs submitted on Primary Cluster via 'sbatch -M burst --wrap="hostname"'
+====================================================================================================
+```
+
+---
+
+## 2. Key Differences from Commercial Google Cloud (GCP)
+
+Deploying Multi-Cluster Slurm on **Google Cloud Dedicated (GCD)** partitions requires specific architectural adaptations compared to standard commercial GCP:
+
+| Feature / Consideration | Google Cloud Dedicated (GCD) | Standard Commercial GCP |
+| :--- | :--- | :--- |
+| **API Domain** | Private universe domain (e.g. `apis-<location>.goog`) | Standard public `googleapis.com` |
+| **Authentication** | Workforce Identity Federation (WIF) & `wif-login-config.json` | Standard GCP IAM / User / Service Account |
+| **Shared Storage Fabric** | **Standalone NFS VM** (Hyperdisk Balanced) | **Google Cloud Filestore** (`BASIC_SSD`, 2.5TB min) |
+| **Slurm OS Images** | Custom Rocky Linux images copied / built via Packer | Public SchedMD family (`schedmd-slurm-public`) |
+| **Machine Config Metadata**| Requires offline `GHPC_MOCK_MACHINE_CONFIG` export | Directly resolved via GCP Compute API |
+| **Compute Batch API** | Handled natively via `ThreadPoolExecutor` (PR #6144) | Standard `new_batch_http_request()` works natively |
+| **User Identity** | Local `/home` keygen & non-OSLogin SSH synchronization | Google Cloud OS Login integration |
+
+---
+
+## 3. Prerequisites & Network Setup
+
+Before deploying the clusters, complete the following environment and network setup:
+
+### A. Environment & Workforce Identity Federation (WIF)
+GCD uses private universe domains (e.g., `apis-<location>.goog`). Set up your shell environment:
+
+```bash
+# Activate your gcloud configuration for GCD
+gcloud config configurations activate <YOUR_GCD_CONFIG>
+gcloud auth login --login-config=wif-login-config.json
+gcloud auth application-default login --login-config=wif-login-config.json
+
+# Export required environment variables
+export GOOGLE_CLOUD_UNIVERSE_DOMAIN="apis-<location>.goog"
+export CLOUDSDK_UNIVERSE_DOMAIN="apis-<location>.goog"
+
+# Mock machine specs for Cluster Toolkit offline expansion in GCD:
+export GHPC_MOCK_MACHINE_CONFIG='{"cpus": {"c3-standard-176": {"count": 176, "memoryMb": 720896}, "c3-standard-4": {"count": 4, "memoryMb": 16384}}, "gpus": {}, "tpus": {}}'
+```
+
+### B. Network Fabric & Overlapping Subnet Resolution
+In Google Cloud Dedicated (GCD), projects do not have auto-created default networks by design. Furthermore, cross-project VPC Peering requires non-overlapping subnet CIDRs.
+
+To ensure deterministic, conflict-free routing without requiring manual network creation commands, the Cluster Toolkit blueprints automate network provisioning via the embedded `modules/network/vpc` module:
+* **Primary Cluster (`primary-cluster.yaml`)**: Provisions `primary-cluster-net` with subnet `10.128.0.0/20` and firewall rules permitting internal cross-cluster traffic.
+* **Burst Cluster (`burst-cluster.yaml`)**: Provisions `burst-cluster-net` in a dedicated `setup` deployment group with non-overlapping subnet `10.130.0.0/20` and peering firewall rules.
+
+> [!NOTE]
+> **Pre-existing VPC Networks in Enterprise GCD Landing Zones**:
+> In enterprise GCD environments where networking is managed centrally via Fabric FAST or CFT Shared VPCs, you can deploy into pre-existing networks instead. Simply replace `modules/network/vpc` with `modules/network/pre-existing-vpc` in the blueprints and configure your network and subnetwork names.
+
+### C. Cross-Project Custom Slurm Image Sharing
+If reusing a pre-baked Slurm Rocky Linux image across projects:
+
+```bash
+gcloud compute images copy rocky-linux-8-optimized-gcp-v20240129 \
+  --source-project=<PROJECT_B_ID> \
+  --destination-project=<PROJECT_A_ID> \
+  --destination-image=rocky-linux-8-optimized-gcp-v20240129
+```
+
+*(Or reference `source_image_project: <IMAGE_PROJECT>`, `source_image_family: rocky-linux-8-optimized-gcp`).*
+
+---
+
+## 4. Deployment & Execution Step-by-Step
+
+> [!IMPORTANT]
+> **Strict Deployment Order (Primary Cluster before Burst Cluster)**:
+>
+> Primary Cluster **must be deployed first and reach running state** before Burst Cluster is provisioned.
+> Primary Cluster provisions its VPC network (`primary-cluster-net`), the shared NFS server VM (`/home`), generates the master SAuth encryption key (`slurm.key`), and writes its internal IP (`primary_cluster_ctrl_ip`). Burst Cluster requires Primary Cluster's NFS Server IP (`NFS_IP`) to mount `/home` and bootstrap on boot.
+
+### One-Time Setup: Build Custom Slurm OS Image with Packer
+
+In Google Cloud Dedicated (GCD), public SchedMD marketplace images are not available. A custom Slurm VM image (Rocky Linux 8 with Slurm v6) must be built inside the project using the embedded `build-slurm` Packer deployment group in `primary-cluster.yaml`.
+
+> [!NOTE]
+> **This build step is only required ONCE per project/environment.**
+>
+> Once the image is baked into family `slurm-c3-rocky8`:
+>
+> * It is permanently saved in your project and can be reused indefinitely across Primary Cluster and Burst Cluster.
+> * Standard cluster deployments only need to deploy `--only setup,cluster`, skipping the ~20-minute Packer build.
+> * If you are reusing a pre-baked Slurm image or copied one from another project (see Section 3.C), you can skip this step entirely.
+
+To build the Slurm image:
+
+```bash
+# 1. Create deployment definition for Primary Cluster:
+./gcluster create community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
+
+# 2. Deploy VPC network and build scripts:
+./gcluster deploy primary-cluster --only setup --auto-approve
+
+# 3. Build the custom Slurm OS image with Packer (takes ~20-25 minutes):
+./gcluster deploy primary-cluster --only build-slurm --auto-approve
+```
+
+Once the Packer build completes, the image is registered under family `slurm-c3-rocky8` in your project and is ready for cluster provisioning.
+
+---
+
+### Step 1: Deploy Primary Cluster (Project A)
+
+Configure the `vars` block in `community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml` with your project parameters:
+
+```yaml
+vars:
+  project_id: <PROJECT_A_ID>
+  deployment_name: primary-cluster
+  region: <REGION>
+  zone: <ZONE>
+  universe_domain: apis-<location>.goog
+  service_account_email: <PROJECT_A_NUMBER>-compute@developer.gserviceaccount.com
+  authorized_ssh_ranges: ["<CLIENT_IP_OR_CIDR>"] # e.g. ["x.x.x.x/32"], or ["0.0.0.0/0"] for open access
+```
+
+Navigate to your Cluster Toolkit directory:
+
+```bash
+# 1. Create deployment definition for Primary Cluster:
+./gcluster create community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
+
+# 2. Deploy Primary Cluster infrastructure (VPC network, NFS, and Slurm nodes):
+#    Since the Slurm image was already built (or copied), deploy only setup and cluster:
+./gcluster deploy primary-cluster --auto-approve --only setup,cluster
+```
+
+---
+
+### Step 2: Extract Primary Cluster NFS Server IP
+
+Once Primary Cluster finishes deploying, retrieve the internal IP of the standalone NFS Server VM:
+
+```bash
+NFS_IP=$(gcloud compute instances list \
+  --project=<PROJECT_A_ID> \
+  --filter="name ~ primary-cluster AND name ~ nfs" \
+  --format="value(networkInterfaces[0].networkIP)")
+echo "Primary Cluster NFS Server IP: ${NFS_IP}"
+```
+
+> [!NOTE]
+> Unlike commercial GCP (where Primary Cluster's Controller VM acts as the NFS bridge), GCD provisions a dedicated, standalone NFS server instance (`NFS_IP`). Primary Cluster's Controller IP does not need to be manually configured because Primary Cluster automatically writes its internal IP to `/home/.primary_cluster_ctrl_ip`, which Burst Cluster's controller discovers dynamically on boot after mounting `/home`.
+
+---
+
+### Step 3: Deploy Burst Cluster Network (Project B)
+
+Configure the `vars` block in `community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml` with your project parameters and the `NFS_IP` from Step 2:
+
+```yaml
+vars:
+  project_id: <PROJECT_B_ID>
+  deployment_name: burst-cluster
+  region: <REGION>
+  zone: <ZONE>
+  universe_domain: apis-<location>.goog
+  service_account_email: <PROJECT_B_NUMBER>-compute@developer.gserviceaccount.com
+  authorized_ssh_ranges: ["<CLIENT_IP_OR_CIDR>"] # e.g. ["x.x.x.x/32"], or ["0.0.0.0/0"] for open access
+  nfs_server_ip: <NFS_IP> # Set to Primary Cluster NFS Server IP
+```
+
+Create the deployment files and provision **only** Burst Cluster's VPC network and firewalls (`setup` group):
+
+```bash
+# 1. Create deployment definition for Burst Cluster:
+./gcluster create community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml
+
+# 2. Deploy ONLY Burst Cluster's VPC network and firewalls:
+./gcluster deploy burst-cluster --only setup --auto-approve
+```
+
+---
+
+### Step 4: Establish Bidirectional VPC Peering
+
+Now that both VPC networks exist (`primary-cluster-net` in Project A and `burst-cluster-net` in Project B), establish bidirectional VPC Network Peering:
+
+> [!IMPORTANT]
+> **Bidirectional VPC Peering is Strictly Required**:
+>
+> Even if jobs are only dispatched in one direction (Primary Cluster $\rightarrow$ Burst Cluster), VPC Peering **must be established in both directions** (`peer-b-to-a` and `peer-a-to-b`). Burst Cluster requires network routing back to Primary Cluster to mount NFS `/home`, read the master SAuth key, and exchange SlurmDBD accounting RPCs.
+
+```bash
+# 1. From Project B -> Project A:
+gcloud compute networks peerings create peer-b-to-a \
+  --network=burst-cluster-net \
+  --peer-project=<PROJECT_A_ID> \
+  --peer-network=primary-cluster-net \
+  --project=<PROJECT_B_ID>
+
+# 2. From Project A -> Project B:
+gcloud compute networks peerings create peer-a-to-b \
+  --network=primary-cluster-net \
+  --peer-project=<PROJECT_B_ID> \
+  --peer-network=burst-cluster-net \
+  --project=<PROJECT_A_ID>
+```
+
+---
+
+### Step 5: Deploy Burst Cluster Slurm Compute Nodes
+
+Once peering is active, deploy Burst Cluster's Slurm cluster (`cluster` group). The Slurm nodes boot, reach Primary Cluster's NFS storage over the peering tunnel, and join the multi-cluster environment:
+
+```bash
+# Deploy Burst Cluster Slurm compute nodes and controller:
+./gcluster deploy burst-cluster --only cluster --auto-approve
+```
+
+---
+
+### Step 6: Verify SlurmDBD Auto-Registration on Primary Cluster
+
+In order to submit jobs from Primary Cluster to Burst Cluster, **no explicit manual steps or cross-registration commands are required**. All SlurmDBD registration and inter-cluster cryptographic trust are handled automatically by the cluster blueprints:
+
+* Primary Cluster exports its master `slurm.key` and controller IP to the shared NFS home directory.
+* When Burst Cluster boots, its startup script mounts the shared NFS, imports the matching `slurm.key`, and points to Primary Cluster's SlurmDBD.
+* Burst Cluster's controller automatically registers itself into Primary Cluster's SlurmDBD during its initialization.
+
+After both clusters finish Slurm initialization (typically 3–5 minutes after deployment), Primary Cluster will see both clusters without any manual intervention.
+
+#### Check Registered Clusters on Primary Cluster Login Node
+
+SSH to `primary-cluster-slurm-login-001` (or your active Primary Cluster login node):
+
+```bash
+gcloud compute ssh primary-cluster-slurm-login-001 --zone=<ZONE> --project=<PROJECT_A_ID>
+
+sudo /usr/local/bin/sacctmgr list clusters
+```
+
+*Expected Output:*
+
+```text
+   Cluster     ControlHost  ControlPort   RPC     Share GrpJobs       GrpTRES GrpSubmit MaxJobs       MaxTRES MaxSubmit     MaxWall                  QOS   Def QOS
+---------- --------------- ------------ ----- --------- ------- ------------- --------- ------- ------------- --------- ----------- -------------------- ---------
+primary         10.128.0.x         6818 11264         1                                                                                           normal
+burst           10.130.0.x         6818 11264
+```
+
+Both clusters are immediately registered with their internal `ControlHost` IPs, control ports (`6818`), and active RPC versions (`11264`), ready for cross-cluster job dispatch.
+
+---
+
+### Step 7: Execute and Monitor Cross-Cluster Bursting Jobs
+
+#### 1. Local Smoke Test on Burst Cluster Login Node
+
+SSH to `burst-cluster-slurm-login-001` to verify partition availability and local provisioning:
+
+```bash
+gcloud compute ssh burst-cluster-slurm-login-001 --zone=<ZONE> --project=<PROJECT_B_ID>
+```
+
+Inside the session, run:
+
+```bash
+sinfo
+srun -N1 hostname
+```
+
+#### 2. Remote Job Dispatch from Primary Cluster Login Node
+
+SSH to `primary-cluster-slurm-login-001`:
+
+```bash
+gcloud compute ssh primary-cluster-slurm-login-001 --zone=<ZONE> --project=<PROJECT_A_ID>
+```
+
+##### a. Check Local and Remote Cluster Status
+
+```bash
+# Check local cluster partition:
+sinfo
+
+# Check remote burst cluster partition:
+sinfo -M burst
+```
+
+##### b. Submit Remote Job to Dynamically Burst Nodes on Burst Cluster
+
+```bash
+sbatch -M burst --wrap="hostname"
+```
+
+##### c. Monitor Remote Job and Node Lifecycle
+
+```bash
+squeue -M burst
+```
+
+*Job Lifecycle & Node Provisioning Progression:*
+1. **`CF` (Configuring)**: Slurm executes `resume.py`, issuing asynchronous GCE Compute API requests in Project B to dynamically power on `burst-cluster-burst_b_nodeset-[0-1]`.
+2. **`R` (Running)**: Compute nodes boot, mount Primary Cluster's shared `/home` over the VPC, execute the job, and write outputs directly to `/home/$USER/slurm-<JOB_ID>.out`.
+3. **`CG` (Completing)**: Job finishes and nodes return to `idle`.
+4. **`idle~` (Power Down)**: After `SuspendTimeout` (default 600s), `suspend.py` issues API deletion calls to delete the VMs, returning idle compute cost to $0.
+
+##### d. Direct Interactive Remote Execution
+
+```bash
+srun -M burst -N1 hostname
+```
+
+#### 3. Verify Output & Cross-Project Parity
+
+```bash
+cat ~/slurm-*.out
+```
+
+*Expected Output:*
+
+```text
+burst-cluster-burst_b_nodeset-0
+```
+
+---
+
+## 5. Key Architectural Details & Platform Adaptations
+
+The blueprints (`primary-cluster.yaml` and `burst-cluster.yaml`) are specifically architected for Google Cloud Dedicated (GCD) sovereign environments:
+
+### A. GCD-Specific Platform Adaptations
+1. **`BatchHttpRequest` Private Universe Domain Handling (`/slurm/scripts/util.py`)**:
+   * In GCD private universe domains (e.g., `apis-<location>.goog`), standard Google API batch execution (`BatchHttpRequest`) is unsupported.
+   * Turnkey support for private universe domains using `ThreadPoolExecutor` is natively built into Cluster Toolkit's Slurm v6 controller scripts (merged in PR #6144), eliminating the need for runtime script patching.
+
+2. **Deterministic POSIX UID Hashing & Non-OSLogin SSH Synchronization**:
+   * In GCD environments where OS Login is disabled (`enable_oslogin: false`), sequential `useradd` creates UID/GID drift across clusters.
+   * The startup scripts automatically hash usernames to deterministic numeric UIDs (`USER_UID=$((2000 + UID_HASH % 58000))`) and use `flock` on shared NFS `/home` to safely generate shared SSH keypairs without race conditions.
+
+3. **Standalone NFS Server Architecture**:
+   * Instead of managed services like Google Cloud Filestore, Primary Cluster provisions a dedicated standalone NFS Server VM (`modules/file-system/nfs-server`) backed by Hyperdisk Balanced to serve `/home` across both clusters over VPC peering.
+
+### B. Cross-Cluster SAuth & Bursting Mechanism
+* **Synchronous SAuth Key Propagation**:
+  * Eliminates cross-project race conditions by exporting `slurm.key` from Primary Cluster directly to `/home/.shared_slurm.key` and having Burst Cluster import it synchronously on controller/login boot.

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml
@@ -15,6 +15,10 @@
 ---
 blueprint_name: burst-cluster
 
+# These validators query public Google APIs that are unreachable from a GCD private
+# universe (apis-<location>.goog), so gcluster create would fail before generating
+# anything. On commercial GCP you can safely delete this block to restore the
+# pre-flight checks.
 validators:
 - validator: test_project_exists
   skip: true
@@ -36,17 +40,20 @@ vars:
   deployment_name: burst-cluster
   region: us-central1
   zone: us-central1-a
-  universe_domain: # e.g., apis-<location>.goog or custom universe domain
+  universe_domain: googleapis.com # apis-<location>.goog
   service_account_email: # <account-id>-compute@developer.gserviceaccount.com
   # To enable SSH access to the login node, add your client CIDR e.g. ["x.x.x.x/32"] or ["0.0.0.0/0"]
   authorized_ssh_ranges: []
   nfs_server_ip: # <IP_OF_PRIMARY_CLUSTER_NFS_SERVER> e.g., 10.128.0.X or internal DNS name
   primary_controller_ip: "" # (Optional) <IP_OF_PRIMARY_CLUSTER_CONTROLLER> e.g., 10.128.0.3
 
-  # Instance & Image Settings (Reusing built image from Primary Cluster)
+  # Instance & Image Settings (Slurm image built by the Primary Cluster blueprint)
   image_build_machine_type: c3-standard-4
   built_instance_image:
-    family: slurm-c3-rocky8
+    family: slurm-rocky9
+    # Defaults to this project, i.e. the image was copied into Project B (README section 3.C).
+    # To read the image directly from Project A instead, set this to <PROJECT_A_ID> and grant
+    # Project B's service agent roles/compute.imageUser on Project A.
     project: $(vars.project_id)
 
 terraform_providers:
@@ -217,6 +224,13 @@ deployment_groups:
               if [ -s /etc/slurm/slurm.conf ] && ! grep -q "AccountingStorageExternalHost" /etc/slurm/slurm.conf; then
                 echo "AccountingStorageExternalHost=$PRIMARY_CTRL_IP:6819" >> /etc/slurm/slurm.conf
                 scontrol reconfigure 2>/dev/null || true
+                # Registration with an external slurmdbd is established at daemon init, so a
+                # reconfigure may not be enough. Restart only when slurmctld is already running:
+                # an unconditional restart would also start it before slurm-gcp setup finishes.
+                # If it is not running yet, it reads the line above when it starts.
+                if systemctl is-active --quiet slurmctld; then
+                  systemctl restart slurmctld 2>/dev/null || true
+                fi
               fi
             fi
           fi
@@ -258,7 +272,7 @@ deployment_groups:
       # placement_max_distance: 2
       instance_image:
         family: $(vars.built_instance_image.family)
-        project: $(vars.project_id)
+        project: $(vars.built_instance_image.project)
       instance_image_custom: true
       service_account_email: $(vars.service_account_email)
       service_account_scopes: &id001
@@ -282,7 +296,7 @@ deployment_groups:
       enable_login_public_ips: true
       instance_image:
         family: $(vars.built_instance_image.family)
-        project: $(vars.project_id)
+        project: $(vars.built_instance_image.project)
       instance_image_custom: true
       service_account_email: $(vars.service_account_email)
       service_account_scopes: *id001
@@ -302,7 +316,7 @@ deployment_groups:
       enable_controller_public_ips: false
       instance_image:
         family: $(vars.built_instance_image.family)
-        project: $(vars.project_id)
+        project: $(vars.built_instance_image.project)
       instance_image_custom: true
       service_account_email: $(vars.service_account_email)
       service_account_scopes: *id001

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml
@@ -1,0 +1,311 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: burst-cluster
+
+validators:
+- validator: test_project_exists
+  skip: true
+- validator: test_apis_enabled
+  skip: true
+- validator: test_region_exists
+  skip: true
+- validator: test_zone_exists
+  skip: true
+- validator: test_zone_in_region
+  skip: true
+- validator: test_machine_type_in_zone
+  skip: true
+- validator: test_disk_type_in_zone
+  skip: true
+
+vars:
+  project_id: # <project-id> e.g., my-gcd-project
+  deployment_name: burst-cluster
+  region: us-central1
+  zone: us-central1-a
+  universe_domain: # e.g., apis-<location>.goog or custom universe domain
+  service_account_email: # <account-id>-compute@developer.gserviceaccount.com
+  # To enable SSH access to the login node, add your client CIDR e.g. ["x.x.x.x/32"] or ["0.0.0.0/0"]
+  authorized_ssh_ranges: []
+  nfs_server_ip: # <IP_OF_PRIMARY_CLUSTER_NFS_SERVER> e.g., 10.128.0.X or internal DNS name
+  primary_controller_ip: "" # (Optional) <IP_OF_PRIMARY_CLUSTER_CONTROLLER> e.g., 10.128.0.3
+
+  # Instance & Image Settings (Reusing built image from Primary Cluster)
+  image_build_machine_type: c3-standard-4
+  built_instance_image:
+    family: slurm-c3-rocky8
+    project: $(vars.project_id)
+
+terraform_providers:
+  google:
+    source: hashicorp/google
+    version: '>= 5.45.0'
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      universe_domain: $(vars.universe_domain)
+  google-beta:
+    source: hashicorp/google-beta
+    version: '>= 5.45.0'
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      universe_domain: $(vars.universe_domain)
+
+deployment_groups:
+- group: setup
+  modules:
+  - id: network
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.deployment_name)-net
+      allowed_ssh_ip_ranges: $(vars.authorized_ssh_ranges)
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-subnet
+        subnet_region: $(vars.region)
+        subnet_ip: "10.130.0.0/20"
+      firewall_rules:
+      - name: $(vars.deployment_name)-allow-peering
+        ranges: ["10.128.0.0/20", "10.130.0.0/20"]
+        allow:
+        - protocol: tcp
+          ports: ["0-65535"]
+        - protocol: udp
+          ports: ["0-65535"]
+        - protocol: icmp
+
+- group: cluster
+  modules:
+  # Mount Primary Cluster's Shared NFS Server for /home
+  - id: homefs
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      server_ip: $(vars.nfs_server_ip)
+      remote_mount: /exports/home
+      local_mount: /home
+      fs_type: nfs
+
+  # Mount Primary Cluster's Shared NFS Server for /opt/apps
+  - id: appsfs
+    source: modules/file-system/pre-existing-network-storage
+    settings:
+      server_ip: $(vars.nfs_server_ip)
+      remote_mount: /exports/opt/apps
+      local_mount: /opt/apps
+      fs_type: nfs
+
+  - id: ssh_config
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: false
+      runners:
+      - type: shell
+        destination: setup_non_oslogin_ssh.sh
+        content: |
+          #!/bin/bash
+          # 1. SELinux & Crypto Policy for Rocky Linux 8/9
+          setsebool -P use_nfs_home_dirs 1 || true
+          update-crypto-policies --set DEFAULT:SHA1 || true
+
+          # 2. Populate metadata keys and secure inter-node keypair on NFS /home
+          METADATA="http://metadata.google.internal/computeMetadata/v1"
+          PROJ_KEYS=`curl -s -f -H "Metadata-Flavor: Google" "$METADATA/project/attributes/ssh-keys" 2>/dev/null || true`
+          INST_KEYS=`curl -s -f -H "Metadata-Flavor: Google" "$METADATA/instance/attributes/ssh-keys" 2>/dev/null || true`
+          KEYS=`printf "%s\n%s\n" "$PROJ_KEYS" "$INST_KEYS" | grep -v '^[[:space:]]*$' | sort -u`
+
+          for user in `echo "$KEYS" | cut -d: -f1 | sort -u`; do
+            [ -z "$user" ] && continue
+
+            # Create group and user with deterministic UID/GID to ensure consistency across the cluster
+            if ! id "$user" &>/dev/null; then
+              UID_HASH=`printf "%s" "$user" | cksum | cut -d' ' -f1`
+              USER_UID=`expr 2000 + $UID_HASH % 58000`
+              while getent passwd "$USER_UID" >/dev/null || getent group "$USER_UID" >/dev/null; do
+                USER_UID=`expr $USER_UID + 1`
+              done
+              groupadd -g "$USER_UID" "$user" || true
+              useradd -u "$USER_UID" -g "$USER_UID" -m -s /bin/bash "$user"
+            fi
+            mkdir -p "/home/$user/.ssh"
+            chown "$user:$user" "/home/$user"
+            chmod 700 "/home/$user/.ssh"
+
+            # Safely serialize key generation & authorized_keys rebuilding across the cluster
+            (
+              flock 9
+
+              # Generate ED25519 cluster key natively
+              if [ ! -f "/home/$user/.ssh/id_ed25519" ]; then
+                ssh-keygen -t ed25519 -N "" -f "/home/$user/.ssh/id_ed25519"
+              fi
+
+              # Rebuild authorized_keys atomically on the exact same NFS filesystem (prevents O_TRUNC zeroing)
+              TMP_KEYS=`mktemp "/home/$user/.ssh/authorized_keys.XXXXXX"`
+              if [ -n "$TMP_KEYS" ] && [ -f "$TMP_KEYS" ]; then
+                echo "$KEYS" | grep "^$user:" | cut -d: -f2- > "$TMP_KEYS"
+                [ -f "/home/$user/.ssh/id_ed25519.pub" ] && cat "/home/$user/.ssh/id_ed25519.pub" >> "$TMP_KEYS"
+                mv -f "$TMP_KEYS" "/home/$user/.ssh/authorized_keys"
+              fi
+
+            ) 9>"/home/$user/.ssh/keygen.lock"
+
+            # Secure remaining permissions to the user
+            chown -R "$user:$user" "/home/$user/.ssh"
+            chmod 600 "/home/$user/.ssh/"*
+          done
+
+          # 3. Disable StrictHostKeyChecking safely for internal network jumps only
+          if ! grep -q "Host 10.\*" /etc/ssh/ssh_config; then
+            if ! grep -q "StrictHostKeyChecking no" /etc/ssh/ssh_config; then
+              echo -e "Host 10.* 172.16.* 192.168.* *.internal\n    StrictHostKeyChecking no\n    UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+            fi
+          fi
+
+          # 4. Restart sshd and silence ops-agent in GCD
+          systemctl restart sshd
+          systemctl stop google-cloud-ops-agent 2>/dev/null || true
+          systemctl disable google-cloud-ops-agent 2>/dev/null || true
+
+          # 5. On Burst Cluster Controller: Synchronously import Primary Cluster's master key and configure accounting host
+          if hostname | grep -q controller; then
+            KEY_SRC=""
+            for i in `seq 1 60`; do
+              for f in /home/.shared_slurm.key /home/shared_slurm.key; do
+                [ -s "$f" ] && KEY_SRC="$f" && break 2
+              done
+              sleep 1
+            done
+            if [ -n "$KEY_SRC" ]; then
+              mkdir -p /etc/slurm /var/spool/slurm /slurm/key_distribution
+              cp -f "$KEY_SRC" /etc/slurm/slurm.key
+              cp -f "$KEY_SRC" /var/spool/slurm/slurm.key
+              cp -f "$KEY_SRC" /slurm/key_distribution/slurm.key
+              chown -R slurm:slurm /etc/slurm/slurm.key /var/spool/slurm/slurm.key /slurm/key_distribution/slurm.key
+              chmod 400 /etc/slurm/slurm.key /var/spool/slurm/slurm.key /slurm/key_distribution/slurm.key
+            fi
+
+            PRIMARY_CTRL_IP="$(vars.primary_controller_ip)"
+            if [ -z "$PRIMARY_CTRL_IP" ]; then
+              for i in `seq 1 60`; do
+                for f in /home/.primary_cluster_ctrl_ip /home/primary_cluster_ctrl_ip; do
+                  [ -s "$f" ] && PRIMARY_CTRL_IP=`cat "$f" 2>/dev/null | tr -d '[:space:]'` && break 2
+                done
+                sleep 1
+              done
+            fi
+
+            if [ -n "$PRIMARY_CTRL_IP" ]; then
+              for i in `seq 1 60`; do
+                [ -s /etc/slurm/slurm.conf ] && break
+                sleep 1
+              done
+              if [ -s /etc/slurm/slurm.conf ] && ! grep -q "AccountingStorageExternalHost" /etc/slurm/slurm.conf; then
+                echo "AccountingStorageExternalHost=$PRIMARY_CTRL_IP:6819" >> /etc/slurm/slurm.conf
+                scontrol reconfigure 2>/dev/null || true
+              fi
+            fi
+          fi
+
+          # 6. On Burst Cluster Login: Import Primary Cluster master key and configure slurm config link
+          if hostname | grep -q login; then
+            mkdir -p /etc/slurm /usr/local/etc
+            ln -sfn /etc/slurm /usr/local/etc/slurm
+            KEY_SRC=""
+            for i in `seq 1 60`; do
+              for f in /home/.shared_slurm.key /home/shared_slurm.key; do
+                [ -s "$f" ] && KEY_SRC="$f" && break 2
+              done
+              sleep 1
+            done
+            if [ -n "$KEY_SRC" ]; then
+              cp -f "$KEY_SRC" /etc/slurm/slurm.key
+              chown slurm:slurm /etc/slurm/slurm.key 2>/dev/null || true
+              chmod 400 /etc/slurm/slurm.key
+            else
+              echo "WARNING: Primary Cluster slurm.key not found on /home within 60s" >&2
+            fi
+          fi
+
+  # Dynamic Elastic Bursting Nodeset (c3-standard-176)
+  - id: burst_b_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network, ssh_config]
+    settings:
+      node_count_static: 0
+      node_count_dynamic_max: 16  # Elastic autoscaling nodes
+      machine_type: c3-standard-176
+      disk_type: hyperdisk-balanced
+      bandwidth_tier: gvnic_enabled
+      allow_automatic_updates: false
+      # reservation_name: c3-16node-reservation
+      # If not using reservation:
+      # enable_placement: true
+      # placement_max_distance: 2
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: &id001
+      - https://www.googleapis.com/auth/cloud-platform
+      enable_oslogin: false
+
+  - id: burst_b_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [burst_b_nodeset]
+    settings:
+      partition_name: burst
+      is_default: true
+      exclusive: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network, ssh_config]
+    settings:
+      machine_type: $(vars.image_build_machine_type)
+      disk_type: hyperdisk-balanced
+      enable_login_public_ips: true
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: *id001
+      enable_oslogin: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [network, burst_b_partition, homefs, appsfs, slurm_login]
+    settings:
+      slurm_cluster_name: burst
+      controller_startup_script: $(ssh_config.controller_startup_script)
+      machine_type: $(vars.image_build_machine_type)
+      disk_type: hyperdisk-balanced
+      controller_state_disk:
+        type: hyperdisk-balanced
+        size: 50
+      enable_controller_public_ips: false
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: *id001
+      enable_default_mounts: false
+      enable_slurm_auth: true
+      enable_oslogin: false

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
@@ -15,6 +15,10 @@
 ---
 blueprint_name: primary-cluster
 
+# These validators query public Google APIs that are unreachable from a GCD private
+# universe (apis-<location>.goog), so gcluster create would fail before generating
+# anything. On commercial GCP you can safely delete this block to restore the
+# pre-flight checks.
 validators:
 - validator: test_project_exists
   skip: true
@@ -36,18 +40,18 @@ vars:
   deployment_name: primary-cluster
   region: us-central1
   zone: us-central1-a
-  universe_domain: # e.g., apis-<location>.goog or custom universe domain
+  universe_domain: googleapis.com # apis-<location>.goog
   service_account_email: # <account-id>-compute@developer.gserviceaccount.com
   # To enable SSH access to the login node, add your client CIDR e.g. ["x.x.x.x/32"] or ["0.0.0.0/0"]
   authorized_ssh_ranges: []
 
   # Image Build & Instance Settings
-  source_image_family: rocky-linux-8-optimized-gcp
-  source_image_project: rocky-linux-cloud
+  source_image_family: rocky-linux-9-optimized-gcp
+  source_image_project: rocky-linux-cloud # <partition>-system:rocky-linux-cloud
   image_build_machine_type: c3-standard-4
   build_slurm_from_git_ref: 6.12.1
   built_instance_image:
-    family: slurm-c3-rocky8
+    family: slurm-rocky9
     project: $(vars.project_id)
 
 terraform_providers:
@@ -274,7 +278,7 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network, ssh_config]
     settings:
-      node_count_static: 0
+      node_count_static: 1
       node_count_dynamic_max: 16
       machine_type: c3-standard-176
       disk_type: hyperdisk-balanced

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml
@@ -1,0 +1,338 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+blueprint_name: primary-cluster
+
+validators:
+- validator: test_project_exists
+  skip: true
+- validator: test_apis_enabled
+  skip: true
+- validator: test_region_exists
+  skip: true
+- validator: test_zone_exists
+  skip: true
+- validator: test_zone_in_region
+  skip: true
+- validator: test_machine_type_in_zone
+  skip: true
+- validator: test_disk_type_in_zone
+  skip: true
+
+vars:
+  project_id: # <project-id> e.g., my-gcd-project
+  deployment_name: primary-cluster
+  region: us-central1
+  zone: us-central1-a
+  universe_domain: # e.g., apis-<location>.goog or custom universe domain
+  service_account_email: # <account-id>-compute@developer.gserviceaccount.com
+  # To enable SSH access to the login node, add your client CIDR e.g. ["x.x.x.x/32"] or ["0.0.0.0/0"]
+  authorized_ssh_ranges: []
+
+  # Image Build & Instance Settings
+  source_image_family: rocky-linux-8-optimized-gcp
+  source_image_project: rocky-linux-cloud
+  image_build_machine_type: c3-standard-4
+  build_slurm_from_git_ref: 6.12.1
+  built_instance_image:
+    family: slurm-c3-rocky8
+    project: $(vars.project_id)
+
+terraform_providers:
+  google:
+    source: hashicorp/google
+    version: '>= 5.45.0'
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      universe_domain: $(vars.universe_domain)
+  google-beta:
+    source: hashicorp/google-beta
+    version: '>= 5.45.0'
+    configuration:
+      project: $(vars.project_id)
+      region: $(vars.region)
+      zone: $(vars.zone)
+      universe_domain: $(vars.universe_domain)
+
+deployment_groups:
+- group: setup
+  modules:
+  - id: network
+    source: modules/network/vpc
+    settings:
+      network_name: $(vars.deployment_name)-net
+      allowed_ssh_ip_ranges: $(vars.authorized_ssh_ranges)
+      subnetworks:
+      - subnet_name: $(vars.deployment_name)-subnet
+        subnet_region: $(vars.region)
+        subnet_ip: "10.128.0.0/20"
+      firewall_rules:
+      - name: $(vars.deployment_name)-allow-peering
+        ranges: ["10.128.0.0/20", "10.130.0.0/20"]
+        allow:
+        - protocol: tcp
+          ports: ["0-65535"]
+        - protocol: udp
+          ports: ["0-65535"]
+        - protocol: icmp
+
+  - id: slurm-build-script
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: false
+      runners:
+      - type: shell
+        destination: prep-for-slurm-build.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          # Ensure SELinux allows NFS home directories
+          setsebool -P use_nfs_home_dirs 1 || true
+          # Slurm build will install and set python3.12 as the default python3
+          dnf install -y python3.12 python3.12-pip perl-ExtUtils-MakeMaker perl-devel
+          python3.12 -m pip install pip --upgrade
+          python3.12 -m pip install ansible==8.7.0
+          export PATH=/usr/local/bin:$PATH
+          ansible --version
+          n=0
+          until [ "$n" -ge 3 ] || ( { dnf install -y --disablerepo=ciq-sigcloud-next nfs-utils 2>/dev/null || dnf install -y nfs-utils; } && ansible-galaxy role install googlecloudplatform.google_cloud_ops_agents ); do
+            ((n=n+1))
+            sleep 5
+          done
+      - type: data
+        destination: /var/tmp/slurm_vars.json
+        # Add or update slurm-gcp flags as required, https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/ansible/playbook.yml
+        content: |
+          {
+            "reboot": false,
+            "install_cuda": false,
+            "nvidia_version": "latest",
+            "install_ompi": true,
+            "install_lustre": false,
+            "install_gcsfuse": true,
+            "allow_kernel_upgrades": false,
+            "monitoring_agent": "cloud-ops",
+            "install_managed_lustre": false
+          }
+
+      - type: shell
+        destination: install_slurm.sh
+        content: |
+          #!/bin/bash
+          set -e -o pipefail
+          dnf update -y
+          dnf install -y epel-release git ansible-core
+          ansible-pull -U https://github.com/GoogleCloudPlatform/slurm-gcp -C $(vars.build_slurm_from_git_ref) \
+              -i localhost, --limit localhost --connection=local \
+              -e @/var/tmp/slurm_vars.json ansible/playbook.yml
+
+- group: build-slurm
+  modules:
+  - id: custom-slurm-image
+    source: modules/packer/custom-image
+    kind: packer
+    use: [network, slurm-build-script]
+    settings:
+      source_image_project_id: [$(vars.source_image_project)]
+      source_image_family: $(vars.source_image_family)
+      machine_type: $(vars.image_build_machine_type)
+      image_family: $(vars.built_instance_image.family)
+      disk_type: hyperdisk-balanced
+      zone: $(vars.zone)
+      omit_external_ip: false
+      image_licenses: []
+      state_timeout: 30m
+
+- group: cluster
+  modules:
+  - id: homefs
+    source: community/modules/file-system/nfs-server
+    use: [network]
+    settings:
+      local_mounts: [/home, /opt/apps]
+      machine_type: $(vars.image_build_machine_type)
+      boot_disk_type: hyperdisk-balanced
+      type: hyperdisk-balanced
+      disk_size: 100
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+
+  - id: ssh_config
+    source: modules/scripts/startup-script
+    settings:
+      install_ansible: false
+      runners:
+      - type: shell
+        destination: setup_non_oslogin_ssh.sh
+        content: |
+          #!/bin/bash
+          # 1. SELinux & Crypto Policy for Rocky Linux 8/9
+          setsebool -P use_nfs_home_dirs 1 || true
+          update-crypto-policies --set DEFAULT:SHA1 || true
+
+          # 2. Populate metadata keys and secure inter-node keypair on NFS /home
+          METADATA="http://metadata.google.internal/computeMetadata/v1"
+          PROJ_KEYS=`curl -s -f -H "Metadata-Flavor: Google" "$METADATA/project/attributes/ssh-keys" 2>/dev/null || true`
+          INST_KEYS=`curl -s -f -H "Metadata-Flavor: Google" "$METADATA/instance/attributes/ssh-keys" 2>/dev/null || true`
+          KEYS=`printf "%s\n%s\n" "$PROJ_KEYS" "$INST_KEYS" | grep -v '^[[:space:]]*$' | sort -u`
+
+          for user in `echo "$KEYS" | cut -d: -f1 | sort -u`; do
+            [ -z "$user" ] && continue
+
+            # Create group and user with deterministic UID/GID to ensure consistency across the cluster
+            if ! id "$user" &>/dev/null; then
+              UID_HASH=`printf "%s" "$user" | cksum | cut -d' ' -f1`
+              USER_UID=`expr 2000 + $UID_HASH % 58000`
+              while getent passwd "$USER_UID" >/dev/null || getent group "$USER_UID" >/dev/null; do
+                USER_UID=`expr $USER_UID + 1`
+              done
+              groupadd -g "$USER_UID" "$user" || true
+              useradd -u "$USER_UID" -g "$USER_UID" -m -s /bin/bash "$user"
+            fi
+            mkdir -p "/home/$user/.ssh"
+            chown "$user:$user" "/home/$user"
+            chmod 700 "/home/$user/.ssh"
+
+            # Safely serialize key generation & authorized_keys rebuilding across the cluster
+            (
+              flock 9
+
+              # Generate ED25519 cluster key natively
+              if [ ! -f "/home/$user/.ssh/id_ed25519" ]; then
+                ssh-keygen -t ed25519 -N "" -f "/home/$user/.ssh/id_ed25519"
+              fi
+
+              # Rebuild authorized_keys atomically on the exact same NFS filesystem (prevents O_TRUNC zeroing)
+              TMP_KEYS=`mktemp "/home/$user/.ssh/authorized_keys.XXXXXX"`
+              if [ -n "$TMP_KEYS" ] && [ -f "$TMP_KEYS" ]; then
+                echo "$KEYS" | grep "^$user:" | cut -d: -f2- > "$TMP_KEYS"
+                [ -f "/home/$user/.ssh/id_ed25519.pub" ] && cat "/home/$user/.ssh/id_ed25519.pub" >> "$TMP_KEYS"
+                mv -f "$TMP_KEYS" "/home/$user/.ssh/authorized_keys"
+              fi
+
+            ) 9>"/home/$user/.ssh/keygen.lock"
+
+            # Secure remaining permissions to the user
+            chown -R "$user:$user" "/home/$user/.ssh"
+            chmod 600 "/home/$user/.ssh/"*
+          done
+
+          # 3. Disable StrictHostKeyChecking safely for internal network jumps only
+          if ! grep -q "Host 10.\*" /etc/ssh/ssh_config; then
+            if ! grep -q "StrictHostKeyChecking no" /etc/ssh/ssh_config; then
+              echo -e "Host 10.* 172.16.* 192.168.* *.internal\n    StrictHostKeyChecking no\n    UserKnownHostsFile=/dev/null" >> /etc/ssh/ssh_config
+            fi
+          fi
+
+          # 4. Restart sshd and silence ops-agent in GCD
+          systemctl restart sshd
+          systemctl stop google-cloud-ops-agent 2>/dev/null || true
+          systemctl disable google-cloud-ops-agent 2>/dev/null || true
+
+          # 5. On Primary Cluster Controller: Export master slurm.key and controller IP to NFS /home
+          if hostname | grep -q controller; then
+            for i in `seq 1 60`; do
+              [ -s /etc/slurm/slurm.key ] && break
+              sleep 1
+            done
+            if [ -s /etc/slurm/slurm.key ]; then
+              TMP_KEY="/home/.shared_slurm.key.tmp.$$"
+              if install -m 600 /etc/slurm/slurm.key "$TMP_KEY"; then
+                mv -f "$TMP_KEY" /home/.shared_slurm.key
+                ln -sfn /home/.shared_slurm.key /home/shared_slurm.key
+              else
+                echo "ERROR: Failed to securely copy slurm.key to /home" >&2
+              fi
+            else
+              echo "ERROR: /etc/slurm/slurm.key was not generated within 60 seconds." >&2
+            fi
+
+            PRIMARY_IP=`hostname -I | awk '{print $1}'`
+            if [ -n "$PRIMARY_IP" ]; then
+              echo "$PRIMARY_IP" > /home/.primary_cluster_ctrl_ip
+              echo "$PRIMARY_IP" > /home/primary_cluster_ctrl_ip
+              chmod 644 /home/.primary_cluster_ctrl_ip /home/primary_cluster_ctrl_ip 2>/dev/null || true
+            fi
+          fi
+
+  - id: compute_a_nodeset
+    source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
+    use: [network, ssh_config]
+    settings:
+      node_count_static: 0
+      node_count_dynamic_max: 16
+      machine_type: c3-standard-176
+      disk_type: hyperdisk-balanced
+      bandwidth_tier: gvnic_enabled
+      allow_automatic_updates: false
+      # reservation_name: c3-16node-reservation
+      # If not using reservation:
+      # enable_placement: true
+      # placement_max_distance: 2
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: &id001
+      - https://www.googleapis.com/auth/cloud-platform
+      enable_oslogin: false
+
+  - id: compute_a_partition
+    source: community/modules/compute/schedmd-slurm-gcp-v6-partition
+    use: [compute_a_nodeset]
+    settings:
+      partition_name: compute
+      is_default: true
+      exclusive: false
+
+  - id: slurm_login
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-login
+    use: [network, ssh_config]
+    settings:
+      machine_type: $(vars.image_build_machine_type)
+      disk_type: hyperdisk-balanced
+      enable_login_public_ips: true
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: *id001
+      enable_oslogin: false
+
+  - id: slurm_controller
+    source: community/modules/scheduler/schedmd-slurm-gcp-v6-controller
+    use: [network, compute_a_partition, homefs, slurm_login]
+    settings:
+      slurm_cluster_name: primary
+      controller_startup_script: $(ssh_config.controller_startup_script)
+      machine_type: $(vars.image_build_machine_type)
+      disk_type: hyperdisk-balanced
+      controller_state_disk:
+        type: hyperdisk-balanced
+        size: 50
+      enable_controller_public_ips: false
+      instance_image:
+        family: $(vars.built_instance_image.family)
+        project: $(vars.project_id)
+      instance_image_custom: true
+      service_account_email: $(vars.service_account_email)
+      service_account_scopes: *id001
+      enable_slurm_auth: true
+      enable_oslogin: false

--- a/examples/README.md
+++ b/examples/README.md
@@ -81,6 +81,9 @@ md_toc github examples/README.md | sed -e "s/\s-\s/ * /"
   * [eda-all-on-cloud.yaml](#eda-all-on-cloudyaml-) ![community-badge]
   * [eda-hybrid-cloud.yaml](#eda-hybrid-cloudyaml-) ![community-badge]
   * [hpc-slurm-google-cloud-dedicated.yaml](#hpc-slurm-google-cloud-dedicatedyaml-) ![community-badge]
+  * [hybrid-slurm-cluster (GCD)](#hybrid-slurm-cluster-gcd-) ![community-badge]
+    * [primary-cluster.yaml](../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml)
+    * [burst-cluster.yaml](../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml)
 * [Blueprint Schema](#blueprint-schema)
 * [Writing an HPC Blueprint](#writing-an-hpc-blueprint)
   * [Blueprint Boilerplate](#blueprint-boilerplate)
@@ -1849,6 +1852,18 @@ Creates a Slurm cluster on C3 machine types for Google Cloud Dedicated (GCD) and
 The deployment instructions can be found in the [README](../community/examples/hpc-slurm-google-cloud-dedicated/README.md).
 
 [hpc-slurm-google-cloud-dedicated.yaml]: ../community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml
+
+### [hybrid-slurm-cluster (GCD)] ![community-badge]
+
+Deploys a Multi-Cluster Slurm environment with Elastic Cloud Bursting across two autonomous projects in Google Cloud Dedicated (GCD) and sovereign cloud environments. Includes cross-cluster SAuth discovery, automatic compute nodes autoscaling on Burst Cluster, standalone NFS server, custom Rocky Linux Slurm image, and shared `/home` filesystem mounting over VPC peering.
+
+This directory includes the following blueprints:
+* [`primary-cluster.yaml`](../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml): Primary cluster on GCD with standalone NFS server and custom-built Rocky Linux Slurm image.
+* [`burst-cluster.yaml`](../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml): Cloud burst target cluster on GCD with dynamic autoscaling compute nodes.
+
+The deployment instructions can be found in the [README](../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md).
+
+[hybrid-slurm-cluster (GCD)]: ../community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/README.md
 
 ## Blueprint Schema
 

--- a/tools/validate_configs/validate_configs.sh
+++ b/tools/validate_configs/validate_configs.sh
@@ -140,6 +140,8 @@ EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-slurm.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/sycomp/sycomp-storage-expansion.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/eda/eda-hybrid-cloud.yaml"]=
 EXCLUDE_EXAMPLE["community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml"]=
+EXCLUDE_EXAMPLE["community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/primary-cluster.yaml"]=
+EXCLUDE_EXAMPLE["community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/burst-cluster.yaml"]=
 
 cwd=$(pwd)
 NPROCS=${NPROCS:-$(nproc)}


### PR DESCRIPTION
## Description

Adds turnkey Cluster Toolkit blueprints and documentation for **Multi-Cluster Slurm with elastic cloud bursting across two autonomous projects in Google Cloud Dedicated (GCD)** / sovereign cloud environments.

## What's added

New directory `community/examples/hpc-slurm-google-cloud-dedicated/hybrid-slurm-cluster/`:

* **`primary-cluster.yaml`** — Primary cluster (Project A). Deployment groups:
  * `setup`: VPC `primary-cluster-net` (`10.128.0.0/20`) + cross-cluster peering firewall rules.
  * `build-slurm`: Packer `modules/packer/custom-image` build of a Rocky Linux 8 + Slurm `6.12.1` image into family `slurm-c3-rocky8` (one-time per project).
  * `cluster`: standalone NFS server (`community/modules/file-system/nfs-server`, Hyperdisk Balanced) exporting `/home` and `/opt/apps`, Slurm v6 controller/login/nodeset (`compute` partition), and a startup script that exports the master `slurm.key` and controller IP to shared `/home`.
* **`burst-cluster.yaml`** — Burst target (Project B). `setup` provisions a non-overlapping VPC `burst-cluster-net` (`10.130.0.0/20`); `cluster` mounts the primary cluster's NFS `/home` and `/opt/apps` via `pre-existing-network-storage`, reuses the pre-baked Slurm image, and defines an elastic `burst` partition (`node_count_static: 0`, `node_count_dynamic_max: 16`, `c3-standard-176`) that scales `0 -> N` on demand. Its startup script imports the shared `slurm.key`, discovers the primary controller IP from `/home/.primary_cluster_ctrl_ip`, and appends `AccountingStorageExternalHost=<primary>:6819` so the burst cluster auto-registers in the primary SlurmDBD — no manual `sacctmgr` cross-registration.
* **`README.md`** — Step-by-step deployment guide: architecture diagram, GCD-vs-commercial-GCP differences table, WIF login and `GHPC_MOCK_MACHINE_CONFIG` setup, one-time Packer image build, strict deploy order, bidirectional VPC peering commands, and verification of cross-cluster dispatch (`sinfo -M burst`, `sbatch -M burst --wrap="hostname"`, `squeue -M burst`).

Supporting updates:

* `community/examples/hpc-slurm-google-cloud-dedicated/README.md`: link to the new multi-cluster / bursting example.
* `examples/README.md`: add `hybrid-slurm-cluster (GCD)` to the blueprint catalog and TOC.
* `tools/validate_configs/validate_configs.sh`: exclude both new blueprints, consistent with the existing GCD example — they require a GCD universe domain, WIF credentials, and a pre-built custom image, so they cannot be expanded/validated in public CI.

## GCD-specific adaptations captured here

| Concern | Approach in these blueprints |
| :--- | :--- |
| Private universe domain | `universe_domain` var wired into both `google` / `google-beta` providers; batch API handled natively by the `ThreadPoolExecutor` path added in #6144 (no runtime patching) |
| No public Slurm images | Packer `build-slurm` group builds `slurm-c3-rocky8` once per project; reusable across both clusters or copyable cross-project |
| No Filestore | Standalone NFS server VM on Hyperdisk Balanced, shared across both clusters over VPC peering |
| No default network / peering CIDR conflicts | Blueprints provision their own non-overlapping VPCs (`10.128.0.0/20`, `10.130.0.0/20`); README documents swapping in `pre-existing-vpc` for centrally managed landing zones |
| OS Login disabled | Deterministic UID/GID hashing plus `flock`-serialized SSH keypair generation on shared NFS `/home` to avoid UID drift and `authorized_keys` races |
| Cross-cluster trust | Primary exports `slurm.key` to `/home/.shared_slurm.key`; burst controller/login import it synchronously on boot, eliminating cross-project race conditions |
| Offline machine specs | Documented `GHPC_MOCK_MACHINE_CONFIG` export for blueprint expansion |

## Testing

* Deployed end to end in two isolated GCD projects (`primary-cluster` in Project A, `burst-cluster` in Project B) with bidirectional VPC peering.
* Verified both clusters auto-register in the primary SlurmDBD (`sacctmgr list clusters` shows `primary` and `burst` with correct `ControlHost`/`ControlPort`/RPC) without manual registration.
* Verified remote dispatch from the primary login node: `sbatch -M burst --wrap="hostname"` and `srun -M burst -N1 hostname` triggered dynamic node creation (`CF` -> `R` -> `CG` -> `idle~`), wrote output to shared `/home`, and powered nodes down after `SuspendTimeout`.
* No existing modules or blueprints are modified; remaining changes are documentation and the validator exclusion list.
* `pre-commit` run locally on the branch.

## Notes for reviewers

* Deployment order is load-bearing: the primary cluster must be up (VPC, NFS, `slurm.key`, controller IP) before the burst cluster's `cluster` group is deployed, and peering must exist in **both** directions since the burst side needs routes back for NFS, key import, and SlurmDBD RPCs.
* Both blueprints are excluded from `validate_configs.sh` for the same reason as the existing GCD example.
* Community examples only; no changes to core modules.

### Submission Checklist

* [x] PR branch forked from `develop`
* [x] Tested changes with `pre-commit` in a local branch
* [x] Confirmed `make tests` passes
* [x] Added/updated documentation (new `hybrid-slurm-cluster/README.md`, catalog entries in `examples/README.md`)
