### PR TITLE
Upgrade Slurm to 25.11.8

### DIFF
--- a/community/examples/hpc-build-slurm-image.yaml
+++ b/community/examples/hpc-build-slurm-image.yaml
@@ -25,7 +25,7 @@ vars:
   # Rocky 9: hpc-rocky-linux-9
   build_from_image_family: hpc-rocky-linux-9
   build_from_image_project: cloud-hpc-image-public
-  build_from_git_ref: 6.12.1
+  build_from_git_ref: 6.12.3
   built_image_family: my-custom-slurm
   built_instance_image:
     family: $(vars.built_image_family)

--- a/community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml
+++ b/community/examples/hpc-slurm-google-cloud-dedicated/hpc-slurm-google-cloud-dedicated.yaml
@@ -26,7 +26,7 @@ vars:
   source_image_family: rocky-linux-8-optimized-gcp
   source_image_project: rocky-linux-cloud
   image_build_machine_type: c3-standard-4
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
   built_instance_image:
     family: slurm-c3-rocky8
     project: $(vars.project_id)

--- a/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
+++ b/community/modules/scheduler/schedmd-slurm-gcp-v6-login/README.md
@@ -52,7 +52,7 @@ modules. For support with the underlying modules, see the instructions in the
 [slurm-gcp README][slurm-gcp-readme].
 
 [slurm-on-gcp]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/7
-[slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/6.12.1#slurm-on-google-cloud-platform
+[slurm-gcp-readme]: https://github.com/GoogleCloudPlatform/slurm-gcp/tree/6.12.3#slurm-on-google-cloud-platform
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-highgpu-8g/a3high-slurm-blueprint.yaml
@@ -35,7 +35,7 @@ vars:
   localssd_mountpoint: /mnt/localssd
   enable_nvidia_dcgm: true
   disk_size_gb: 200
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
   #Provisioning models (set to true or fill in reservation name, pick only one)
   a3_reservation_name: "" # supply reservation name
   a3_dws_flex_enabled: false

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-blueprint.yaml
@@ -36,7 +36,7 @@ vars:
   enable_login_public_ips: true
   enable_controller_public_ips: true
   localssd_mountpoint: /mnt/localssd
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
   #Provisioning models (set to true or fill in reservation name, pick only one)
   a3mega_reservation_name: ""  # supply reservation name
   a3mega_dws_flex_enabled: false

--- a/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-gcsfuse-lssd-blueprint.yaml
+++ b/examples/machine-learning/a3-megagpu-8g/a3mega-slurm-gcsfuse-lssd-blueprint.yaml
@@ -31,7 +31,7 @@ vars:
   a3mega_maintenance_interval: ""
   enable_placement: false
   local_mount_homefs: /home
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
   instance_image:
     family: $(vars.final_image_family)
     project: $(vars.project_id)

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/README.md
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/README.md
@@ -24,7 +24,7 @@ This blueprint installs and configures several key software components. While th
 * **NVIDIA CUDA Toolkit:** 13.0 (and related `datacenter-gpu-manager` packages)
 * **Mellanox OFED (DOCA):** 3.2.0 for Ubuntu 24.04 arm64-sbsa
 * **Mellanox Firmware Tools (MFT):** 4.34.0-145
-* **Slurm:** Git ref `6.12.1` from `https://github.com/GoogleCloudPlatform/slurm-gcp`
+* **Slurm:** Git ref `6.12.3` from `https://github.com/GoogleCloudPlatform/slurm-gcp`
 * **NCCL Plugin Image:** `us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-gib-a4x-max-arm64` (Version: `v1.1.1`)
 * **ASAPd Image:** `us-docker.pkg.dev/gce-ai-infra/asapd-lite/asapd-lite:v0.0.8`
 

--- a/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4x-maxgpu-4g-metal/a4xmax-bm-slurm-blueprint.yaml
@@ -30,7 +30,7 @@ vars:
   image_build_disk_type: hyperdisk-balanced
   image_disk_size_gb: 100
   built_image_family: slurm-ubuntu2404-a4x-max-metal # Needs to be built with MOFED
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
 
   # Cluster env settings
   net0_range: 10.1.1.0/24

--- a/examples/machine-learning/build-service-images/a4x/blueprint.yaml
+++ b/examples/machine-learning/build-service-images/a4x/blueprint.yaml
@@ -118,7 +118,7 @@ deployment_groups:
           #!/bin/bash
           set -e -o pipefail
           ansible-pull \
-              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.12.1 \
+              -U https://github.com/GoogleCloudPlatform/slurm-gcp -C 6.12.3 \
               -i localhost, --limit localhost --connection=local \
               -e @/var/tmp/slurm_vars.json \
               ansible/playbook.yml

--- a/examples/machine-learning/build-service-images/shared.yaml
+++ b/examples/machine-learning/build-service-images/shared.yaml
@@ -16,7 +16,7 @@ vars:
   region: us-central1
   zone: us-central1-a
 
-  slurm_gcp_version: 6.12.1
+  slurm_gcp_version: 6.12.3
 
   # to supply
   family:

--- a/examples/ml-slurm-g4-vgpu.yaml
+++ b/examples/ml-slurm-g4-vgpu.yaml
@@ -29,7 +29,7 @@ vars:
   image_build_machine_type: n2-standard-4
   image_disk_size_gb: 50
   built_image_family: slurm-vgpu-ubuntu2404
-  build_slurm_from_git_ref: 6.12.1
+  build_slurm_from_git_ref: 6.12.3
 
   # Cluster env settings
   net0_range: 192.168.0.0/24

--- a/examples/ml-slurm-g4.yaml
+++ b/examples/ml-slurm-g4.yaml
@@ -30,7 +30,7 @@ vars:
   image_build_machine_type: n2-standard-4
   image_disk_size_gb: 50
   built_image_family: slurm-g4-ubuntu2404
-  build_slurm_from_git_ref: 6.12.1 # Or a newer stable tag
+  build_slurm_from_git_ref: 6.12.3 # Or a newer stable tag
 
   # Cluster env settings
   net0_range: 192.168.0.0/24


### PR DESCRIPTION
Slurm Security Patches: Upgraded Slurm to version `25.11.8` to address multiple CVEs:

`CVE-2026-65107`: Fixes sbcast shared objects skipping credential verification and addresses a possible slurmd crash on invalid sbcast filenames.
`CVE-2026-65108`: Fixes a slurmstepd stack overflow when a job environment contains an oversized SPANK option variable.
`CVE-2026-65109`: Fixes slurmstepd removing files outside the container spool directory when cleaning up an OCI container, and prevents leaving spool directories behind when ContainerPath contains a task id pattern.
`CVE-2026-65138`: Fixes a heap over-read when unpacking a malformed forward data RPC in slurmd, as well as a slurmd crash when handling a malformed forward data RPC with a missing socket address.
`CVE-2026-65139`: Enhance accounting database security by rejecting non-numeric ID values and validating cluster names against unsafe characters during queries, slurmdbd connections, and accounting usage, add, or runaway job paths.
`CVE-2026-65140`: Fixes a privilege escalation where an operator could alter Administrator accounts through the accounting database.
`CVE-2026-65165`: Fixes the node count for job steps that use an arbitrary distribution. It also rejects these job steps if they contain a hostlist function in their node list or if their node list disagrees with the node count.
`CVE-2026-65168`: Fixes a possible slurmstepd crash on invalid step socket requests.