### PR TITLE
Cut over daily tests to dev-2

### DIFF
--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -70,7 +70,7 @@ When prompted for project, use integration test project.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_daily_tests_dev_exceptions"></a> [daily\_tests\_dev\_exceptions](#input\_daily\_tests\_dev\_exceptions) | List of daily tests that must run in hpc-toolkit-dev in addition to hpc-toolkit-dev-2 (e.g. due to hardware reservations or quota constraints) | `list(string)` | <pre>[<br/>  "gke-g4-confidential",<br/>  "gke-tpu-7x"<br/>]</pre> | no |
+| <a name="input_daily_tests_dev_exceptions"></a> [daily\_tests\_dev\_exceptions](#input\_daily\_tests\_dev\_exceptions) | List of daily tests that must run in hpc-toolkit-dev in addition to hpc-toolkit-dev-2 (e.g. due to hardware reservations or quota constraints) | `set(string)` | <pre>[<br/>  "gke-g4-confidential",<br/>  "gke-tpu-7x"<br/>]</pre> | no |
 | <a name="input_daily_tests_project_id"></a> [daily\_tests\_project\_id](#input\_daily\_tests\_project\_id) | The GCP project for daily tests | `string` | `"hpc-toolkit-dev-2"` | no |
 | <a name="input_daily_tests_service_account"></a> [daily\_tests\_service\_account](#input\_daily\_tests\_service\_account) | The service account to run daily tests under. If null, the default Cloud Build service account is used. For projects enforcing BYOSA (like hpc-toolkit-dev-2), you must set this via environment variable, e.g. export TF\_VAR\_daily\_tests\_service\_account="projects/..." | `string` | `null` | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |

--- a/tools/cloud-build/provision/README.md
+++ b/tools/cloud-build/provision/README.md
@@ -40,7 +40,7 @@ When prompted for project, use integration test project.
 | <a name="module_daily_project_cleanup_schedule"></a> [daily\_project\_cleanup\_schedule](#module\_daily\_project\_cleanup\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_project_cleanup_slurm_schedule"></a> [daily\_project\_cleanup\_slurm\_schedule](#module\_daily\_project\_cleanup\_slurm\_schedule) | ./trigger-schedule | n/a |
 | <a name="module_daily_test_schedule"></a> [daily\_test\_schedule](#module\_daily\_test\_schedule) | ./trigger-schedule | n/a |
-| <a name="module_daily_test_schedule_migrated"></a> [daily\_test\_schedule\_migrated](#module\_daily\_test\_schedule\_migrated) | ./trigger-schedule | n/a |
+| <a name="module_daily_test_schedule_exceptions"></a> [daily\_test\_schedule\_exceptions](#module\_daily\_test\_schedule\_exceptions) | ./trigger-schedule | n/a |
 | <a name="module_weekly_build_dependency_check_schedule"></a> [weekly\_build\_dependency\_check\_schedule](#module\_weekly\_build\_dependency\_check\_schedule) | ./trigger-schedule | n/a |
 
 ## Resources
@@ -51,7 +51,7 @@ When prompted for project, use integration test project.
 | [google_cloudbuild_trigger.daily_project_cleanup_filestore](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_project_cleanup_slurm](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.daily_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
-| [google_cloudbuild_trigger.daily_test_migrated](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
+| [google_cloudbuild_trigger.daily_test_exceptions](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.image_build_test_runner](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_go_build_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
 | [google_cloudbuild_trigger.pr_ofe_test](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloudbuild_trigger) | resource |
@@ -70,9 +70,9 @@ When prompted for project, use integration test project.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_daily_tests_dev_exceptions"></a> [daily\_tests\_dev\_exceptions](#input\_daily\_tests\_dev\_exceptions) | List of daily tests that must run in hpc-toolkit-dev in addition to hpc-toolkit-dev-2 (e.g. due to hardware reservations or quota constraints) | `list(string)` | <pre>[<br/>  "gke-g4-confidential",<br/>  "gke-tpu-7x"<br/>]</pre> | no |
 | <a name="input_daily_tests_project_id"></a> [daily\_tests\_project\_id](#input\_daily\_tests\_project\_id) | The GCP project for daily tests | `string` | `"hpc-toolkit-dev-2"` | no |
 | <a name="input_daily_tests_service_account"></a> [daily\_tests\_service\_account](#input\_daily\_tests\_service\_account) | The service account to run daily tests under. If null, the default Cloud Build service account is used. For projects enforcing BYOSA (like hpc-toolkit-dev-2), you must set this via environment variable, e.g. export TF\_VAR\_daily\_tests\_service\_account="projects/..." | `string` | `null` | no |
-| <a name="input_kueue_migrated_tests"></a> [kueue\_migrated\_tests](#input\_kueue\_migrated\_tests) | List of tests migrated to Kueue | `list(string)` | <pre>[<br/>  "slurm-gcp-v6-rocky8",<br/>  "batch-mpi",<br/>  "htcondor",<br/>  "packer",<br/>  "monitoring",<br/>  "chrome-remote-desktop",<br/>  "chrome-remote-desktop-ubuntu",<br/>  "ansible-vm",<br/>  "e2e",<br/>  "hcls",<br/>  "slurm-gke",<br/>  "slurm-flex",<br/>  "ml-slurm",<br/>  "htc-slurm",<br/>  "hpc-build-slurm-image",<br/>  "hpc-enterprise-slurm",<br/>  "spack-gromacs",<br/>  "gcluster-dockerfile",<br/>  "gke",<br/>  "gke-inactive-reservation",<br/>  "ml-gke",<br/>  "ml-gke-e2e",<br/>  "gke-storage",<br/>  "gke-managed-hyperdisk",<br/>  "slurm-rapid-storage",<br/>  "gke-managed-lustre",<br/>  "pfs-managed-lustre-slurm",<br/>  "pfs-managed-lustre-vm",<br/>  "netapp-volumes",<br/>  "slurm-gcp-v6-reconfig-size",<br/>  "slurm-gcp-v6-simple-job-completion",<br/>  "slurm-gcp-v6-startup-scripts",<br/>  "slurm-gcp-v6-topology",<br/>  "slurm-gcp-v6-debian",<br/>  "slurm-gcp-v6-ubuntu",<br/>  "slurm-gcp-v6-ssd",<br/>  "gke-a2-highgpu-kueue-onspot",<br/>  "gke-a4-onspot",<br/>  "gke-g4-onspot",<br/>  "gke-h4d-onspot",<br/>  "ml-h4d-onspot-slurm",<br/>  "h4d-vm",<br/>  "ml-a3-highgpu-onspot-slurm",<br/>  "ml-a4-highgpu-onspot-slurm",<br/>  "ml-g4-onspot-slurm",<br/>  "gke-a3-highgpu-onspot",<br/>  "gke-a3-megagpu-onspot",<br/>  "gke-tpu-v6e",<br/>  "ml-a3-megagpu-onspot-slurm-ubuntu",<br/>  "gke-a3-ultragpu-onspot",<br/>  "ml-a3-ultragpu-onspot-slurm",<br/>  "ml-a3-ultragpu-onspot-jbvms",<br/>  "gke-a4x",<br/>  "ml-a4x-highgpu-slurm",<br/>  "batch",<br/>  "gke-g4-confidential",<br/>  "gke-tpu-v5e",<br/>  "gke-tpu-7x",<br/>  "gke-tpu-v5p"<br/>]</pre> | no |
 | <a name="input_project_id"></a> [project\_id](#input\_project\_id) | GCP project ID | `string` | `"hpc-toolkit-dev"` | no |
 | <a name="input_region"></a> [region](#input\_region) | GCP region | `string` | `"us-central1"` | no |
 | <a name="input_repo_uri"></a> [repo\_uri](#input\_repo\_uri) | URI of GitHub repo | `string` | `"https://github.com/GoogleCloudPlatform/cluster-toolkit"` | no |

--- a/tools/cloud-build/provision/daily-tests.tf
+++ b/tools/cloud-build/provision/daily-tests.tf
@@ -52,8 +52,9 @@ module "daily_test_schedule" {
 
 # Exception daily tests running in project_id (hpc-toolkit-dev)
 resource "google_cloudbuild_trigger" "daily_test_exceptions" {
-  for_each    = toset(var.daily_tests_dev_exceptions)
+  for_each    = var.daily_tests_dev_exceptions
   name        = "DAILY-test-${each.key}"
+  project     = var.project_id
   description = "Runs the '${each.key}' integration test against `develop`"
   tags        = [local.notify_chat_tag]
 
@@ -80,7 +81,7 @@ resource "google_cloudbuild_trigger" "daily_test_exceptions" {
 
 module "daily_test_schedule_exceptions" {
   source   = "./trigger-schedule"
-  for_each = toset(var.daily_tests_dev_exceptions)
+  for_each = var.daily_tests_dev_exceptions
   trigger  = google_cloudbuild_trigger.daily_test_exceptions[each.key]
   schedule = data.external.list_tests_midnight.result[each.key]
 }

--- a/tools/cloud-build/provision/daily-tests.tf
+++ b/tools/cloud-build/provision/daily-tests.tf
@@ -12,11 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Daily tests running in daily_tests_project_id (hpc-toolkit-dev-2)
 resource "google_cloudbuild_trigger" "daily_test" {
-  for_each    = data.external.list_tests_midnight.result
-  name        = "DAILY-test-${each.key}"
-  description = "Runs the '${each.key}' integration test against `develop`"
-  tags        = [local.notify_chat_tag]
+  for_each = data.external.list_tests_midnight.result
+  name     = "DAILY-test-${each.key}"
+  project  = var.daily_tests_project_id
+  tags     = [local.notify_chat_tag]
+  # For projects with BYOSA enforced (e.g. hpc-toolkit-dev-2), export the service account environment variable before applying:
+  # export TF_VAR_daily_tests_service_account="projects/MY_PROJECT/serviceAccounts/my-service-account@MY_PROJECT.iam.gserviceaccount.com"
+  service_account = var.daily_tests_service_account
 
   git_file_source {
     path      = "tools/cloud-build/daily-tests/builds/${each.key}.yaml"
@@ -46,14 +50,12 @@ module "daily_test_schedule" {
   schedule = each.value
 }
 
-resource "google_cloudbuild_trigger" "daily_test_migrated" {
-  for_each = toset(var.kueue_migrated_tests)
-  name     = "DAILY-test-${each.key}"
-  project  = var.daily_tests_project_id
-  tags     = [local.notify_chat_tag]
-  # For projects with BYOSA enforced (e.g. hpc-toolkit-dev-2), export the service account environment variable before applying:
-  # export TF_VAR_daily_tests_service_account="projects/MY_PROJECT/serviceAccounts/my-service-account@MY_PROJECT.iam.gserviceaccount.com"
-  service_account = var.daily_tests_service_account
+# Exception daily tests running in project_id (hpc-toolkit-dev)
+resource "google_cloudbuild_trigger" "daily_test_exceptions" {
+  for_each    = toset(var.daily_tests_dev_exceptions)
+  name        = "DAILY-test-${each.key}"
+  description = "Runs the '${each.key}' integration test against `develop`"
+  tags        = [local.notify_chat_tag]
 
   git_file_source {
     path      = "tools/cloud-build/daily-tests/builds/${each.key}.yaml"
@@ -76,9 +78,9 @@ resource "google_cloudbuild_trigger" "daily_test_migrated" {
   }
 }
 
-module "daily_test_schedule_migrated" {
+module "daily_test_schedule_exceptions" {
   source   = "./trigger-schedule"
-  for_each = toset(var.kueue_migrated_tests)
-  trigger  = google_cloudbuild_trigger.daily_test_migrated[each.key]
+  for_each = toset(var.daily_tests_dev_exceptions)
+  trigger  = google_cloudbuild_trigger.daily_test_exceptions[each.key]
   schedule = data.external.list_tests_midnight.result[each.key]
 }

--- a/tools/cloud-build/provision/list_tests.py
+++ b/tools/cloud-build/provision/list_tests.py
@@ -99,7 +99,8 @@ def schedule_evenly(builds: list[str], start: int, end: int) -> dict[str, int]:
 
 def check_resource_constraints(schedule: dict[str, int]) -> bool:
     for tests, min_distance in TEMPORAL_CONSTRAINTS:
-        for a, b  in itertools.combinations(tests, 2):
+        active_tests = [t for t in tests if t in schedule]
+        for a, b in itertools.combinations(active_tests, 2):
             if abs(schedule[a] - schedule[b]) < min_distance:
                 return False
     return True

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -44,69 +44,12 @@ variable "daily_tests_project_id" {
   default     = "hpc-toolkit-dev-2"
 }
 
-variable "kueue_migrated_tests" {
-  description = "List of tests migrated to Kueue"
+variable "daily_tests_dev_exceptions" {
+  description = "List of daily tests that must run in hpc-toolkit-dev in addition to hpc-toolkit-dev-2 (e.g. due to hardware reservations or quota constraints)"
   type        = list(string)
   default = [
-    "slurm-gcp-v6-rocky8",
-    "batch-mpi",
-    "htcondor",
-    "packer",
-    "monitoring",
-    "chrome-remote-desktop",
-    "chrome-remote-desktop-ubuntu",
-    "ansible-vm",
-    "e2e",
-    "hcls",
-    "slurm-gke",
-    "slurm-flex",
-    "ml-slurm",
-    "htc-slurm",
-    "hpc-build-slurm-image",
-    "hpc-enterprise-slurm",
-    "spack-gromacs",
-    "gcluster-dockerfile",
-    "gke",
-    "gke-inactive-reservation",
-    "ml-gke",
-    "ml-gke-e2e",
-    "gke-storage",
-    "gke-managed-hyperdisk",
-    "slurm-rapid-storage",
-    "gke-managed-lustre",
-    "pfs-managed-lustre-slurm",
-    "pfs-managed-lustre-vm",
-    "netapp-volumes",
-    "slurm-gcp-v6-reconfig-size",
-    "slurm-gcp-v6-simple-job-completion",
-    "slurm-gcp-v6-startup-scripts",
-    "slurm-gcp-v6-topology",
-    "slurm-gcp-v6-debian",
-    "slurm-gcp-v6-ubuntu",
-    "slurm-gcp-v6-ssd",
-    "gke-a2-highgpu-kueue-onspot",
-    "gke-a4-onspot",
-    "gke-g4-onspot",
-    "gke-h4d-onspot",
-    "ml-h4d-onspot-slurm",
-    "h4d-vm",
-    "ml-a3-highgpu-onspot-slurm",
-    "ml-a4-highgpu-onspot-slurm",
-    "ml-g4-onspot-slurm",
-    "gke-a3-highgpu-onspot",
-    "gke-a3-megagpu-onspot",
-    "gke-tpu-v6e",
-    "ml-a3-megagpu-onspot-slurm-ubuntu",
-    "gke-a3-ultragpu-onspot",
-    "ml-a3-ultragpu-onspot-slurm",
-    "ml-a3-ultragpu-onspot-jbvms",
-    "gke-a4x",
-    "ml-a4x-highgpu-slurm",
-    "batch",
     "gke-g4-confidential",
-    "gke-tpu-v5e",
     "gke-tpu-7x",
-    "gke-tpu-v5p"
   ]
 }
 

--- a/tools/cloud-build/provision/variables.tf
+++ b/tools/cloud-build/provision/variables.tf
@@ -46,7 +46,7 @@ variable "daily_tests_project_id" {
 
 variable "daily_tests_dev_exceptions" {
   description = "List of daily tests that must run in hpc-toolkit-dev in addition to hpc-toolkit-dev-2 (e.g. due to hardware reservations or quota constraints)"
-  type        = list(string)
+  type        = set(string)
   default = [
     "gke-g4-confidential",
     "gke-tpu-7x",


### PR DESCRIPTION
## Description
This PR transitions the daily integration test `hpc-toolkit-dev-2`. It also establishes an explicit exceptions list for tests that must continue running in `hpc-toolkit-dev`.

## Changes Made
1. **Dynamic Test Discovery in `hpc-toolkit-dev-2` ([`daily-tests.tf`](file:///usr/local/google/home/rahimkh/Desktop/Projects/cluster-toolkit/tools/cloud-build/provision/daily-tests.tf)):**
   - Cut over `google_cloudbuild_trigger.daily_test` and `module.daily_test_schedule` to `var.daily_tests_project_id` (`hpc-toolkit-dev-2`), dynamically referencing `data.external.list_tests_midnight.result`. Any new test YAML added to `builds/` is now automatically scheduled without modifying Terraform variables.

2. **Explicit Exceptions in `hpc-toolkit-dev` ([`variables.tf`](file:///usr/local/google/home/rahimkh/Desktop/Projects/cluster-toolkit/tools/cloud-build/provision/variables.tf)):**
   - Added `google_cloudbuild_trigger.daily_test_exceptions` and `module.daily_test_schedule_exceptions` to run these tests in `hpc-toolkit-dev`.

3. **Defensive Scheduling Bugfix in [`list_tests.py`](file:///usr/local/google/home/rahimkh/Desktop/Projects/cluster-toolkit/tools/cloud-build/provision/list_tests.py):**
   - Filtered `TEMPORAL_CONSTRAINTS` to only evaluate tests present in the generated schedule (`active_tests = [t for t in tests if t in schedule]`). This prevents `KeyError` crashes when tests referenced in temporal constraints are deleted.