### PR TITLE
fix(ci): resolve failing PR tests for release 1.103.0

### DIFF
--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -158,7 +158,7 @@ deployment_groups:
     use: [gke-a4-net-0, workload_service_account]
     settings:
       auto_monitoring_scope: $(vars.auto_monitoring_scope)
-      system_node_pool_machine_type: "n2d-standard-16"
+      system_node_pool_machine_type: "n2d-standard-8"
       system_node_pool_disk_size_gb: $(vars.system_node_pool_disk_size_gb)
       system_node_pool_taints: []
       enable_dcgm_monitoring: true

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -21,7 +21,7 @@ vars:
   # The GCP Region used for this deployment.
   region: us-central1
   # The GCP Zone used for this deployment.
-  zone: us-central1-a
+  zone: us-central1-b
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
   authorized_cidr:  # <your-ip-address>/32

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -118,6 +118,7 @@ deployment_groups:
     use: [network, workload_service_account]
     settings:
       version_prefix: $(vars.version_prefix)
+      system_node_pool_machine_type: "n2d-standard-4"
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       configure_workload_identity_sa: true
       enable_private_endpoint: false  # Allows for access from authorized public IPs
@@ -143,5 +144,5 @@ deployment_groups:
     settings:
       name: gke-lustre-pool
       zones: [$(vars.zone)]
-      machine_type: n2-standard-16
+      machine_type: n2d-standard-4
       auto_upgrade: true

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -21,7 +21,7 @@ vars:
   # The GCP Region used for this deployment.
   region: us-central1
   # The GCP Zone used for this deployment.
-  zone: us-central1-b
+  zone: us-central1-a
   # Cidr block containing the IP of the machine calling terraform.
   # The following line must be updated for this example to work.
   authorized_cidr:  # <your-ip-address>/32
@@ -32,7 +32,7 @@ vars:
   # The values of size_gib and per_unit_storage_throughput are co-related
   # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
   # Storage capacity of the lustre instance in GiB
-  size_gib: 36000
+  size_gib: 18000
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
   kms_key: ""

--- a/examples/gke-managed-lustre.yaml
+++ b/examples/gke-managed-lustre.yaml
@@ -36,6 +36,7 @@ vars:
   # Maximum throughput of the lustre instance in MBps per TiB
   per_unit_storage_throughput: 500
   kms_key: ""
+  system_node_pool_machine_type: "n2d-standard-4"
 
 deployment_groups:
 - group: primary
@@ -118,7 +119,7 @@ deployment_groups:
     use: [network, workload_service_account]
     settings:
       version_prefix: $(vars.version_prefix)
-      system_node_pool_machine_type: "n2d-standard-4"
+      system_node_pool_machine_type: $(vars.system_node_pool_machine_type)
       enable_managed_lustre_csi: true # Enable Managed Lustre for the cluster
       configure_workload_identity_sa: true
       enable_private_endpoint: false  # Allows for access from authorized public IPs

--- a/examples/image-builder.yaml
+++ b/examples/image-builder.yaml
@@ -27,7 +27,7 @@ vars:
   custom_image:
     family: my-slurm-image
     project: $(vars.project_id)
-  disk_size: 32
+  disk_size: 50
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md

--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -438,7 +438,7 @@ deployment_groups:
     settings:
       disk_size_gb: $(vars.disk_size_gb)
       enable_login_public_ips: true
-      machine_type: n2d-standard-16
+      machine_type: n2d-standard-8
       metadata:
         user-data: |
           #cloud-config
@@ -501,7 +501,7 @@ deployment_groups:
       enable_controller_public_ips: true
       disk_type: pd-extreme
       disk_size_gb: $(vars.disk_size_gb)
-      machine_type: n2d-standard-16
+      machine_type: n2d-standard-8
       controller_startup_script: $(controller_startup.startup_script)
       enable_external_prolog_epilog: true
       compute_startup_scripts_timeout: 1800

--- a/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-inactive-reservation.yaml
@@ -153,7 +153,7 @@ steps:
               echo '    use: [network1]'                                    >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
-              echo '      zone: us-central1-a'                              >> \$$EXAMPLE_BP
+              echo '      zone: us-east4-a'                              >> \$$EXAMPLE_BP
 
               # Adding node pool with reservation defined
               echo '  - id: compute-pool-reservation'                       >> \$$EXAMPLE_BP
@@ -161,7 +161,7 @@ steps:
               echo '    use: [gke_cluster, node_pool_service_account]'      >> \$$EXAMPLE_BP
               echo '    settings:'                                          >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'                     >> \$$EXAMPLE_BP
-              echo '      zones: [us-central1-a]'                           >> \$$EXAMPLE_BP
+              echo '      zones: [us-east4-a]'                           >> \$$EXAMPLE_BP
               echo '      static_node_count: 0'                             >> \$$EXAMPLE_BP
               echo '      is_reservation_active: false'                     >> \$$EXAMPLE_BP
               echo '      reservation_affinity:'                            >> \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -154,7 +154,7 @@ steps:
               echo '    use: [network]'                      >> \$$EXAMPLE_BP
               echo '    settings:'                           >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'       >> \$$EXAMPLE_BP
-              echo '      zone: us-central1-a'               >> \$$EXAMPLE_BP
+              echo '      zone: us-central1-b'               >> \$$EXAMPLE_BP
 
               IP=\$(curl ifconfig.me)
               sed -i "s|.*authorized_cidr:.*|  authorized_cidr: \$$IP/32|" \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-managed-lustre.yaml
@@ -154,7 +154,7 @@ steps:
               echo '    use: [network]'                      >> \$$EXAMPLE_BP
               echo '    settings:'                           >> \$$EXAMPLE_BP
               echo '      machine_type: n2d-standard-2'       >> \$$EXAMPLE_BP
-              echo '      zone: us-central1-b'               >> \$$EXAMPLE_BP
+              echo '      zone: $(vars.zone)'                 >> \$$EXAMPLE_BP
 
               IP=\$(curl ifconfig.me)
               sed -i "s|.*authorized_cidr:.*|  authorized_cidr: \$$IP/32|" \$$EXAMPLE_BP

--- a/tools/cloud-build/daily-tests/builds/gke.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke.yaml
@@ -149,7 +149,7 @@ steps:
               echo '    use: [network1]'                     >> \$$SG_EXAMPLE
               echo '    settings:'                           >> \$$SG_EXAMPLE
               echo '      machine_type: n2d-standard-2'       >> \$$SG_EXAMPLE
-              echo '      zone: us-central1-a'               >> \$$SG_EXAMPLE
+              echo '      zone: us-east4-a'               >> \$$SG_EXAMPLE
 
               echo '  - id: ubuntu_pool'                                         >> \$$SG_EXAMPLE
               echo '    source: modules/compute/gke-node-pool'                   >> \$$SG_EXAMPLE

--- a/tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-inactive-reservation.yml
@@ -14,8 +14,8 @@
 ---
 test_name: gke-inactive-reservation
 deployment_name: gke-ir-{{ build }}
-region: us-central1
-zone: us-central1-a
+region: us-east4
+zone: us-east4-a
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-gke.yaml"
 network: "{{ deployment_name }}-net"

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -15,7 +15,7 @@
 test_name: gke-managed-lustre
 deployment_name: gke-ml-{{ build }}
 region: us-central1
-zone: us-central1-a
+zone: us-central1-b
 lustre_instance_id: "{{ deployment_name }}-lstr"
 size_gib: 36000
 per_unit_storage_throughput: 500

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -37,3 +37,4 @@ cli_deployment_vars:
   per_unit_storage_throughput: "{{ per_unit_storage_throughput }}"
   gcp_public_cidrs_access_enabled: true
   kms_key: "projects/{{ project }}/locations/us-central1/keyRings/lustre-keyring/cryptoKeys/lustre-key"
+  system_node_pool_machine_type: "n2d-standard-4"

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -15,9 +15,9 @@
 test_name: gke-managed-lustre
 deployment_name: gke-ml-{{ build }}
 region: us-central1
-zone: us-central1-b
+zone: us-central1-a
 lustre_instance_id: "{{ deployment_name }}-lstr"
-size_gib: 36000
+size_gib: 18000
 per_unit_storage_throughput: 500
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/gke-managed-lustre.yaml"

--- a/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-managed-lustre.yml
@@ -37,4 +37,3 @@ cli_deployment_vars:
   per_unit_storage_throughput: "{{ per_unit_storage_throughput }}"
   gcp_public_cidrs_access_enabled: true
   kms_key: "projects/{{ project }}/locations/us-central1/keyRings/lustre-keyring/cryptoKeys/lustre-key"
-  system_node_pool_machine_type: "n2d-standard-4"

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -23,4 +23,6 @@ cli_deployment_vars:
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
   region: us-east4
+  zone: "{{ zone }}"
 post_deploy_tests: []
+

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -25,4 +25,3 @@ cli_deployment_vars:
   region: us-east4
   zone: "{{ zone }}"
 post_deploy_tests: []
-

--- a/tools/cloud-build/daily-tests/tests/gke.yml
+++ b/tools/cloud-build/daily-tests/tests/gke.yml
@@ -14,7 +14,7 @@
 ---
 test_name: hpc-gke
 deployment_name: gke-{{ build }}
-zone: us-central1-a  # for remote node
+zone: us-east4-a  # for remote node
 workspace: /workspace
 blueprint_yaml: "{{ workspace }}/examples/hpc-gke.yaml"
 network: "{{ deployment_name }}-net"
@@ -22,4 +22,5 @@ remote_node: "{{ deployment_name }}-0"
 cli_deployment_vars:
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
+  region: us-east4
 post_deploy_tests: []


### PR DESCRIPTION
- **GKE A4 & Slurm A4**: Downsize system and login/controller nodes to `n2d-standard-8` to reduce quota pressure and prevent Compute Engine stockouts.
- **Image Builder**: Increase default `disk_size` in `examples/image-builder.yaml` from 32 GB to 50 GB to satisfy base Rocky Linux 9 HPC disk requirements during Packer builds.
- **GKE & Inactive Reservation Integration Tests**: Relocate daily/PR integration tests (`hpc-gke` and `gke-inactive-reservation`) to `us-east4` / `us-east4-a` to eliminate `us-central1` stockouts without modifying public examples, ensuring `zone` is explicitly passed in `cli_deployment_vars`.
- **GKE Managed Lustre Integration Test**:
  - Adopt `n2d-standard-4` for GKE system and workload node pools to eliminate 40-minute cluster creation timeouts caused by regional `N4` and `N2` stockouts in `us-central1`.
  - Downsize Managed Lustre storage from 36 TiB to 18 TiB (`size_gib: 18000`), matching the documented minimum for the 500 MBps/TiB tier and halving hardware allocation requirements.
  - Set zone to `us-central1-a` to bypass storage exhaustion in `us-central1-b` while preserving compatibility with the regional `us-central1` CMEK key.