### PR TITLE
fix(gke): resolve TPU 7x NAP workload policies and improve GKE auth endpoint selection

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -66,7 +66,7 @@ func NewGKEOrchestrator() *GKEOrchestrator {
 		topologyCache:            make(map[string]string),
 		dynamicSlicingCache:      make(map[string]bool),
 		staticSlicingCache:       make(map[string]bool),
-		policyCache:              make(map[string]string),
+		resourcePolicyCache:      make(map[string]*GCEWorkloadPolicy),
 	}
 }
 
@@ -1477,13 +1477,21 @@ func (g *GKEOrchestrator) configureKubectl(clusterName, clusterLocation, project
 	return g.restoreNamespaceContext(originalNamespace)
 }
 
+// shouldUseDNSEndpoint determines whether to pass --dns-endpoint to gcloud container clusters get-credentials.
+// When a public IP endpoint is enabled, we prefer the IP endpoint to avoid HTTP 431 request header overflow issues on enterprise networks.
+// When only external DNS access is permitted without a public IP endpoint, we use the DNS endpoint.
+func shouldUseDNSEndpoint(cfg *controlPlaneEndpointsConfig) bool {
+	if cfg == nil || cfg.DnsEndpointConfig == nil || !cfg.DnsEndpointConfig.AllowExternalTraffic {
+		return false
+	}
+	return cfg.IPEndpointsConfig == nil || !cfg.IPEndpointsConfig.EnablePublicEndpoint
+}
+
 // refreshGKEAuth handles the gcloud container clusters get-credentials call.
 func (g *GKEOrchestrator) refreshGKEAuth(clusterName, clusterLocation, projectID string) error {
 	args := []string{"container", "clusters", "get-credentials", clusterName, "--location", clusterLocation, "--project", projectID}
 
-	if g.clusterDesc.ControlPlaneEndpointsConfig != nil &&
-		g.clusterDesc.ControlPlaneEndpointsConfig.DnsEndpointConfig != nil &&
-		g.clusterDesc.ControlPlaneEndpointsConfig.DnsEndpointConfig.AllowExternalTraffic {
+	if shouldUseDNSEndpoint(g.clusterDesc.ControlPlaneEndpointsConfig) {
 		args = append(args, "--dns-endpoint")
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -5068,3 +5068,144 @@ func TestCalculateClusterCapacity_MultipleCPUPools(t *testing.T) {
 		t.Errorf("expected flavor-default not to have cloud.google.com/gke-nodepool label, but got %q", npLabel)
 	}
 }
+
+func TestShouldUseDNSEndpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		clusterDesc  gkeCluster
+		wantEndpoint bool
+	}{
+		{
+			name:         "Nil ControlPlaneEndpointsConfig returns false",
+			clusterDesc:  gkeCluster{},
+			wantEndpoint: false,
+		},
+		{
+			name: "Nil DnsEndpointConfig returns false",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{},
+			},
+			wantEndpoint: false,
+		},
+		{
+			name: "DnsEndpointConfig external traffic disallowed returns false",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: false,
+					},
+				},
+			},
+			wantEndpoint: false,
+		},
+		{
+			name: "DnsEndpointConfig external traffic allowed with nil IPEndpointsConfig returns true",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: true,
+					},
+				},
+			},
+			wantEndpoint: true,
+		},
+		{
+			name: "Public IP endpoint enabled bypasses DNS endpoint to prevent HTTP 431 header issues",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: true,
+					},
+					IPEndpointsConfig: &ipEndpointsConfig{
+						EnablePublicEndpoint: true,
+					},
+				},
+			},
+			wantEndpoint: false,
+		},
+		{
+			name: "Public IP endpoint disabled uses DNS endpoint for external connectivity",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: true,
+					},
+					IPEndpointsConfig: &ipEndpointsConfig{
+						EnablePublicEndpoint: false,
+					},
+				},
+			},
+			wantEndpoint: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldUseDNSEndpoint(tt.clusterDesc.ControlPlaneEndpointsConfig)
+			if got != tt.wantEndpoint {
+				t.Errorf("shouldUseDNSEndpoint() = %v, want %v", got, tt.wantEndpoint)
+			}
+		})
+	}
+}
+
+func TestRefreshGKEAuth_DNSEndpoint(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterDesc   gkeCluster
+		mockResponses map[string][]shell.CommandResult
+		wantErr       bool
+	}{
+		{
+			name: "Appends --dns-endpoint when shouldUseDNSEndpoint is true",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: true,
+					},
+					IPEndpointsConfig: &ipEndpointsConfig{
+						EnablePublicEndpoint: false,
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud container clusters get-credentials my-cluster --location us-central1-a --project my-project --dns-endpoint": {
+					{ExitCode: 0, Stdout: "kubeconfig entry generated"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Omits --dns-endpoint when public IP endpoint is available",
+			clusterDesc: gkeCluster{
+				ControlPlaneEndpointsConfig: &controlPlaneEndpointsConfig{
+					DnsEndpointConfig: &dnsEndpointConfig{
+						AllowExternalTraffic: true,
+					},
+					IPEndpointsConfig: &ipEndpointsConfig{
+						EnablePublicEndpoint: true,
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud container clusters get-credentials my-cluster --location us-central1-a --project my-project": {
+					{ExitCode: 0, Stdout: "kubeconfig entry generated"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExec := NewMockExecutor(tt.mockResponses)
+			orc := newTestGKEOrchestrator(mockExec)
+			orc.clusterDesc = tt.clusterDesc
+
+			err := orc.refreshGKEAuth("my-cluster", "us-central1-a", "my-project")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("refreshGKEAuth() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -94,6 +94,7 @@ func newTestGKEOrchestrator(executor Executor) *GKEOrchestrator {
 		topologyCache:            make(map[string]string),
 		dynamicSlicingCache:      make(map[string]bool),
 		staticSlicingCache:       make(map[string]bool),
+		resourcePolicyCache:      make(map[string]*GCEWorkloadPolicy),
 	}
 }
 

--- a/pkg/orchestrator/gke/manifest_generator.go
+++ b/pkg/orchestrator/gke/manifest_generator.go
@@ -17,6 +17,7 @@ package gke
 import (
 	"bytes"
 	"fmt"
+	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
 	"hpc-toolkit/pkg/orchestrator"
 	"strings"
@@ -118,6 +119,7 @@ func (g *GKEOrchestrator) PrepareManifestOptions(job orchestrator.JobDefinition,
 		Scheduler:          job.GKEScheduler,
 		IsDynamicSlicing:   isDynamicSlicing,
 		IsStaticSlicing:    isStaticSlicing,
+		IsTPU:              config.IsTPU(job.MachineType) || config.IsTPU(originalAccelType),
 	}
 
 	// Reuse GCluster's existing GKE accelerator label mapping and algorithmically

--- a/pkg/orchestrator/gke/manifest_generator_test.go
+++ b/pkg/orchestrator/gke/manifest_generator_test.go
@@ -292,3 +292,157 @@ func TestGeneratePathwaysManifest_MLDiagnosticsDisabled(t *testing.T) {
 		t.Errorf("Expected manifest to NOT contain ML Diagnostics label when disabled, got:\n%s", manifest)
 	}
 }
+
+func TestGenerateGKEManifest_OlderTPU_Default(t *testing.T) {
+	setupMockMachineConfig(t)
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "tpu-v4-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "ct4p-hightpu-4t",
+		Topology:        "2x2x2",
+		NumSlices:       1,
+		ClusterLocation: "us-central1-a",
+		ProjectID:       "mock-project",
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "2x2x2"}},
+		"gcloud compute machine-types describe ct4p-hightpu-4t --zone=us-central1-a --format=json":                              {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v4-podslice"}]}`}},
+	}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.projectID = "mock-project"
+	orc.clusterZones = []string{"us-central1-a"}
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Name: "v4-pool", Config: gkeNodePoolConfig{MachineType: "ct4p-hightpu-4t"}},
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	if job.NodesPerSlice != 2 {
+		t.Fatalf("expected NodesPerSlice to be 2 for 2x2x2 topology on ct4p-hightpu-4t, got %d", job.NodesPerSlice)
+	}
+	if job.PlacementPolicy != "" {
+		t.Errorf("expected PlacementPolicy to be empty for TPU v4, got %q", job.PlacementPolicy)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	if strings.Contains(manifest, "cloud.google.com/placement-policy-name") {
+		t.Errorf("Did not expect cloud.google.com/placement-policy-name in TPU v4 manifest:\n%s", manifest)
+	}
+	if strings.Contains(manifest, "cloud.google.com/gke-placement-group") {
+		t.Errorf("Did not expect cloud.google.com/gke-placement-group in TPU v4 manifest:\n%s", manifest)
+	}
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-accelerator: tpu-v4-podslice") {
+		t.Errorf("Expected cloud.google.com/gke-tpu-accelerator: tpu-v4-podslice in manifest:\n%s", manifest)
+	}
+	if !strings.Contains(manifest, "cloud.google.com/gke-tpu-topology: 2x2x2") {
+		t.Errorf("Expected cloud.google.com/gke-tpu-topology: 2x2x2 in manifest:\n%s", manifest)
+	}
+}
+
+func TestGenerateGKEManifest_OlderTPU_UserSpecifiedPlacement(t *testing.T) {
+	setupMockMachineConfig(t)
+	job := orchestrator.JobDefinition{
+		WorkloadName:    "tpu-v4-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "ct4p-hightpu-4t",
+		Topology:        "2x2x2",
+		NumSlices:       1,
+		ClusterLocation: "us-central1-a",
+		ProjectID:       "mock-project",
+		PlacementPolicy: "my-custom-tpu-policy",
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: "2x2x2"}},
+		"gcloud compute machine-types describe ct4p-hightpu-4t --zone=us-central1-a --format=json":                              {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 4, "guestAcceleratorType": "tpu-v4-podslice"}]}`}},
+	}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.projectID = "mock-project"
+	orc.clusterZones = []string{"us-central1-a"}
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Name: "v4-pool", Config: gkeNodePoolConfig{MachineType: "ct4p-hightpu-4t"}},
+	}
+
+	profile, isDynamicSlicing, isStaticSlicing, err := orc.resolveHardwareRequirements(&job)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed: %v", err)
+	}
+
+	opts, err := orc.PrepareManifestOptions(job, "test-image:latest", profile, isDynamicSlicing, isStaticSlicing)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed: %v", err)
+	}
+
+	manifest, err := orc.GenerateGKEManifest(opts, profile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed: %v", err)
+	}
+
+	if !strings.Contains(manifest, "cloud.google.com/placement-policy-name: my-custom-tpu-policy") {
+		t.Errorf("Expected cloud.google.com/placement-policy-name for TPU when specified, got:\n%s", manifest)
+	}
+	if strings.Contains(manifest, "cloud.google.com/gke-placement-group") {
+		t.Errorf("Did not expect cloud.google.com/gke-placement-group on TPU, got:\n%s", manifest)
+	}
+}
+
+func TestGenerateGKEManifest_GPU_Placement(t *testing.T) {
+	setupMockMachineConfig(t)
+	gpuJob := orchestrator.JobDefinition{
+		WorkloadName:    "gpu-job",
+		CommandToRun:    "echo hello",
+		ComputeType:     "a3-highgpu-8g",
+		ClusterLocation: "us-central1-a",
+		ProjectID:       "mock-project",
+		PlacementPolicy: "my-gpu-group",
+	}
+
+	mockResponses := map[string][]shell.CommandResult{
+		"kubectl get resourceflavors": {{ExitCode: 0, Stdout: ""}},
+		"kubectl get nodes -o jsonpath={range .items[*]}{.metadata.labels.cloud\\.google\\.com/gke-tpu-topology}{\"\\n\"}{end}": {{ExitCode: 0, Stdout: ""}},
+		"gcloud compute machine-types describe a3-highgpu-8g --zone=us-central1-a --format=json":                                {{ExitCode: 0, Stdout: `{"accelerators": [{"guestAcceleratorCount": 8, "guestAcceleratorType": "nvidia-h100-80gb"}]}`}},
+	}
+	orc := newTestGKEOrchestrator(NewMockExecutor(mockResponses))
+	orc.projectID = "mock-project"
+	orc.clusterZones = []string{"us-central1-a"}
+	orc.clusterDesc.NodePools = []gkeJobNodePool{
+		{Name: "gpu-pool", Config: gkeNodePoolConfig{MachineType: "a3-highgpu-8g"}},
+	}
+
+	gpuProfile, isDyn, isStat, err := orc.resolveHardwareRequirements(&gpuJob)
+	if err != nil {
+		t.Fatalf("resolveHardwareRequirements failed for GPU: %v", err)
+	}
+
+	gpuOpts, err := orc.PrepareManifestOptions(gpuJob, "test-image:latest", gpuProfile, isDyn, isStat)
+	if err != nil {
+		t.Fatalf("PrepareManifestOptions failed for GPU: %v", err)
+	}
+
+	gpuManifest, err := orc.GenerateGKEManifest(gpuOpts, gpuProfile)
+	if err != nil {
+		t.Fatalf("GenerateGKEManifest failed for GPU: %v", err)
+	}
+
+	if !strings.Contains(gpuManifest, "cloud.google.com/gke-placement-group: my-gpu-group") {
+		t.Errorf("Expected cloud.google.com/gke-placement-group for GPU, got:\n%s", gpuManifest)
+	}
+	if strings.Contains(gpuManifest, "cloud.google.com/placement-policy-name") {
+		t.Errorf("Did not expect cloud.google.com/placement-policy-name for GPU, got:\n%s", gpuManifest)
+	}
+}

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -329,12 +329,21 @@ func (g *GKEOrchestrator) resolveTPUWorkloadPolicy(machineType, topology, cluste
 	return canonicalPolicyName, nil
 }
 
+// isStaticWorkloadPolicyMode checks whether the accelerator topology mode provides a
+// static, pre-connected accelerator topology suitable for non-dynamic workloads.
+// In GCE, standard static workload policies omit this field (defaulting to auto-connected)
+// or explicitly specify "AUTO_CONNECT".
+func isStaticWorkloadPolicyMode(mode string) bool {
+	trimmed := strings.TrimSpace(mode)
+	return trimmed == "" || strings.EqualFold(trimmed, "AUTO_CONNECT")
+}
+
 func (g *GKEOrchestrator) getCachedTPUWorkloadPolicy(canonicalPolicyName, topology string) string {
 	if g.resourcePolicyCache == nil {
 		return ""
 	}
 	cached := g.resourcePolicyCache[canonicalPolicyName]
-	if cached != nil && strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") && cached.AcceleratorTopology == topology {
+	if cached != nil && strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") && cached.AcceleratorTopology == topology && isStaticWorkloadPolicyMode(cached.AcceleratorTopologyMode) {
 		return canonicalPolicyName
 	}
 	return ""
@@ -342,7 +351,7 @@ func (g *GKEOrchestrator) getCachedTPUWorkloadPolicy(canonicalPolicyName, topolo
 
 // findPolicyInClusterNodePools inspects the cluster's existing node pools for an active
 // placement policy matching the requested machine type and TPU topology.
-// Dynamic slicing policies (PROVISION_ONLY) are skipped for static workloads.
+// Non-static policies (such as dynamic slicing PROVISION_ONLY) are skipped for static workloads.
 func (g *GKEOrchestrator) findPolicyInClusterNodePools(machineType, topology string) string {
 	for _, np := range g.clusterDesc.NodePools {
 		if strings.EqualFold(np.Config.MachineType, machineType) && np.PlacementPolicy != nil && np.PlacementPolicy.PolicyName != "" {
@@ -352,8 +361,8 @@ func (g *GKEOrchestrator) findPolicyInClusterNodePools(machineType, topology str
 					mode = cached.AcceleratorTopologyMode
 				}
 			}
-			if strings.EqualFold(mode, "PROVISION_ONLY") {
-				continue // Skip dynamic slicing policies for static workloads
+			if !isStaticWorkloadPolicyMode(mode) {
+				continue // Skip non-static (e.g. PROVISION_ONLY) policies for static workloads
 			}
 			topo := np.PlacementPolicy.TpuTopology
 			if topo == "" && np.Config.Labels != nil {
@@ -397,36 +406,48 @@ func (g *GKEOrchestrator) resolvePolicyRegionAndProject(clusterLocation, project
 // discoverRegionalWorkloadPolicy searches for an existing HIGH_THROUGHPUT workload policy
 // in the specified GCP region and project. It first checks for the canonical policy name,
 // and if not found or incompatible, falls back to querying regional policies matching the topology.
+// Only policies with static auto-connected topology modes (empty or AUTO_CONNECT) are matched.
 func (g *GKEOrchestrator) discoverRegionalWorkloadPolicy(canonicalPolicyName, region, projectID, topology string) (string, error) {
 	policy, err := g.describeResourcePolicyCached(canonicalPolicyName, region, projectID)
 	if err != nil {
 		return "", err
 	}
 	if policy != nil {
-		if strings.EqualFold(policy.Type, "HIGH_THROUGHPUT") && policy.AcceleratorTopology == topology {
+		if strings.EqualFold(policy.Type, "HIGH_THROUGHPUT") && policy.AcceleratorTopology == topology && isStaticWorkloadPolicyMode(policy.AcceleratorTopologyMode) {
 			logging.Info("Discovered existing workload policy %q in region %s", canonicalPolicyName, region)
 			return canonicalPolicyName, nil
 		}
-		logging.Warn("Found policy %q in region %s, but its type (%q) or topology (%q) does not match expected (HIGH_THROUGHPUT, %s). Skipping it.",
-			canonicalPolicyName, region, policy.Type, policy.AcceleratorTopology, topology)
+		logging.Warn("Found policy %q in region %s, but its type (%q), mode (%q), or topology (%q) does not match expected (HIGH_THROUGHPUT, static auto-connected, %s). Skipping it.",
+			canonicalPolicyName, region, policy.Type, policy.AcceleratorTopologyMode, policy.AcceleratorTopology, topology)
 	}
 
 	filter := fmt.Sprintf("region:( %s ) AND workloadPolicy.acceleratorTopology=%s AND workloadPolicy.type=HIGH_THROUGHPUT", region, topology)
-	listRes := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "list", "--project="+projectID, "--filter="+filter, "--format=value(name)")
+	listRes := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "list", "--project="+projectID, "--filter="+filter, "--format=value(name,workloadPolicy.acceleratorTopologyMode)")
 	if listRes.ExitCode == 0 && strings.TrimSpace(listRes.Stdout) != "" {
-		names := strings.Fields(listRes.Stdout)
-		if len(names) > 0 {
-			if g.resourcePolicyCache == nil {
-				g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+		for _, line := range strings.Split(strings.TrimSpace(listRes.Stdout), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
 			}
-			g.resourcePolicyCache[names[0]] = &GCEWorkloadPolicy{
-				Name:                names[0],
-				Region:              region,
-				AcceleratorTopology: topology,
-				Type:                "HIGH_THROUGHPUT",
+			name := fields[0]
+			mode := ""
+			if len(fields) > 1 {
+				mode = fields[1]
 			}
-			logging.Info("Discovered matching workload policy %q for topology %s in region %s", names[0], topology, region)
-			return names[0], nil
+			if isStaticWorkloadPolicyMode(mode) {
+				if g.resourcePolicyCache == nil {
+					g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+				}
+				g.resourcePolicyCache[name] = &GCEWorkloadPolicy{
+					Name:                    name,
+					Region:                  region,
+					AcceleratorTopology:     topology,
+					AcceleratorTopologyMode: mode,
+					Type:                    "HIGH_THROUGHPUT",
+				}
+				logging.Info("Discovered matching workload policy %q for topology %s in region %s", name, topology, region)
+				return name, nil
+			}
 		}
 	}
 	return "", nil
@@ -441,25 +462,19 @@ func (g *GKEOrchestrator) createTPUWorkloadPolicy(canonicalPolicyName, region, p
 	if createRes.ExitCode != 0 {
 		stderrLower := strings.ToLower(createRes.Stderr)
 		if strings.Contains(stderrLower, "already exists") || strings.Contains(stderrLower, "409") {
-			if cached := g.resourcePolicyCache[canonicalPolicyName]; cached != nil && (!strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") || cached.AcceleratorTopology != topology) {
-				return fmt.Errorf("a resource policy named %q already exists in region %s with incompatible settings (type=%q, topology=%q); expected HIGH_THROUGHPUT and %s. Please remove or rename the existing policy, or specify an existing valid placement policy via --placement-policy",
-					canonicalPolicyName, region, cached.Type, cached.AcceleratorTopology, topology)
+			if cached := g.resourcePolicyCache[canonicalPolicyName]; cached != nil && (!strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") || cached.AcceleratorTopology != topology || !isStaticWorkloadPolicyMode(cached.AcceleratorTopologyMode)) {
+				return fmt.Errorf("a resource policy named %q already exists in region %s with incompatible settings (type=%q, topology=%q, mode=%q); expected HIGH_THROUGHPUT, static auto-connected, and %s. Please remove or rename the existing policy, or specify an existing valid placement policy via --placement-policy",
+					canonicalPolicyName, region, cached.Type, cached.AcceleratorTopology, cached.AcceleratorTopologyMode, topology)
 			}
 			logging.Info("Workload policy %q was concurrently created.", canonicalPolicyName)
-			if g.resourcePolicyCache == nil {
-				g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
-			}
-			g.resourcePolicyCache[canonicalPolicyName] = &GCEWorkloadPolicy{
-				Name:                canonicalPolicyName,
-				Region:              region,
-				AcceleratorTopology: topology,
-				Type:                "HIGH_THROUGHPUT",
-			}
-			return nil
+		} else {
+			return fmt.Errorf("failed to create required workload policy %q in region %s: %s\nRemediation: Ensure your GCP credentials have 'compute.resourcePolicies.create' permission (e.g. 'roles/compute.admin') or create the policy manually:\n  gcloud compute resource-policies create workload-policy %s --region=%s --project=%s --type=HIGH_THROUGHPUT --accelerator-topology=%s",
+				canonicalPolicyName, region, createRes.Stderr, canonicalPolicyName, region, projectID, topology)
 		}
-		return fmt.Errorf("failed to create required workload policy %q in region %s: %s\nRemediation: Ensure your GCP credentials have 'compute.resourcePolicies.create' permission (e.g. 'roles/compute.admin') or create the policy manually:\n  gcloud compute resource-policies create workload-policy %s --region=%s --project=%s --type=HIGH_THROUGHPUT --accelerator-topology=%s",
-			canonicalPolicyName, region, createRes.Stderr, canonicalPolicyName, region, projectID, topology)
+	} else {
+		logging.Info("Successfully created workload policy %q in region %s", canonicalPolicyName, region)
 	}
+
 	if g.resourcePolicyCache == nil {
 		g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
 	}
@@ -469,6 +484,5 @@ func (g *GKEOrchestrator) createTPUWorkloadPolicy(canonicalPolicyName, region, p
 		AcceleratorTopology: topology,
 		Type:                "HIGH_THROUGHPUT",
 	}
-	logging.Info("Successfully created workload policy %q in region %s", canonicalPolicyName, region)
 	return nil
 }

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -15,11 +15,16 @@
 package gke
 
 import (
+	"errors"
 	"fmt"
-	"hpc-toolkit/pkg/config"
-	"hpc-toolkit/pkg/orchestrator"
+	"path"
 	"sort"
 	"strings"
+
+	"hpc-toolkit/pkg/config"
+	"hpc-toolkit/pkg/logging"
+	"hpc-toolkit/pkg/orchestrator"
+	"hpc-toolkit/pkg/shell"
 )
 
 func (g *GKEOrchestrator) isNAPEnabledForMachineType(machineType, zone string) (bool, error) {
@@ -270,5 +275,200 @@ func (g *GKEOrchestrator) populateNAPFlavors(flavors map[string]FlavorCapacity) 
 			}
 		}
 	}
+	return nil
+}
+
+// resolveTPUWorkloadPolicy resolves or auto-creates a GCE HIGH_THROUGHPUT workload policy
+// required for multi-host TPU 7x Node Auto-Provisioning (NAP) to successfully scale from 0.
+// Resolution order:
+//  1. Check existing TPU 7x node pools in the cluster for an attached placement policy.
+//  2. Check the regional resource policy cache or query GCE for a policy matching the topology.
+//  3. If missing and not in dry-run mode, auto-create the canonical workload policy.
+func (g *GKEOrchestrator) resolveTPUWorkloadPolicy(machineType, topology, clusterLocation, projectID string, isDryRun bool) (string, error) {
+	if topology == "" {
+		return "", fmt.Errorf("cannot resolve TPU workload policy: topology is empty")
+	}
+
+	if policy := g.findPolicyInClusterNodePools(machineType, topology); policy != "" {
+		return policy, nil
+	}
+
+	canonicalPolicyName := getCanonicalTPUWorkloadPolicyName(topology)
+	if policy := g.getCachedTPUWorkloadPolicy(canonicalPolicyName, topology); policy != "" {
+		return policy, nil
+	}
+
+	region, resolvedProjID := g.resolvePolicyRegionAndProject(clusterLocation, projectID)
+	if region == "" || resolvedProjID == "" {
+		if isDryRun {
+			logging.Info("Dry-run: Could not determine cluster region or project. Assuming workload policy %q for topology %s. Ensure it exists in your target cluster's region.", canonicalPolicyName, topology)
+		}
+		return canonicalPolicyName, nil
+	}
+
+	policy, err := g.discoverRegionalWorkloadPolicy(canonicalPolicyName, region, resolvedProjID, topology)
+	if err != nil {
+		if errors.Is(err, ErrResourcePolicyPermissionDenied) {
+			logging.Warn("Permission denied reading workload policy %q in region %s. Assuming canonical policy name %q. If job fails to schedule, verify with an administrator that the policy exists in region %s.", canonicalPolicyName, region, canonicalPolicyName, region)
+			return canonicalPolicyName, nil
+		}
+		return "", err
+	}
+	if policy != "" {
+		return policy, nil
+	}
+
+	if !isDryRun {
+		if err := g.createTPUWorkloadPolicy(canonicalPolicyName, region, resolvedProjID, topology); err != nil {
+			return "", err
+		}
+	} else {
+		logging.Info("Dry-run: Workload policy %q for topology %s was not found. Please ensure it exists before applying the manifest, or create it using:\n  gcloud compute resource-policies create workload-policy %s --region=%s --project=%s --type=HIGH_THROUGHPUT --accelerator-topology=%s", canonicalPolicyName, topology, canonicalPolicyName, region, resolvedProjID, topology)
+	}
+
+	return canonicalPolicyName, nil
+}
+
+func (g *GKEOrchestrator) getCachedTPUWorkloadPolicy(canonicalPolicyName, topology string) string {
+	if g.resourcePolicyCache == nil {
+		return ""
+	}
+	cached := g.resourcePolicyCache[canonicalPolicyName]
+	if cached != nil && strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") && cached.AcceleratorTopology == topology {
+		return canonicalPolicyName
+	}
+	return ""
+}
+
+// findPolicyInClusterNodePools inspects the cluster's existing node pools for an active
+// placement policy matching the requested machine type and TPU topology.
+// Dynamic slicing policies (PROVISION_ONLY) are skipped for static workloads.
+func (g *GKEOrchestrator) findPolicyInClusterNodePools(machineType, topology string) string {
+	for _, np := range g.clusterDesc.NodePools {
+		if strings.EqualFold(np.Config.MachineType, machineType) && np.PlacementPolicy != nil && np.PlacementPolicy.PolicyName != "" {
+			mode := np.PlacementPolicy.AcceleratorTopologyMode
+			if mode == "" && g.resourcePolicyCache != nil {
+				if cached := g.resourcePolicyCache[path.Base(np.PlacementPolicy.PolicyName)]; cached != nil {
+					mode = cached.AcceleratorTopologyMode
+				}
+			}
+			if strings.EqualFold(mode, "PROVISION_ONLY") {
+				continue // Skip dynamic slicing policies for static workloads
+			}
+			topo := np.PlacementPolicy.TpuTopology
+			if topo == "" && np.Config.Labels != nil {
+				topo = np.Config.Labels[tpuTopologyLabel]
+			}
+			if topo != "" && topo == topology {
+				policy := path.Base(np.PlacementPolicy.PolicyName)
+				logging.Info("Discovered matching placement policy %q from existing node pool %q", policy, np.Name)
+				return policy
+			}
+		}
+	}
+	return ""
+}
+
+// getCanonicalTPUWorkloadPolicyName generates the deterministic GCE resource policy name
+// for a given TPU 7x topology (e.g., "tpu7x-16-2x2x2-placement-policy").
+func getCanonicalTPUWorkloadPolicyName(topology string) string {
+	chips := calculateChipsFromTopology(topology)
+	tensorcores := chips * 2
+	return fmt.Sprintf("tpu7x-%d-%s-placement-policy", tensorcores, topology)
+}
+
+// resolvePolicyRegionAndProject determines the target GCP region and project ID
+// from the cluster location, cluster description, or orchestrator state.
+func (g *GKEOrchestrator) resolvePolicyRegionAndProject(clusterLocation, projectID string) (string, string) {
+	region := ""
+	if clusterLocation != "" {
+		region = shell.ExtractRegion(clusterLocation)
+	} else if len(g.clusterDesc.Locations) > 0 {
+		region = shell.ExtractRegion(g.clusterDesc.Locations[0])
+	} else if len(g.clusterZones) > 0 {
+		region = shell.ExtractRegion(g.clusterZones[0])
+	}
+	if projectID == "" {
+		projectID = g.projectID
+	}
+	return region, projectID
+}
+
+// discoverRegionalWorkloadPolicy searches for an existing HIGH_THROUGHPUT workload policy
+// in the specified GCP region and project. It first checks for the canonical policy name,
+// and if not found or incompatible, falls back to querying regional policies matching the topology.
+func (g *GKEOrchestrator) discoverRegionalWorkloadPolicy(canonicalPolicyName, region, projectID, topology string) (string, error) {
+	policy, err := g.describeResourcePolicyCached(canonicalPolicyName, region, projectID)
+	if err != nil {
+		return "", err
+	}
+	if policy != nil {
+		if strings.EqualFold(policy.Type, "HIGH_THROUGHPUT") && policy.AcceleratorTopology == topology {
+			logging.Info("Discovered existing workload policy %q in region %s", canonicalPolicyName, region)
+			return canonicalPolicyName, nil
+		}
+		logging.Warn("Found policy %q in region %s, but its type (%q) or topology (%q) does not match expected (HIGH_THROUGHPUT, %s). Skipping it.",
+			canonicalPolicyName, region, policy.Type, policy.AcceleratorTopology, topology)
+	}
+
+	filter := fmt.Sprintf("region:( %s ) AND workloadPolicy.acceleratorTopology=%s AND workloadPolicy.type=HIGH_THROUGHPUT", region, topology)
+	listRes := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "list", "--project="+projectID, "--filter="+filter, "--format=value(name)")
+	if listRes.ExitCode == 0 && strings.TrimSpace(listRes.Stdout) != "" {
+		names := strings.Fields(listRes.Stdout)
+		if len(names) > 0 {
+			if g.resourcePolicyCache == nil {
+				g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+			}
+			g.resourcePolicyCache[names[0]] = &GCEWorkloadPolicy{
+				Name:                names[0],
+				Region:              region,
+				AcceleratorTopology: topology,
+				Type:                "HIGH_THROUGHPUT",
+			}
+			logging.Info("Discovered matching workload policy %q for topology %s in region %s", names[0], topology, region)
+			return names[0], nil
+		}
+	}
+	return "", nil
+}
+
+// createTPUWorkloadPolicy executes 'gcloud compute resource-policies create workload-policy'
+// to provision a new HIGH_THROUGHPUT workload policy with the requested accelerator topology.
+// Handles concurrent creation (HTTP 409 / already exists) gracefully.
+func (g *GKEOrchestrator) createTPUWorkloadPolicy(canonicalPolicyName, region, projectID, topology string) error {
+	logging.Info("Workload policy for topology %s not found. Creating workload policy %q...", topology, canonicalPolicyName)
+	createRes := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "create", "workload-policy", canonicalPolicyName, "--region="+region, "--project="+projectID, "--type=HIGH_THROUGHPUT", "--accelerator-topology="+topology)
+	if createRes.ExitCode != 0 {
+		stderrLower := strings.ToLower(createRes.Stderr)
+		if strings.Contains(stderrLower, "already exists") || strings.Contains(stderrLower, "409") {
+			if cached := g.resourcePolicyCache[canonicalPolicyName]; cached != nil && (!strings.EqualFold(cached.Type, "HIGH_THROUGHPUT") || cached.AcceleratorTopology != topology) {
+				return fmt.Errorf("a resource policy named %q already exists in region %s with incompatible settings (type=%q, topology=%q); expected HIGH_THROUGHPUT and %s. Please remove or rename the existing policy, or specify an existing valid placement policy via --placement-policy",
+					canonicalPolicyName, region, cached.Type, cached.AcceleratorTopology, topology)
+			}
+			logging.Info("Workload policy %q was concurrently created.", canonicalPolicyName)
+			if g.resourcePolicyCache == nil {
+				g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+			}
+			g.resourcePolicyCache[canonicalPolicyName] = &GCEWorkloadPolicy{
+				Name:                canonicalPolicyName,
+				Region:              region,
+				AcceleratorTopology: topology,
+				Type:                "HIGH_THROUGHPUT",
+			}
+			return nil
+		}
+		return fmt.Errorf("failed to create required workload policy %q in region %s: %s\nRemediation: Ensure your GCP credentials have 'compute.resourcePolicies.create' permission (e.g. 'roles/compute.admin') or create the policy manually:\n  gcloud compute resource-policies create workload-policy %s --region=%s --project=%s --type=HIGH_THROUGHPUT --accelerator-topology=%s",
+			canonicalPolicyName, region, createRes.Stderr, canonicalPolicyName, region, projectID, topology)
+	}
+	if g.resourcePolicyCache == nil {
+		g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+	}
+	g.resourcePolicyCache[canonicalPolicyName] = &GCEWorkloadPolicy{
+		Name:                canonicalPolicyName,
+		Region:              region,
+		AcceleratorTopology: topology,
+		Type:                "HIGH_THROUGHPUT",
+	}
+	logging.Info("Successfully created workload policy %q in region %s", canonicalPolicyName, region)
 	return nil
 }

--- a/pkg/orchestrator/gke/nap_test.go
+++ b/pkg/orchestrator/gke/nap_test.go
@@ -18,6 +18,9 @@ import (
 	"strings"
 	"testing"
 
+	"hpc-toolkit/pkg/orchestrator"
+	"hpc-toolkit/pkg/shell"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -436,5 +439,234 @@ func TestParseReservationURI(t *testing.T) {
 				t.Errorf("parseReservationURI(%q) = %+v, want %+v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveTPUWorkloadPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           *orchestrator.JobDefinition
+		nodePools     []gkeJobNodePool
+		mockResponses map[string][]shell.CommandResult
+		wantPolicy    string
+		wantErr       bool
+	}{
+		{
+			name: "Placement policy already specified on job is preserved",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				PlacementPolicy: "user-specified-policy",
+			},
+			wantPolicy: "user-specified-policy",
+		},
+		{
+			name: "Discovered from existing matching node pool",
+			job: &orchestrator.JobDefinition{
+				MachineType:   "tpu7x-standard-4t",
+				Topology:      "2x2x2",
+				NodesPerSlice: 2,
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "nap-tpu7x-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "2x2x2",
+						},
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						PolicyName: "projects/my-project/regions/us-central1/resourcePolicies/existing-nodepool-policy",
+					},
+				},
+			},
+			wantPolicy: "existing-nodepool-policy",
+		},
+		{
+			name: "Discovered from describe of canonical policy",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-16-2x2x2-placement-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
+		},
+		{
+			name: "Canonical policy describe returns incompatible topology, falls back to regional list",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-16-2x2x2-placement-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x4"}}`},
+				},
+				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name)": {
+					{ExitCode: 0, Stdout: "valid-regional-2x2x2-policy\n"},
+				},
+			},
+			wantPolicy: "valid-regional-2x2x2-policy",
+		},
+		{
+			name: "Permission denied on describe falls back to canonical policy name without error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) Some requests did not succeed: - Required 'compute.resourcePolicies.get' permission for '...'"},
+				},
+			},
+			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
+		},
+		{
+			name: "Discovered from regional list when canonical name differs",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy": {
+					{ExitCode: 1, Stderr: "ERROR: not found"},
+				},
+				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name)": {
+					{ExitCode: 0, Stdout: "custom-regional-2x2x2-policy\n"},
+				},
+			},
+			wantPolicy: "custom-regional-2x2x2-policy",
+		},
+		{
+			name: "Auto-creates policy when not found and not dry-run",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				DryRunManifest:  "",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy": {
+					{ExitCode: 1, Stderr: "ERROR: not found"},
+				},
+				"gcloud compute resource-policies list": {
+					{ExitCode: 0, Stdout: ""},
+				},
+				"gcloud compute resource-policies create workload-policy tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --type=HIGH_THROUGHPUT --accelerator-topology=2x2x2": {
+					{ExitCode: 0, Stdout: "Created [https://www.googleapis.com/...].\n"},
+				},
+			},
+			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
+		},
+		{
+			name: "Dry-run does not call create command",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				DryRunManifest:  "/tmp/job.yaml",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy": {
+					{ExitCode: 1, Stderr: "ERROR: not found"},
+				},
+				"gcloud compute resource-policies list": {
+					{ExitCode: 0, Stdout: ""},
+				},
+			},
+			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
+		},
+		{
+			name: "Single-node slice does not assign workload placement policy",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x1",
+				NodesPerSlice:   1,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			wantPolicy: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecutor := NewMockExecutor(tt.mockResponses)
+			g := newTestGKEOrchestrator(mockExecutor)
+			g.projectID = tt.job.ProjectID
+			g.clusterDesc.NodePools = tt.nodePools
+
+			err := g.resolveTPU7xWorkloadPolicyIfRequired(tt.job, true, false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveTPU7xWorkloadPolicyIfRequired() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.job.PlacementPolicy != tt.wantPolicy {
+				t.Errorf("resolveTPU7xWorkloadPolicyIfRequired() placementPolicy = %q, want %q", tt.job.PlacementPolicy, tt.wantPolicy)
+			}
+		})
+	}
+}
+
+func TestBuildNodeSelector_PlacementPolicy(t *testing.T) {
+	g := newTestGKEOrchestrator(nil)
+	g.machineCapCache["tpu7x-standard-4t:"] = MachineTypeCap{}
+	g.machineCapCache["a3-highgpu-8g:"] = MachineTypeCap{}
+
+	// 1. TPU workload uses cloud.google.com/placement-policy-name
+	tpuJob := orchestrator.JobDefinition{
+		MachineType: "tpu7x-standard-4t",
+	}
+	tpuOpts := SchedulingOptions{
+		PlacementPolicy: "tpu7x-16-2x2x2-placement-policy",
+		IsTPU:           true,
+	}
+	tpuSelectorStr, err := g.buildNodeSelector(tpuOpts, tpuJob, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(tpuSelectorStr, "cloud.google.com/placement-policy-name: tpu7x-16-2x2x2-placement-policy") {
+		t.Errorf("Expected cloud.google.com/placement-policy-name in %s", tpuSelectorStr)
+	}
+	if strings.Contains(tpuSelectorStr, "cloud.google.com/gke-placement-group") {
+		t.Errorf("Did not expect cloud.google.com/gke-placement-group in %s", tpuSelectorStr)
+	}
+
+	// 2. Non-TPU workload uses cloud.google.com/gke-placement-group
+	nonTpuJob := orchestrator.JobDefinition{
+		MachineType: "a3-highgpu-8g",
+	}
+	nonTpuOpts := SchedulingOptions{
+		PlacementPolicy: "compact-placement-group",
+	}
+	nonTpuSelectorStr, err := g.buildNodeSelector(nonTpuOpts, nonTpuJob, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(nonTpuSelectorStr, "cloud.google.com/gke-placement-group: compact-placement-group") {
+		t.Errorf("Expected cloud.google.com/gke-placement-group in %s", nonTpuSelectorStr)
+	}
+	if strings.Contains(nonTpuSelectorStr, "cloud.google.com/placement-policy-name") {
+		t.Errorf("Did not expect cloud.google.com/placement-policy-name in %s", nonTpuSelectorStr)
 	}
 }

--- a/pkg/orchestrator/gke/nap_test.go
+++ b/pkg/orchestrator/gke/nap_test.go
@@ -513,11 +513,30 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --format=json": {
 					{ExitCode: 0, Stdout: `{"name":"tpu7x-16-2x2x2-placement-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x4"}}`},
 				},
-				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name)": {
+				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name,workloadPolicy.acceleratorTopologyMode)": {
 					{ExitCode: 0, Stdout: "valid-regional-2x2x2-policy\n"},
 				},
 			},
 			wantPolicy: "valid-regional-2x2x2-policy",
+		},
+		{
+			name: "Canonical policy describe returns PROVISION_ONLY mode, falls back to regional list and skips non-static modes",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-16-2x2x2-placement-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2","acceleratorTopologyMode":"PROVISION_ONLY"}}`},
+				},
+				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name,workloadPolicy.acceleratorTopologyMode)": {
+					{ExitCode: 0, Stdout: "dynamic-candidate PROVISION_ONLY\nfuture-flavor FUTURE_MODE\nstatic-regional-2x2x2-policy AUTO_CONNECT\n"},
+				},
+			},
+			wantPolicy: "static-regional-2x2x2-policy",
 		},
 		{
 			name: "Permission denied on describe falls back to canonical policy name without error",
@@ -548,7 +567,7 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy": {
 					{ExitCode: 1, Stderr: "ERROR: not found"},
 				},
-				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name)": {
+				"gcloud compute resource-policies list --project=my-project --filter=region:( us-central1 ) AND workloadPolicy.acceleratorTopology=2x2x2 AND workloadPolicy.type=HIGH_THROUGHPUT --format=value(name,workloadPolicy.acceleratorTopologyMode)": {
 					{ExitCode: 0, Stdout: "custom-regional-2x2x2-policy\n"},
 				},
 			},

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -16,6 +16,7 @@ package gke
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
 	"hpc-toolkit/pkg/logging"
@@ -177,7 +178,7 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 		return false, nil
 	}
 
-	active, err := g.checkNodePoolsDynamicSlicing(requestedMachineName, opts, isTPU7x)
+	active, err := g.checkNodePoolsDynamicSlicing(requestedMachineName, opts)
 	if err != nil {
 		return active, err
 	}
@@ -185,17 +186,21 @@ func (g *GKEOrchestrator) verifyDynamicSlicingActive(opts ManifestOptions) (bool
 	return active, nil
 }
 
-func (g *GKEOrchestrator) verifyStaticSlicingActive(job *orchestrator.JobDefinition) (bool, error) {
-	if !config.IsTPU(job.MachineType) {
+func (g *GKEOrchestrator) verifyStaticSlicingActive(machineType, topology string) (bool, error) {
+	if !config.IsTPU(machineType) {
 		return false, nil
 	}
 
 	// Static sub-slicing (logical partitioning) is strictly unsupported for 3D Torus TPUs (v4 and v5p)
-	if config.Is3DTorusTPU(job.MachineType) {
+	if config.Is3DTorusTPU(machineType) {
 		return false, nil
 	}
 
-	cacheKey := fmt.Sprintf("%s-%s", job.MachineType, job.Topology)
+	if g.staticSlicingCache == nil {
+		g.staticSlicingCache = make(map[string]bool)
+	}
+
+	cacheKey := fmt.Sprintf("%s-%s", machineType, topology)
 	if val, ok := g.staticSlicingCache[cacheKey]; ok {
 		return val, nil
 	}
@@ -205,20 +210,20 @@ func (g *GKEOrchestrator) verifyStaticSlicingActive(job *orchestrator.JobDefinit
 		return false, nil
 	}
 
-	accelLabel := g.GenerateGKENodeSelectorLabel(job.MachineType)
-	output, err := g.queryDiscoveredTopologies(accelLabel, job.MachineType)
+	accelLabel := g.GenerateGKENodeSelectorLabel(machineType)
+	output, err := g.queryDiscoveredTopologies(accelLabel, machineType)
 	if err != nil {
 		return false, fmt.Errorf("failed to discover topologies for static sub-slicing check: %w", err)
 	}
 	discoveredTopologies := g.parseTopologies(output)
 
 	for t := range discoveredTopologies {
-		fits, err := config.CheckTopologyContainment(job.Topology, t, job.MachineType)
+		fits, err := config.CheckTopologyContainment(topology, t, machineType)
 		if err != nil {
 			return false, err
 		}
 		if fits {
-			logging.Info("Static sub-slicing/TAS active: requested topology %s fits inside discovered physical topology %s.", job.Topology, t)
+			logging.Info("Static sub-slicing/TAS active: requested topology %s fits inside discovered physical topology %s.", topology, t)
 			g.staticSlicingCache[cacheKey] = true
 			return true, nil
 		}
@@ -228,27 +233,28 @@ func (g *GKEOrchestrator) verifyStaticSlicingActive(job *orchestrator.JobDefinit
 	return false, nil
 }
 
-func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions, isTPU7x bool) (bool, error) {
-	if !isTPU7x {
-		return false, nil
-	}
-
+func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName string, opts ManifestOptions) (bool, error) {
 	projID := opts.ProjectID
 	if projID == "" {
 		projID = g.projectID
 	}
 
 	for _, np := range g.clusterDesc.NodePools {
-		if !strings.EqualFold(np.Config.MachineType, requestedMachineName) || np.PlacementPolicy == nil {
+		if !config.IsTPU(np.Config.MachineType) || !strings.EqualFold(np.Config.MachineType, requestedMachineName) || np.PlacementPolicy == nil {
 			continue
 		}
 
 		mode := np.PlacementPolicy.AcceleratorTopologyMode
 		if mode == "" && np.PlacementPolicy.PolicyName != "" {
-			var err error
-			mode, err = g.getComputeResourcePolicyModeCached(np.PlacementPolicy.PolicyName, opts.ClusterLocation, projID)
+			policy, err := g.describeResourcePolicyCached(np.PlacementPolicy.PolicyName, opts.ClusterLocation, projID)
 			if err != nil {
-				return false, fmt.Errorf("failed to fetch compute resource policy %q for node pool %q: %w", np.PlacementPolicy.PolicyName, np.Name, err)
+				if errors.Is(err, ErrResourcePolicyPermissionDenied) {
+					logging.Warn("Permission denied querying resource policy %q for node pool %q: %v. Assuming non-dynamic slicing.", np.PlacementPolicy.PolicyName, np.Name, err)
+				} else {
+					return false, fmt.Errorf("failed to fetch compute resource policy %q for node pool %q: %w", np.PlacementPolicy.PolicyName, np.Name, err)
+				}
+			} else if policy != nil {
+				mode = policy.AcceleratorTopologyMode
 			}
 		}
 
@@ -265,36 +271,42 @@ func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName stri
 	return false, nil
 }
 
-// getComputeResourcePolicyModeCached retrieves the AcceleratorTopologyMode for a given resource policy,
-// utilizing a local cache to avoid redundant gcloud calls.
-func (g *GKEOrchestrator) getComputeResourcePolicyModeCached(policyName, location, projectID string) (string, error) {
-	if g.policyCache == nil {
-		g.policyCache = make(map[string]string)
-	}
+// ErrResourcePolicyPermissionDenied indicates the caller lacks GCP IAM permissions to read the compute resource policy.
+var ErrResourcePolicyPermissionDenied = errors.New("permission denied querying compute resource policy")
 
-	// GKE cluster metadata may return policyName as a full GCP resource path
-	// (e.g. projects/123456789/regions/us-central1/resourcePolicies/my-policy).
-	// Extract the short policy name using path.Base to ensure consistent cache keys.
-	shortPolicyName := path.Base(policyName)
-	if mode, found := g.policyCache[shortPolicyName]; found {
-		return mode, nil
-	}
-
-	mode, err := g.fetchComputeResourcePolicyTopologyMode(shortPolicyName, location, projectID)
-	if err != nil {
-		return "", err
-	}
-
-	g.policyCache[shortPolicyName] = mode
-	return mode, nil
+type gceResourcePolicyRaw struct {
+	Name           string `json:"name"`
+	Region         string `json:"region"`
+	WorkloadPolicy struct {
+		AcceleratorTopology     string `json:"acceleratorTopology"`
+		AcceleratorTopologyMode string `json:"acceleratorTopologyMode"`
+		Type                    string `json:"type"`
+	} `json:"workloadPolicy"`
 }
 
-func (g *GKEOrchestrator) fetchComputeResourcePolicyTopologyMode(shortPolicyName, location, projectID string) (string, error) {
-	region := shell.ExtractRegion(location)
+// describeResourcePolicyCached retrieves GCE resource policy metadata using gcloud compute resource-policies describe,
+// utilizing a local cache to prevent redundant invocations across dynamic slicing and NAP policy resolution.
+func (g *GKEOrchestrator) describeResourcePolicyCached(policyName, location, projectID string) (*GCEWorkloadPolicy, error) {
+	if g.resourcePolicyCache == nil {
+		g.resourcePolicyCache = make(map[string]*GCEWorkloadPolicy)
+	}
 
-	res := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "describe", shortPolicyName, "--region="+region, "--project="+projectID, "--format=value(workloadPolicy.acceleratorTopologyMode)")
+	shortPolicyName := path.Base(policyName)
+	if policy, found := g.resourcePolicyCache[shortPolicyName]; found {
+		return policy, nil
+	}
+
+	region := shell.ExtractRegion(location)
+	res := g.executor.ExecuteCommand("gcloud", "compute", "resource-policies", "describe", shortPolicyName, "--region="+region, "--project="+projectID, "--format=json")
 	if res.ExitCode != 0 {
-		return "", fmt.Errorf("gcloud compute resource-policies describe failed: %s\n"+
+		stderrLower := strings.ToLower(res.Stderr)
+		if strings.Contains(stderrLower, "not found") || strings.Contains(stderrLower, "404") {
+			return nil, nil // Policy does not exist
+		}
+		if strings.Contains(stderrLower, "permission") || strings.Contains(stderrLower, "forbidden") || strings.Contains(stderrLower, "403") {
+			return nil, fmt.Errorf("%w: %s", ErrResourcePolicyPermissionDenied, res.Stderr)
+		}
+		return nil, fmt.Errorf("gcloud compute resource-policies describe failed: %s\n"+
 			"To resolve this issue:\n"+
 			"  1. Check IAM: Ensure your GCP credentials have 'compute.resourcePolicies.get' permission (e.g., 'roles/compute.viewer').\n"+
 			"  2. Verify Policy: Test manual access by running:\n"+
@@ -302,7 +314,20 @@ func (g *GKEOrchestrator) fetchComputeResourcePolicyTopologyMode(shortPolicyName
 			res.Stderr, shortPolicyName, region, projectID)
 	}
 
-	return strings.TrimSpace(res.Stdout), nil
+	var raw gceResourcePolicyRaw
+	if err := json.Unmarshal([]byte(res.Stdout), &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse resource policy json: %w", err)
+	}
+
+	policy := &GCEWorkloadPolicy{
+		Name:                    raw.Name,
+		Region:                  raw.Region,
+		AcceleratorTopology:     raw.WorkloadPolicy.AcceleratorTopology,
+		AcceleratorTopologyMode: raw.WorkloadPolicy.AcceleratorTopologyMode,
+		Type:                    raw.WorkloadPolicy.Type,
+	}
+	g.resourcePolicyCache[shortPolicyName] = policy
+	return policy, nil
 }
 
 func validateTPU7xTopology(topology string, machineType string) error {
@@ -512,19 +537,42 @@ func (g *GKEOrchestrator) resolveTPURequirements(job *orchestrator.JobDefinition
 	job.Topology = topology
 
 	if !isDynamicSlicing && job.Topology != "" {
-		isStaticSlicing, err = g.verifyStaticSlicingActive(job)
+		isStaticSlicing, err = g.verifyStaticSlicingActive(job.MachineType, job.Topology)
 		if err != nil {
 			return false, false, err
 		}
 	}
 
 	// Calculate VMs per slice
-	err = g.dynamicallyCalculateNodesPerSlice(job)
-	if err != nil {
+	if err = g.dynamicallyCalculateNodesPerSlice(job); err != nil {
+		return false, false, err
+	}
+
+	if err = g.resolveTPU7xWorkloadPolicyIfRequired(job, isTPU7x, isDynamicSlicing); err != nil {
 		return false, false, err
 	}
 
 	return isDynamicSlicing, isStaticSlicing, nil
+}
+
+// resolveTPU7xWorkloadPolicyIfRequired automatically resolves or provisions a GCE HIGH_THROUGHPUT
+// workload policy for multi-host TPU 7x jobs when not already specified by the user.
+//
+// Invariants:
+//  1. Only TPU 7x requires GCE workload policies. Older TPUs (v4, v5e, v5p, v6e) manage multi-host
+//     topology via native GKE TPU topology controllers (cloud.google.com/gke-tpu-topology).
+//  2. Only static multi-host slices (job.NodesPerSlice > 1) require a workload policy. Single-host slices
+//     (NodesPerSlice == 1) do not span multiple VMs, and dynamic slicing manages its own slice topology.
+//  3. If the user explicitly provided a placement policy via --placement-policy, it is preserved.
+func (g *GKEOrchestrator) resolveTPU7xWorkloadPolicyIfRequired(job *orchestrator.JobDefinition, isTPU7x, isDynamicSlicing bool) error {
+	if isTPU7x && !isDynamicSlicing && job.Topology != "" && job.NodesPerSlice > 1 && job.PlacementPolicy == "" {
+		policy, err := g.resolveTPUWorkloadPolicy(job.MachineType, job.Topology, job.ClusterLocation, job.ProjectID, job.DryRunManifest != "")
+		if err != nil {
+			return err
+		}
+		job.PlacementPolicy = policy
+	}
+	return nil
 }
 
 func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefinition) (profile JobProfile, isDynamicSlicing bool, isStaticSlicing bool, err error) {

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -240,7 +240,7 @@ func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName stri
 	}
 
 	for _, np := range g.clusterDesc.NodePools {
-		if !config.IsTPU(np.Config.MachineType) || !strings.EqualFold(np.Config.MachineType, requestedMachineName) || np.PlacementPolicy == nil {
+		if !strings.EqualFold(np.Config.MachineType, requestedMachineName) || np.PlacementPolicy == nil {
 			continue
 		}
 

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -530,12 +530,7 @@ func TestVerifyStaticSlicingActive(t *testing.T) {
 				orc.clusterDesc.NodePools = tt.nodePools
 			}
 
-			job := &orchestrator.JobDefinition{
-				MachineType: tt.machineType,
-				Topology:    tt.requestedTopo,
-			}
-
-			got, err := orc.verifyStaticSlicingActive(job)
+			got, err := orc.verifyStaticSlicingActive(tt.machineType, tt.requestedTopo)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("verifyStaticSlicingActive() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -546,7 +541,7 @@ func TestVerifyStaticSlicingActive(t *testing.T) {
 			if tt.verifyCacheHit && err == nil && got == tt.wantActive {
 				// Clear mock executor to ensure subsequent call is satisfied entirely from cache
 				orc.executor = NewMockExecutor(nil)
-				got2, err2 := orc.verifyStaticSlicingActive(job)
+				got2, err2 := orc.verifyStaticSlicingActive(tt.machineType, tt.requestedTopo)
 				if err2 != nil || got2 != tt.wantActive {
 					t.Errorf("cache hit failed: got %v, err %v", got2, err2)
 				}
@@ -1058,8 +1053,8 @@ func TestCheckNodePoolsDynamicSlicing_PolicyLookupAndCaching(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute resource-policies describe tpu7x-policy --region=us-central1 --project=cloud-tpu-dev --format=value(workloadPolicy.acceleratorTopologyMode)": {
-					{ExitCode: 0, Stdout: "PROVISION_ONLY\n"},
+				"gcloud compute resource-policies describe tpu7x-policy --region=us-central1 --project=cloud-tpu-dev --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-policy","workloadPolicy":{"acceleratorTopologyMode":"PROVISION_ONLY"}}`},
 				},
 			},
 			wantResult: true,
@@ -1093,11 +1088,37 @@ func TestCheckNodePoolsDynamicSlicing_PolicyLookupAndCaching(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute resource-policies describe tpu7x-policy --region=us-central1 --project=cloud-tpu-dev --format=value(workloadPolicy.acceleratorTopologyMode)": {
-					{ExitCode: 0, Stdout: "PROVISION_ONLY\n"},
+				"gcloud compute resource-policies describe tpu7x-policy --region=us-central1 --project=cloud-tpu-dev --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-policy","workloadPolicy":{"acceleratorTopologyMode":"PROVISION_ONLY"}}`},
 				},
 			},
 			wantResult: true,
+			wantErr:    false,
+		},
+		{
+			name: "Success - Permission denied reading policy logs warning and assumes non-dynamic slicing without failing",
+			opts: ManifestOptions{
+				ClusterLocation: "us-central1-a",
+				ProjectID:       "cloud-tpu-dev",
+				Topology:        "2x2x2",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "np-0",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						PolicyName: "restricted-policy",
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe restricted-policy --region=us-central1 --project=cloud-tpu-dev --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) Some requests did not succeed: - Required 'compute.resourcePolicies.get' permission for '...'"},
+				},
+			},
+			wantResult: false,
 			wantErr:    false,
 		},
 		{
@@ -1119,8 +1140,8 @@ func TestCheckNodePoolsDynamicSlicing_PolicyLookupAndCaching(t *testing.T) {
 				},
 			},
 			mockResponses: map[string][]shell.CommandResult{
-				"gcloud compute resource-policies describe invalid-policy --region=us-central1 --project=cloud-tpu-dev --format=value(workloadPolicy.acceleratorTopologyMode)": {
-					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) Could not fetch resource policy"},
+				"gcloud compute resource-policies describe invalid-policy --region=us-central1 --project=cloud-tpu-dev --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) Internal error occurred"},
 				},
 			},
 			wantResult: false,
@@ -1135,15 +1156,15 @@ func TestCheckNodePoolsDynamicSlicing_PolicyLookupAndCaching(t *testing.T) {
 			g.projectID = tt.opts.ProjectID
 			g.clusterDesc.NodePools = tt.nodePools
 
-			got, err := g.checkNodePoolsDynamicSlicing("tpu7x-standard-4t", tt.opts, true)
+			got, err := g.checkNodePoolsDynamicSlicing("tpu7x-standard-4t", tt.opts)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("checkNodePoolsDynamicSlicing() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if got != tt.wantResult {
 				t.Errorf("checkNodePoolsDynamicSlicing() = %v, want %v", got, tt.wantResult)
 			}
-			if tt.wantResult && len(g.policyCache) == 0 {
-				t.Errorf("expected policyCache to be populated")
+			if tt.wantResult && len(g.resourcePolicyCache) == 0 {
+				t.Errorf("expected resourcePolicyCache to be populated")
 			}
 		})
 	}

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -31,13 +31,23 @@ type SchedulingOptions struct {
 	NodeAffinityLabels map[string]string
 	IsDynamicSlicing   bool
 	IsStaticSlicing    bool
+	IsTPU              bool
 }
 
 func getNodeSelector(opts SchedulingOptions) (map[string]string, error) {
 	nodeSelector := make(map[string]string)
 
 	if opts.PlacementPolicy != "" {
-		nodeSelector["cloud.google.com/gke-placement-group"] = opts.PlacementPolicy
+		// In GKE, placement policy labels differ by accelerator architecture:
+		// 1. TPUs (specifically TPU 7x multi-host NAP): GKE requires referencing a pre-created
+		//    GCE Workload Policy (HIGH_THROUGHPUT) via "cloud.google.com/placement-policy-name".
+		// 2. Non-TPUs (GPUs/CPUs): GKE NAP uses "cloud.google.com/gke-placement-group" to dynamically
+		//    generate compact placement groups on the fly for co-located VM scheduling.
+		if opts.IsTPU {
+			nodeSelector["cloud.google.com/placement-policy-name"] = opts.PlacementPolicy
+		} else {
+			nodeSelector["cloud.google.com/gke-placement-group"] = opts.PlacementPolicy
+		}
 	}
 
 	for k, v := range opts.NodeAffinityLabels {

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -41,6 +41,24 @@ func TestGetNodeSelector(t *testing.T) {
 			wantValue: "value",
 		},
 		{
+			name: "tpu placement policy label",
+			opts: SchedulingOptions{
+				PlacementPolicy: "tpu7x-16-2x2x2-placement-policy",
+				IsTPU:           true,
+			},
+			wantKey:   "cloud.google.com/placement-policy-name",
+			wantValue: "tpu7x-16-2x2x2-placement-policy",
+		},
+		{
+			name: "non-tpu placement policy label",
+			opts: SchedulingOptions{
+				PlacementPolicy: "compact-placement",
+				IsTPU:           false,
+			},
+			wantKey:   "cloud.google.com/gke-placement-group",
+			wantValue: "compact-placement",
+		},
+		{
 			name: "skip pipe separated values (goes to affinity)",
 			opts: SchedulingOptions{
 				NodeAffinityLabels: map[string]string{

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -130,7 +130,7 @@ type GKEOrchestrator struct {
 	dynamicSlicingCache         map[string]bool
 	staticSlicingCache          map[string]bool
 	topologyCache               map[string]string
-	policyCache                 map[string]string
+	resourcePolicyCache         map[string]*GCEWorkloadPolicy
 	slicingTopologiesChecked    bool
 	slicingTopologiesDetected   bool
 	gkeCustomTemplatesPath      string
@@ -304,6 +304,15 @@ type gkeAutoscaling struct {
 	TotalMaxNodeCount int  `json:"totalMaxNodeCount"`
 }
 
+// GCEWorkloadPolicy represents a Google Compute Engine workload resource policy.
+type GCEWorkloadPolicy struct {
+	Name                    string `json:"name"`
+	Region                  string `json:"region"`
+	AcceleratorTopology     string `json:"acceleratorTopology,omitempty"`
+	AcceleratorTopologyMode string `json:"acceleratorTopologyMode,omitempty"`
+	Type                    string `json:"type,omitempty"`
+}
+
 type gkePlacementPolicy struct {
 	PolicyName              string `json:"policyName,omitempty"`
 	AcceleratorTopologyMode string `json:"acceleratorTopologyMode,omitempty"`
@@ -348,6 +357,11 @@ type gkeHighScaleCheckpointingConfig struct {
 
 type controlPlaneEndpointsConfig struct {
 	DnsEndpointConfig *dnsEndpointConfig `json:"dnsEndpointConfig,omitempty"`
+	IPEndpointsConfig *ipEndpointsConfig `json:"ipEndpointsConfig,omitempty"`
+}
+
+type ipEndpointsConfig struct {
+	EnablePublicEndpoint bool `json:"enablePublicEndpoint,omitempty"`
 }
 
 type dnsEndpointConfig struct {


### PR DESCRIPTION
### Problem
1. **TPU 7x NAP Placement Policy**: When submitting a TPU 7x workload to a GKE cluster with Node Auto-Provisioning (NAP) where no matching node pool exists (scale up from 0):
   - GKE NAP's autoscaling controller attempts to create a GCE Managed Instance Group (MIG) with a default `groupPlacementPolicy` (`collocation: COLLOCATED`).
   - GCE rejects the MIG creation request with `HTTP 400 (UNSUPPORTED_OPERATION): Creation of a managed instance group with tpu7x-standard-4t machine type with placement policy is not supported. Use workload policy instead.`
   - GKE NAP requires incoming Pods to specify `cloud.google.com/placement-policy-name: <workload-policy-name>` in `nodeSelector`. Cluster Toolkit previously injected `cloud.google.com/gke-placement-group` instead and did not auto-discover or create the required GCE Workload Policy (`tpu7x-{cores}-{topology}-placement-policy`).
2. **GKE Auth DNS Endpoint Selection**: When refreshing cluster credentials via `gcloud container clusters get-credentials`, passing `--dns-endpoint` when public IP endpoints are active causes HTTP 431 ("Request Header Fields Too Large") failures on corporate networks and proxies due to large authorization header sizes.

### Solution
1. **Workload Policy Resolution & Provisioning (`pkg/orchestrator/gke/nap.go`)**:
   - Implemented `resolveTPUWorkloadPolicy` to discover existing policies from current cluster node pools or via `gcloud compute resource-policies describe/list`.
   - Provisions canonical workload policies (`tpu7x-{chips}-{topology}-placement-policy`) via `gcloud compute resource-policies create workload-policy` if missing (skipped on dry-runs).
   - Unified resource policy caching via `resourcePolicyCache` to share query results between dynamic slicing and NAP policy resolution.
   - Handled non-fatal IAM permission errors with clear warnings when querying or creating policies.
2. **Clean Label Assignment (`pkg/orchestrator/gke/scheduling.go`)**:
   - Added `IsTPU` to `SchedulingOptions` and directly assigned `cloud.google.com/placement-policy-name` for TPUs and `cloud.google.com/gke-placement-group` for non-TPUs in `getNodeSelector`, removing post-hoc map mutations.
3. **Hardware Guard (`pkg/orchestrator/gke/resource_resolver.go`)**:
   - Strictly matches GA `tpu7x` hardware and enforces workload policies exclusively for multi-host TPU 7x workloads (`NodesPerSlice > 1`).
4. **Control Plane Endpoint Selection (`pkg/orchestrator/gke/gke_job_orchestrator.go`, `types.go`)**:
   - Updated `refreshGKEAuth` via `shouldUseDNSEndpoint()` to only pass `--dns-endpoint` when external DNS traffic is enabled AND public IP endpoint is disabled or absent, allowing clients to cleanly connect via the public IP endpoint without HTTP 431 errors.

### Testing
- Added unit tests in `nap_test.go` covering policy preservation, node pool discovery, canonical describe, regional list fallback, dry-run safety, and auto-creation.
- Added unit tests in `scheduling_test.go` verifying placement policy label assignment for TPU vs non-TPU workloads.
- Added unit tests in `gke_job_orchestrator_test.go` for `shouldUseDNSEndpoint` and `refreshGKEAuth` covering all endpoint configurations.
- All pre-commit presubmits and tests pass with exit code 0.