### PR TITLE
remove deprecated debian-11 image

### DIFF
--- a/community/examples/gcloud-example.yaml
+++ b/community/examples/gcloud-example.yaml
@@ -40,6 +40,6 @@ deployment_groups:
           --network=$(vars.deployment_name)-net
           --subnet=$(vars.deployment_name)-subnet
           --machine-type=n2d-standard-2
-          --image-family=debian-11
+          --image-family=debian-12
           --image-project=debian-cloud
         delete: "gcloud compute instances delete $(vars.deployment_name)-vm --project=$(vars.project_id) --zone=$(vars.zone) --quiet"

--- a/docs/vm-images.md
+++ b/docs/vm-images.md
@@ -5,7 +5,7 @@
   * [Pinning Specific Images](#pinning-specifics-images)
 * [Cluster Toolkit Supported Images](#cluster-toolkit-supported-images)
   * [HPC Rocky Linux 9](#hpc-rocky-linux-9)
-  * [Debian 11](#debian-11)
+  * [Debian 12](#debian-12)
   * [Ubuntu 22.04 LTS](#ubuntu-2204-lts)
   * [Windows](#windows)
   * [Other Images](#other-images)
@@ -71,7 +71,7 @@ blueprint:
         project: cloud-hpc-image-public
 
       instance_image:
-        family: debian-11
+        family: debian-12
         project: debian-cloud
 
       instance_image:
@@ -109,9 +109,9 @@ project and the new image name in the `instance_image` field discussed in
 
 HPC Rocky Linux 9 is the primary supported VM image for HPC workloads on Google Cloud.
 
-### Debian 11
+### Debian 12
 
-The Cluster Toolkit officially supports Debian 11 based VM images in the majority of
+The Cluster Toolkit officially supports Debian 12 based VM images in the majority of
 our modules, with a couple of exceptions.
 
 ### Ubuntu 22.04 LTS

--- a/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
+++ b/tools/cloud-build/daily-tests/blueprints/ansible-vm.yaml
@@ -82,18 +82,6 @@ deployment_groups:
         family: ubuntu-2404-lts-arm64
         project: ubuntu-os-cloud
 
-  - id: workstation-debian-11
-    source: modules/compute/vm-instance
-    use:
-    - network1
-    - startup-script
-    settings:
-      name_prefix: deb11
-      add_deployment_name_before_prefix: true
-      instance_image:
-        family: debian-11
-        project: debian-cloud
-
   - id: workstation-debian-12
     source: modules/compute/vm-instance
     use:
@@ -104,6 +92,18 @@ deployment_groups:
       add_deployment_name_before_prefix: true
       instance_image:
         family: debian-12
+        project: debian-cloud
+
+  - id: workstation-debian-13
+    source: modules/compute/vm-instance
+    use:
+    - network1
+    - startup-script
+    settings:
+      name_prefix: deb13
+      add_deployment_name_before_prefix: true
+      instance_image:
+        family: debian-13
         project: debian-cloud
 
   - id: workstation-rocky-8
@@ -161,8 +161,8 @@ deployment_groups:
       - $(workstation-ubuntu-2204.name[0])
       - $(workstation-ubuntu-2404.name[0])
       - $(workstation-ubuntu-2404-arm.name[0])
-      - $(workstation-debian-11.name[0])
       - $(workstation-debian-12.name[0])
+      - $(workstation-debian-13.name[0])
       - $(workstation-rocky-8.name[0])
       - $(workstation-rocky-9.name[0])
       - $(workstation-rhel-8.name[0])

--- a/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-filestore.yaml
@@ -31,7 +31,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/batch-startup.yaml
@@ -31,7 +31,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-crd.yaml
@@ -25,7 +25,7 @@ vars:
     family: ubuntu-2204-lts
     project: ubuntu-os-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:

--- a/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-filestore.yaml
@@ -103,7 +103,7 @@ deployment_groups:
     - homefs
     settings:
       instance_image:
-        family: debian-11
+        family: debian-12
         project: debian-cloud
       name_prefix: workstation-debian
       instance_count: 1

--- a/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
+++ b/tools/validate_configs/os_compatibility_tests/vm-startup.yaml
@@ -32,7 +32,7 @@ vars:
     family: rocky-linux-8
     project: rocky-linux-cloud
   # instance_image:
-  #   family: debian-11
+  #   family: debian-12
   #   project: debian-cloud
 
 deployment_groups:


### PR DESCRIPTION
This PR removes the deprecated debian-11 image family from ansible-vm blueprint and references from other files.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
