### PR TITLE
fix(ci): resolve PR-test-gke-storage stockout for release 1.103.0

### DIFF
--- a/examples/storage-gke.yaml
+++ b/examples/storage-gke.yaml
@@ -79,6 +79,8 @@ deployment_groups:
       configure_workload_identity_sa: true  # needed when using GCS
       enable_private_endpoint: false  # Allows for access from authorized public IPs
       gcp_public_cidrs_access_enabled: $(vars.gcp_public_cidrs_access_enabled)
+      system_node_pool_machine_type: n2d-standard-4
+      system_node_pool_zones: [$(vars.zone)]
       master_authorized_networks:
       - display_name: deployment-machine
         cidr_block: $(vars.authorized_cidr)


### PR DESCRIPTION
### Description
- **GKE Storage Integration Test (`examples/storage-gke.yaml`)**:
  - Adopt `n2d-standard-4` for `system_node_pool_machine_type` and pin `system_node_pool_zones: [$(vars.zone)]` on `gke_cluster` to eliminate GKE cluster creation timeouts caused by multi-zone Compute Engine stockouts.

### Root Cause
During CI test execution for `PR-test-gke-storage`, the GKE cluster creation failed with repeated `[GCE_STOCKOUT]` errors across `us-central1-a`, `us-central1-b`, and `us-central1-c`:
Google Compute Engine: Not all instances running in IGM after 35m. Expected 1, running 0, transitioning 1. Current errors: [GCE_STOCKOUT]: Instance '...-default-pool-...' creation failed: The zone 'projects/hpc-toolkit-dev/zones/us-central1-c' does not have enough resources available to fulfill the request. The zone 'projects/hpc-toolkit-dev/zones/us-central1-b' does not have enough resources available to fulfill the request. The zone 'projects/hpc-toolkit-dev/zones/us-central1-a' does not have enough resources available to fulfill the request.

Because `examples/storage-gke.yaml` configured a regional GKE cluster without specifying `system_node_pool_zones` or `system_node_pool_machine_type`, `modules/scheduler/gke-cluster` defaulted to allocating `n4-standard-4` system nodes across all four zones of `us-central1`. Persistent N4 capacity shortages in `us-central1` blocked cluster creation for 35 minutes per attempt, exhausting retry limits and resulting in 7-hour pipeline runs.
### Fix
1. Explicitly pin `system_node_pool_zones: [$(vars.zone)]` (`us-central1-b`) where the integration test workload node pools (`debug_pool`, `local-ssd-pool`, `hp-pool`) and Hyperdisk storage pools live, preventing GKE from attempting to allocate system nodes across other congested zones.
2. Explicitly set `system_node_pool_machine_type: n2d-standard-4` to utilize mature fleet capacity and avoid N4 stockouts.