### PR TITLE
feat(gke): Unify A4 blueprint with dynamic consumption models

### DIFF
--- a/examples/gke-a4/gke-a4-deployment.yaml
+++ b/examples/gke-a4/gke-a4-deployment.yaml
@@ -32,16 +32,34 @@ vars:
   # The GCP Zone used for this deployment.
   zone:
 
-  # The number of nodes to be created.
-  static_node_count:
-
   # Cidr block containing the IP of the machine calling terraform.
   # To allow all (IAM restrictions still enforced), use 0.0.0.0/0
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
-  # The name of the compute engine reservation in the form of
-  # <reservation-name>
-  # To target a BLOCK_NAME, the name of the extended reservation
-  # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
-  reservation:
+## Choose ONE consumption model from the options below (default is Specific Reservation):
+
+## --- Option 1: Specific Reservation ---
+## See for more information: https://github.com/GoogleCloudPlatform/cluster-toolkit/tree/main/modules/compute/gke-node-pool#using-gce-reservations
+  reservation_affinity:
+    consume_reservation_type: SPECIFIC_RESERVATION
+    specific_reservations:
+    - name:
+  static_node_count:
+
+## --- Option 2: DWS Flex Start ---
+  #enable_flex_start: true
+  #static_node_count: $(null)
+
+## --- Option 3: DWS Flex Start + Queued Provisioning ---
+  ## Change this variable if you want to have a custom kueue config file
+  #kueue_configuration_path: $(ghpc_stage("../dws-sample-workloads/dws-queues.yaml.tftpl"))
+  #enable_flex_start: true
+  #enable_queued_provisioning: true
+  #static_node_count: $(null)
+
+## --- Option 4: Spot ---
+  #spot: true
+  #static_node_count:
+  #placement_policy:
+  #  type: COMPACT

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -37,11 +37,14 @@ vars:
   # To allow only your IP address, use <YOUR-IP-ADDRESS>/32
   authorized_cidr:
 
-  # The name of the compute engine reservation in the form of
-  # <reservation-name>
-  # To target a BLOCK_NAME, the name of the extended reservation
-  # can be inputted as <reservation-name>/reservationBlocks/<reservation-block-name>
-  reservation:
+  # Consumption model variables
+  spot: false
+  reservation_affinity: {consume_reservation_type: "NO_RESERVATION", specific_reservations: []}
+  enable_flex_start: false
+  auto_repair: true
+  enable_queued_provisioning: false
+  autoscaling_total_min_nodes: 0
+  placement_policy: {type: null, name: null}
 
   kueue_configuration_path: $(ghpc_stage("./kueue-configuration.yaml.tftpl"))
   gib_installer_path: $(ghpc_stage("./nccl-installer.yaml.tftpl"))
@@ -236,10 +239,13 @@ deployment_groups:
       guest_accelerator:
       - type: $(vars.accelerator_type)
         count: 8
-      reservation_affinity:
-        consume_reservation_type: SPECIFIC_RESERVATION
-        specific_reservations:
-        - name: $(vars.reservation)
+      spot: $(vars.spot)
+      reservation_affinity: $(vars.reservation_affinity)
+      enable_flex_start: $(vars.enable_flex_start)
+      auto_repair: "$((vars.enable_flex_start) ? false : vars.auto_repair)"
+      enable_queued_provisioning: $(vars.enable_queued_provisioning)
+      autoscaling_total_min_nodes: $(vars.autoscaling_total_min_nodes)
+      placement_policy: $(vars.placement_policy)
     outputs: [instructions]
 
   # Install Kueue, Jobset, and NCCL installer
@@ -269,7 +275,7 @@ deployment_groups:
       image: nvidia/cuda:11.0.3-runtime-ubuntu20.04
       command:
       - nvidia-smi
-      node_count: $(vars.static_node_count)
+      node_count: "$((vars.static_node_count != null) ? vars.static_node_count : 2)"
       name: run-nvidia-smi
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]

--- a/examples/gke-a4/nccl-jobset-flex-queue.yaml
+++ b/examples/gke-a4/nccl-jobset-flex-queue.yaml
@@ -1,0 +1,214 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  generateName: ag-2-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: dws-local-queue
+  annotations:
+    provreq.kueue.x-k8s.io/maxRunDurationSeconds: "1200"
+spec:
+  ttlSecondsAfterFinished: 1200
+  suspend: False
+  network:
+    enableDNSHostnames: true
+  replicatedJobs:
+  - name: w
+    template:
+      spec:
+        parallelism: 2
+        completions: 2
+
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
+              networking.gke.io/default-interface: 'eth0'
+          spec:
+            # Limit benchmark run duration
+            activeDeadlineSeconds: 3600
+            restartPolicy: Never
+            nodeSelector:
+              cloud.google.com/gke-flex-start: "true"
+            tolerations:
+            - key: cloud.google.com/gke-queued
+              effect: NoSchedule
+              value: "true"
+
+            - key: "nvidia.com/gpu"
+              operator: "Exists"
+              effect: "NoSchedule"
+
+            setHostnameAsFQDN: true
+            volumes:
+            - name: gib
+              hostPath:
+                path: /home/kubernetes/bin/gib
+            - name: nvidia
+              hostPath:
+                path: /home/kubernetes/bin/nvidia
+            - name: lib64
+              hostPath:
+                path: /lib64
+            - name: shared-memory
+              emptyDir:
+                medium: "Memory"
+                sizeLimit: 250Gi
+            - name: sys
+              hostPath:
+                path: /sys
+            - name: proc-sys
+              hostPath:
+                path: /proc/sys
+            resourceClaims:
+            - name: rdma
+              resourceClaimTemplateName: default-rdma
+
+            initContainers:
+            - name: gpu-healthcheck
+              image: alpine:latest
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+                apk add --no-cache bash  # Install bash
+                /bin/bash -c "set -ex
+                NUM_GPUS=$(/usr/local/nvidia/bin/nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits | wc -l)
+                if [ \${NUM_GPUS} -lt 8 ]; then
+                  echo \"Error: Only \${NUM_GPUS} GPUs and expected 8\"
+                  exit 1
+                fi
+                gpu_errors=(\$(/usr/local/nvidia/bin/nvidia-smi --query-gpu=ecc.errors.uncorrected.volatile.total --format=csv,noheader,nounits))
+                for gpu_index in \${!gpu_errors[@]}; do
+                    if [ \${gpu_errors[\$gpu_index]} == '[N/A]' ]; then
+                        echo 'Error: ERR detected in GPU index '\$gpu_index
+                        exit 1
+                    elif [ \${gpu_errors[\$gpu_index]} -gt 0 ]; then
+                        echo 'Error: Unrecoverable ECC errors detected in GPU index '\$gpu_index
+                        exit 1
+                    fi
+                done
+                echo \${NUM_GPUS} GPUs found with no ERR or Unrecoverable ECC errors"
+
+              volumeMounts:
+              - name: nvidia
+                mountPath: /usr/local/nvidia
+              - name: lib64
+                mountPath: /lib64
+              securityContext:
+                privileged: true
+              env:
+              - name: LD_LIBRARY_PATH
+                value: /usr/local/nvidia/lib64
+
+            containers:
+            - name: nccl
+              stdin: true
+              tty: true
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
+              securityContext:
+                privileged: true
+              env:
+              - name: MY_NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              - name: OMPI_ALLOW_RUN_AS_ROOT
+                value: "1"
+              - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+                value: "1"
+              command:
+              - bash
+              - -c
+              - |
+                set -x
+                export N_NODES=2
+                echo "Starting workload container on ${MY_NODE_NAME} for $N_NODES benchmark"
+
+                # Load all the cuda libs
+                /sbin/ldconfig
+
+                # Install ping
+                apt update -y
+                apt install -y iputils-ping
+
+                # Start sshd
+                /scripts/container_entry.sh daemon &
+
+                # Get helper variables to form all hostnames
+                export POSTFIX=$(hostname | cut -d . -f 2-)
+                export WORKERS_BASENAME=$(hostname | cut -d . -f 1 | rev | cut -d - -f 2- | rev )
+                export NODE_RANK=$JOB_COMPLETION_INDEX
+
+                # For every worker, wait till online and add to hostfile
+                for i in `seq 0 $(($N_NODES-1))`; do
+                  OTHER=${WORKERS_BASENAME}-${i}.${POSTFIX}
+                  until ssh -p 222 -o StrictHostKeyChecking=no $OTHER hostname; do
+                    echo Waiting for ${OTHER}...
+                    sleep 10
+                  done
+                  echo ${OTHER} port=222 slots=8 | tee -a /tmp/hostfile;
+                done
+
+                cat /tmp/hostfile
+
+                # Launch from head node
+                if [[ "${NODE_RANK}" -eq "0" ]]; then
+
+                    # World Level = 0x0, Rail Aligned = 0x7
+                    export NCCL_TESTS_SPLIT_MASK="0x0";
+
+                    # Force use of libnccl-gib
+                    export NCCL_NET=gIB
+
+                    # Set all the correct libnccl-gib environment variables
+                    source /usr/local/gib/scripts/set_nccl_env.sh
+
+                    # Get all relevant NCCL / env vars to pass to all workers
+                    ENV_VARS=$(echo ${!NCCL*} ${!OMPI*} LD_LIBRARY_PATH PATH | sed 's/ / -x /g')
+
+                    mpirun --hostfile /tmp/hostfile \
+                      -x $ENV_VARS  \
+                      -mca plm_rsh_no_tree_spawn 1 \
+                      --mca orte_keep_fqdn_hostnames 1 \
+                      --mca btl self,tcp \
+                      --mca btl_tcp_if_include eth0 \
+                      --bind-to none \
+                      --mca plm_rsh_agent "ssh -q -o LogLevel=ERROR -o StrictHostKeyChecking=no -p 222" \
+                      /third_party/nccl-tests/build/all_gather_perf -b 1K -e 8G -f 2 -g 1 -w 5 --iters 100 -c 1
+
+                else
+                    while ping -c 1 ${WORKERS_BASENAME}-0.${POSTFIX}; do
+                    sleep 5
+                done
+                fi
+
+                exit 0
+
+              volumeMounts:
+              - name: nvidia
+                mountPath: /usr/local/nvidia
+              - name: gib
+                mountPath: /usr/local/gib
+              - name: shared-memory
+                mountPath: /dev/shm
+              resources:
+                limits:
+                  nvidia.com/gpu: 8
+                requests:
+                  nvidia.com/gpu: 8
+                claims:
+                - name: rdma

--- a/examples/gke-a4/nccl-jobset-flex.yaml
+++ b/examples/gke-a4/nccl-jobset-flex.yaml
@@ -1,0 +1,210 @@
+# Copyright 2026 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: jobset.x-k8s.io/v1alpha2
+kind: JobSet
+metadata:
+  generateName: ag-2-
+  namespace: default
+spec:
+  ttlSecondsAfterFinished: 1200
+  suspend: False
+  network:
+    enableDNSHostnames: true
+  replicatedJobs:
+  - name: w
+    template:
+      spec:
+        parallelism: 2
+        completions: 2
+
+        template:
+          metadata:
+            annotations:
+              kueue.x-k8s.io/podset-preferred-topology: "kubernetes.io/hostname"
+              networking.gke.io/default-interface: 'eth0'
+          spec:
+            # Limit benchmark run duration
+            activeDeadlineSeconds: 3600
+            restartPolicy: Never
+            nodeSelector:
+              cloud.google.com/gke-flex-start: "true"
+            tolerations:
+            - key: cloud.google.com/gke-queued
+              effect: NoSchedule
+              value: "true"
+
+            - key: "nvidia.com/gpu"
+              operator: "Exists"
+              effect: "NoSchedule"
+
+            setHostnameAsFQDN: true
+            volumes:
+            - name: gib
+              hostPath:
+                path: /home/kubernetes/bin/gib
+            - name: nvidia
+              hostPath:
+                path: /home/kubernetes/bin/nvidia
+            - name: lib64
+              hostPath:
+                path: /lib64
+            - name: shared-memory
+              emptyDir:
+                medium: "Memory"
+                sizeLimit: 250Gi
+            - name: sys
+              hostPath:
+                path: /sys
+            - name: proc-sys
+              hostPath:
+                path: /proc/sys
+            resourceClaims:
+            - name: rdma
+              resourceClaimTemplateName: default-rdma
+
+            initContainers:
+            - name: gpu-healthcheck
+              image: alpine:latest
+              command: ["/bin/sh", "-c"]
+              args:
+              - |
+                apk add --no-cache bash  # Install bash
+                /bin/bash -c "set -ex
+                NUM_GPUS=$(/usr/local/nvidia/bin/nvidia-smi --query-gpu=driver_version --format=csv,noheader,nounits | wc -l)
+                if [ \${NUM_GPUS} -lt 8 ]; then
+                  echo \"Error: Only \${NUM_GPUS} GPUs and expected 8\"
+                  exit 1
+                fi
+                gpu_errors=(\$(/usr/local/nvidia/bin/nvidia-smi --query-gpu=ecc.errors.uncorrected.volatile.total --format=csv,noheader,nounits))
+                for gpu_index in \${!gpu_errors[@]}; do
+                    if [ \${gpu_errors[\$gpu_index]} == '[N/A]' ]; then
+                        echo 'Error: ERR detected in GPU index '\$gpu_index
+                        exit 1
+                    elif [ \${gpu_errors[\$gpu_index]} -gt 0 ]; then
+                        echo 'Error: Unrecoverable ECC errors detected in GPU index '\$gpu_index
+                        exit 1
+                    fi
+                done
+                echo \${NUM_GPUS} GPUs found with no ERR or Unrecoverable ECC errors"
+
+              volumeMounts:
+              - name: nvidia
+                mountPath: /usr/local/nvidia
+              - name: lib64
+                mountPath: /lib64
+              securityContext:
+                privileged: true
+              env:
+              - name: LD_LIBRARY_PATH
+                value: /usr/local/nvidia/lib64
+
+            containers:
+            - name: nccl
+              stdin: true
+              tty: true
+              image: us-docker.pkg.dev/gce-ai-infra/gpudirect-gib/nccl-plugin-gib-diagnostic:v1.1.2
+              securityContext:
+                privileged: true
+              env:
+              - name: MY_NODE_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: spec.nodeName
+              - name: OMPI_ALLOW_RUN_AS_ROOT
+                value: "1"
+              - name: OMPI_ALLOW_RUN_AS_ROOT_CONFIRM
+                value: "1"
+              command:
+              - bash
+              - -c
+              - |
+                set -x
+                export N_NODES=2
+                echo "Starting workload container on ${MY_NODE_NAME} for $N_NODES benchmark"
+
+                # Load all the cuda libs
+                /sbin/ldconfig
+
+                # Install ping
+                apt update -y
+                apt install -y iputils-ping
+
+                # Start sshd
+                /scripts/container_entry.sh daemon &
+
+                # Get helper variables to form all hostnames
+                export POSTFIX=$(hostname | cut -d . -f 2-)
+                export WORKERS_BASENAME=$(hostname | cut -d . -f 1 | rev | cut -d - -f 2- | rev )
+                export NODE_RANK=$JOB_COMPLETION_INDEX
+
+                # For every worker, wait till online and add to hostfile
+                for i in `seq 0 $(($N_NODES-1))`; do
+                  OTHER=${WORKERS_BASENAME}-${i}.${POSTFIX}
+                  until ssh -p 222 -o StrictHostKeyChecking=no $OTHER hostname; do
+                    echo Waiting for ${OTHER}...
+                    sleep 10
+                  done
+                  echo ${OTHER} port=222 slots=8 | tee -a /tmp/hostfile;
+                done
+
+                cat /tmp/hostfile
+
+                # Launch from head node
+                if [[ "${NODE_RANK}" -eq "0" ]]; then
+
+                    # World Level = 0x0, Rail Aligned = 0x7
+                    export NCCL_TESTS_SPLIT_MASK="0x0";
+
+                    # Force use of libnccl-gib
+                    export NCCL_NET=gIB
+
+                    # Set all the correct libnccl-gib environment variables
+                    source /usr/local/gib/scripts/set_nccl_env.sh
+
+                    # Get all relevant NCCL / env vars to pass to all workers
+                    ENV_VARS=$(echo ${!NCCL*} ${!OMPI*} LD_LIBRARY_PATH PATH | sed 's/ / -x /g')
+
+                    mpirun --hostfile /tmp/hostfile \
+                      -x $ENV_VARS  \
+                      -mca plm_rsh_no_tree_spawn 1 \
+                      --mca orte_keep_fqdn_hostnames 1 \
+                      --mca btl self,tcp \
+                      --mca btl_tcp_if_include eth0 \
+                      --bind-to none \
+                      --mca plm_rsh_agent "ssh -q -o LogLevel=ERROR -o StrictHostKeyChecking=no -p 222" \
+                      /third_party/nccl-tests/build/all_gather_perf -b 1K -e 8G -f 2 -g 1 -w 5 --iters 100 -c 1
+
+                else
+                    while ping -c 1 ${WORKERS_BASENAME}-0.${POSTFIX}; do
+                    sleep 5
+                done
+                fi
+
+                exit 0
+
+              volumeMounts:
+              - name: nvidia
+                mountPath: /usr/local/nvidia
+              - name: gib
+                mountPath: /usr/local/gib
+              - name: shared-memory
+                mountPath: /dev/shm
+              resources:
+                limits:
+                  nvidia.com/gpu: 8
+                requests:
+                  nvidia.com/gpu: 8
+                claims:
+                - name: rdma

--- a/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a4-onspot.yaml
@@ -183,6 +183,8 @@ steps:
               echo '      machine_type: n2d-standard-2'            >> \$$EXAMPLE_BP
               echo '      name_prefix: remote-node'                >> \$$EXAMPLE_BP
               echo '      add_deployment_name_before_prefix: true' >> \$$EXAMPLE_BP
+              echo '      spot: $(null)'                            >> \$$EXAMPLE_BP
+              echo '      placement_policy: $(null)'                >> \$$EXAMPLE_BP
               echo ''
               echo '  - id: job_template_hostname'                       >> \$$EXAMPLE_BP
               echo '    source: modules/compute/gke-job-template'        >> \$$EXAMPLE_BP
@@ -204,13 +206,8 @@ steps:
                 echo "INFO: Using \$$GKE_VARS_FILE as it is for SPOT provisioning."
               fi
 
-              # Setting placement policy as compact for nccl test to run on spot VMs, adding spot variable and removing reservation from blueprint.
-              sed -i -e '/reservation_affinity:/,+3c\      placement_policy:\n        type: COMPACT\n      spot: '"\$$ENABLE_SPOT"'' \$$EXAMPLE_BP
-              sed -i '/reservation/d' \$$EXAMPLE_BP
-
               # Override force_destroy from false to true for training and checkpoint storage buckets
               sed -i -E 's/force_destroy:\s*false/force_destroy: true/g' \$$EXAMPLE_BP
-
               bash tools/add_ttl_label.sh "\$$EXAMPLE_BP"
 
               ansible-playbook tools/cloud-build/daily-tests/ansible_playbooks/base-integration-test.yml \

--- a/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
+++ b/tools/cloud-build/daily-tests/tests/gke-a4-onspot.yml
@@ -36,6 +36,9 @@ cli_deployment_vars:
   authorized_cidr: "{{ build_ip.stdout }}/32"
   gcp_public_cidrs_access_enabled: true
   k8s_service_account_name: "{{ k8s_service_account_name}}"
+  spot: "{{ enable_spot | default(true) }}"
+  placement_policy:
+    type: COMPACT
 custom_vars:
   project: "{{ project }}"
   instance_labels:


### PR DESCRIPTION
- Add dynamic consumption variables (spot, reservation_affinity, enable_flex_start, auto_repair, enable_queued_provisioning, placement_policy) to GKE A4 blueprint.
- Standardize A4 deployment template across 4 consumption options with Option 1 (Specific Reservation) active by default.
- Add multi-node DRANET-compatible NCCL test JobSets for DWS Flex Start and DWS Flex Start + Queued Provisioning.
- Align daily Cloud Build Spot integration tests.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
