### PR TITLE
A4h lustre Support

### DIFF
--- a/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
+++ b/examples/machine-learning/a4-highgpu-8g/a4high-slurm-blueprint.yaml
@@ -23,9 +23,7 @@ vars:
   a4h_cluster_size: # supply cluster size
   # Image settings
   # Cluster env settings
-  # net0 and filestore ranges must not overlap
   net0_range: 192.168.0.0/19
-  filestore_ip_range: 192.168.32.0/24
   net1_range: 192.168.64.0/18
   rdma_net_range: 192.168.128.0/18
   # Cluster Settings
@@ -42,21 +40,19 @@ vars:
   a4h_dws_flex_enabled: false
   a4h_enable_spot_vm: false
 
-  # To enable Managed-Lustre please uncomment this section and fill out the settings.
-  # Additionally, please uncomment the private_service_access and managed-lustre modules.
   # Managed Lustre is only supported in specific regions and zones
   # Please refer https://cloud.google.com/managed-lustre/docs/locations
 
   # Managed-Lustre instance name. This should be unique for each deployment.
-  # lustre_instance_id: lustre-instance
+  lustre_instance_id: $(vars.deployment_name)-lustre
 
   # The values of size_gib and per_unit_storage_throughput are co-related
   # Please refer https://cloud.google.com/managed-lustre/docs/create-instance#performance-tiers
   # Storage capacity of the lustre instance in GiB
-  # lustre_size_gib: 36000
+  lustre_size_gib: 36000
 
   # Maximum throughput of the lustre instance in MBps per TiB
-  # per_unit_storage_throughput: 500
+  per_unit_storage_throughput: 500
 
 deployment_groups:
 
@@ -110,42 +106,23 @@ deployment_groups:
         ip_range: $(vars.rdma_net_range)
         region: $(vars.region)
 
+  - id: private_service_access
+    source: modules/network/private-service-access
+    use: [a4high-slurm-net-0]
+
   - id: homefs
-    source: modules/file-system/filestore
+    source: modules/file-system/managed-lustre
     use:
     - a4high-slurm-net-0
+    - private_service_access
     settings:
-      filestore_tier: HIGH_SCALE_SSD
-      size_gb: 10240
+      size_gib: $(vars.lustre_size_gib)
+      name: $(vars.lustre_instance_id)
       local_mount: /home
-      reserved_ip_range: $(vars.filestore_ip_range)
-      deletion_protection:
-        enabled: true
-        reason: Avoid data loss
+      remote_mount: lustrefs
+      per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
     outputs:
     - network_storage
-
-  # To use Managed Lustre as for the shared /home directory:
-  # 1. Comment out the filestore block above and the`filestore_ip_range` line in the vars block.
-  # 2. Uncomment the managed-lustre and private-service-access blocks
-  # 3. Change the value for "install_managed_lustre" in /var/tmp/slurm_vars.json above to true
-  # - id: private_service_access
-  #   source: modules/network/private-service-access
-  #   use: [a4high-slurm-net-0]
-
-  # - id: homefs
-  #   source: modules/file-system/managed-lustre
-  #   use:
-  #   - a4high-slurm-net-0
-  #   - private_service_access
-  #   settings:
-  #     size_gib: $(vars.lustre_size_gib)
-  #     name: $(vars.lustre_instance_id)
-  #     local_mount: /home
-  #     remote_mount: lustrefs
-  #     per_unit_storage_throughput: $(vars.per_unit_storage_throughput)
-  #   outputs:
-  #   - network_storage
 
   # The following four modules create and mount a Cloud Storage Bucket with
   # gcsfuse.  They are optional but recommended for many use cases.

--- a/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
+++ b/tools/cloud-build/daily-tests/builds/ml-a4-highgpu-onspot-slurm.yaml
@@ -16,7 +16,8 @@
 tags:
 - m.cloud-storage-bucket
 - m.pre-existing-network-storage
-- m.filestore
+- m.managed-lustre
+- m.private-service-access
 - m.gpu-rdma-vpc
 - m.schedmd-slurm-gcp-v6-controller
 - m.schedmd-slurm-gcp-v6-login
@@ -113,12 +114,10 @@ steps:
           - name: runner
             image: us-central1-docker.pkg.dev/$PROJECT_ID/hpc-toolkit-repo/test-runner:$BUILD_ID
             env:
-            - name: CHECK_FILESTORE
+            - name: CHECK_LUSTRE
               value: "true"
-            - name: REQUIRED_FILESTORE_TIER
-              value: "HIGH_SCALE_SSD"
-            - name: REQUIRED_FILESTORE_GB
-              value: "10240"
+            - name: REQUIRED_LUSTRE_GB
+              value: "36000"
             - name: ANSIBLE_HOST_KEY_CHECKING
               value: "false"
             - name: ANSIBLE_CONFIG


### PR DESCRIPTION
This PR transitions the A4 HighGPU Slurm blueprint from using Filestore to using Managed Lustre.

### Changes
* **a4high-slurm-blueprint.yaml**:
  * Replaced `filestore` module with `private-service-access` and `managed-lustre` for `/home`.
  * Removed `filestore_ip_range` and activated Managed Lustre configuration variables.
* **ml-a4-highgpu-onspot-slurm.yaml**:
  * Replaced `CHECK_FILESTORE` with `CHECK_LUSTRE` (36000 GiB) for zone selection.
  * Updated build tags to include `m.managed-lustre` and `m.private-service-access` while removing `m.filestore`.
