### PR TITLE
fix(ci): clean up decommissioned parallelstore repo in slurm-storage test

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml
@@ -59,14 +59,16 @@
 - name: Ensure fio is installed (safe for all OS)
   ansible.builtin.raw: |
     if ! command -v fio >/dev/null 2>&1; then
-      # Clean up decommissioned parallelstore repository configs
-      rm -f /etc/yum.repos.d/parallelstore*.repo 2>/dev/null || true
       if command -v apt-get >/dev/null 2>&1; then
         apt-get update -y && apt-get install -y fio
       elif command -v dnf >/dev/null 2>&1; then
-        dnf install -y --disablerepo="parallelstore*" fio || dnf install -y fio
+        # Clean up decommissioned parallelstore repository configs
+        rm -f /etc/yum.repos.d/parallelstore*.repo 2>/dev/null || true
+        dnf install -y --disablerepo="parallelstore*" fio
       elif command -v yum >/dev/null 2>&1; then
-        yum install -y --disablerepo="parallelstore*" fio || yum install -y fio
+        # Clean up decommissioned parallelstore repository configs
+        rm -f /etc/yum.repos.d/parallelstore*.repo 2>/dev/null || true
+        yum install -y --disablerepo="parallelstore*" fio
       fi
     fi
   become: true

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml
@@ -59,12 +59,14 @@
 - name: Ensure fio is installed (safe for all OS)
   ansible.builtin.raw: |
     if ! command -v fio >/dev/null 2>&1; then
+      # Clean up decommissioned parallelstore repository configs
+      rm -f /etc/yum.repos.d/parallelstore*.repo 2>/dev/null || true
       if command -v apt-get >/dev/null 2>&1; then
         apt-get update -y && apt-get install -y fio
-      elif command -v yum >/dev/null 2>&1; then
-        yum install -y fio
       elif command -v dnf >/dev/null 2>&1; then
-        dnf install -y fio
+        dnf install -y --disablerepo="parallelstore*" fio || dnf install -y fio
+      elif command -v yum >/dev/null 2>&1; then
+        yum install -y --disablerepo="parallelstore*" fio || yum install -y fio
       fi
     fi
   become: true


### PR DESCRIPTION
### Summary

Fixes the `slurm-storage` daily test and PR validation (`PR-test-slurm-storage`) failures where installing `fio` on the Slurm login node fails with HTTP 404 attempting to refresh metadata from decommissioned `parallelstore-packages` repository configs.

---

### Root Cause

During `slurm-storage` test validation in `tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml`, the task `Ensure fio is installed (safe for all OS)` runs `dnf install -y fio` / `yum install -y fio` on the Slurm login node. 

Because the Slurm login node VM uses the HPC Rocky Linux 9 image where `/etc/yum.repos.d/parallelstore-v2-6-el9.repo` was pre-installed, `dnf`/`yum` attempts to refresh metadata from `https://us-central1-yum.pkg.dev/projects/parallelstore-packages/v2-6-el9`, which returns HTTP 404 following the upstream deletion of the repository, causing the playbook to abort.

---

### Changes Made

In `tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-slurm-storage.yml`:
1. Clean up any `/etc/yum.repos.d/parallelstore*.repo` files prior to running package manager checks/installation.
2. Pass `--disablerepo="parallelstore*"` to `dnf install` and `yum install` as an additional defensive fallback.

---

### Submission Checklist

* [x] Fork your PR branch from the Toolkit "develop" branch (not main)
* [x] Test all changes with pre-commit in a local branch
* [x] Confirm that "make tests" passes all tests
* [x] Follow Cluster Toolkit Contribution guidelines