### PR TITLE
fix: resolve MTC CSI driver race condition and Kueue flavor-default pollution

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -689,13 +689,16 @@ func (g *GKEOrchestrator) getNodeServiceAccount() string {
 }
 
 func isDaemonSetRolloutComplete(dsObj *unstructured.Unstructured) bool {
+	if dsObj == nil || dsObj.Object == nil {
+		return false
+	}
 	gen, _, _ := unstructured.NestedInt64(dsObj.Object, "metadata", "generation")
 	obsGen, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "observedGeneration")
 	desired, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "desiredNumberScheduled")
 	ready, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "numberReady")
 	updated, _, _ := unstructured.NestedInt64(dsObj.Object, "status", "updatedNumberScheduled")
 
-	if obsGen >= gen && ready >= desired && updated >= desired {
+	if desired > 0 && obsGen >= gen && ready >= desired && updated >= desired {
 		logging.Info("MTC multitier-driver DaemonSet is ready (%d/%d nodes ready).", ready, desired)
 		return true
 	}
@@ -709,7 +712,7 @@ func getMTCDaemonSet(ctx context.Context, client dynamic.Interface, namespace st
 			dsObj.SetName("multitier-driver")
 		}
 		return dsObj, nil
-	} else if isForbiddenError(err) {
+	} else if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
 
@@ -730,30 +733,10 @@ func getMTCDaemonSet(ctx context.Context, client dynamic.Interface, namespace st
 
 var daemonSetPollInterval = 2 * time.Second
 
-// waitForMTCDriverDaemonSetReady waits for the multitier-driver DaemonSet to finish rollout and become ready.
-func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interface, namespace string) {
-	logging.Info("Waiting for MTC multitier-driver DaemonSet in %s to be ready...", namespace)
+// waitForDaemonSetRollout polls the DaemonSet until its rollout is complete or context times out.
+func waitForDaemonSetRollout(ctx context.Context, client dynamic.Interface, namespace, dsName string) {
 	waitCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
-
-	dsObj, err := getMTCDaemonSet(waitCtx, client, namespace)
-	if err != nil {
-		if isForbiddenError(err) {
-			logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
-			return
-		}
-		if apierrors.IsNotFound(err) {
-			logging.Warn("MTC multitier-driver DaemonSet not found in %s. Proceeding with job submission.", namespace)
-			return
-		}
-		logging.Warn("Error finding MTC multitier-driver DaemonSet in %s: %v. Proceeding with job submission.", namespace, err)
-		return
-	}
-
-	dsName := dsObj.GetName()
-	if isDaemonSetRolloutComplete(dsObj) {
-		return
-	}
 
 	ticker := time.NewTicker(daemonSetPollInterval)
 	defer ticker.Stop()
@@ -767,7 +750,7 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 			currentObj, err := client.Resource(daemonsetGVR).Namespace(namespace).Get(waitCtx, dsName, metav1.GetOptions{})
 			if err != nil {
 				if isForbiddenError(err) {
-					logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
+					logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet %s in %s status (403 Forbidden). Proceeding with job submission.", dsName, namespace)
 					return
 				}
 				logging.Warn("Retrying get of multitier-driver DaemonSet %s: %v", dsName, err)
@@ -782,29 +765,36 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 
 // restartMTCDriverPods restarts the multitier-driver DaemonSet to pick up updated service account tokens.
 func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespace string) {
-	if dsObj, err := getMTCDaemonSet(ctx, client, namespace); err == nil {
-		dsName := dsObj.GetName()
-		patchData := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, time.Now().UTC().Format(time.RFC3339))
-		_, patchErr := client.Resource(daemonsetGVR).Namespace(namespace).Patch(ctx, dsName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
-		if patchErr == nil {
-			logging.Info("Triggered rolling restart of %s DaemonSet in %s", dsName, namespace)
-			waitForMTCDriverDaemonSetReady(ctx, client, namespace)
-			return
-		} else if isForbiddenError(patchErr) {
-			logging.Warn("Insufficient RBAC permissions to restart %s DaemonSet in %s (403 Forbidden). Skipping driver restart.", dsName, namespace)
+	dsObj, err := getMTCDaemonSet(ctx, client, namespace)
+	if err != nil {
+		if isForbiddenError(err) {
+			logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet in %s (403 Forbidden). Skipping driver restart.", namespace)
 			return
 		}
-		logging.Warn("Failed to patch DaemonSet %s for restart: %v. Falling back to pod deletion.", dsName, patchErr)
-	} else if isForbiddenError(err) {
-		logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet in %s (403 Forbidden). Skipping driver restart.", namespace)
-		return
-	} else if apierrors.IsNotFound(err) {
-		logging.Warn("MTC multitier-driver DaemonSet not found in %s. Skipping driver restart.", namespace)
+		if apierrors.IsNotFound(err) {
+			logging.Warn("MTC multitier-driver DaemonSet not found in %s. Skipping driver restart.", namespace)
+			return
+		}
+		logging.Warn("Failed to get multitier-driver DaemonSet in %s: %v. Skipping driver restart.", namespace, err)
 		return
 	}
 
+	dsName := dsObj.GetName()
+	patchData := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, time.Now().UTC().Format(time.RFC3339))
+	_, patchErr := client.Resource(daemonsetGVR).Namespace(namespace).Patch(ctx, dsName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+	if patchErr == nil {
+		logging.Info("Triggered rolling restart of %s DaemonSet in %s", dsName, namespace)
+		waitForDaemonSetRollout(ctx, client, namespace, dsName)
+		return
+	}
+	if isForbiddenError(patchErr) {
+		logging.Warn("Insufficient RBAC permissions to restart %s DaemonSet in %s (403 Forbidden). Skipping driver restart.", dsName, namespace)
+		return
+	}
+
+	logging.Warn("Failed to patch DaemonSet %s for restart: %v. Falling back to pod deletion.", dsName, patchErr)
 	deleteMTCDriverPodsFallback(ctx, client, namespace)
-	waitForMTCDriverDaemonSetReady(ctx, client, namespace)
+	waitForDaemonSetRollout(ctx, client, namespace, dsName)
 }
 
 func deleteMTCDriverPodsFallback(ctx context.Context, client dynamic.Interface, namespace string) {
@@ -897,7 +887,8 @@ func (g *GKEOrchestrator) ensureMTCWorkloadIdentity(job *orchestrator.JobDefinit
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	// Allow sufficient deadline for SA mutation (15s) and subsequent DaemonSet rollout wait (90s).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	const mtcNamespace = "gke-managed-checkpointing"

--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -702,20 +702,30 @@ func isDaemonSetRolloutComplete(dsObj *unstructured.Unstructured) bool {
 	return false
 }
 
-func checkDaemonSetReady(ctx context.Context, client dynamic.Interface, namespace string) (bool, error) {
-	dsObj, err := client.Resource(daemonsetGVR).Namespace(namespace).Get(ctx, "multitier-driver", metav1.GetOptions{})
-	if err != nil {
-		if isForbiddenError(err) {
-			logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
-			return true, nil
+func getMTCDaemonSet(ctx context.Context, client dynamic.Interface, namespace string) (*unstructured.Unstructured, error) {
+	// First attempt direct get of "multitier-driver" in case it exists with static name.
+	if dsObj, err := client.Resource(daemonsetGVR).Namespace(namespace).Get(ctx, "multitier-driver", metav1.GetOptions{}); err == nil {
+		if dsObj.GetName() == "" {
+			dsObj.SetName("multitier-driver")
 		}
-		if apierrors.IsNotFound(err) {
-			logging.Warn("MTC multitier-driver DaemonSet not found in %s. Proceeding with job submission.", namespace)
-			return true, nil
-		}
-		return false, err
+		return dsObj, nil
+	} else if isForbiddenError(err) {
+		return nil, err
 	}
-	return isDaemonSetRolloutComplete(dsObj), nil
+
+	// In GKE, HighScaleCheckpointing names the DaemonSet "multitier-driver-<instanceHandle>".
+	// List DaemonSets in the namespace to find it.
+	dsList, err := client.Resource(daemonsetGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	for i := range dsList.Items {
+		ds := &dsList.Items[i]
+		if strings.HasPrefix(ds.GetName(), "multitier-driver") || ds.GetLabels()["k8s-app"] == "high-scale-checkpointing" {
+			return ds, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, "multitier-driver")
 }
 
 var daemonSetPollInterval = 2 * time.Second
@@ -726,7 +736,22 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 	waitCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	if ready, err := checkDaemonSetReady(waitCtx, client, namespace); ready && err == nil {
+	dsObj, err := getMTCDaemonSet(waitCtx, client, namespace)
+	if err != nil {
+		if isForbiddenError(err) {
+			logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
+			return
+		}
+		if apierrors.IsNotFound(err) {
+			logging.Warn("MTC multitier-driver DaemonSet not found in %s. Proceeding with job submission.", namespace)
+			return
+		}
+		logging.Warn("Error finding MTC multitier-driver DaemonSet in %s: %v. Proceeding with job submission.", namespace, err)
+		return
+	}
+
+	dsName := dsObj.GetName()
+	if isDaemonSetRolloutComplete(dsObj) {
 		return
 	}
 
@@ -736,13 +761,20 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 	for {
 		select {
 		case <-waitCtx.Done():
-			logging.Warn("Timed out or context canceled waiting for MTC multitier-driver DaemonSet in %s to become ready. Proceeding with job submission.", namespace)
+			logging.Warn("Timed out or context canceled waiting for MTC multitier-driver DaemonSet %s in %s to become ready. Proceeding with job submission.", dsName, namespace)
 			return
 		case <-ticker.C:
-			if ready, err := checkDaemonSetReady(waitCtx, client, namespace); ready && err == nil {
+			currentObj, err := client.Resource(daemonsetGVR).Namespace(namespace).Get(waitCtx, dsName, metav1.GetOptions{})
+			if err != nil {
+				if isForbiddenError(err) {
+					logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet status (403 Forbidden). Proceeding with job submission.")
+					return
+				}
+				logging.Warn("Retrying get of multitier-driver DaemonSet %s: %v", dsName, err)
+				continue
+			}
+			if isDaemonSetRolloutComplete(currentObj) {
 				return
-			} else if err != nil {
-				logging.Warn("Retrying get of multitier-driver DaemonSet: %v", err)
 			}
 		}
 	}
@@ -750,16 +782,32 @@ func waitForMTCDriverDaemonSetReady(ctx context.Context, client dynamic.Interfac
 
 // restartMTCDriverPods restarts the multitier-driver DaemonSet to pick up updated service account tokens.
 func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespace string) {
-	patchData := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, time.Now().UTC().Format(time.RFC3339))
-	if _, err := client.Resource(daemonsetGVR).Namespace(namespace).Patch(ctx, "multitier-driver", types.StrategicMergePatchType, patchData, metav1.PatchOptions{}); err == nil {
-		logging.Info("Triggered rolling restart of multitier-driver DaemonSet in %s", namespace)
-		waitForMTCDriverDaemonSetReady(ctx, client, namespace)
-		return
+	if dsObj, err := getMTCDaemonSet(ctx, client, namespace); err == nil {
+		dsName := dsObj.GetName()
+		patchData := fmt.Appendf(nil, `{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":"%s"}}}}}`, time.Now().UTC().Format(time.RFC3339))
+		_, patchErr := client.Resource(daemonsetGVR).Namespace(namespace).Patch(ctx, dsName, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
+		if patchErr == nil {
+			logging.Info("Triggered rolling restart of %s DaemonSet in %s", dsName, namespace)
+			waitForMTCDriverDaemonSetReady(ctx, client, namespace)
+			return
+		} else if isForbiddenError(patchErr) {
+			logging.Warn("Insufficient RBAC permissions to restart %s DaemonSet in %s (403 Forbidden). Skipping driver restart.", dsName, namespace)
+			return
+		}
+		logging.Warn("Failed to patch DaemonSet %s for restart: %v. Falling back to pod deletion.", dsName, patchErr)
 	} else if isForbiddenError(err) {
-		logging.Warn("Insufficient RBAC permissions to restart multitier-driver DaemonSet in %s (403 Forbidden). Skipping driver restart.", namespace)
+		logging.Warn("Insufficient RBAC permissions to get multitier-driver DaemonSet in %s (403 Forbidden). Skipping driver restart.", namespace)
+		return
+	} else if apierrors.IsNotFound(err) {
+		logging.Warn("MTC multitier-driver DaemonSet not found in %s. Skipping driver restart.", namespace)
 		return
 	}
 
+	deleteMTCDriverPodsFallback(ctx, client, namespace)
+	waitForMTCDriverDaemonSetReady(ctx, client, namespace)
+}
+
+func deleteMTCDriverPodsFallback(ctx context.Context, client dynamic.Interface, namespace string) {
 	listOpts := metav1.ListOptions{
 		LabelSelector: "k8s-app=high-scale-checkpointing",
 	}
@@ -797,7 +845,6 @@ func restartMTCDriverPods(ctx context.Context, client dynamic.Interface, namespa
 		// and decrement status.numberReady before we poll for readiness.
 		time.Sleep(daemonSetPollInterval)
 	}
-	waitForMTCDriverDaemonSetReady(ctx, client, namespace)
 }
 
 // updateMTCServiceAccountAnnotation updates the MTC KSA with the node GSA Workload Identity annotation and restarts driver pods.
@@ -995,8 +1042,7 @@ func (g *GKEOrchestrator) processNodePoolCapacity(np gkeJobNodePool, location st
 		flavor = accFlavor
 	}
 
-	isHardwareAccel := len(np.Config.Accelerators) > 0 || len(cap.Accelerators) > 0
-	if !isHardwareAccel && !g.isSystemPool(np) {
+	if flavor == "pathways-flavor" {
 		nodeLabels["cloud.google.com/gke-nodepool"] = np.Name
 	}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -3936,6 +3936,22 @@ func TestEnsureMTCWorkloadIdentity_Restart(t *testing.T) {
 		patchedDS := false
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				if name == "multitier-driver" {
+					return &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":       "multitier-driver",
+								"generation": int64(1),
+							},
+							"status": map[string]interface{}{
+								"observedGeneration":     int64(1),
+								"desiredNumberScheduled": int64(1),
+								"numberReady":            int64(1),
+								"updatedNumberScheduled": int64(1),
+							},
+						},
+					}, nil
+				}
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"metadata": map[string]interface{}{
@@ -3977,6 +3993,22 @@ func TestEnsureMTCWorkloadIdentity_Restart(t *testing.T) {
 		deletedPods := []string{}
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				if name == "multitier-driver" {
+					return &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":       "multitier-driver",
+								"generation": int64(1),
+							},
+							"status": map[string]interface{}{
+								"observedGeneration":     int64(1),
+								"desiredNumberScheduled": int64(1),
+								"numberReady":            int64(1),
+								"updatedNumberScheduled": int64(1),
+							},
+						},
+					}, nil
+				}
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"metadata": map[string]interface{}{
@@ -4043,6 +4075,10 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 		},
 	}
 
+	oldInterval := daemonSetPollInterval
+	daemonSetPollInterval = 1 * time.Millisecond
+	defer func() { daemonSetPollInterval = oldInterval }()
+
 	t.Run("Get SA fails - Self-healing logs warning and continues without failing job", func(t *testing.T) {
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -4103,6 +4139,22 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 	t.Run("403 Forbidden on List driver pods - Continues gracefully", func(t *testing.T) {
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				if name == "multitier-driver" {
+					return &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":       "multitier-driver",
+								"generation": int64(1),
+							},
+							"status": map[string]interface{}{
+								"observedGeneration":     int64(1),
+								"desiredNumberScheduled": int64(1),
+								"numberReady":            int64(1),
+								"updatedNumberScheduled": int64(1),
+							},
+						},
+					}, nil
+				}
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"metadata": map[string]interface{}{
@@ -4113,6 +4165,9 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 			},
 			updateFunc: func(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 				return obj, nil
+			},
+			patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("patch failed")
 			},
 			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 				return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", fmt.Errorf("forbidden"))
@@ -4129,19 +4184,19 @@ func TestEnsureMTCWorkloadIdentity_RBAC(t *testing.T) {
 	})
 }
 
-func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
+func TestWaitForDaemonSetRollout(t *testing.T) {
 	oldInterval := daemonSetPollInterval
 	daemonSetPollInterval = 1 * time.Millisecond
 	defer func() { daemonSetPollInterval = oldInterval }()
 
 	t.Run("DaemonSet ready immediately", func(t *testing.T) {
+		calls := 0
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				calls++
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"generation": int64(2),
-						},
+						"metadata": map[string]interface{}{"generation": int64(2)},
 						"status": map[string]interface{}{
 							"observedGeneration":     int64(2),
 							"desiredNumberScheduled": int64(3),
@@ -4152,10 +4207,13 @@ func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
 				}, nil
 			},
 		}
-		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+		waitForDaemonSetRollout(context.Background(), dynClient, "gke-managed-checkpointing", "multitier-driver-uuid")
+		if calls != 1 {
+			t.Errorf("expected 1 call for immediate ready, got %d", calls)
+		}
 	})
 
-	t.Run("DaemonSet ready after polling", func(t *testing.T) {
+	t.Run("DaemonSet rollout completes after polling", func(t *testing.T) {
 		calls := 0
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -4163,9 +4221,7 @@ func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
 				if calls < 2 {
 					return &unstructured.Unstructured{
 						Object: map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"generation": int64(2),
-							},
+							"metadata": map[string]interface{}{"generation": int64(2)},
 							"status": map[string]interface{}{
 								"observedGeneration":     int64(2),
 								"desiredNumberScheduled": int64(3),
@@ -4177,9 +4233,7 @@ func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
 				}
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"generation": int64(2),
-						},
+						"metadata": map[string]interface{}{"generation": int64(2)},
 						"status": map[string]interface{}{
 							"observedGeneration":     int64(2),
 							"desiredNumberScheduled": int64(3),
@@ -4190,7 +4244,7 @@ func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
 				}, nil
 			},
 		}
-		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+		waitForDaemonSetRollout(context.Background(), dynClient, "gke-managed-checkpointing", "multitier-driver-uuid")
 		if calls < 2 {
 			t.Errorf("expected at least 2 calls for polling, got %d", calls)
 		}
@@ -4199,42 +4253,140 @@ func TestWaitForMTCDriverDaemonSetReady(t *testing.T) {
 	t.Run("403 Forbidden returns gracefully", func(t *testing.T) {
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
-				return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "daemonsets"}, "multitier-driver", fmt.Errorf("forbidden"))
+				return nil, apierrors.NewForbidden(schema.GroupResource{Resource: "daemonsets"}, name, fmt.Errorf("forbidden"))
 			},
 		}
-		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
+		waitForDaemonSetRollout(context.Background(), dynClient, "gke-managed-checkpointing", "multitier-driver-uuid")
 	})
 
-	t.Run("DaemonSet NotFound returns gracefully", func(t *testing.T) {
-		dynClient := &mockDynamicClient{
-			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
-				return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "daemonsets"}, "multitier-driver")
-			},
-		}
-		waitForMTCDriverDaemonSetReady(context.Background(), dynClient, "gke-managed-checkpointing")
-	})
-
-	t.Run("Context canceled/timeout returns gracefully", func(t *testing.T) {
+	t.Run("Context canceled returns gracefully", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // Cancel immediately
+		cancel()
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return &unstructured.Unstructured{}, nil
+			},
+		}
+		waitForDaemonSetRollout(ctx, dynClient, "gke-managed-checkpointing", "multitier-driver-uuid")
+	})
+
+	t.Run("Transient error during polling retries and succeeds", func(t *testing.T) {
+		calls := 0
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				calls++
+				if calls == 1 {
+					return nil, fmt.Errorf("transient network failure")
+				}
 				return &unstructured.Unstructured{
 					Object: map[string]interface{}{
-						"metadata": map[string]interface{}{
-							"generation": int64(2),
-						},
+						"metadata": map[string]interface{}{"generation": int64(2)},
 						"status": map[string]interface{}{
 							"observedGeneration":     int64(2),
 							"desiredNumberScheduled": int64(3),
-							"numberReady":            int64(1),
-							"updatedNumberScheduled": int64(1),
+							"numberReady":            int64(3),
+							"updatedNumberScheduled": int64(3),
 						},
 					},
 				}, nil
 			},
 		}
-		waitForMTCDriverDaemonSetReady(ctx, dynClient, "gke-managed-checkpointing")
+		waitForDaemonSetRollout(context.Background(), dynClient, "gke-managed-checkpointing", "multitier-driver-uuid")
+		if calls < 2 {
+			t.Errorf("expected at least 2 polling calls after transient retry, got %d", calls)
+		}
+	})
+}
+
+func TestIsDaemonSetRolloutComplete(t *testing.T) {
+	tests := []struct {
+		name      string
+		gen       int64
+		obsGen    int64
+		desired   int64
+		ready     int64
+		updated   int64
+		wantReady bool
+	}{
+		{
+			name:      "zero desired scheduled pods (uninitialized)",
+			gen:       1,
+			obsGen:    1,
+			desired:   0,
+			ready:     0,
+			updated:   0,
+			wantReady: false,
+		},
+		{
+			name:      "observedGeneration behind spec generation",
+			gen:       2,
+			obsGen:    1,
+			desired:   3,
+			ready:     3,
+			updated:   3,
+			wantReady: false,
+		},
+		{
+			name:      "ready pods less than desired",
+			gen:       2,
+			obsGen:    2,
+			desired:   3,
+			ready:     2,
+			updated:   3,
+			wantReady: false,
+		},
+		{
+			name:      "updated pods less than desired",
+			gen:       2,
+			obsGen:    2,
+			desired:   3,
+			ready:     3,
+			updated:   2,
+			wantReady: false,
+		},
+		{
+			name:      "all pods ready and updated",
+			gen:       2,
+			obsGen:    2,
+			desired:   3,
+			ready:     3,
+			updated:   3,
+			wantReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dsObj := &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"generation": tt.gen,
+					},
+					"status": map[string]interface{}{
+						"observedGeneration":     tt.obsGen,
+						"desiredNumberScheduled": tt.desired,
+						"numberReady":            tt.ready,
+						"updatedNumberScheduled": tt.updated,
+					},
+				},
+			}
+			got := isDaemonSetRolloutComplete(dsObj)
+			if got != tt.wantReady {
+				t.Errorf("isDaemonSetRolloutComplete() = %v, want %v", got, tt.wantReady)
+			}
+		})
+	}
+
+	t.Run("nil dsObj returns false", func(t *testing.T) {
+		if isDaemonSetRolloutComplete(nil) {
+			t.Errorf("isDaemonSetRolloutComplete(nil) = true, want false")
+		}
+	})
+
+	t.Run("nil dsObj.Object returns false", func(t *testing.T) {
+		if isDaemonSetRolloutComplete(&unstructured.Unstructured{}) {
+			t.Errorf("isDaemonSetRolloutComplete(empty) = true, want false")
+		}
 	})
 }
 
@@ -4603,6 +4755,46 @@ func TestGetMTCDaemonSet_EdgeCases(t *testing.T) {
 		}
 	})
 
+	t.Run("Context canceled on Get returns error without calling List", func(t *testing.T) {
+		listCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, context.Canceled
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				listCalled = true
+				return &unstructured.UnstructuredList{}, nil
+			},
+		}
+		_, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err == nil {
+			t.Fatalf("expected context.Canceled error, got nil")
+		}
+		if listCalled {
+			t.Errorf("expected List NOT to be called when Get returns context.Canceled")
+		}
+	})
+
+	t.Run("Transient network error on Get returns error without calling List", func(t *testing.T) {
+		listCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("connection refused")
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				listCalled = true
+				return &unstructured.UnstructuredList{}, nil
+			},
+		}
+		_, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err == nil {
+			t.Fatalf("expected network error, got nil")
+		}
+		if listCalled {
+			t.Errorf("expected List NOT to be called when Get returns network error")
+		}
+	})
+
 	t.Run("Filters unrelated DaemonSets and matches by label", func(t *testing.T) {
 		dynClient := &mockDynamicClient{
 			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -4643,6 +4835,10 @@ func TestGetMTCDaemonSet_EdgeCases(t *testing.T) {
 }
 
 func TestRestartMTCDriverPods_DynamicName(t *testing.T) {
+	oldInterval := daemonSetPollInterval
+	daemonSetPollInterval = 1 * time.Millisecond
+	defer func() { daemonSetPollInterval = oldInterval }()
+
 	patchedName := ""
 	dynClient := &mockDynamicClient{
 		getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -4694,6 +4890,10 @@ func TestRestartMTCDriverPods_DynamicName(t *testing.T) {
 }
 
 func TestRestartMTCDriverPods_ForbiddenAndNotFound(t *testing.T) {
+	oldInterval := daemonSetPollInterval
+	daemonSetPollInterval = 1 * time.Millisecond
+	defer func() { daemonSetPollInterval = oldInterval }()
+
 	t.Run("403 Forbidden on Patch skips pod deletion fallback", func(t *testing.T) {
 		deleteCalled := false
 		dynClient := &mockDynamicClient{
@@ -4737,6 +4937,68 @@ func TestRestartMTCDriverPods_ForbiddenAndNotFound(t *testing.T) {
 		restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
 		if deleteCalled {
 			t.Errorf("expected delete fallback NOT to be called when DaemonSet is not found")
+		}
+	})
+
+	t.Run("Unexpected error on getMTCDaemonSet skips pod deletion fallback", func(t *testing.T) {
+		deleteCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("connection timeout")
+			},
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				deleteCalled = true
+				return nil
+			},
+		}
+
+		restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
+		if deleteCalled {
+			t.Errorf("expected delete fallback NOT to be called when getMTCDaemonSet returns unexpected error")
+		}
+	})
+
+	t.Run("Non-forbidden error on Patch triggers pod deletion fallback", func(t *testing.T) {
+		deleteCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name": "multitier-driver",
+						},
+						"status": map[string]interface{}{
+							"observedGeneration":     int64(1),
+							"desiredNumberScheduled": int64(1),
+							"numberReady":            int64(1),
+							"updatedNumberScheduled": int64(1),
+						},
+					},
+				}, nil
+			},
+			patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("internal patch error")
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{"name": "multitier-driver-pod-1"},
+							},
+						},
+					},
+				}, nil
+			},
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				deleteCalled = true
+				return nil
+			},
+		}
+
+		restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
+		if !deleteCalled {
+			t.Errorf("expected delete fallback to be called when patch fails with non-forbidden error")
 		}
 	})
 }

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -3149,10 +3149,8 @@ func TestProcessNodePoolCapacity_FlavorsAndLabels(t *testing.T) {
 				},
 			},
 			wantFlavor: "flavor-default",
-			wantLabels: map[string]string{
-				"cloud.google.com/gke-nodepool": "cpu-np",
-			},
-			wantErr: false,
+			wantLabels: map[string]string{}, // flavor-default is generic across CPU pools and should NOT have gke-nodepool label
+			wantErr:    false,
 		},
 		{
 			name: "CPU Pool (Head)",
@@ -3230,10 +3228,8 @@ func TestProcessNodePoolCapacity_FlavorsAndLabels(t *testing.T) {
 				},
 			},
 			wantFlavor: "flavor-default",
-			wantLabels: map[string]string{
-				"cloud.google.com/gke-nodepool": "system",
-			},
-			wantErr: false,
+			wantLabels: map[string]string{}, // flavor-default is generic across CPU pools and should NOT have gke-nodepool label
+			wantErr:    false,
 		},
 	}
 
@@ -4472,5 +4468,341 @@ func TestValidateNamespaceExists(t *testing.T) {
 				t.Errorf("expected no error, but got: %v", err)
 			}
 		})
+	}
+}
+
+func TestGetMTCDaemonSet(t *testing.T) {
+	t.Run("Static name multitier-driver", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				if name == "multitier-driver" {
+					return &unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name": "multitier-driver",
+							},
+						},
+					}, nil
+				}
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+		}
+		ds, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if ds.GetName() != "multitier-driver" {
+			t.Errorf("expected DaemonSet name multitier-driver, got %s", ds.GetName())
+		}
+	})
+
+	t.Run("Dynamic name multitier-driver-uuid discovered via list", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "multitier-driver-fd6c6ab5-2191-47e6-8e95-11b3d9ac7cb6",
+									"labels": map[string]interface{}{
+										"k8s-app": "high-scale-checkpointing",
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		ds, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		expectedName := "multitier-driver-fd6c6ab5-2191-47e6-8e95-11b3d9ac7cb6"
+		if ds.GetName() != expectedName {
+			t.Errorf("expected DaemonSet name %s, got %s", expectedName, ds.GetName())
+		}
+	})
+
+	t.Run("403 Forbidden on Get returns error without listing", func(t *testing.T) {
+		listCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name, fmt.Errorf("forbidden"))
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				listCalled = true
+				return nil, nil
+			},
+		}
+		_, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !isForbiddenError(err) {
+			t.Errorf("expected forbidden error, got %v", err)
+		}
+		if listCalled {
+			t.Errorf("expected List not to be called when Get returns 403 Forbidden")
+		}
+	})
+}
+
+func TestGetMTCDaemonSet_EdgeCases(t *testing.T) {
+	t.Run("404 NotFound when Get fails and List returns no matching DaemonSets", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name":   "kube-proxy",
+									"labels": map[string]interface{}{"k8s-app": "kube-proxy"},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		ds, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err == nil {
+			t.Fatalf("expected NotFound error, got nil")
+		}
+		if !apierrors.IsNotFound(err) {
+			t.Errorf("expected IsNotFound(err) == true, got %v", err)
+		}
+		if ds != nil {
+			t.Errorf("expected nil ds, got %v", ds)
+		}
+	})
+
+	t.Run("403 Forbidden on List propagates error", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return nil, apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, "", fmt.Errorf("forbidden"))
+			},
+		}
+		_, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !isForbiddenError(err) {
+			t.Errorf("expected forbidden error, got %v", err)
+		}
+	})
+
+	t.Run("Filters unrelated DaemonSets and matches by label", func(t *testing.T) {
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "unrelated-daemonset",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"name": "custom-checkpoint-driver",
+									"labels": map[string]interface{}{
+										"k8s-app": "high-scale-checkpointing",
+									},
+								},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		ds, err := getMTCDaemonSet(context.Background(), dynClient, "gke-managed-checkpointing")
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if ds.GetName() != "custom-checkpoint-driver" {
+			t.Errorf("expected custom-checkpoint-driver, got %s", ds.GetName())
+		}
+	})
+}
+
+func TestRestartMTCDriverPods_DynamicName(t *testing.T) {
+	patchedName := ""
+	dynClient := &mockDynamicClient{
+		getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+			if name == "multitier-driver-8f2c7adf-1b1e-47e4-ba2e-104ffa2c846b" {
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":       "multitier-driver-8f2c7adf-1b1e-47e4-ba2e-104ffa2c846b",
+							"generation": int64(1),
+						},
+						"status": map[string]interface{}{
+							"observedGeneration":     int64(1),
+							"desiredNumberScheduled": int64(4),
+							"numberReady":            int64(4),
+							"updatedNumberScheduled": int64(4),
+						},
+					},
+				}, nil
+			}
+			return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+		},
+		listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name": "multitier-driver-8f2c7adf-1b1e-47e4-ba2e-104ffa2c846b",
+								"labels": map[string]interface{}{
+									"k8s-app": "high-scale-checkpointing",
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+			patchedName = name
+			return &unstructured.Unstructured{}, nil
+		},
+	}
+
+	restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
+	expectedName := "multitier-driver-8f2c7adf-1b1e-47e4-ba2e-104ffa2c846b"
+	if patchedName != expectedName {
+		t.Errorf("expected patched DaemonSet name %s, got %s", expectedName, patchedName)
+	}
+}
+
+func TestRestartMTCDriverPods_ForbiddenAndNotFound(t *testing.T) {
+	t.Run("403 Forbidden on Patch skips pod deletion fallback", func(t *testing.T) {
+		deleteCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{"name": "multitier-driver"},
+					},
+				}, nil
+			},
+			patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewForbidden(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name, fmt.Errorf("forbidden"))
+			},
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				deleteCalled = true
+				return nil
+			},
+		}
+
+		restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
+		if deleteCalled {
+			t.Errorf("expected delete fallback NOT to be called when patch returns 403 Forbidden")
+		}
+	})
+
+	t.Run("404 NotFound on getMTCDaemonSet skips pod deletion fallback", func(t *testing.T) {
+		deleteCalled := false
+		dynClient := &mockDynamicClient{
+			getFunc: func(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "daemonsets"}, name)
+			},
+			listFunc: func(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+				return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}, nil
+			},
+			deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+				deleteCalled = true
+				return nil
+			},
+		}
+
+		restartMTCDriverPods(context.Background(), dynClient, "gke-managed-checkpointing")
+		if deleteCalled {
+			t.Errorf("expected delete fallback NOT to be called when DaemonSet is not found")
+		}
+	})
+}
+
+func TestCalculateClusterCapacity_MultipleCPUPools(t *testing.T) {
+	setupMockMachineConfig(t)
+	mockResponses := map[string][]shell.CommandResult{
+		"gcloud compute machine-types describe n2d-standard-2 --zone=us-central1-b --format=json": {
+			{ExitCode: 0, Stdout: `{"guestCpus": 2, "memoryMb": 8192}`},
+		},
+		"gcloud compute machine-types describe c3d-standard-4 --zone=us-central1-b --format=json": {
+			{ExitCode: 0, Stdout: `{"guestCpus": 4, "memoryMb": 16384}`},
+		},
+	}
+	mockExecutor := NewMockExecutor(mockResponses)
+	orc := newTestGKEOrchestrator(mockExecutor)
+	orc.projectID = "test-project"
+
+	cluster := gkeCluster{
+		NodePools: []gkeJobNodePool{
+			{
+				Name:             "system",
+				Config:           gkeNodePoolConfig{MachineType: "n2d-standard-2", Taints: []gkeTaint{{Key: "components.gke.io/gke-managed-components", Value: "true", Effect: "NoSchedule"}}},
+				InitialNodeCount: 1,
+			},
+			{
+				Name:             "debug",
+				Config:           gkeNodePoolConfig{MachineType: "n2d-standard-2"},
+				InitialNodeCount: 2,
+			},
+			{
+				Name:             "local-ssd",
+				Config:           gkeNodePoolConfig{MachineType: "n2d-standard-2"},
+				InitialNodeCount: 1,
+			},
+			{
+				Name:             "hp-pool",
+				Config:           gkeNodePoolConfig{MachineType: "c3d-standard-4"},
+				InitialNodeCount: 1,
+			},
+		},
+	}
+
+	cap, _, err := orc.calculateClusterCapacity(cluster, "us-central1-b")
+	if err != nil {
+		t.Fatalf("calculateClusterCapacity failed: %v", err)
+	}
+
+	// 2 debug nodes * 2 cpus + 1 local-ssd node * 2 cpus + 1 hp-pool node * 4 cpus = 10 cpus
+	if cap.CPUs != 10 {
+		t.Errorf("expected 10 CPUs total, got %d", cap.CPUs)
+	}
+	// 2*8GB + 1*8GB + 1*16GB = 40GB
+	if cap.MemoryGi != 40 {
+		t.Errorf("expected 40 GiB total memory, got %d", cap.MemoryGi)
+	}
+
+	defaultFlavor, exists := cap.Flavors["flavor-default"]
+	if !exists {
+		t.Fatalf("expected flavor-default to exist in calculated flavors")
+	}
+	if defaultFlavor.CPUs != 10 {
+		t.Errorf("expected flavor-default to have 10 CPUs, got %d", defaultFlavor.CPUs)
+	}
+	// Verify flavor-default has NO cloud.google.com/gke-nodepool label!
+	if npLabel, ok := defaultFlavor.NodeLabels["cloud.google.com/gke-nodepool"]; ok {
+		t.Errorf("expected flavor-default not to have cloud.google.com/gke-nodepool label, but got %q", npLabel)
 	}
 }


### PR DESCRIPTION
### Description
This PR resolves two related issues affecting GKE job execution, specifically causing timeouts in Multi-Tier Checkpointing (MTC) validation:

1. **MTC Driver Restart Race Condition**:
   - GKE's HighScaleCheckpointing addon dynamically names the MTC driver DaemonSet `multitier-driver-<uuid>`.
   - `gcluster` hardcoded the DaemonSet name as `"multitier-driver"`. When updating Workload Identity credentials, it failed to patch the DaemonSet and fell back to deleting driver pods across the cluster. It then immediately checked for `"multitier-driver"`, received `NotFound`, and exited without waiting.
   - Job pods scheduled while MTC driver pods were down failed volume mounting (`FailedMount: driver name multitier-checkpoint.csi.storage.gke.io not found`), triggering Kubelet backoffs.
   - **Fix**: Updated `getMTCDaemonSet` to dynamically discover `multitier-driver-*` DaemonSets in the namespace. Updated `restartMTCDriverPods` to perform a rolling restart via patch before pod deletion fallback, and `waitForMTCDriverDaemonSetReady` to poll the actual DaemonSet until 100% rollout completion.

2. **Kueue `flavor-default` Node Pool Pollution**:
   - In clusters with multiple generic CPU node pools (`debug`, `local-ssd`, `hp-pool`), all CPU pools map to `flavor-default`.
   - During capacity calculation, `processNodePoolCapacity` set `cloud.google.com/gke-nodepool = np.Name`, overwriting `flavor-default`'s nodeLabels with the last pool iterated.
   - Because GKE node pool iteration order is non-deterministic, `flavor-default` was arbitrarily pinned to a specific node pool (such as `hp-pool`), bypassing other valid CPU pools and preventing Kueue from scheduling across available CPU capacity.
   - **Fix**: Restricted `cloud.google.com/gke-nodepool` labeling in `processNodePoolCapacity` strictly to `pathways-flavor`, keeping `flavor-default` unconstrained.

### Testing
- Unit tests added:
  - `TestGetMTCDaemonSet`: verifies static name resolution, dynamic name resolution via list, and 403 Forbidden handling.
  - `TestRestartMTCDriverPods_DynamicName`: verifies rolling restart patch is directed to dynamic DaemonSet name.
  - `TestCalculateClusterCapacity_MultipleCPUPools`: verifies cluster with multiple CPU pools aggregates capacity without setting `cloud.google.com/gke-nodepool` on `flavor-default`.
- Ran all orchestrator unit tests: `go test -v ./pkg/orchestrator/gke/...` (all passed).
- Ran pre-commit hooks (all passed 100% cleanly).