### PR TITLE
[Telemetry] Adding hpc-toolkit-dev-2 to testProjects

### DIFF
--- a/pkg/telemetry/collector.go
+++ b/pkg/telemetry/collector.go
@@ -36,7 +36,7 @@ var (
 	isGkeModulePatterns        = []string{"gke-node-pool", "gke-cluster"}
 	isSlurmModulePatterns      = []string{"schedmd-slurm-gcp-"}
 	isVmInstanceModulePatterns = []string{"vm-instance"}
-	testProjects               = []string{"hpc-toolkit-dev"}
+	testProjects               = []string{"hpc-toolkit-dev", "hpc-toolkit-dev-2"}
 )
 
 // NewCollector creates and initializes a new Telemetry Collector.

--- a/pkg/telemetry/collector_test.go
+++ b/pkg/telemetry/collector_test.go
@@ -456,6 +456,11 @@ func TestGetIsTestData(t *testing.T) {
 			want:      "true",
 		},
 		{
+			name:      "dev-2 project",
+			projectID: "hpc-toolkit-dev-2",
+			want:      "true",
+		},
+		{
 			name:      "prod project",
 			projectID: "some-other-project",
 			want:      "false",


### PR DESCRIPTION
### [Telemetry] Adding `hpc-toolkit-dev-2` to `testProjects`
#### Overview
The integration and daily test suites were migrated to run in `hpc-toolkit-dev-2`. Previously, only `hpc-toolkit-dev` was recognized in `testProjects`, causing test runs in `hpc-toolkit-dev-2` to report `CLUSTER_TOOLKIT_IS_TEST_DATA = "false"` and skew production telemetry metrics.

#### Changes
- **Collector**: Added `hpc-toolkit-dev-2` to `testProjects` in `pkg/telemetry/collector.go` to ensure blueprints running in the new daily test project are identified with `CLUSTER_TOOLKIT_IS_TEST_DATA = "true"`.
- **Tests**: Added a unit test case for `hpc-toolkit-dev-2` in `TestGetIsTestData` (`pkg/telemetry/collector_test.go`) to validate test project detection.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
