### PR TITLE
feat(daily-tests): Add physical host topology logging and _ZONE override support

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/tasks/get_instance_ids.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/tasks/get_instance_ids.yml
@@ -24,7 +24,7 @@
   ansible.builtin.command: >-
     gcloud compute instances list
     --filter="labels.ghpc_deployment={{ deployment_name }}"
-    --format='json(name,zone,id,status)'
+    --format='json(name,zone,id,status,resourceStatus.physicalHost)'
 - name: Print instance information
   when: instances is defined
   ansible.builtin.debug:

--- a/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
+++ b/tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml
@@ -25,6 +25,7 @@ tags:
 substitutions:
   _PROVISIONING_MODEL: ""
   _TEST_PREFIX: "" # Default to no prefix
+  _ZONE: "" # Optional zone override for manual debugging
 
 timeout: 86400s
 queueTtl: 86400s  # 24hr
@@ -129,6 +130,8 @@ steps:
               value: "gs://$${OPTIONS_BUCKET}/a3hoptions.txt"
             - name: _TEST_PREFIX
               value: "${_TEST_PREFIX}"
+            - name: _ZONE
+              value: "${_ZONE}"
             - name: PROVISIONING_MODEL
               value: "$_PROVISIONING_MODEL"
             - name: GCLUSTER_GCS_PATH
@@ -158,8 +161,13 @@ steps:
               source /workspace/tools/cloud-build/kueue_cleanup_pod.sh
               trap cleanup_pod EXIT SIGTERM SIGINT
 
-              echo "Sourcing find_available_zone.sh to determine zone."
-              source /workspace/tools/cloud-build/wait_for_available_zone.sh
+              if [ -n "${_ZONE}" ]; then
+                ZONE="${_ZONE}"
+                echo "INFO: Manual override requested. Forcing ZONE=\$$ZONE"
+              else
+                echo "Sourcing find_available_zone.sh to determine zone."
+                source /workspace/tools/cloud-build/wait_for_available_zone.sh
+              fi
               if [ -z "\$${ZONE:-}" ]; then
                 echo "ERROR: ZONE not found" >&2
                 exit 1


### PR DESCRIPTION
### Description
This PR addresses diagnostic requirements for GKE A3 High GPU daily benchmark tests:

1. **Step 0 Topology Logging**:
   - Updates `tools/cloud-build/daily-tests/ansible_playbooks/tasks/get_instance_ids.yml` to include `resourceStatus.physicalHost` in the `gcloud compute instances list` format.
   - Enables capturing GCE 4-level physical VM placement (`/CLUSTER/BLOCK/SUBBLOCK/HOST`) via the control-plane API during Step 0 on `localhost`, without requiring compute node SSH or `kubectl` access.

2. **`_ZONE` Substitution & Override Support**:
   - Updates `tools/cloud-build/daily-tests/builds/gke-a3-highgpu-onspot.yaml` to define `_ZONE` under `substitutions` and pass `_ZONE` to the runner container environment.
   - Bypasses `wait_for_available_zone.sh` when `_ZONE` is explicitly set via `gcloud builds submit --substitutions=_ZONE="..."`, allowing manual multi-zone diagnostic benchmarking.

### Testing
- Tested via manual `gcloud builds submit`:
  - `_ZONE="asia-east1-c"` (`e10c3824`): Forced target zone successfully, captured `physicalHost`, and verified **28.84 GB/s** (PASS).
  - `_ZONE="europe-west2-c"` (`3e40debf`): Forced target zone successfully, captured `physicalHost`, and verified **20.02 GB/s** (FAIL).