### PR TITLE
fix(daily-tests): authenticate git clone of CHS repo using gcloud access token

### DIFF
--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -73,6 +73,7 @@
         accept_hostkey: true
       environment:
         GIT_HTTP_EXTRAHEADER: "Authorization: Bearer {{ gcp_access_token.stdout | trim }}"
+      no_log: true
       async: 120
       poll: 10
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -59,12 +59,19 @@
         suffix: chs_clone
       register: chs_temp_dir
 
+    - name: Get GCP access token for Git authentication
+      ansible.builtin.command: gcloud auth print-access-token
+      register: gcp_access_token
+      changed_when: false
+
     - name: Clone CHS repository
       ansible.builtin.git:
         repo: "{{ chs_repo }}"
         dest: "{{ chs_temp_dir.path }}"
         version: release
         accept_hostkey: true
+      environment:
+        GIT_HTTP_EXTRAHEADER: "Authorization: Bearer {{ gcp_access_token.stdout | trim }}"
       async: 120
       poll: 10
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -63,6 +63,7 @@
       ansible.builtin.command: gcloud auth print-access-token
       register: gcp_access_token
       changed_when: false
+      no_log: true
 
     - name: Clone CHS repository
       ansible.builtin.git:

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -65,6 +65,7 @@
         dest: "{{ chs_temp_dir.path }}"
         version: release
         accept_hostkey: true
+      no_log: true
       async: 120
       poll: 10
 

--- a/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
+++ b/tools/cloud-build/daily-tests/ansible_playbooks/test-validation/test-chs.yml
@@ -59,21 +59,12 @@
         suffix: chs_clone
       register: chs_temp_dir
 
-    - name: Get GCP access token for Git authentication
-      ansible.builtin.command: gcloud auth print-access-token
-      register: gcp_access_token
-      changed_when: false
-      no_log: true
-
     - name: Clone CHS repository
       ansible.builtin.git:
         repo: "{{ chs_repo }}"
         dest: "{{ chs_temp_dir.path }}"
         version: release
         accept_hostkey: true
-      environment:
-        GIT_HTTP_EXTRAHEADER: "Authorization: Bearer {{ gcp_access_token.stdout | trim }}"
-      no_log: true
       async: 120
       poll: 10
 


### PR DESCRIPTION
### Description
Fixes automated integration test failures during the CHS repository clone step.

### Problem
Following permission updates to `cluster-toolkit/cluster-health-scanner` on Git-on-Borg, unauthenticated HTTP requests return `401 Unauthorized`. In non-interactive test runner environments, `git clone` fails with `fatal: could not read Username for 'https://cluster-toolkit.googlesource.com': No such device or address`.

### Solution
Fetch a GCP OAuth access token via `gcloud auth print-access-token` for the test runner's Service Account and pass it to `ansible.builtin.git` via `GIT_HTTP_EXTRAHEADER: "Authorization: Bearer <token>"`.