### PR TITLE
fix(validators): remove legacy GCSFuse IAM role validator and update blueprint comments

### DIFF
--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -242,10 +242,8 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, a3-ultragpu-cluster]

--- a/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
+++ b/examples/gke-a3-ultragpu/gke-a3-ultragpu.yaml
@@ -242,9 +242,9 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -274,9 +274,9 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4/gke-a4.yaml
+++ b/examples/gke-a4/gke-a4.yaml
@@ -274,10 +274,8 @@ deployment_groups:
       k8s_service_account_name: workload-identity-k8s-sa
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, a4-cluster]

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -314,10 +314,8 @@ deployment_groups:
       force_destroy: false
       enable_hierarchical_namespace: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, a4x-max-cluster]

--- a/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
+++ b/examples/gke-a4x-max-bm/gke-a4x-max-bm.yaml
@@ -314,9 +314,9 @@ deployment_groups:
       force_destroy: false
       enable_hierarchical_namespace: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -308,10 +308,8 @@ deployment_groups:
         effect: NoSchedule
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, a4x-cluster]

--- a/examples/gke-a4x/gke-a4x.yaml
+++ b/examples/gke-a4x/gke-a4x.yaml
@@ -308,9 +308,9 @@ deployment_groups:
         effect: NoSchedule
     outputs: [instructions]
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -242,10 +242,8 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-7x-cluster]

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-7x/gke-tpu-7x.yaml
@@ -242,9 +242,9 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -241,9 +241,9 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start-queued-provisioning/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -241,10 +241,8 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-v6e-cluster]

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -239,9 +239,9 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-7x/gke-tpu-7x.yaml
@@ -239,10 +239,8 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-7x-cluster]

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -238,10 +238,8 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-v6-cluster]

--- a/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
+++ b/examples/gke-consumption-options/dws-flex-start/gke-tpu-v6e/gke-tpu-v6e.yaml
@@ -238,9 +238,9 @@ deployment_groups:
       jobset:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -269,9 +269,9 @@ deployment_groups:
       cert_manager:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
+++ b/examples/gke-tpu-7x/gke-tpu-7x-advanced.yaml
@@ -269,10 +269,8 @@ deployment_groups:
       cert_manager:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-7x-cluster]

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -262,9 +262,9 @@ deployment_groups:
       cert_manager:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, you must ensure the GKE Service Agent
-  # possesses the 'gke.gcsfuse.profileUser' custom IAM role assigned out-of-band.
-  # Please refer to 'modules/file-system/gke-persistent-volume/README.md' for instructions.
+  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
+  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
+  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
   # Persistent Volume for training data using GCS Fuse Storage Profile
   - id: training-pv
     source: modules/file-system/gke-persistent-volume

--- a/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
+++ b/examples/gke-tpu-v6e/gke-tpu-v6e-advanced.yaml
@@ -262,10 +262,8 @@ deployment_groups:
       cert_manager:
         install: true
 
-  # When utilizing GCS Fuse Storage Profiles, the GKE Service Agent requires permissions on the
-  # bucket to manage storage caching. By default, this module automatically grants 'roles/storage.admin'.
-  # For least-privilege custom role configuration or shared buckets, see modules/file-system/gke-persistent-volume/README.md.
-  # Persistent Volume for training data using GCS Fuse Storage Profile
+  # Persistent Volume for training data using GCS Fuse Storage Profile.
+  # For shared buckets or custom IAM roles, see modules/file-system/gke-persistent-volume/README.md
   - id: training-pv
     source: modules/file-system/gke-persistent-volume
     use: [training_bucket, gke-tpu-v6e-cluster]

--- a/modules/file-system/gke-persistent-volume/README.md
+++ b/modules/file-system/gke-persistent-volume/README.md
@@ -153,6 +153,22 @@ gcloud iam roles create gke.gcsfuse.profileUser \
       gcsfuse_service_agent_role: "projects/<YOUR_PROJECT_ID>/roles/gke.gcsfuse.profileUser"
 ```
 
+#### Disabling Automatic IAM Grants (Shared / Pre-Configured Buckets)
+
+If your deployment targets a pre-existing or shared Cloud Storage bucket managed by another team, your deploying identity may not have permissions to modify bucket IAM policies (`storage.buckets.setIamPolicy`).
+
+To prevent Terraform from attempting the IAM grant, set `grant_gcsfuse_service_agent_role: false` and ensure a bucket administrator binds the required role (`roles/storage.admin` or custom role) out-of-band:
+
+```yaml
+  - id: shared-data-bucket-pv
+    source: modules/file-system/gke-persistent-volume
+    use: [gke_cluster]
+    settings:
+      gcs_bucket_name: pre-existing-shared-bucket
+      gcsfuse_storage_class_name: gcsfusecsi-training
+      grant_gcsfuse_service_agent_role: false
+```
+
 ### Connecting Via Use
 
 The diagram below shows the valid `use` relationships for the GKE Cluster Toolkit

--- a/pkg/validators/cloud.go
+++ b/pkg/validators/cloud.go
@@ -19,16 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"hpc-toolkit/pkg/config"
-	"hpc-toolkit/pkg/logging"
 	"regexp"
 	"strings"
 
 	"github.com/zclconf/go-cty/cty"
 	"golang.org/x/exp/maps"
-	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
-	iam "google.golang.org/api/iam/v1"
 	"google.golang.org/api/option"
 	serviceusage "google.golang.org/api/serviceusage/v1"
 )
@@ -39,8 +36,6 @@ var resKeyRegex = regexp.MustCompile(`^(.*_)?reservation(_name)?$`)
 var newComputeService = func(ctx context.Context) (*compute.Service, error) {
 	return compute.NewService(ctx)
 }
-
-const gcsFuseProfileUserRole = "gke.gcsfuse.profileUser"
 
 func getErrorReason(err googleapi.Error) (string, map[string]interface{}) {
 	for _, d := range err.Details {
@@ -599,93 +594,4 @@ func testMachineTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) 
 // testDiskTypeInZoneAvailability automatically validates disk types in modules
 func testDiskTypeInZoneAvailability(bp config.Blueprint, inputs config.Dict) error {
 	return testResourceInZoneAvailability(bp, inputs, "test_disk_type_in_zone", "disk_type", "disk type", validateDiskTypeInZone)
-}
-
-// testGCSFuseIAMRoleExistsCheck verifies that the required custom IAM role for GCS Fuse exists.
-// High-level logic for failures:
-//   - Hard Failure (404): If the role explicitly does not exist, we block deployment because
-//     GCS Fuse Storage Profiles will fail at runtime without it.
-//   - Soft Warning (403/other): If we cannot verify the role due to permission issues (e.g., the
-//     runner lacks 'iam.roles.get'), we log a warning but do not block. This prevents blocking
-//     users who have deployment permissions but not project-wide IAM read permissions.
-func testGCSFuseIAMRoleExistsCheck(projectID string) error {
-	ctx := context.Background()
-	s, err := iam.NewService(ctx)
-	if err != nil {
-		return handleClientError(err)
-	}
-
-	roleName := fmt.Sprintf("projects/%s/roles/%s", projectID, gcsFuseProfileUserRole)
-	_, err = s.Projects.Roles.Get(roleName).Do()
-	if err != nil {
-		var herr *googleapi.Error
-		if errors.As(err, &herr) && herr.Code == 404 {
-			return config.HintError{
-				Err: fmt.Errorf("custom IAM role '%s' was not found in project %s", gcsFuseProfileUserRole, projectID),
-				Hint: "GCS Fuse CSI Storage Profiles require this custom IAM role.\n" +
-					"Please refer to modules/file-system/gke-persistent-volume/README.md for instructions.",
-			}
-		}
-		logging.Error("\n[!] WARNING: Unable to verify existence of the custom IAM role '%s'.", roleName)
-		logging.Error("    Permission 'iam.roles.get' was denied. GCS Fuse CSI Storage Profiles require this role to scan and mount storage.")
-		logging.Error("    Please verify with your Google Cloud administrator that the custom IAM role has been provisioned successfully.")
-		logging.Error("    Reference: modules/file-system/gke-persistent-volume/README.md\n")
-		return nil
-	}
-
-	// Optional Check: Validate IAM Binding for the GKE Service Agent
-	checkGCSFuseIAMBinding(ctx, projectID, roleName)
-
-	return nil
-}
-
-func checkGCSFuseIAMBinding(ctx context.Context, projectID string, roleName string) {
-	crmService, err := cloudresourcemanager.NewService(ctx)
-	if err != nil {
-		logging.Error("WARNING: Could not initialize Cloud Resource Manager service: %v. Skipping IAM binding check.", err)
-		return
-	}
-
-	project, err := crmService.Projects.Get(projectID).Do()
-	if err != nil {
-		logging.Error("WARNING: Could not fetch project number for %s: %v. Skipping IAM binding check.", projectID, err)
-		return
-	}
-
-	policy, err := crmService.Projects.GetIamPolicy(projectID, &cloudresourcemanager.GetIamPolicyRequest{}).Do()
-	if err != nil {
-		logging.Error("WARNING: Could not fetch IAM policy for %s: %v. Skipping IAM binding check.", projectID, err)
-		return
-	}
-
-	agentMember := fmt.Sprintf("serviceAccount:service-%d@container-engine-robot.iam.gserviceaccount.com", project.ProjectNumber)
-	roleGranted := false
-
-	for _, binding := range policy.Bindings {
-		if binding.Role == roleName {
-			for _, member := range binding.Members {
-				if member == agentMember {
-					roleGranted = true
-					break
-				}
-			}
-		}
-	}
-
-	if !roleGranted {
-		logging.Error("\n[!] WARNING: GKE Service Agent (%s) does not appear to have the custom role '%s' assigned.", agentMember, roleName)
-		logging.Error("    This might cause GCS Fuse CSI drivers to fail at runtime.")
-		logging.Error("    Refer to modules/file-system/gke-persistent-volume/README.md to manually bind permissions.\n")
-	}
-}
-
-func testGCSFuseIAMRoleExists(bp config.Blueprint, inputs config.Dict) error {
-	if err := checkInputs(inputs, []string{"project_id"}); err != nil {
-		return err
-	}
-	m, err := inputsAsStrings(inputs)
-	if err != nil {
-		return err
-	}
-	return testGCSFuseIAMRoleExistsCheck(m["project_id"])
 }

--- a/pkg/validators/validators.go
+++ b/pkg/validators/validators.go
@@ -88,7 +88,6 @@ const (
 	testMachineTypeInZone             = "test_machine_type_in_zone"
 	testReservationExistsName         = "test_reservation_exists"
 	testDiskTypeInZone                = "test_disk_type_in_zone"
-	testGCSFuseIAMRoleExistsName      = "test_gcsfuse_iam_role_exists"
 )
 
 func implementations() map[string]func(config.Blueprint, config.Dict) error {
@@ -104,7 +103,6 @@ func implementations() map[string]func(config.Blueprint, config.Dict) error {
 		testMachineTypeInZone:             testMachineTypeInZoneAvailability,
 		testReservationExistsName:         testReservationExists,
 		testDiskTypeInZone:                testDiskTypeInZoneAvailability,
-		testGCSFuseIAMRoleExistsName:      testGCSFuseIAMRoleExists,
 	}
 }
 
@@ -232,19 +230,6 @@ func inputsAsStrings(inputs config.Dict) (map[string]string, error) {
 	return ms, nil
 }
 
-func blueprintHasGCSFuse(bp config.Blueprint) bool {
-	hasGCSFuse := false
-	bp.WalkModulesSafe(func(_ config.ModulePath, mod *config.Module) {
-		if strings.Contains(mod.Source, "gke-persistent-volume") && mod.Settings.Has("gcsfuse_storage_class_name") {
-			v := mod.Settings.Get("gcsfuse_storage_class_name")
-			if !v.IsNull() && v.Type() == cty.String && v.AsString() != "" {
-				hasGCSFuse = true
-			}
-		}
-	})
-	return hasGCSFuse
-}
-
 // Creates a list of default validators for the given blueprint,
 // inspect the blueprint for global variables that exist and add an appropriate validators.
 func defaults(bp config.Blueprint) []config.Validator {
@@ -273,13 +258,6 @@ func defaults(bp config.Blueprint) []config.Validator {
 			Validator: testApisEnabledName,
 			Inputs:    inputs,
 		})
-
-		if blueprintHasGCSFuse(bp) {
-			defaults = append(defaults, config.Validator{
-				Validator: testGCSFuseIAMRoleExistsName,
-				Inputs:    inputs,
-			})
-		}
 	}
 
 	if projectIDExists && regionExists {

--- a/pkg/validators/validators_test.go
+++ b/pkg/validators/validators_test.go
@@ -166,6 +166,29 @@ func (s *MySuite) TestDefaultValidators(c *C) {
 		c.Check(defaults(bp), DeepEquals, []config.Validator{
 			unusedMods, unusedVars, projectExists, apisEnabled, zoneExists, machineTypeInZone, diskTypeInZone, myResExists})
 	}
+
+	{ // Blueprint with GCSFuse persistent volume
+		bp := config.Blueprint{
+			Vars: config.Dict{}.
+				With("project_id", cty.StringVal("f00b")),
+			Groups: []config.Group{
+				{
+					Modules: []config.Module{
+						{
+							ID:     "training-pv",
+							Source: "modules/file-system/gke-persistent-volume",
+							Settings: config.NewDict(map[string]cty.Value{
+								"gcsfuse_storage_class_name": cty.StringVal("gcsfusecsi-training"),
+							}),
+						},
+					},
+				},
+			},
+		}
+
+		c.Check(defaults(bp), DeepEquals, []config.Validator{
+			unusedMods, unusedVars, projectExists, apisEnabled})
+	}
 }
 
 // Helper to create a mock compute service for unit tests


### PR DESCRIPTION
This PR resolves an issue where `gcluster create` failed with a fatal HTTP 404 error on clean Google Cloud projects when validating GCSFuse custom IAM roles (`test_gcsfuse_iam_role_exists`), forcing users to bypass validation using `-l IGNORE`.

### Architectural Context & Root Cause

1. **Separation of Lifecycle Stages (Day 0 vs Day 2)**:
   - **`gcluster create` (Day 0 - Infrastructure Provisioning)**: Validates cloud infrastructure feasibility (project existence, enabled APIs, machine types, zones, reservations). It does not have context on runtime user workloads or target GCS buckets.
   - **`gcluster job submit` (Day 2 - Workload Execution)**: This is where pre-flight IAM validation properly belongs. When a user submits a job targeting a bucket (`--mount gs://<bucket>=/data;profile=...`), `gcluster` will inspect the bucket's IAM policy (`storage.buckets.getIamPolicy`) at runtime and emit non-blocking advisory warnings if permissions are missing.

2. **Decoupled Deployment Automation**:
   - `modules/file-system/gke-persistent-volume` already automates granting the required Anywhere Cache permissions to the GKE Service Agent using Google's built-in `roles/storage.admin` directly on the target bucket, eliminating the requirement for project-level custom IAM role creation (`iam.roles.create`).

---

### Key Changes

* **`pkg/validators/`**:
  * Removed `test_gcsfuse_iam_role_exists`, `testGCSFuseIAMRoleExistsCheck`, and `checkGCSFuseIAMBinding` from `pkg/validators/cloud.go`.
  * Removed `testGCSFuseIAMRoleExistsName` and `blueprintHasGCSFuse` from `pkg/validators/validators.go` and `defaults(bp)`.
  * Cleaned up associated unit tests and unused IAM/CRM client imports.

* **`modules/file-system/gke-persistent-volume/README.md`**:
  * Added documentation and blueprint examples for disabling automatic IAM grants (`grant_gcsfuse_service_agent_role: false`) when targeting shared or pre-configured enterprise buckets.

* **`examples/`**:
  * Updated comments across 10 GKE blueprint examples to clarify that `roles/storage.admin` is automatically granted by default and reference the module documentation for custom least-privilege role overrides.

---

*NOTE:  Runtime pre-flight IAM verification against target buckets will be integrated into `gcluster job submit` as part of the dynamic GCSFuse Storage Profile workflow.

---

### Testing

- [x] Ran `go test -v ./pkg/validators/...` (All 34 tests passed).
- [x] Ran `make gcluster` (Compiled cleanly with zero errors).
- [x] Ran pre-commit hooks (`go fmt`, `go vet`, `golangci-lint`, `yamllint`, `codespell`).

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

* Fork your PR branch from the Toolkit "develop" branch (not main)
* Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
* Confirm that "make tests" passes all tests
* Add or modify unit tests to cover code changes
* Ensure that unit test coverage remains above 80%
* Update all applicable documentation
* Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
