### PR TITLE
feat(artifact-registry): add repository_name override and fix registry URL output

### DIFF
--- a/community/modules/container/artifact-registry/README.md
+++ b/community/modules/container/artifact-registry/README.md
@@ -47,6 +47,17 @@ Create a standard Docker repository.
     format: DOCKER
 ```
 
+Create a standard Docker repository with a custom name.
+
+```yaml
+- id: custom_registry
+  source: community/modules/container/artifact-registry
+  settings:
+    repository_name: my-custom-repo
+    repo_mode: STANDARD_REPOSITORY
+    format: DOCKER
+```
+
 Mirror of public Docker Hub repository.
 
 ```yaml
@@ -145,6 +156,7 @@ No modules.
 | <a name="input_repo_public_repository"></a> [repo\_public\_repository](#input\_repo\_public\_repository) | For REMOTE\_REPOSITORY, name of a known public repo as per the Terraform module<br/>(e.g., DOCKER\_HUB) or null for custom repo. | `string` | `null` | no |
 | <a name="input_repo_username"></a> [repo\_username](#input\_repo\_username) | Username for external repository. | `string` | `null` | no |
 | <a name="input_repository_base"></a> [repository\_base](#input\_repository\_base) | For APT/YUM public repos, repository\_base (e.g., 'DEBIAN', 'UBUNTU'). | `string` | `null` | no |
+| <a name="input_repository_name"></a> [repository\_name](#input\_repository\_name) | The repository name (ID) for the Artifact Registry repository. If null, deployment\_name (lowercased, with dots and underscores replaced with hyphens) with a random suffix is used. | `string` | `null` | no |
 | <a name="input_repository_path"></a> [repository\_path](#input\_repository\_path) | For APT/YUM public repos, repository\_path (e.g., 'debian/dists/buster'). | `string` | `null` | no |
 | <a name="input_use_upstream_credentials"></a> [use\_upstream\_credentials](#input\_use\_upstream\_credentials) | Configure Service Account to use upstream credentials for REMOTE\_REPOSITORY:<br/>If true, a username/password is used for the REMOTE\_REPOSITORY mirror.<br/>If false (or if repo\_password == null), no password is created at all.<br/>Note: Blueprint credentials will be stored in Secrets Manager. | `bool` | `false` | no |
 | <a name="input_user_managed_replication"></a> [user\_managed\_replication](#input\_user\_managed\_replication) | (Optional) A list of objects to enable user-managed replication.<br/>Each object can have:<br/>  location        = string<br/>  kms\_key\_name    = optional(string)<br/>If empty, auto replication is used. | <pre>list(object({<br/>    location     = string<br/>    kms_key_name = optional(string)<br/>  }))</pre> | `[]` | no |
@@ -153,5 +165,9 @@ No modules.
 
 | Name | Description |
 | ---- | ----------- |
-| <a name="output_registry_url"></a> [registry\_url](#output\_registry\_url) | The URL of the created artifact registry. |
+| <a name="output_registry_url"></a> [registry\_url](#output\_registry\_url) | The URL of the artifact registry repo. |
+| <a name="output_repo_url"></a> [repo\_url](#output\_repo\_url) | The URL of the artifact registry repo. |
+| <a name="output_repository_id"></a> [repository\_id](#output\_repository\_id) | The ID of the created artifact registry repository. |
+| <a name="output_repository_name"></a> [repository\_name](#output\_repository\_name) | The name (ID) of the created artifact registry repository. |
+| <a name="output_repository_resource_name"></a> [repository\_resource\_name](#output\_repository\_resource\_name) | The full resource name of the repository. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/community/modules/container/artifact-registry/main.tf
+++ b/community/modules/container/artifact-registry/main.tf
@@ -21,36 +21,17 @@ locals {
   # Auto (i.e., empty) vs user-managed replication
   auto = length(var.user_managed_replication) == 0 ? true : false
 
-  # For remote custom repositories, parse out host to create a base_component name
-  mirror_url_no_proto = var.repo_mirror_url != null ? replace(replace(var.repo_mirror_url, "https://", ""), "http://", "") : ""
-  mirror_host         = local.mirror_url_no_proto != "" ? split("/", local.mirror_url_no_proto)[0] : ""
-
-  base_component = replace(
-    replace(
-      replace(
-        lower(
-          local.mirror_host != ""
-          ? "${var.format}-${var.repo_mode}-${local.mirror_host}"
-          : "${var.format}-${var.repo_mode}-nohost"
-        ),
-        "\\.", "-"
-      ),
-      "/", "-"
-    ),
-    "_", "-"
+  # The final name for the artifact registry repository
+  repository_name = var.repository_name != null ? var.repository_name : replace(
+    lower("${var.deployment_name}-${random_id.resource_name_suffix.hex}"),
+    "/[_.]/",
+    "-"
   )
 
-  repository_suffix = random_id.resource_name_suffix.hex
-
-  # The final name for the artifact registry repository
-  repository_name = replace(
-    replace(
-      lower(
-        format("%s-%s", local.base_component, local.repository_suffix)
-      ),
-      ".", "-"
-    ),
-    "/", "-"
+  repo_url = (
+    contains(["APT", "YUM"], upper(var.format)) ?
+    "${var.region}-${lower(var.format)}.pkg.dev/projects/${var.project_id}/${local.repository_name}" :
+    "${var.region}-${lower(var.format)}.pkg.dev/${var.project_id}/${local.repository_name}"
   )
 
   # The secret name is derived from the repository name

--- a/community/modules/container/artifact-registry/outputs.tf
+++ b/community/modules/container/artifact-registry/outputs.tf
@@ -12,7 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+output "repo_url" {
+  description = "The URL of the artifact registry repo."
+  value       = local.repo_url
+}
+
 output "registry_url" {
-  description = "The URL of the created artifact registry."
-  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${var.deployment_name}"
+  description = "The URL of the artifact registry repo."
+  # Technically, this is the repo URL, not the registry URL
+  # It is preserved for backward compatibility
+  value = local.repo_url
+}
+
+output "repository_id" {
+  description = "The ID of the created artifact registry repository."
+  value       = local.repository_name
+}
+
+output "repository_name" {
+  description = "The name (ID) of the created artifact registry repository."
+  value       = local.repository_name
+}
+
+output "repository_resource_name" {
+  description = "The full resource name of the repository."
+  value       = google_artifact_registry_repository.artifact_registry.name
 }

--- a/community/modules/container/artifact-registry/variables.tf
+++ b/community/modules/container/artifact-registry/variables.tf
@@ -27,6 +27,17 @@ variable "deployment_name" {
   type        = string
 }
 
+variable "repository_name" {
+  description = "The repository name (ID) for the Artifact Registry repository. If null, deployment_name (lowercased, with dots and underscores replaced with hyphens) with a random suffix is used."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.repository_name == null ? true : can(regex("^[a-z][-a-z0-9]{0,61}[a-z0-9]$", var.repository_name))
+    error_message = "The repository_name must be between 2 and 63 characters, start with a lowercase letter, end with a lowercase letter or number, and contain only lowercase letters, numbers, and hyphens."
+  }
+}
+
 variable "labels" {
   description = "Labels to add to the artifact registry. Key-value pairs."
   type        = map(string)


### PR DESCRIPTION
- Allow overriding the Artifact Registry repository name via the `repository_name` variable
- Default repository name to `${var.deployment_name}-${random_suffix}`, substituting dashes for underscores, which aren't supported in artifact repo names
- Fix `registry_url` output to point to the actual created repository ID instead of `var.deployment_name`
- Add `repo_url`, `repository_id`, and `repository_name` outputs for downstream modules
- Update documentation to reflect new inputs and outputs

**BREAKING CHANGE:**
Changing the default naming convention for repository_name from the previous format/mode/host-based name to the new `${var.deployment_name}-${random_id.resource_name_suffix.hex}` scheme is a breaking change. For any existing deployments upgrading to this version, the change in repository_id will force the recreation of the google_artifact_registry_repository resource, resulting in the deletion of all stored container images and artifacts. Users can avoid this by 'pinning' their existing repository name as described in the  README.md.

### Submission Checklist

NOTE: Community submissions can take up to 2 weeks to be reviewed.

Please take the following actions before submitting this pull request.

- [x] Fork your PR branch from the Toolkit "develop" branch (not main)
- [x] Test all changes with pre-commit in a local branch [#](https://goo.gle/hpc-toolkit#development)
- [x] Confirm that "make tests" passes all tests
- [x] Add or modify unit tests to cover code changes
- [x] Ensure that unit test coverage remains above 80%
- [x] Update all applicable documentation
- [x] Follow Cluster Toolkit Contribution guidelines [#](https://goo.gle/hpc-toolkit-contributing)
