### PR TITLE
feat(gke): validate placement policy, reservation, and queue at job submission

### DIFF
--- a/pkg/orchestrator/gke/gke_job_orchestrator.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator.go
@@ -1151,13 +1151,18 @@ func (g *GKEOrchestrator) configureClusterEnvironment(job *orchestrator.JobDefin
 			return fmt.Errorf("failed to check if LocalQueue exists: %w", err)
 		}
 		if !exists {
-			promptMsg := fmt.Sprintf("LocalQueue '%s' does not exist in namespace '%s'. Do you want gcluster to create default Kueue resources (ClusterQueue and LocalQueue) with calculated cluster capacity?", localQueue, ns)
+			availableQueues := g.listLocalQueues(ns)
+			availableStr := ""
+			if len(availableQueues) > 0 {
+				availableStr = fmt.Sprintf(" Available LocalQueues in namespace '%s': %s.", ns, strings.Join(availableQueues, ", "))
+			}
+			promptMsg := fmt.Sprintf("LocalQueue '%s' does not exist in namespace '%s'.%s Do you want gcluster to create default Kueue resources (ClusterQueue and LocalQueue) with calculated cluster capacity?", localQueue, ns, availableStr)
 			if shell.PromptYesNo(promptMsg) {
 				if err := g.createDefaultQueues(localQueue, ns); err != nil {
 					return err
 				}
 			} else {
-				return fmt.Errorf("LocalQueue '%s' does not exist in namespace '%s' and user declined to create default queues. Please create one manually or specify an existing queue using --queue flag", localQueue, ns)
+				return fmt.Errorf("LocalQueue '%s' does not exist in namespace '%s' and user declined to create default queues.%s Please create one manually or specify an existing queue using --queue flag", localQueue, ns, availableStr)
 			}
 		}
 

--- a/pkg/orchestrator/gke/gke_job_orchestrator_test.go
+++ b/pkg/orchestrator/gke/gke_job_orchestrator_test.go
@@ -2839,6 +2839,12 @@ func TestSharedReservationManifestGeneration(t *testing.T) {
 	orc.napLimits = map[string]int64{
 		"nvidia.com/gpu": 100,
 	}
+	mockResponses := map[string][]shell.CommandResult{
+		"gcloud compute reservations describe my-shared-res --zone=us-central1-a --project=my-owner-project --format=json": {
+			{ExitCode: 0, Stdout: `{"name":"my-shared-res","specificReservation":{"instanceProperties":{"machineType":"a3-highgpu-8g"}}}`},
+		},
+	}
+	orc.executor = NewMockExecutor(mockResponses)
 	// Mock machine capabilities fetcher to avoid actual API calls
 	orc.machineCapCache = map[string]MachineTypeCap{
 		"a3-highgpu-8g:us-central1-a": {
@@ -2901,6 +2907,12 @@ func TestSharedReservationSubblockManifestGeneration(t *testing.T) {
 	orc.napLimits = map[string]int64{
 		"nvidia.com/gpu": 100,
 	}
+	mockResponses := map[string][]shell.CommandResult{
+		"gcloud compute reservations describe my-shared-res --zone=us-central1-a --project=my-owner-project --format=json": {
+			{ExitCode: 0, Stdout: `{"name":"my-shared-res","specificReservation":{"instanceProperties":{"machineType":"a3-highgpu-8g"}}}`},
+		},
+	}
+	orc.executor = NewMockExecutor(mockResponses)
 	// Mock machine capabilities fetcher to avoid actual API calls
 	orc.machineCapCache = map[string]MachineTypeCap{
 		"a3-highgpu-8g:us-central1-a": {

--- a/pkg/orchestrator/gke/kueue.go
+++ b/pkg/orchestrator/gke/kueue.go
@@ -30,6 +30,7 @@ import (
 	"hpc-toolkit/pkg/shell"
 
 	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // -----------------------------------------------------------------------------
@@ -82,21 +83,43 @@ var kueueCRDs = []string{
 	"workloads.kueue.x-k8s.io",
 }
 
-// -----------------------------------------------------------------------------
-// 2. Kueue Job Queue Resolution & Setup (Job-Level)
-// -----------------------------------------------------------------------------
+// parseKueueQueueName extracts and validates the Kueue LocalQueue name.
+// Supports bare names ("my-queue") and resource paths ("namespaces/default/localQueues/my-queue").
+func parseKueueQueueName(raw string) (string, error) {
+	queueName := strings.TrimSuffix(strings.TrimSpace(raw), "/")
+	if strings.Contains(queueName, "/") {
+		queueName = extractURIPart(queueName, "localQueues")
+		if queueName == "" || strings.Contains(queueName, "/") {
+			return "", fmt.Errorf("invalid queue name %q: must not contain slashes", raw)
+		}
+	}
+
+	if queueName == "" {
+		return "", fmt.Errorf("queue name cannot be empty")
+	}
+
+	if errs := validation.IsDNS1123Subdomain(queueName); len(errs) > 0 {
+		return "", fmt.Errorf("invalid queue name %q: %s", queueName, strings.Join(errs, ", "))
+	}
+
+	return queueName, nil
+}
 
 // resolveKueueQueue resolves which Kueue LocalQueue to use for job submission.
 // Precedence rules:
-// 1. If requestedQueueName is specified explicitly by the user, return it directly.
+// 1. If requestedQueueName is specified explicitly by the user, validate and return it directly.
 // 2. If 0 LocalQueues are found in the namespace, fall back to defaultLocalQueue ("default").
 // 3. If exactly 1 LocalQueue is found, auto-discover and return it.
 // 4. If multiple LocalQueues exist, check for standard "default", then "multislice-queue".
 // 5. If multiple non-standard LocalQueues exist, return an error asking the user to specify --queue.
 func (g *GKEOrchestrator) resolveKueueQueue(requestedQueueName, ns string) (string, error) {
 	if requestedQueueName != "" {
-		logging.Info("Using provided Kueue LocalQueue: %s", requestedQueueName)
-		return requestedQueueName, nil
+		cleanName, err := parseKueueQueueName(requestedQueueName)
+		if err != nil {
+			return "", err
+		}
+		logging.Info("Using provided Kueue LocalQueue: %s", cleanName)
+		return cleanName, nil
 	}
 
 	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", "-n", ns, "-o", "jsonpath={.items[*].metadata.name}")
@@ -126,6 +149,15 @@ func (g *GKEOrchestrator) resolveKueueQueue(requestedQueueName, ns string) (stri
 	}
 
 	return "", fmt.Errorf("multiple LocalQueues found (%v) and no standard '%s' or '%s' present. Please specify which one to use using --queue flag", queues, defaultLocalQueue, multisliceLocalQueue)
+}
+
+// listLocalQueues returns a slice of existing LocalQueue names in the given namespace.
+func (g *GKEOrchestrator) listLocalQueues(ns string) []string {
+	res := g.executor.ExecuteCommand("kubectl", "get", "localqueue", "-n", ns, "-o", "jsonpath={.items[*].metadata.name}")
+	if res.ExitCode != 0 || strings.TrimSpace(res.Stdout) == "" {
+		return nil
+	}
+	return strings.Fields(strings.TrimSpace(res.Stdout))
 }
 
 // checkLocalQueueExists checks if a LocalQueue with the given name exists in the namespace.

--- a/pkg/orchestrator/gke/kueue_test.go
+++ b/pkg/orchestrator/gke/kueue_test.go
@@ -152,6 +152,55 @@ func TestResolveKueueQueue(t *testing.T) {
 			wantErr:       false,
 		},
 		{
+			name:          "User requested name with resource path",
+			requestedName: "namespaces/default/localQueues/custom-q",
+			kubectlOutput: "",
+			wantName:      "custom-q",
+			wantErr:       false,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (uppercase)",
+			requestedName: "CustomQueue",
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (underscore)",
+			requestedName: "custom_q",
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (starts with hyphen)",
+			requestedName: "-custom-q",
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (raw slash path)",
+			requestedName: "custom/invalid/queue",
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (ends with hyphen)",
+			requestedName: "custom-q-",
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
+			name:          "User requested invalid RFC 1123 name (exceeds 253 characters)",
+			requestedName: strings.Repeat("a", 254),
+			kubectlOutput: "",
+			wantName:      "",
+			wantErr:       true,
+		},
+		{
 			name:          "No queues found, fallback to default",
 			requestedName: "",
 			kubectlOutput: "",
@@ -1138,5 +1187,78 @@ func TestCheckKueueInstallPermissions_MissingPermission(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "missing required RBAC permissions: ['create namespaces', 'create clusterroles.rbac.authorization.k8s.io']") {
 		t.Errorf("checkKueueInstallPermissions error = %v; want aggregated missing permissions list", err)
+	}
+}
+
+func TestParseKueueQueueName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantQueue string
+		wantErr   bool
+	}{
+		{
+			name:      "Valid simple name",
+			input:     "default",
+			wantQueue: "default",
+		},
+		{
+			name:      "Valid with hyphens and dots",
+			input:     "my-team.queue-1",
+			wantQueue: "my-team.queue-1",
+		},
+		{
+			name:      "Resource path parsed to bare name",
+			input:     "namespaces/team-a/localQueues/custom-q",
+			wantQueue: "custom-q",
+		},
+		{
+			name:    "Uppercase rejected",
+			input:   "DefaultQueue",
+			wantErr: true,
+		},
+		{
+			name:    "Underscore rejected",
+			input:   "default_queue",
+			wantErr: true,
+		},
+		{
+			name:    "Starts with hyphen rejected",
+			input:   "-default",
+			wantErr: true,
+		},
+		{
+			name:    "Ends with hyphen rejected",
+			input:   "custom-q-",
+			wantErr: true,
+		},
+		{
+			name:    "Name exceeding 253 characters rejected",
+			input:   strings.Repeat("a", 254),
+			wantErr: true,
+		},
+		{
+			name:      "Max length 253 characters valid RFC 1123 subdomain succeeds",
+			input:     strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 60),
+			wantQueue: strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 60),
+			wantErr:   false,
+		},
+		{
+			name:    "Empty name rejected",
+			input:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseKueueQueueName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseKueueQueueName(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if got != tt.wantQueue {
+				t.Errorf("parseKueueQueueName(%q) = %q, want %q", tt.input, got, tt.wantQueue)
+			}
+		})
 	}
 }

--- a/pkg/orchestrator/gke/nap.go
+++ b/pkg/orchestrator/gke/nap.go
@@ -15,6 +15,7 @@
 package gke
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -83,13 +84,6 @@ func (g *GKEOrchestrator) validateGPUNAPLimit(resolvedType string, cap MachineTy
 	return g.napLimits["nvidia.com/gpu"] > 0, nil
 }
 
-func (g *GKEOrchestrator) checkNAPFlagsSupported(hasNAPFlags bool, job *orchestrator.JobDefinition) error {
-	if !g.napEnabled && hasNAPFlags {
-		return fmt.Errorf("GKE NAP provisioning options (--gke-nap-provisioning %q, --gke-nap-reservation %q) are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled. The current cluster does not have NAP enabled.\nRemediation: Enable Node Auto-Provisioning on your cluster to use these options, or submit your job without them", job.GKENAPProvisioning, job.GKENAPReservation)
-	}
-	return nil
-}
-
 func (g *GKEOrchestrator) getConfiguredLimitsError(computeType string) error {
 	var configuredLimits []string
 	for k, v := range g.napLimits {
@@ -102,14 +96,12 @@ func (g *GKEOrchestrator) getConfiguredLimitsError(computeType string) error {
 }
 
 func (g *GKEOrchestrator) validateConsumptionForStaticCluster(job *orchestrator.JobDefinition) error {
-	hasNAPFlags := job.GKENAPProvisioning != ""
-
-	if err := g.checkNAPFlagsSupported(hasNAPFlags, job); err != nil {
-		return err
+	if job.GKENAPProvisioning == "" {
+		return nil
 	}
 
-	if !g.napEnabled || !hasNAPFlags {
-		return nil
+	if !g.napEnabled {
+		return fmt.Errorf("GKE NAP provisioning options (--gke-nap-provisioning %q, --gke-nap-reservation %q) are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled. The current cluster does not have NAP enabled.\nRemediation: Enable Node Auto-Provisioning on your cluster to use these options, or submit your job without them", job.GKENAPProvisioning, job.GKENAPReservation)
 	}
 
 	// NAP flags were requested. Validate strictly against GKE NAP limits.
@@ -121,7 +113,161 @@ func (g *GKEOrchestrator) validateConsumptionForStaticCluster(job *orchestrator.
 		return g.getConfiguredLimitsError(job.ComputeType)
 	}
 
+	return g.validateNAPReservation(job)
+}
+
+// validateNAPReservation verifies that the requested GCE reservation exists and is compatible.
+func (g *GKEOrchestrator) validateNAPReservation(job *orchestrator.JobDefinition) error {
+	if job.GKENAPProvisioning != "reservation" || job.GKENAPReservation == "" {
+		return nil
+	}
+
+	res := parseReservationURI(job.GKENAPReservation)
+	if res.Name == "" {
+		return fmt.Errorf("invalid reservation URI %q: unable to determine reservation name", job.GKENAPReservation)
+	}
+
+	if job.DryRunManifest != "" {
+		return nil
+	}
+
+	clusterRegion := shell.ExtractRegion(job.ClusterLocation)
+	if res.Zone != "" && clusterRegion != "" {
+		resRegion := shell.ExtractRegion(res.Zone)
+		if resRegion != "" && !strings.EqualFold(resRegion, clusterRegion) {
+			return fmt.Errorf("reservation %q belongs to zone %q (region %q), but cluster is in region %q", res.Name, res.Zone, resRegion, clusterRegion)
+		}
+	}
+
+	projectID := res.Project
+	if projectID == "" {
+		projectID = job.ProjectID
+	}
+
+	zone := res.Zone
+	if zone == "" && len(strings.Split(job.ClusterLocation, "-")) == 3 {
+		zone = job.ClusterLocation
+	}
+
+	if zone != "" {
+		return g.validateZonalReservation(res.Name, zone, projectID, job.MachineType)
+	}
+
+	return g.validateRegionalReservation(res.Name, job.ClusterLocation, projectID, job.MachineType)
+}
+
+func (g *GKEOrchestrator) validateZonalReservation(name, zone, projectID, expectedMachineType string) error {
+	resCmd := g.executor.ExecuteCommand("gcloud", "compute", "reservations", "describe", name, "--zone="+zone, "--project="+projectID, "--format=json")
+	if resCmd.ExitCode != 0 {
+		stderrLower := strings.ToLower(resCmd.Stderr)
+		if strings.Contains(stderrLower, "not found") || strings.Contains(stderrLower, "404") {
+			return fmt.Errorf("reservation %q does not exist in zone %s (project %s)", name, zone, projectID)
+		}
+		if isPermissionDenied(stderrLower) {
+			logging.Warn("Permission denied querying reservation %q in zone %s (project %s): %s. Proceeding without reservation validation.", name, zone, projectID, resCmd.Stderr)
+			return nil
+		}
+		return fmt.Errorf("failed to describe reservation %q: %s", name, resCmd.Stderr)
+	}
+
+	var rData struct {
+		SpecificReservation struct {
+			InstanceProperties struct {
+				MachineType string `json:"machineType"`
+			} `json:"instanceProperties"`
+		} `json:"specificReservation"`
+	}
+	if err := json.Unmarshal([]byte(resCmd.Stdout), &rData); err != nil {
+		return fmt.Errorf("failed to parse reservation describe json: %w", err)
+	}
+	var resMachineType string
+	if rawMT := rData.SpecificReservation.InstanceProperties.MachineType; rawMT != "" {
+		resMachineType = path.Base(rawMT)
+	}
+	var expected string
+	if expectedMachineType != "" {
+		expected = path.Base(expectedMachineType)
+	}
+	if resMachineType != "" && expected != "" && resMachineType != expected {
+		return fmt.Errorf("reservation %q is configured for machine type %q, which does not match requested machine type %q", name, resMachineType, expectedMachineType)
+	}
 	return nil
+}
+
+func (g *GKEOrchestrator) validateRegionalReservation(name, clusterLocation, projectID, expectedMachineType string) error {
+	filter := fmt.Sprintf("name=( '%s' )", name)
+	listCmd := g.executor.ExecuteCommand("gcloud", "compute", "reservations", "list", "--project="+projectID, "--filter="+filter, "--format=json")
+	if listCmd.ExitCode != 0 {
+		if isPermissionDenied(strings.ToLower(listCmd.Stderr)) {
+			logging.Warn("Permission denied listing reservations for %q in project %s: %s. Proceeding without reservation validation.", name, projectID, listCmd.Stderr)
+			return nil
+		}
+		return fmt.Errorf("failed to list reservations for %q: %s", name, listCmd.Stderr)
+	}
+
+	var listData []reservationListItem
+	if err := json.Unmarshal([]byte(listCmd.Stdout), &listData); err != nil {
+		return fmt.Errorf("failed to parse reservations list json: %w", err)
+	}
+
+	if len(listData) == 0 {
+		return fmt.Errorf("reservation %q does not exist in project %s", name, projectID)
+	}
+
+	return checkRegionalReservationMatch(name, clusterLocation, expectedMachineType, listData)
+}
+
+func checkRegionalReservationMatch(name, clusterLocation, expectedMachineType string, listData []reservationListItem) error {
+	clusterRegion := shell.ExtractRegion(clusterLocation)
+	var expected string
+	if expectedMachineType != "" {
+		expected = path.Base(expectedMachineType)
+	}
+
+	foundInRegion, mismatched := findRegionalReservationMismatches(listData, clusterRegion, expected)
+	if foundInRegion {
+		if len(mismatched) == 0 {
+			return nil
+		}
+		return fmt.Errorf("reservation %q is configured for machine type(s) %v, which does not match requested machine type %q", name, mismatched, expectedMachineType)
+	}
+
+	if clusterRegion != "" {
+		return fmt.Errorf("reservation %q was found in zones %v, which do not match cluster region %q", name, collectItemZones(listData), clusterRegion)
+	}
+	return nil
+}
+
+func findRegionalReservationMismatches(listData []reservationListItem, clusterRegion, expected string) (bool, []string) {
+	var foundInRegion bool
+	var mismatched []string
+	for _, item := range listData {
+		if item.Zone == "" || (clusterRegion != "" && !strings.HasPrefix(path.Base(item.Zone), clusterRegion)) {
+			continue
+		}
+		foundInRegion = true
+		var resMT string
+		if rawMT := item.SpecificReservation.InstanceProperties.MachineType; rawMT != "" {
+			resMT = path.Base(rawMT)
+		}
+		if resMT != "" && expected != "" && resMT == expected {
+			return true, nil
+		}
+		if resMT != "" {
+			mismatched = append(mismatched, resMT)
+		}
+	}
+	return foundInRegion, mismatched
+}
+
+func collectItemZones(listData []reservationListItem) []string {
+	var zones []string
+	for _, item := range listData {
+		if item.Zone != "" {
+			zones = append(zones, path.Base(item.Zone))
+		}
+	}
+	return zones
 }
 
 // resolveFallbackName returns a fallback reservation name from the URI parts.
@@ -131,46 +277,47 @@ func resolveFallbackName(parts []string) string {
 	}
 	// If it has reservationBlocks, the name is the one before it
 	for i, part := range parts {
-		if part == "reservationBlocks" && i > 0 {
+		if strings.EqualFold(part, "reservationBlocks") && i > 0 {
 			return parts[i-1]
 		}
 	}
-	// Fallback to last element
-	return parts[len(parts)-1]
+	// Fallback to last element, unless it's the collection name itself
+	last := parts[len(parts)-1]
+	if strings.EqualFold(last, "reservations") {
+		return ""
+	}
+	return last
 }
 
 // parseReservationURI parses a GCE reservation resource URI or reservation path into its components.
 // E.g.,
 // - "my-res" -> Name: "my-res"
 // - "projects/my-project/reservations/my-res" -> Project: "my-project", Name: "my-res"
+// - "projects/my-project/zones/us-central1-a/reservations/my-res" -> Project: "my-project", Zone: "us-central1-a", Name: "my-res"
+// - "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-res" -> Project: "my-project", Zone: "us-central1-a", Name: "my-res"
 // - "projects/my-project/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2" -> Project: "my-project", Name: "my-res", Block: "block-1", Subblock: "subblock-2"
 func parseReservationURI(resName string) parsedReservation {
-	resName = strings.TrimSuffix(resName, "/")
-	var parsed parsedReservation
+	resName = strings.TrimSuffix(strings.TrimSpace(resName), "/")
 	if !strings.Contains(resName, "/") {
-		parsed.Name = strings.ToLower(resName)
-		return parsed
+		return parsedReservation{Name: strings.ToLower(resName)}
 	}
 
-	parts := strings.Split(resName, "/")
-	for i := 0; i < len(parts)-1; i++ {
-		switch parts[i] {
-		case "projects":
-			parsed.Project = strings.ToLower(parts[i+1])
-		case "reservations":
-			parsed.Name = strings.ToLower(parts[i+1])
-		case "reservationBlocks":
-			parsed.Block = strings.ToLower(parts[i+1])
-		case "reservationSubBlocks":
-			parsed.Subblock = strings.ToLower(parts[i+1])
-		}
+	name := extractURIPart(resName, "reservations")
+	if name == "" {
+		name = resolveFallbackName(strings.Split(resName, "/"))
+	}
+	subblock := extractURIPart(resName, "reservationsubblocks")
+	if subblock == "" {
+		subblock = extractURIPart(resName, "subblocks")
 	}
 
-	if parsed.Name == "" {
-		parsed.Name = strings.ToLower(resolveFallbackName(parts))
+	return parsedReservation{
+		Project:  strings.ToLower(extractURIPart(resName, "projects")),
+		Zone:     strings.ToLower(extractURIPart(resName, "zones")),
+		Name:     strings.ToLower(name),
+		Block:    strings.ToLower(extractURIPart(resName, "reservationblocks")),
+		Subblock: strings.ToLower(subblock),
 	}
-
-	return parsed
 }
 
 func isSpecificGPUKey(key string) bool {
@@ -303,6 +450,11 @@ func (g *GKEOrchestrator) resolveTPUWorkloadPolicy(machineType, topology, cluste
 		if isDryRun {
 			logging.Info("Dry-run: Could not determine cluster region or project. Assuming workload policy %q for topology %s. Ensure it exists in your target cluster's region.", canonicalPolicyName, topology)
 		}
+		return canonicalPolicyName, nil
+	}
+
+	if isDryRun {
+		logging.Info("Dry-run: Assuming workload policy %q for topology %s. Ensure it exists before applying the manifest, or create it using:\n  gcloud compute resource-policies create workload-policy %s --region=%s --project=%s --type=HIGH_THROUGHPUT --accelerator-topology=%s", canonicalPolicyName, topology, canonicalPolicyName, region, resolvedProjID, topology)
 		return canonicalPolicyName, nil
 	}
 

--- a/pkg/orchestrator/gke/nap_test.go
+++ b/pkg/orchestrator/gke/nap_test.go
@@ -412,7 +412,18 @@ func TestParseReservationURI(t *testing.T) {
 			input: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-res",
 			want: parsedReservation{
 				Project: "my-project",
+				Zone:    "us-central1-a",
 				Name:    "my-res",
+			},
+		},
+		{
+			input: "https://www.googleapis.com/compute/v1/projects/my-project/zones/us-central1-a/reservations/my-res/reservationBlocks/block-1/reservationSubBlocks/subblock-2",
+			want: parsedReservation{
+				Project:  "my-project",
+				Zone:     "us-central1-a",
+				Name:     "my-res",
+				Block:    "block-1",
+				Subblock: "subblock-2",
 			},
 		},
 		{
@@ -428,6 +439,22 @@ func TestParseReservationURI(t *testing.T) {
 				Name:     "my-res",
 				Block:    "block-1",
 				Subblock: "subblock-2",
+			},
+		},
+		{
+			input: "projects/my-project/zones/us-central1-a/reservations/",
+			want: parsedReservation{
+				Project: "my-project",
+				Zone:    "us-central1-a",
+				Name:    "",
+			},
+		},
+		{
+			input: "projects/my-project/zones/us-central1-a/reservations",
+			want: parsedReservation{
+				Project: "my-project",
+				Zone:    "us-central1-a",
+				Name:    "",
 			},
 		},
 	}
@@ -452,16 +479,6 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 		wantErr       bool
 	}{
 		{
-			name: "Placement policy already specified on job is preserved",
-			job: &orchestrator.JobDefinition{
-				MachineType:     "tpu7x-standard-4t",
-				Topology:        "2x2x2",
-				NodesPerSlice:   2,
-				PlacementPolicy: "user-specified-policy",
-			},
-			wantPolicy: "user-specified-policy",
-		},
-		{
 			name: "Discovered from existing matching node pool",
 			job: &orchestrator.JobDefinition{
 				MachineType:   "tpu7x-standard-4t",
@@ -483,6 +500,37 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 				},
 			},
 			wantPolicy: "existing-nodepool-policy",
+		},
+		{
+			name: "Existing node pool with PROVISION_ONLY policy is skipped for static workload",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+			},
+			nodePools: []gkeJobNodePool{
+				{
+					Name: "dynamic-tpu7x-pool",
+					Config: gkeNodePoolConfig{
+						MachineType: "tpu7x-standard-4t",
+						Labels: map[string]string{
+							"cloud.google.com/gke-tpu-topology": "2x2x2",
+						},
+					},
+					PlacementPolicy: &gkePlacementPolicy{
+						PolicyName:              "dynamic-slicing-policy",
+						AcceleratorTopologyMode: "PROVISION_ONLY",
+					},
+				},
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe tpu7x-16-2x2x2-placement-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"tpu7x-16-2x2x2-placement-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
 		},
 		{
 			name: "Discovered from describe of canonical policy",
@@ -616,17 +664,6 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 			},
 			wantPolicy: "tpu7x-16-2x2x2-placement-policy",
 		},
-		{
-			name: "Single-node slice does not assign workload placement policy",
-			job: &orchestrator.JobDefinition{
-				MachineType:     "tpu7x-standard-4t",
-				Topology:        "2x2x1",
-				NodesPerSlice:   1,
-				ClusterLocation: "us-central1-c",
-				ProjectID:       "my-project",
-			},
-			wantPolicy: "",
-		},
 	}
 
 	for _, tt := range tests {
@@ -636,56 +673,448 @@ func TestResolveTPUWorkloadPolicy(t *testing.T) {
 			g.projectID = tt.job.ProjectID
 			g.clusterDesc.NodePools = tt.nodePools
 
-			err := g.resolveTPU7xWorkloadPolicyIfRequired(tt.job, true, false)
+			policy, err := g.resolveTPUWorkloadPolicy(tt.job.MachineType, tt.job.Topology, tt.job.ClusterLocation, tt.job.ProjectID, tt.job.DryRunManifest != "")
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("resolveTPU7xWorkloadPolicyIfRequired() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("resolveTPUWorkloadPolicy() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if tt.job.PlacementPolicy != tt.wantPolicy {
-				t.Errorf("resolveTPU7xWorkloadPolicyIfRequired() placementPolicy = %q, want %q", tt.job.PlacementPolicy, tt.wantPolicy)
+			if !tt.wantErr && policy != tt.wantPolicy {
+				t.Errorf("resolveTPUWorkloadPolicy() = %q, want %q", policy, tt.wantPolicy)
 			}
 		})
 	}
 }
 
-func TestBuildNodeSelector_PlacementPolicy(t *testing.T) {
-	g := newTestGKEOrchestrator(nil)
-	g.machineCapCache["tpu7x-standard-4t:"] = MachineTypeCap{}
-	g.machineCapCache["a3-highgpu-8g:"] = MachineTypeCap{}
+func TestValidateConsumptionForStaticCluster(t *testing.T) {
+	tests := []struct {
+		name        string
+		napEnabled  bool
+		napLimits   map[string]int64
+		nodePools   []gkeJobNodePool
+		job         orchestrator.JobDefinition
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:       "Static Cluster - Explicit on-demand flag fails",
+			napEnabled: false,
+			job: orchestrator.JobDefinition{
+				GKENAPProvisioning: "on-demand",
+			},
+			wantErr:     true,
+			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"on-demand\", --gke-nap-reservation \"\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
+		},
+		{
+			name:       "Static Cluster - Empty string consumption model",
+			napEnabled: false,
+			job: orchestrator.JobDefinition{
+				GKENAPProvisioning: "",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "Static Cluster - Consumption model flag set to spot",
+			napEnabled: false,
+			job: orchestrator.JobDefinition{
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"spot\", --gke-nap-reservation \"\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
+		},
+		{
+			name:       "Static Cluster - Reservation name flag set",
+			napEnabled: false,
+			job: orchestrator.JobDefinition{
+				GKENAPProvisioning: "on-demand",
+				GKENAPReservation:  "my-res",
+			},
+			wantErr:     true,
+			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"on-demand\", --gke-nap-reservation \"my-res\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
+		},
+		{
+			name:       "NAP Cluster - Machine type in NAP limits",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"tpu-v6e-slice": 100,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "ct6e-standard-8t", // TPU
+				GKENAPProvisioning: "spot",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "NAP Cluster - Machine type not in limits, but matches static pool",
+			napEnabled: true,
+			napLimits:  map[string]int64{},
+			nodePools: []gkeJobNodePool{
+				{
+					Config: gkeNodePoolConfig{
+						MachineType: "n2-standard-4",
+						Labels: map[string]string{
+							"cloud.google.com/gke-provisioning": "spot",
+						},
+					},
+				},
+			},
+			job: orchestrator.JobDefinition{
+				ComputeType:        "n2-standard-4",
+				MachineType:        "n2-standard-4",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - Machine type not in limits, and mismatches static pool",
+			napEnabled: true,
+			napLimits:  map[string]int64{},
+			nodePools: []gkeJobNodePool{
+				{
+					Config: gkeNodePoolConfig{
+						MachineType: "n2-standard-4",
+						Labels: map[string]string{
+							"cloud.google.com/gke-provisioning": "standard",
+						},
+					},
+				},
+			},
+			job: orchestrator.JobDefinition{
+				ComputeType:        "n2-standard-4",
+				MachineType:        "n2-standard-4",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - Machine type covered by generic TPU limit fallback",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"google.com/tpu": 100,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "ct6e-standard-8t",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr: false,
+		},
+		{
+			name:       "NAP Cluster - Machine type with unknown GPU accelerator fails fast",
+			napEnabled: true,
+			napLimits:  map[string]int64{},
+			job: orchestrator.JobDefinition{
+				MachineType:        "my-unknown-gpu-machine",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "unknown accelerator label: \"unknown-gpu\"",
+		},
+		{
+			name:       "NAP Cluster - TPU: Specific limit configured, requesting different TPU (Should Fail)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"tpu-v6e-slice":  8,
+				"google.com/tpu": 8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "ct5lp-hightpu-4t", // TPU v5e (tpu-v5-lite-podslice)
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - GPU: Specific limit configured, requesting different GPU (Should Fail)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"nvidia-h100-mega-80gb": 8,
+				"nvidia.com/gpu":        8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "g2-standard-12", // L4 GPU (nvidia-l4)
+				GKENAPProvisioning: "spot",
+			},
+			wantErr:     true,
+			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
+		},
+		{
+			name:       "NAP Cluster - GPU: Generic limit only, requesting GPU (Should Pass)",
+			napEnabled: true,
+			napLimits: map[string]int64{
+				"nvidia.com/gpu": 8,
+			},
+			job: orchestrator.JobDefinition{
+				MachineType:        "g2-standard-12",
+				GKENAPProvisioning: "spot",
+			},
+			wantErr: false,
+		},
+	}
 
-	// 1. TPU workload uses cloud.google.com/placement-policy-name
-	tpuJob := orchestrator.JobDefinition{
-		MachineType: "tpu7x-standard-4t",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orc := newTestGKEOrchestrator(nil)
+			orc.napEnabled = tt.napEnabled
+			orc.napLimits = tt.napLimits
+			orc.clusterDesc.NodePools = tt.nodePools
+			orc.machineCapCache = map[string]MachineTypeCap{
+				"n2-standard-4:": {
+					GuestCpus: 4,
+					MemoryMb:  16000,
+				},
+				"my-unknown-gpu-machine:": {
+					GuestCpus: 8,
+					MemoryMb:  32000,
+					Accelerators: []struct {
+						Count int    `json:"guestAcceleratorCount"`
+						Type  string `json:"guestAcceleratorType"`
+					}{
+						{
+							Count: 1,
+							Type:  "unknown-gpu",
+						},
+					},
+				},
+				"g2-standard-12:": {
+					GuestCpus: 12,
+					MemoryMb:  48000,
+					Accelerators: []struct {
+						Count int    `json:"guestAcceleratorCount"`
+						Type  string `json:"guestAcceleratorType"`
+					}{
+						{
+							Count: 1,
+							Type:  "nvidia-l4",
+						},
+					},
+				},
+			}
+
+			err := orc.validateConsumptionForStaticCluster(&tt.job)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.expectedErr, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+		})
 	}
-	tpuOpts := SchedulingOptions{
-		PlacementPolicy: "tpu7x-16-2x2x2-placement-policy",
-		IsTPU:           true,
-	}
-	tpuSelectorStr, err := g.buildNodeSelector(tpuOpts, tpuJob, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(tpuSelectorStr, "cloud.google.com/placement-policy-name: tpu7x-16-2x2x2-placement-policy") {
-		t.Errorf("Expected cloud.google.com/placement-policy-name in %s", tpuSelectorStr)
-	}
-	if strings.Contains(tpuSelectorStr, "cloud.google.com/gke-placement-group") {
-		t.Errorf("Did not expect cloud.google.com/gke-placement-group in %s", tpuSelectorStr)
+}
+
+func TestValidateNAPReservation(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           *orchestrator.JobDefinition
+		mockResponses map[string][]shell.CommandResult
+		wantErr       bool
+	}{
+		{
+			name: "Valid reservation matching machine type succeeds",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "my-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe my-res --zone=us-central1-a --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"my-res","specificReservation":{"instanceProperties":{"machineType":"ct5p-hightpu-4t"}}}`},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Reservation in full HTTPS URL with zone parsed and validated",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "https://www.googleapis.com/compute/v1/projects/my-owner/zones/us-central1-b/reservations/shared-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe shared-res --zone=us-central1-b --project=my-owner --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"shared-res","specificReservation":{"instanceProperties":{"machineType":"ct5p-hightpu-4t"}}}`},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Reservation not found (404) returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "missing-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe missing-res --zone=us-central1-a --project=my-project --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.reservations.describe) The resource 'projects/my-project/zones/us-central1-a/reservations/missing-res' was not found"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Reservation machine type mismatch returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "wrong-type-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe wrong-type-res --zone=us-central1-a --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"wrong-type-res","specificReservation":{"instanceProperties":{"machineType":"a3-highgpu-8g"}}}`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Reservation 403 Forbidden degrades gracefully with warning",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "forbidden-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe forbidden-res --zone=us-central1-a --project=my-project --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.reservations.describe) 403 Forbidden: Required 'compute.reservations.get' permission"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Reservation check skipped on dry-run",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "dry-run-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+				DryRunManifest:     "/tmp/job.yaml",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Regional cluster reservation matching region and partial URI machine type succeeds",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "reg-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations list": {
+					{ExitCode: 0, Stdout: `[{"zone":"projects/my-project/zones/us-central1-a","specificReservation":{"instanceProperties":{"machineType":"zones/us-central1-a/machineTypes/ct5p-hightpu-4t"}}}]`},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Regional cluster reservation found in different region returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "reg-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations list": {
+					{ExitCode: 0, Stdout: `[{"zone":"europe-west4-a","specificReservation":{"instanceProperties":{"machineType":"ct5p-hightpu-4t"}}}]`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Reservation URI with region locality mismatch returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "projects/my-project/zones/europe-west4-a/reservations/my-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1",
+				ProjectID:          "my-project",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Zonal reservation with malformed JSON returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "corrupt-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1-a",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations describe corrupt-res --zone=us-central1-a --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{invalid-json`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Regional cluster multi-zone reservation with first zone mismatch and second zone match succeeds",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "reg-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations list": {
+					{ExitCode: 0, Stdout: `[
+						{"zone":"projects/my-project/zones/us-central1-a","specificReservation":{"instanceProperties":{"machineType":"a3-highgpu-8g"}}},
+						{"zone":"projects/my-project/zones/us-central1-b","specificReservation":{"instanceProperties":{"machineType":"ct5p-hightpu-4t"}}}
+					]`},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Regional cluster multi-zone reservation with all zones mismatched returns error",
+			job: &orchestrator.JobDefinition{
+				GKENAPProvisioning: "reservation",
+				GKENAPReservation:  "reg-res",
+				MachineType:        "ct5p-hightpu-4t",
+				ClusterLocation:    "us-central1",
+				ProjectID:          "my-project",
+			},
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute reservations list": {
+					{ExitCode: 0, Stdout: `[
+						{"zone":"projects/my-project/zones/us-central1-a","specificReservation":{"instanceProperties":{"machineType":"a3-highgpu-8g"}}},
+						{"zone":"projects/my-project/zones/us-central1-b","specificReservation":{"instanceProperties":{"machineType":"n1-standard-4"}}}
+					]`},
+				},
+			},
+			wantErr: true,
+		},
 	}
 
-	// 2. Non-TPU workload uses cloud.google.com/gke-placement-group
-	nonTpuJob := orchestrator.JobDefinition{
-		MachineType: "a3-highgpu-8g",
-	}
-	nonTpuOpts := SchedulingOptions{
-		PlacementPolicy: "compact-placement-group",
-	}
-	nonTpuSelectorStr, err := g.buildNodeSelector(nonTpuOpts, nonTpuJob, false)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !strings.Contains(nonTpuSelectorStr, "cloud.google.com/gke-placement-group: compact-placement-group") {
-		t.Errorf("Expected cloud.google.com/gke-placement-group in %s", nonTpuSelectorStr)
-	}
-	if strings.Contains(nonTpuSelectorStr, "cloud.google.com/placement-policy-name") {
-		t.Errorf("Did not expect cloud.google.com/placement-policy-name in %s", nonTpuSelectorStr)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecutor := NewMockExecutor(tt.mockResponses)
+			g := newTestGKEOrchestrator(mockExecutor)
+			g.projectID = tt.job.ProjectID
+
+			err := g.validateNAPReservation(tt.job)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateNAPReservation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }

--- a/pkg/orchestrator/gke/resource_resolver.go
+++ b/pkg/orchestrator/gke/resource_resolver.go
@@ -274,16 +274,6 @@ func (g *GKEOrchestrator) checkNodePoolsDynamicSlicing(requestedMachineName stri
 // ErrResourcePolicyPermissionDenied indicates the caller lacks GCP IAM permissions to read the compute resource policy.
 var ErrResourcePolicyPermissionDenied = errors.New("permission denied querying compute resource policy")
 
-type gceResourcePolicyRaw struct {
-	Name           string `json:"name"`
-	Region         string `json:"region"`
-	WorkloadPolicy struct {
-		AcceleratorTopology     string `json:"acceleratorTopology"`
-		AcceleratorTopologyMode string `json:"acceleratorTopologyMode"`
-		Type                    string `json:"type"`
-	} `json:"workloadPolicy"`
-}
-
 // describeResourcePolicyCached retrieves GCE resource policy metadata using gcloud compute resource-policies describe,
 // utilizing a local cache to prevent redundant invocations across dynamic slicing and NAP policy resolution.
 func (g *GKEOrchestrator) describeResourcePolicyCached(policyName, location, projectID string) (*GCEWorkloadPolicy, error) {
@@ -303,7 +293,7 @@ func (g *GKEOrchestrator) describeResourcePolicyCached(policyName, location, pro
 		if strings.Contains(stderrLower, "not found") || strings.Contains(stderrLower, "404") {
 			return nil, nil // Policy does not exist
 		}
-		if strings.Contains(stderrLower, "permission") || strings.Contains(stderrLower, "forbidden") || strings.Contains(stderrLower, "403") {
+		if isPermissionDenied(res.Stderr) {
 			return nil, fmt.Errorf("%w: %s", ErrResourcePolicyPermissionDenied, res.Stderr)
 		}
 		return nil, fmt.Errorf("gcloud compute resource-policies describe failed: %s\n"+
@@ -543,34 +533,107 @@ func (g *GKEOrchestrator) resolveTPURequirements(job *orchestrator.JobDefinition
 		}
 	}
 
-	// Calculate VMs per slice
 	if err = g.dynamicallyCalculateNodesPerSlice(job); err != nil {
 		return false, false, err
 	}
 
-	if err = g.resolveTPU7xWorkloadPolicyIfRequired(job, isTPU7x, isDynamicSlicing); err != nil {
+	if err = g.resolveTPUPlacementPolicy(job, isTPU7x, isDynamicSlicing); err != nil {
 		return false, false, err
 	}
 
 	return isDynamicSlicing, isStaticSlicing, nil
 }
 
-// resolveTPU7xWorkloadPolicyIfRequired automatically resolves or provisions a GCE HIGH_THROUGHPUT
-// workload policy for multi-host TPU 7x jobs when not already specified by the user.
-//
-// Invariants:
-//  1. Only TPU 7x requires GCE workload policies. Older TPUs (v4, v5e, v5p, v6e) manage multi-host
-//     topology via native GKE TPU topology controllers (cloud.google.com/gke-tpu-topology).
-//  2. Only static multi-host slices (job.NodesPerSlice > 1) require a workload policy. Single-host slices
-//     (NodesPerSlice == 1) do not span multiple VMs, and dynamic slicing manages its own slice topology.
-//  3. If the user explicitly provided a placement policy via --placement-policy, it is preserved.
-func (g *GKEOrchestrator) resolveTPU7xWorkloadPolicyIfRequired(job *orchestrator.JobDefinition, isTPU7x, isDynamicSlicing bool) error {
-	if isTPU7x && !isDynamicSlicing && job.Topology != "" && job.NodesPerSlice > 1 && job.PlacementPolicy == "" {
+func (g *GKEOrchestrator) resolveTPUPlacementPolicy(job *orchestrator.JobDefinition, isTPU7x, isDynamicSlicing bool) error {
+	if job.PlacementPolicy != "" {
+		return g.resolveWorkloadPlacementPolicy(job, isTPU7x, isDynamicSlicing)
+	}
+	if isTPU7x && !isDynamicSlicing && job.NodesPerSlice > 1 {
 		policy, err := g.resolveTPUWorkloadPolicy(job.MachineType, job.Topology, job.ClusterLocation, job.ProjectID, job.DryRunManifest != "")
 		if err != nil {
 			return err
 		}
 		job.PlacementPolicy = policy
+	}
+	return nil
+}
+
+// parseResourcePolicyURI parses a GCE resource policy URI, URL, or plain name into its components.
+// E.g.:
+// - "my-policy" -> Name: "my-policy"
+// - "projects/my-proj/regions/us-central1/resourcePolicies/my-policy" -> Project: "my-proj", Region: "us-central1", Name: "my-policy"
+// - "https://www.googleapis.com/compute/v1/projects/my-proj/regions/us-central1/resourcePolicies/my-policy" -> Project: "my-proj", Region: "us-central1", Name: "my-policy"
+func parseResourcePolicyURI(policyStr string) parsedResourcePolicy {
+	policyStr = strings.TrimSuffix(strings.TrimSpace(policyStr), "/")
+	if !strings.Contains(policyStr, "/") {
+		return parsedResourcePolicy{Name: policyStr}
+	}
+
+	return parsedResourcePolicy{
+		Project: extractURIPart(policyStr, "projects"),
+		Region:  extractURIPart(policyStr, "regions"),
+		Name:    extractURIPart(policyStr, "resourcepolicies"),
+	}
+}
+
+// resolveWorkloadPlacementPolicy sanitizes user-specified placement policy URIs into bare resource names
+// and validates their existence, project/region locality, topology, and static mode for TPU 7x workloads.
+func (g *GKEOrchestrator) resolveWorkloadPlacementPolicy(job *orchestrator.JobDefinition, isTPU7x, isDynamicSlicing bool) error {
+	if job.PlacementPolicy == "" {
+		return nil
+	}
+
+	parsed := parseResourcePolicyURI(job.PlacementPolicy)
+	if parsed.Name == "" {
+		return fmt.Errorf("invalid placement policy %q: unable to determine policy name", job.PlacementPolicy)
+	}
+	job.PlacementPolicy = parsed.Name
+
+	if err := validateResourcePolicyLocality(parsed, job.ProjectID, job.ClusterLocation); err != nil {
+		return err
+	}
+
+	// GCE Workload Resource Policies are only queried and validated for static multi-host TPU 7x workloads.
+	// For GPUs/CPUs, GKE NAP dynamically creates compact placement groups on the fly.
+	if isTPU7x && !isDynamicSlicing && job.NodesPerSlice > 1 && job.DryRunManifest == "" {
+		clusterRegion := shell.ExtractRegion(job.ClusterLocation)
+		return g.validateTPU7xPlacementPolicy(parsed.Name, clusterRegion, job.ProjectID, job.Topology)
+	}
+
+	return nil
+}
+
+func validateResourcePolicyLocality(parsed parsedResourcePolicy, projectID, clusterLocation string) error {
+	if parsed.Project != "" && projectID != "" && !strings.EqualFold(parsed.Project, projectID) {
+		return fmt.Errorf("placement policy %q belongs to project %q, but cluster is in project %q", parsed.Name, parsed.Project, projectID)
+	}
+	clusterRegion := shell.ExtractRegion(clusterLocation)
+	if parsed.Region != "" && clusterRegion != "" && !strings.EqualFold(parsed.Region, clusterRegion) {
+		return fmt.Errorf("placement policy %q belongs to region %q, but cluster is in region %q", parsed.Name, parsed.Region, clusterRegion)
+	}
+	return nil
+}
+
+func (g *GKEOrchestrator) validateTPU7xPlacementPolicy(name, region, projectID, expectedTopology string) error {
+	policy, err := g.describeResourcePolicyCached(name, region, projectID)
+	if err != nil {
+		if errors.Is(err, ErrResourcePolicyPermissionDenied) {
+			logging.Warn("Permission denied querying placement policy %q: %v. Proceeding without policy validation.", name, err)
+			return nil
+		}
+		return fmt.Errorf("failed to describe placement policy %q: %w", name, err)
+	}
+	if policy == nil {
+		return fmt.Errorf("placement policy %q does not exist in region %s (project %s)", name, region, projectID)
+	}
+	if policy.Type != "" && !strings.EqualFold(policy.Type, "HIGH_THROUGHPUT") {
+		return fmt.Errorf("placement policy %q has type %q; expected %q", name, policy.Type, "HIGH_THROUGHPUT")
+	}
+	if !isStaticWorkloadPolicyMode(policy.AcceleratorTopologyMode) {
+		return fmt.Errorf("placement policy %q has mode %q, which is incompatible with static multi-host TPU workloads (expected AUTO_CONNECT or default static placement)", name, policy.AcceleratorTopologyMode)
+	}
+	if expectedTopology != "" && policy.AcceleratorTopology != "" && !strings.EqualFold(policy.AcceleratorTopology, expectedTopology) {
+		return fmt.Errorf("placement policy %q has topology %q; expected %q", name, policy.AcceleratorTopology, expectedTopology)
 	}
 	return nil
 }
@@ -600,6 +663,11 @@ func (g *GKEOrchestrator) resolveHardwareRequirements(job *orchestrator.JobDefin
 			if job.GKEScheduler == "gke.io/tpu-provisioning-request" {
 				return JobProfile{}, false, false, fmt.Errorf("TPU ProvisioningRequest (DWS Flex) is not supported on GKE Node Auto-Provisioning (NAP) workloads")
 			}
+		}
+	} else {
+		// For non-TPU workloads (GPU/CPU), validate placement policy if specified.
+		if err := g.resolveWorkloadPlacementPolicy(job, false, false); err != nil {
+			return JobProfile{}, isDynamicSlicing, isStaticSlicing, err
 		}
 	}
 	isCPUMachine, capacity, err := g.determineIfCPUMachine(job)

--- a/pkg/orchestrator/gke/resource_resolver_test.go
+++ b/pkg/orchestrator/gke/resource_resolver_test.go
@@ -676,229 +676,6 @@ func TestResolveHardwareRequirements_NAPIncompatibilities(t *testing.T) {
 	}
 }
 
-func TestValidateConsumptionForStaticCluster(t *testing.T) {
-	tests := []struct {
-		name        string
-		napEnabled  bool
-		napLimits   map[string]int64
-		nodePools   []gkeJobNodePool
-		job         orchestrator.JobDefinition
-		wantErr     bool
-		expectedErr string
-	}{
-		{
-			name:       "Static Cluster - Explicit on-demand flag fails",
-			napEnabled: false,
-			job: orchestrator.JobDefinition{
-				GKENAPProvisioning: "on-demand",
-			},
-			wantErr:     true,
-			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"on-demand\", --gke-nap-reservation \"\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
-		},
-		{
-			name:       "Static Cluster - Empty string consumption model",
-			napEnabled: false,
-			job: orchestrator.JobDefinition{
-				GKENAPProvisioning: "",
-			},
-			wantErr: false,
-		},
-		{
-			name:       "Static Cluster - Consumption model flag set to spot",
-			napEnabled: false,
-			job: orchestrator.JobDefinition{
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"spot\", --gke-nap-reservation \"\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
-		},
-		{
-			name:       "Static Cluster - Reservation name flag set",
-			napEnabled: false,
-			job: orchestrator.JobDefinition{
-				GKENAPProvisioning: "on-demand",
-				GKENAPReservation:  "my-res",
-			},
-			wantErr:     true,
-			expectedErr: "GKE NAP provisioning options (--gke-nap-provisioning \"on-demand\", --gke-nap-reservation \"my-res\") are only supported on GKE clusters with Node Auto-Provisioning (NAP) enabled",
-		},
-		{
-			name:       "NAP Cluster - Machine type in NAP limits",
-			napEnabled: true,
-			napLimits: map[string]int64{
-				"tpu-v6e-slice": 100,
-			},
-			job: orchestrator.JobDefinition{
-				MachineType:        "ct6e-standard-8t", // TPU
-				GKENAPProvisioning: "spot",
-			},
-			wantErr: false,
-		},
-		{
-			name:       "NAP Cluster - Machine type not in limits, but matches static pool",
-			napEnabled: true,
-			napLimits:  map[string]int64{},
-			nodePools: []gkeJobNodePool{
-				{
-					Config: gkeNodePoolConfig{
-						MachineType: "n2-standard-4",
-						Labels: map[string]string{
-							"cloud.google.com/gke-provisioning": "spot",
-						},
-					},
-				},
-			},
-			job: orchestrator.JobDefinition{
-				ComputeType:        "n2-standard-4",
-				MachineType:        "n2-standard-4",
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
-		},
-		{
-			name:       "NAP Cluster - Machine type not in limits, and mismatches static pool",
-			napEnabled: true,
-			napLimits:  map[string]int64{},
-			nodePools: []gkeJobNodePool{
-				{
-					Config: gkeNodePoolConfig{
-						MachineType: "n2-standard-4",
-						Labels: map[string]string{
-							"cloud.google.com/gke-provisioning": "standard",
-						},
-					},
-				},
-			},
-			job: orchestrator.JobDefinition{
-				ComputeType:        "n2-standard-4",
-				MachineType:        "n2-standard-4",
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
-		},
-		{
-			name:       "NAP Cluster - Machine type covered by generic TPU limit fallback",
-			napEnabled: true,
-			napLimits: map[string]int64{
-				"google.com/tpu": 100,
-			},
-			job: orchestrator.JobDefinition{
-				MachineType:        "ct6e-standard-8t",
-				GKENAPProvisioning: "spot",
-			},
-			wantErr: false,
-		},
-		{
-			name:       "NAP Cluster - Machine type with unknown GPU accelerator fails fast",
-			napEnabled: true,
-			napLimits:  map[string]int64{},
-			job: orchestrator.JobDefinition{
-				MachineType:        "my-unknown-gpu-machine",
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "unknown accelerator label: \"unknown-gpu\"",
-		},
-		{
-			name:       "NAP Cluster - TPU: Specific limit configured, requesting different TPU (Should Fail)",
-			napEnabled: true,
-			napLimits: map[string]int64{
-				"tpu-v6e-slice":  8,
-				"google.com/tpu": 8,
-			},
-			job: orchestrator.JobDefinition{
-				MachineType:        "ct5lp-hightpu-4t", // TPU v5e (tpu-v5-lite-podslice)
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
-		},
-		{
-			name:       "NAP Cluster - GPU: Specific limit configured, requesting different GPU (Should Fail)",
-			napEnabled: true,
-			napLimits: map[string]int64{
-				"nvidia-h100-mega-80gb": 8,
-				"nvidia.com/gpu":        8,
-			},
-			job: orchestrator.JobDefinition{
-				MachineType:        "g2-standard-12", // L4 GPU (nvidia-l4)
-				GKENAPProvisioning: "spot",
-			},
-			wantErr:     true,
-			expectedErr: "is not configured within your cluster's Node Auto-Provisioning (NAP) limits",
-		},
-		{
-			name:       "NAP Cluster - GPU: Generic limit only, requesting GPU (Should Pass)",
-			napEnabled: true,
-			napLimits: map[string]int64{
-				"nvidia.com/gpu": 8,
-			},
-			job: orchestrator.JobDefinition{
-				MachineType:        "g2-standard-12",
-				GKENAPProvisioning: "spot",
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			orc := newTestGKEOrchestrator(nil)
-			orc.napEnabled = tt.napEnabled
-			orc.napLimits = tt.napLimits
-			orc.clusterDesc.NodePools = tt.nodePools
-			orc.machineCapCache = map[string]MachineTypeCap{
-				"n2-standard-4:": {
-					GuestCpus: 4,
-					MemoryMb:  16000,
-				},
-				"my-unknown-gpu-machine:": {
-					GuestCpus: 8,
-					MemoryMb:  32000,
-					Accelerators: []struct {
-						Count int    `json:"guestAcceleratorCount"`
-						Type  string `json:"guestAcceleratorType"`
-					}{
-						{
-							Count: 1,
-							Type:  "unknown-gpu",
-						},
-					},
-				},
-				"g2-standard-12:": {
-					GuestCpus: 12,
-					MemoryMb:  48000,
-					Accelerators: []struct {
-						Count int    `json:"guestAcceleratorCount"`
-						Type  string `json:"guestAcceleratorType"`
-					}{
-						{
-							Count: 1,
-							Type:  "nvidia-l4",
-						},
-					},
-				},
-			}
-
-			err := orc.validateConsumptionForStaticCluster(&tt.job)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				if !strings.Contains(err.Error(), tt.expectedErr) {
-					t.Errorf("expected error containing %q, got: %v", tt.expectedErr, err)
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-			}
-		})
-	}
-}
-
 type ZoneSelectiveMockMachineTypeClient struct {
 	AllowedZone string
 	MT          *compute.MachineType
@@ -1165,6 +942,329 @@ func TestCheckNodePoolsDynamicSlicing_PolicyLookupAndCaching(t *testing.T) {
 			}
 			if tt.wantResult && len(g.resourcePolicyCache) == 0 {
 				t.Errorf("expected resourcePolicyCache to be populated")
+			}
+		})
+	}
+}
+
+func TestParseResourcePolicyURI(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantPolicy  string
+		wantProject string
+		wantRegion  string
+	}{
+		{
+			name:       "Plain policy name",
+			input:      "my-policy",
+			wantPolicy: "my-policy",
+		},
+		{
+			name:        "Relative resource URI",
+			input:       "projects/my-project/regions/us-central1/resourcePolicies/my-policy",
+			wantPolicy:  "my-policy",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Full HTTPS URL with compute/v1",
+			input:       "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/resourcePolicies/my-policy",
+			wantPolicy:  "my-policy",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Relative resource URI with trailing slash",
+			input:       "projects/my-project/regions/us-central1/resourcePolicies/my-policy/",
+			wantPolicy:  "my-policy",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Full HTTPS URL with subdomain compute.googleapis.com",
+			input:       "https://compute.googleapis.com/compute/v1/projects/prod-project/regions/europe-west4/resourcePolicies/prod-policy",
+			wantPolicy:  "prod-policy",
+			wantProject: "prod-project",
+			wantRegion:  "europe-west4",
+		},
+		{
+			name:        "Incomplete resource URI ending at resourcePolicies with trailing slash",
+			input:       "projects/my-project/regions/us-central1/resourcePolicies/",
+			wantPolicy:  "",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Incomplete resource URI ending at resourcePolicies without trailing slash",
+			input:       "projects/my-project/regions/us-central1/resourcePolicies",
+			wantPolicy:  "",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Resource policy named resourcepolicies-xyz in full URI",
+			input:       "projects/my-project/regions/us-central1/resourcePolicies/resourcepolicies-xyz",
+			wantPolicy:  "resourcepolicies-xyz",
+			wantProject: "my-project",
+			wantRegion:  "us-central1",
+		},
+		{
+			name:        "Non-canonical path without resourcePolicies collection returns empty policy name",
+			input:       "custom/resourcepolicies-xyz",
+			wantPolicy:  "",
+			wantProject: "",
+			wantRegion:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseResourcePolicyURI(tt.input)
+			if got.Name != tt.wantPolicy {
+				t.Errorf("parseResourcePolicyURI(%q).Name = %q, want %q", tt.input, got.Name, tt.wantPolicy)
+			}
+			if got.Project != tt.wantProject {
+				t.Errorf("parseResourcePolicyURI(%q).Project = %q, want %q", tt.input, got.Project, tt.wantProject)
+			}
+			if got.Region != tt.wantRegion {
+				t.Errorf("parseResourcePolicyURI(%q).Region = %q, want %q", tt.input, got.Region, tt.wantRegion)
+			}
+		})
+	}
+}
+
+func TestResolveWorkloadPlacementPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		job           *orchestrator.JobDefinition
+		isTPU7x       bool
+		mockResponses map[string][]shell.CommandResult
+		wantPolicy    string
+		wantErr       bool
+	}{
+		{
+			name: "Placement policy already specified on job is verified and preserved",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "user-specified-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe user-specified-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"user-specified-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantPolicy: "user-specified-policy",
+		},
+		{
+			name: "Placement policy specified as relative URI is sanitized and verified",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "projects/my-project/regions/us-central1/resourcePolicies/user-specified-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe user-specified-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"user-specified-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantPolicy: "user-specified-policy",
+		},
+		{
+			name: "Placement policy specified as HTTPS URL is sanitized and verified",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "https://www.googleapis.com/compute/v1/projects/my-project/regions/us-central1/resourcePolicies/user-specified-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe user-specified-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"user-specified-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantPolicy: "user-specified-policy",
+		},
+		{
+			name: "Placement policy with URI in dry-run mode is sanitized without GCE call",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				DryRunManifest:  "/tmp/job.yaml",
+				PlacementPolicy: "projects/my-project/regions/us-central1/resourcePolicies/user-specified-policy",
+			},
+			isTPU7x:    true,
+			wantPolicy: "user-specified-policy",
+		},
+		{
+			name: "Non-TPU workload sanitizes placement policy URI without GCE query",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "a3-highgpu-8g",
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "projects/my-project/regions/us-central1/resourcePolicies/gpu-policy",
+			},
+			isTPU7x:    false,
+			wantPolicy: "gpu-policy",
+		},
+		{
+			name: "Placement policy project mismatch returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "projects/other-project/regions/us-central1/resourcePolicies/user-specified-policy",
+			},
+			isTPU7x: true,
+			wantErr: true,
+		},
+		{
+			name: "Placement policy region mismatch returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "projects/my-project/regions/europe-west4/resourcePolicies/user-specified-policy",
+			},
+			isTPU7x: true,
+			wantErr: true,
+		},
+		{
+			name: "Placement policy not found (404) returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "missing-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe missing-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) The resource 'projects/my-project/regions/us-central1/resourcePolicies/missing-policy' was not found"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Placement policy topology mismatch returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "mismatched-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe mismatched-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"mismatched-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x4"}}`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Placement policy PROVISION_ONLY mode on static workload returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "dynamic-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe dynamic-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"dynamic-policy","region":"us-central1","workloadPolicy":{"type":"HIGH_THROUGHPUT","acceleratorTopology":"2x2x2","acceleratorTopologyMode":"PROVISION_ONLY"}}`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Placement policy invalid type returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "group-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe group-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 0, Stdout: `{"name":"group-policy","region":"us-central1","workloadPolicy":{"type":"GROUP_PLACEMENT","acceleratorTopology":"2x2x2"}}`},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Placement policy permission denied (403) warns and proceeds",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "forbidden-policy",
+			},
+			isTPU7x: true,
+			mockResponses: map[string][]shell.CommandResult{
+				"gcloud compute resource-policies describe forbidden-policy --region=us-central1 --project=my-project --format=json": {
+					{ExitCode: 1, Stderr: "ERROR: (gcloud.compute.resource-policies.describe) 403 Forbidden: Required 'compute.resourcePolicies.get' permission"},
+				},
+			},
+			wantPolicy: "forbidden-policy",
+		},
+		{
+			name: "Incomplete placement policy URI missing name returns error",
+			job: &orchestrator.JobDefinition{
+				MachineType:     "tpu7x-standard-4t",
+				Topology:        "2x2x2",
+				NodesPerSlice:   2,
+				ClusterLocation: "us-central1-c",
+				ProjectID:       "my-project",
+				PlacementPolicy: "projects/my-project/regions/us-central1/resourcePolicies/",
+			},
+			isTPU7x: true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockExecutor := NewMockExecutor(tt.mockResponses)
+			g := newTestGKEOrchestrator(mockExecutor)
+			g.projectID = tt.job.ProjectID
+
+			err := g.resolveWorkloadPlacementPolicy(tt.job, tt.isTPU7x, false)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("resolveWorkloadPlacementPolicy() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && tt.job.PlacementPolicy != tt.wantPolicy {
+				t.Errorf("resolveWorkloadPlacementPolicy() placementPolicy = %q, want %q", tt.job.PlacementPolicy, tt.wantPolicy)
 			}
 		})
 	}

--- a/pkg/orchestrator/gke/scheduling.go
+++ b/pkg/orchestrator/gke/scheduling.go
@@ -17,6 +17,7 @@ package gke
 import (
 	"fmt"
 	"hpc-toolkit/pkg/config"
+	"path"
 	"slices"
 	"strconv"
 	"strings"
@@ -28,10 +29,10 @@ type SchedulingOptions struct {
 	PlacementPolicy    string
 	Topology           string
 	Scheduler          string
+	IsTPU              bool
 	NodeAffinityLabels map[string]string
 	IsDynamicSlicing   bool
 	IsStaticSlicing    bool
-	IsTPU              bool
 }
 
 func getNodeSelector(opts SchedulingOptions) (map[string]string, error) {
@@ -43,10 +44,12 @@ func getNodeSelector(opts SchedulingOptions) (map[string]string, error) {
 		//    GCE Workload Policy (HIGH_THROUGHPUT) via "cloud.google.com/placement-policy-name".
 		// 2. Non-TPUs (GPUs/CPUs): GKE NAP uses "cloud.google.com/gke-placement-group" to dynamically
 		//    generate compact placement groups on the fly for co-located VM scheduling.
+		// Slashes from full URIs/paths are stripped so the label value conforms to Kubernetes RFC 1123 format.
+		policyName := path.Base(strings.TrimSuffix(strings.TrimSpace(opts.PlacementPolicy), "/"))
 		if opts.IsTPU {
-			nodeSelector["cloud.google.com/placement-policy-name"] = opts.PlacementPolicy
+			nodeSelector["cloud.google.com/placement-policy-name"] = policyName
 		} else {
-			nodeSelector["cloud.google.com/gke-placement-group"] = opts.PlacementPolicy
+			nodeSelector["cloud.google.com/gke-placement-group"] = policyName
 		}
 	}
 

--- a/pkg/orchestrator/gke/scheduling_test.go
+++ b/pkg/orchestrator/gke/scheduling_test.go
@@ -16,7 +16,10 @@ package gke
 
 import (
 	"slices"
+	"strings"
 	"testing"
+
+	"hpc-toolkit/pkg/orchestrator"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -57,6 +60,33 @@ func TestGetNodeSelector(t *testing.T) {
 			},
 			wantKey:   "cloud.google.com/gke-placement-group",
 			wantValue: "compact-placement",
+		},
+		{
+			name: "tpu placement policy with relative URI is sanitized to bare name",
+			opts: SchedulingOptions{
+				PlacementPolicy: "projects/my-proj/regions/us-central1/resourcePolicies/tpu-policy",
+				IsTPU:           true,
+			},
+			wantKey:   "cloud.google.com/placement-policy-name",
+			wantValue: "tpu-policy",
+		},
+		{
+			name: "non-tpu placement policy with HTTPS URL is sanitized to bare name",
+			opts: SchedulingOptions{
+				PlacementPolicy: "https://www.googleapis.com/compute/v1/projects/my-proj/regions/us-central1/resourcePolicies/gpu-policy",
+				IsTPU:           false,
+			},
+			wantKey:   "cloud.google.com/gke-placement-group",
+			wantValue: "gpu-policy",
+		},
+		{
+			name: "placement policy with trailing slash is sanitized to bare name",
+			opts: SchedulingOptions{
+				PlacementPolicy: "projects/my-proj/regions/us-central1/resourcePolicies/trailing-policy/",
+				IsTPU:           true,
+			},
+			wantKey:   "cloud.google.com/placement-policy-name",
+			wantValue: "trailing-policy",
 		},
 		{
 			name: "skip pipe separated values (goes to affinity)",
@@ -369,5 +399,64 @@ func TestGetAffinity_ConstraintsAndMerging(t *testing.T) {
 				t.Errorf("Expected to find requirement for key %s", tt.wantKey)
 			}
 		})
+	}
+}
+
+func TestBuildNodeSelector_PlacementPolicy(t *testing.T) {
+	g := newTestGKEOrchestrator(nil)
+	g.machineCapCache["tpu7x-standard-4t:"] = MachineTypeCap{}
+	g.machineCapCache["a3-highgpu-8g:"] = MachineTypeCap{}
+
+	// 1. TPU workload uses cloud.google.com/placement-policy-name
+	tpuJob := orchestrator.JobDefinition{
+		MachineType: "tpu7x-standard-4t",
+	}
+	tpuOpts := SchedulingOptions{
+		PlacementPolicy: "tpu7x-16-2x2x2-placement-policy",
+		IsTPU:           true,
+	}
+	tpuSelectorStr, err := g.buildNodeSelector(tpuOpts, tpuJob, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(tpuSelectorStr, "cloud.google.com/placement-policy-name: tpu7x-16-2x2x2-placement-policy") {
+		t.Errorf("Expected cloud.google.com/placement-policy-name in %s", tpuSelectorStr)
+	}
+	if strings.Contains(tpuSelectorStr, "cloud.google.com/gke-placement-group") {
+		t.Errorf("Did not expect cloud.google.com/gke-placement-group in %s", tpuSelectorStr)
+	}
+
+	// 2. Non-TPU workload uses cloud.google.com/gke-placement-group
+	nonTpuJob := orchestrator.JobDefinition{
+		MachineType: "a3-highgpu-8g",
+	}
+	nonTpuOpts := SchedulingOptions{
+		PlacementPolicy: "compact-placement-group",
+	}
+	nonTpuSelectorStr, err := g.buildNodeSelector(nonTpuOpts, nonTpuJob, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(nonTpuSelectorStr, "cloud.google.com/gke-placement-group: compact-placement-group") {
+		t.Errorf("Expected cloud.google.com/gke-placement-group in %s", nonTpuSelectorStr)
+	}
+	if strings.Contains(nonTpuSelectorStr, "cloud.google.com/placement-policy-name") {
+		t.Errorf("Did not expect cloud.google.com/placement-policy-name in %s", nonTpuSelectorStr)
+	}
+
+	// 3. Placement policy passed as URI with trailing slash is sanitized into bare name
+	uriJob := orchestrator.JobDefinition{
+		MachineType: "tpu7x-standard-4t",
+	}
+	uriOpts := SchedulingOptions{
+		PlacementPolicy: "projects/my-proj/regions/us-central1/resourcePolicies/tpu7x-16-2x2x2-placement-policy/",
+		IsTPU:           true,
+	}
+	uriSelectorStr, err := g.buildNodeSelector(uriOpts, uriJob, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(uriSelectorStr, "cloud.google.com/placement-policy-name: tpu7x-16-2x2x2-placement-policy") {
+		t.Errorf("Expected sanitized placement policy name in %s", uriSelectorStr)
 	}
 }

--- a/pkg/orchestrator/gke/types.go
+++ b/pkg/orchestrator/gke/types.go
@@ -516,7 +516,64 @@ type kueueWorkloadList struct {
 // parsedReservation holds the extracted components of a GCE reservation URI/path.
 type parsedReservation struct {
 	Project  string
+	Zone     string
 	Name     string
 	Block    string
 	Subblock string
+}
+
+// parsedResourcePolicy holds the extracted components of a GCE resource policy URI/path.
+type parsedResourcePolicy struct {
+	Project string
+	Region  string
+	Name    string
+}
+
+// reservationListItem represents an entry in the JSON response from gcloud compute reservations list.
+type reservationListItem struct {
+	Zone                string `json:"zone"`
+	SpecificReservation struct {
+		InstanceProperties struct {
+			MachineType string `json:"machineType"`
+		} `json:"instanceProperties"`
+	} `json:"specificReservation"`
+}
+
+// gceResourcePolicyRaw represents the raw JSON output from gcloud compute resource-policies describe.
+type gceResourcePolicyRaw struct {
+	Name           string `json:"name"`
+	Region         string `json:"region"`
+	WorkloadPolicy struct {
+		AcceleratorTopology     string `json:"acceleratorTopology"`
+		AcceleratorTopologyMode string `json:"acceleratorTopologyMode"`
+		Type                    string `json:"type"`
+	} `json:"workloadPolicy"`
+}
+
+// extractURIPart returns the path segment immediately following the given key segment in a slash-delimited URI or URL.
+// Comparison is case-insensitive.
+// E.g., extractURIPart("projects/p/regions/r/resourcePolicies/name", "regions") -> "r"
+func extractURIPart(uri, key string) string {
+	uri = strings.TrimSuffix(strings.TrimSpace(uri), "/")
+	for {
+		part, rest, found := strings.Cut(uri, "/")
+		if strings.EqualFold(part, key) {
+			val, _, _ := strings.Cut(rest, "/")
+			return val
+		}
+		if !found {
+			break
+		}
+		uri = rest
+	}
+	return ""
+}
+
+// isPermissionDenied returns true if the error text indicates a GCP IAM permission denial (403).
+func isPermissionDenied(errStr string) bool {
+	lower := strings.ToLower(errStr)
+	return strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "permission_denied") ||
+		strings.Contains(lower, "required 'compute.") ||
+		(strings.Contains(lower, "403") && strings.Contains(lower, "forbidden"))
 }

--- a/pkg/orchestrator/gke/types_test.go
+++ b/pkg/orchestrator/gke/types_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gke
+
+import (
+	"testing"
+)
+
+func TestExtractURIPart(t *testing.T) {
+	tests := []struct {
+		name     string
+		uri      string
+		key      string
+		expected string
+	}{
+		{
+			name:     "Standard relative URI with project and region",
+			uri:      "projects/my-project/regions/us-central1/resourcePolicies/my-policy",
+			key:      "regions",
+			expected: "us-central1",
+		},
+		{
+			name:     "Full HTTPS URL with zone and reservation",
+			uri:      "https://www.googleapis.com/compute/v1/projects/my-proj/zones/us-central1-a/reservations/my-res",
+			key:      "reservations",
+			expected: "my-res",
+		},
+		{
+			name:     "Case-insensitive key matching",
+			uri:      "projects/my-project/REGIONS/europe-west4/resourcePolicies/test-policy",
+			key:      "regions",
+			expected: "europe-west4",
+		},
+		{
+			name:     "Trailing slash handling",
+			uri:      "projects/my-proj/regions/us-central1/resourcePolicies/my-policy/",
+			key:      "resourcePolicies",
+			expected: "my-policy",
+		},
+		{
+			name:     "Key at the end of URI returns empty string",
+			uri:      "projects/my-proj/regions/",
+			key:      "regions",
+			expected: "",
+		},
+		{
+			name:     "Key not present returns empty string",
+			uri:      "projects/my-proj/zones/us-central1-a",
+			key:      "regions",
+			expected: "",
+		},
+		{
+			name:     "Empty URI returns empty string",
+			uri:      "",
+			key:      "projects",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractURIPart(tt.uri, tt.key)
+			if got != tt.expected {
+				t.Errorf("extractURIPart(%q, %q) = %q, want %q", tt.uri, tt.key, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsPermissionDenied(t *testing.T) {
+	tests := []struct {
+		name     string
+		errStr   string
+		expected bool
+	}{
+		{
+			name:     "403 Forbidden error string",
+			errStr:   "ERROR: (gcloud.compute.reservations.describe) 403 Forbidden: Required 'compute.reservations.get' permission",
+			expected: true,
+		},
+		{
+			name:     "Permission denied error text",
+			errStr:   "googleapi: Error 403: Permission denied on resource",
+			expected: true,
+		},
+		{
+			name:     "GCE required compute permission",
+			errStr:   "ERROR: (gcloud.compute.reservations.describe) Could not fetch resource: - Required 'compute.reservations.get' permission for 'projects/p/zones/z/reservations/r'",
+			expected: true,
+		},
+		{
+			name:     "PERMISSION_DENIED gRPC status code",
+			errStr:   "ERROR: (gcloud.compute.reservations.describe) PERMISSION_DENIED: caller does not have permission",
+			expected: true,
+		},
+		{
+			name:     "Resource name containing 403 or permission is not treated as permission denied",
+			errStr:   "ERROR: (gcloud.compute.reservations.describe) The resource 'projects/p/zones/z/reservations/res-403' was not found",
+			expected: false,
+		},
+		{
+			name:     "Resource name containing permission is not treated as permission denied",
+			errStr:   "ERROR: (gcloud.compute.resource-policies.describe) The resource 'projects/p/regions/r/resourcePolicies/my-permission-policy' was not found",
+			expected: false,
+		},
+		{
+			name:     "Not found error (404) returns false",
+			errStr:   "ERROR: (gcloud.compute.reservations.describe) The resource was not found (404)",
+			expected: false,
+		},
+		{
+			name:     "Connection timeout returns false",
+			errStr:   "i/o timeout connecting to compute.googleapis.com",
+			expected: false,
+		},
+		{
+			name:     "Empty error returns false",
+			errStr:   "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isPermissionDenied(tt.errStr)
+			if got != tt.expected {
+				t.Errorf("isPermissionDenied(%q) = %v, want %v", tt.errStr, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
This pull request adds preflight validation and locality resolution across `--placement-policy`, `--gke-nap-reservation`, and `--queue` during GKE job submission, failing fast with actionable errors rather than letting workloads sit pending or fail late during cluster deployment.

### Key Changes
1. **Workload Placement Policy Validation (`--placement-policy`)**:
   - Validates existence, project, and region locality against GCE Compute REST API contracts before writing to Kubernetes manifests.
   - For static multi-host TPU 7x workloads, validates that policies are of type `HIGH_THROUGHPUT` and use non-dynamic topology modes (`AUTO_CONNECT` or default static placement), skipping dynamic slicing `PROVISION_ONLY` policies.
   - Sanitizes full HTTPS URLs and relative resource URIs down to bare names for Kubernetes node selectors (`cloud.google.com/placement-policy-name` for TPU, `cloud.google.com/gke-placement-group` for non-TPU).
2. **GKE NAP Reservation Validation (`--gke-nap-reservation`)**:
   - Preflight checks GCE reservations (zonal describe and regional list) against requested machine type and cluster locality.
   - Normalizes partial URI machine types using `path.Base` to prevent false mismatches.
   - Supports cross-project shared reservations while enforcing regional compatibility.
3. **Kueue LocalQueue Validation (`--queue`)**:
   - Enforces Kubernetes RFC 1123 DNS subdomain naming rules via `validation.IsDNS1123Subdomain` to prevent HTTP 422 API server rejections.
   - Strips resource path prefixes (`namespaces/.../localQueues/...`) if provided.
4. **Resilience & Enterprise IAM**:
   - Gracefully handles `403 Forbidden` / permission denied errors by logging an informational warning and proceeding, ensuring least-privilege enterprise users are never blocked.
   - Bypasses all network calls when `--dry-run-out` is specified.
5. **Architecture & Clean Code**:
   - Consolidated GCE API DTOs into `types.go`.
   - Introduced single-pass `parseURIParts` dictionary parser to avoid repetitive URI token scanning.
   - Inlined single-caller thin wrappers (`checkNAPFlagsSupported`, `resolveTPU7xWorkloadPolicyIfRequired`).

### Testing
- Unit tests added covering all new validation branches, edge cases, and error paths.
- Executed `go test -v ./pkg/orchestrator/gke/...` with 100% pass rate.
- Verified all pre-commit hooks (`pre-commit run`) passed cleanly (`go fmt`, `go vet`, `go imports`, `go-cyclo`, `golangci-lint`, `addlicense`, `codespell`).
