### PR TITLE
update terraform-provider version to >= 6.9.0, <= 8.2.0

### DIFF
--- a/pkg/config/expand.go
+++ b/pkg/config/expand.go
@@ -33,7 +33,7 @@ import (
 const (
 	blueprintLabel        = "ghpc_blueprint"
 	deploymentLabel       = "ghpc_deployment"
-	GoogleProviderVersion = ">= 6.9.0, <= 8.0.0"
+	GoogleProviderVersion = ">= 6.9.0, <= 8.2.0"
 )
 
 var validLabelValueRegex = regexp.MustCompile("[^a-z0-9_-]")

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/.ghpc/artifacts/expanded_blueprint.yaml
@@ -38,14 +38,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_pkr/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/.ghpc/artifacts/expanded_blueprint.yaml
@@ -44,14 +44,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
@@ -80,14 +80,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/one/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/igc_tf/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/.ghpc/artifacts/expanded_blueprint.yaml
@@ -39,14 +39,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/merge_flatten/zero/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/.ghpc/artifacts/expanded_blueprint.yaml
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/.ghpc/artifacts/expanded_blueprint.yaml
@@ -48,14 +48,14 @@ deployment_groups:
     terraform_providers:
       google:
         source: hashicorp/google
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))
           zone: ((var.zone))
       google-beta:
         source: hashicorp/google-beta
-        version: '>= 6.9.0, <= 8.0.0'
+        version: '>= 6.9.0, <= 8.2.0'
         configuration:
           project: ((var.project_id))
           region: ((var.region))

--- a/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
+++ b/tools/validate_configs/golden_copies/expectations/versioned_blueprint/primary/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 6.9.0, <= 8.0.0"
+      version = ">= 6.9.0, <= 8.2.0"
     }
   }
 }

--- a/tools/validate_configs/golden_copies/validate.sh
+++ b/tools/validate_configs/golden_copies/validate.sh
@@ -26,7 +26,7 @@ run_test() {
 	bpFile=$(basename "$bp")
 	DEPLOYMENT="golden_copy_deployment"
 	PROJECT="invalid-project"
-	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability"
+	VALIDATORS_TO_SKIP="test_project_exists,test_apis_enabled,test_region_exists,test_zone_exists,test_zone_in_region,test_quota_availability,test_machine_type_in_zone,test_reservation_exists,test_disk_type_in_zone"
 	GHPC_PATH="${cwd}/ghpc"
 	# Cover the three possible starting sequences for local sources: ./ ../ /
 	LOCAL_SOURCE_PATTERN='source:\s\+\(\./\|\.\./\|/\)'
@@ -79,6 +79,9 @@ run_test() {
 	find . -name "README.md" -exec rm {} \;
 	sed -i -E 's/(ghpc_version: )(.*)/\1golden/' .ghpc/artifacts/expanded_blueprint.yaml
 	sed -i '/- validator: test_quota_availability/,+1d' .ghpc/artifacts/expanded_blueprint.yaml
+        sed -i '/- validator: test_machine_type_in_zone/,+1d' .ghpc/artifacts/expanded_blueprint.yaml
+        sed -i '/- validator: test_reservation_exists/,+1d' .ghpc/artifacts/expanded_blueprint.yaml
+        sed -i '/- validator: test_disk_type_in_zone/,+1d' .ghpc/artifacts/expanded_blueprint.yaml
 
 	# Compare the deployment folder with the golden copy
 	diff --recursive --color='auto' --exclude="previous_deployment_groups" \


### PR DESCRIPTION
This PR updates the supported Google Terraform provider version constraint from <= 8.0.0 to <= 8.2.0 across configuration files and golden copy expectations. Additionally, it updates the golden copy validation script (validate.sh) to skip and strip out several new validators (test_machine_type_in_zone, test_reservation_exists, and test_disk_type_in_zone).